### PR TITLE
some slimming down of the input cells and the output cells with tabbed p...

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrFunc.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrFunc.css
@@ -195,18 +195,27 @@
     vertical-align: middle;
 }
 
-.kb-cell-params input {
-    margin-left: 5px;
-    margin-top: 5px;
+.kb-cell-params thead>tr>th, .kb-cell-params  tbody>tr>th, .kb-cell-params  tfoot>tr>th, .kb-cell-params  thead>tr>td, .kb-cell-params  tbody>tr>td, .kb-cell-params  tfoot>tr>td {
+    padding: 2px 4px;
 }
-.kb-cell-params tr:nth-child(odd) {
+
+.kb-cell-params input {
+   /* margin-left: 5px;
+    margin-top: 5px; */
+}
+/*.kb-cell-params tr:nth-child(odd) {
     background-color: #eee;
     border-bottom: 1px solid #ddd;    
 }
 .kb-cell-params tr:nth-child(even) {
     background-color: #fff;
     border-bottom: 1px solid #ddd;    
+}*/
+
+.kb-cell-params tr:hover td, .kb-cell-params tr:hover th {
+    background:#eee;
 }
+
 /* grey out the form while running */
 .kb-cell-run.running form {
     opacity: 0.6;
@@ -269,6 +278,12 @@
   color: #31708f;
   background-color: #d9edf7;
   border-color: #bce8f1;
+  padding: 5px 10px;
+}
+
+.kb-func-panel .panel-body {
+    padding: 0px 10px;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 
 .kb-func-panel > .panel-heading + .panel-collapse .panel-body {
@@ -278,3 +293,25 @@
 .kb-func-panel > .panel-footer + .panel-collapse .panel-body {
   border-bottom-color: #bce8f1;
 }
+
+.kb-func-panel .panel-footer {
+    /*background-color: #fff;
+    border-top: none; */
+    padding: 2px 15px;
+}
+
+/** output cell styling */
+.kb-cell-output .panel .panel-heading {
+    padding: 5px 10px;
+}
+
+.rendered_html .kb-cell-output ul {
+    margin: 0 0 10px 0;
+}
+
+.kb-cell-output .nav>li>a {
+    padding: 5px 10px;
+}
+
+
+

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/kbaseDefaultNarrativeInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/kbaseDefaultNarrativeInput.js
@@ -40,14 +40,14 @@
 
                 var input_default = (p.default !== "" && p.default !== undefined) ?
                                     " placeholder='" + p.default + "'" : "";
-                input = "<input class='form-control' style='width: 85%' name='" + pid + "'" + input_default +
+                input = "<input class='form-control' style='width: 95%' name='" + pid + "'" + input_default +
                         " value='' type='text'></input>";
 
                 var cellStyle = "border:none; vertical-align:middle;";
                 inputDiv += "<tr style='" + cellStyle + "'>" + 
-                                "<td style='" + cellStyle + "'>" + p.ui_name + "</td>" +
-                                "<td style='" + cellStyle + " width: 50%;'>" + input + "</td>" +
-                                "<td style='" + cellStyle + "'>" + p.description + "</td>" +
+                                "<th style='" + cellStyle + " font-family: 'OxygenBold', sans-serif; font-weight: bold;>" + p.ui_name + "</th>" +
+                                "<td style='" + cellStyle + " width: 40%;'>" + input + "</td>" +
+                                "<td style='" + cellStyle + " color: #777;'>" + p.description + "</td>" +
                             "</tr>";
             }
             inputDiv += "</table></div>";


### PR DESCRIPTION
This is in response to:
https://atlassian.kbase.us/browse/NAR-190

As a start, I'm looking into making the input and output widgets smaller and less heavyweight looking. I've removed a lot of the margin/padding in the input cells. I also removed the row striping but added in striping on hover. 

For both the input and output widgets, I've shrunk the panel header. For the tabbed panels within the output cells, I've removed some of the padding/margins (though I'm not sure I did so in the right place, I added the css to kbaseNarrFunc.css)

I tested the three Featured Narratives on Chrome, FF, and Safari. 

Please have a look and see if these changes seem reasonable or if you have other changes you'd like to request.
