### PR TITLE
Plant table size bug fix 2014 08 05

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
@@ -2,7 +2,7 @@
         requirejs.config({
         	//baseUrl: 'static/foo/bar/',
             //urlArgs: "bust=" + (new Date()).getTime(),
-            waitSeconds : 30 ,
+            waitSeconds : 30,
             paths : {
                 'jquery'      : 'kbase/js/ui-common/ext/jquery/jquery-1.10.2.min',
                 'jqueryui'    : 'kbase/js/ui-common/ext/jquery-ui/1.10.3/js/jquery-ui-1.10.3.custom.min',


### PR DESCRIPTION
Points to a fresh ui-common/hardy revision with bug fixes to the display of kbasePlantNetworkTable and kbasePlantNTO (creates vertically collapsed rows by default, and autoscrolls when clicking the "More..." link, respectively)

Also drops margins from kbaseTable, for prettier narrative display.
