### PR TITLE
Add missing python modules in Docker.update

### DIFF
--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -19,6 +19,7 @@ EXPOSE 8888
 # Copy in the narrative repo
 ADD ./narrative /kb/dev_container/narrative
 ADD ./narrative/kbase-logdb.conf /tmp/kbase-logdb.conf
+RUN apt-get install -y python-virtualenv python-thrift python-yaml python-paramiko
 RUN cd /kb/dev_container/narrative; /bin/bash install.sh -p /kb/deployment/services narrative
 RUN cd /tmp/narrative
 


### PR DESCRIPTION
This is needed to resolve some missing python modules.  I've put it in Docker.update for now.  Eventually we can move it into the base when we re-spin it.
