### PR TITLE
Method panel styling - issue #102

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -104,7 +104,7 @@
                               .append($('<div>')
                                       .addClass('kb-narr-panel-body')
                                       .css({ 
-                                          'max-height' : this.options.maxHeight,
+//                                          'max-height' : this.options.maxHeight,
                                           'overflow-y' : 'auto'
                                       })
                                       .append(this.$bodyDiv)));

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -165,6 +165,7 @@
                     if (filterString) {
                         this.$searchDiv.show();
                         this.$searchInput.val(filterString);
+                        this.$searchInput.trigger('input');
                     }
                 }, this)
             );

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -419,18 +419,11 @@
                                         .attr('href', this.options.methodHelpLink + method.id)));
 
             var $moreBtn = $('<span>')
-                           .addClass('btn btn-default btn-xs kb-data-list-more-btn pull-right fa fa-plus')
+                           .addClass('btn btn-default btn-xs kb-data-list-more-btn pull-right fa fa-ellipsis-h')
                            .attr('aria-hidden', 'true')
                            .css({'color' : '#999'})
                            .click(function(e) {
-                               $more.slideToggle('fast', $.proxy(function() {
-                                   if ($more.is(':visible')) {
-                                       $(this).removeClass('fa-plus').addClass('fa-minus');
-                                   }
-                                   else {
-                                       $(this).removeClass('fa-minus').addClass('fa-plus');
-                                   }
-                                }, this));
+                               $more.slideToggle('fast');
                            });
 
             var $mainDiv = $('<div>')

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -46,9 +46,10 @@
                 this.options.methodStoreURL = window.kbconfig.urls.narrative_method_store;
             }
 
-            var $searchDiv = $('<div>')
+            this.$searchDiv = $('<div>')
                              .addClass('input-group')
                              .css({'margin-bottom' : '3px'})
+                             .hide();
 
             this.$searchInput = $('<input type="text">')
                                 .addClass('form-control')
@@ -87,8 +88,8 @@
                                                 this.$searchInput.trigger('input'); 
                                             }, this)
                                           ));
-            $searchDiv.append(this.$searchInput)
-                      .append($clearSearchBtn);
+            this.$searchDiv.append(this.$searchInput)
+                           .append($clearSearchBtn);
 
             var $ipyButtonDiv = $('<div style="margin-bottom:5px">')
                                 .append($('<button>')
@@ -108,12 +109,16 @@
                                             IPython.notebook.insert_cell_below('markdown');
                                         }));
 
+            // placeholder for apps and methods once they're loaded.
+            this.$methodList = $('<div>')
+                               .css({'height' : '300px', 'overflow-y': 'auto', 'overflow-x' : 'hidden'});
             // Make a function panel for everything to sit inside.
             this.$functionPanel = $('<div>')
                                   .addClass('kb-function-body')
                                   .append($ipyButtonDiv)
-                                  .append($searchDiv)
-                                  .append(this.$toggleHiddenDiv);
+                                  .append(this.$searchDiv)
+                                  .append(this.$toggleHiddenDiv)
+                                  .append(this.$methodList);
 
             // The 'loading' panel should just have a spinning gif in it.
             this.$loadingPanel = $('<div>')
@@ -145,6 +150,12 @@
                 }, this)
             );
 
+            this.addButton($('<button>')
+                           .addClass('btn btn-xs btn-default')
+                           .append('<span class="fa fa-search"></span>')
+                           .click($.proxy(function(event) {
+                               this.$searchDiv.slideToggle(400);
+                           }, this)));
             this.addButton($('<button>')
                            .addClass('btn btn-xs btn-default')
                            .append('<span class="glyphicon glyphicon-play"></span>')
@@ -298,10 +309,7 @@
             var $methodPanel = generatePanel(catSet, methSet, 'M', triggerMethod);
             var $appPanel = generatePanel(catSet, appSet, 'A', triggerApp);
 
-            console.log(this.methodSet);
-
-            this.$functionPanel.append($appPanel);
-            this.$functionPanel.append($methodPanel);
+            this.$methodList.empty().append($appPanel).append($methodPanel);
         },
 
         /**

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -689,9 +689,22 @@
             return [$block, topElements];
         },
 
+        /**
+         * A *REALLY* simple filter based on whether the given pattern string is present in the 
+         * method's name.
+         * Returns true if so, false if not.
+         * Doesn't care if its a method or an app, since they both have name fields at their root.
+         */
         textFilter: function(pattern, method) {
             var lcName = method.name.toLowerCase();
             return lcName.indexOf(pattern.toLowerCase()) > -1;
+        },
+
+        /**
+         * Returns true if the type is available as in input to the method, false otherwise
+         */
+        inputFilter: function(type, spec) {
+            return true;
         },
 
         /**
@@ -762,6 +775,7 @@
          * }
          */
         visualFilter: function(filterFn, fnInput) {
+            console.log(this.methodSet);
             var numHidden = 0;
             for (var methId in this.methodSet) {
                 if (!filterFn(fnInput, this.methodSet[methId])) {
@@ -817,21 +831,6 @@
                              .addClass('kb-side-tab')
                              .append(tab.content));
             }
-
-            // // if show, show 'em all, and trigger the class for the kb-has-hidden attribute
-            // if (show) {
-            //     this.$functionPanel.find('.panel-default').show();
-            //     this.$functionPanel.find('.kb-data-obj-name').parent().show();
-            //     this.$functionPanel.find('[kb-has-hidden]').addClass('kb-function-cat-dim');
-            // }
-            // // otherwise, remove the kb-function-cat-dim class from everything, and
-            // // show only those that do not have kb-function-dim, and hide the rest
-            // else {
-            //     this.$functionPanel.find('.panel-default').removeClass('kb-function-cat-dim');
-            //     this.$functionPanel.find('.kb-function-dim').hide();
-            //     this.$functionPanel.find('.panel:not(.kb-function-dim)').show();
-            //     this.$functionPanel.find('li:not(.kb-function-dim)').show();
-            // }
             $header.find('div').click(function(event) {
                 event.preventDefault();
                 event.stopPropagation();

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -160,6 +160,15 @@
                 }, this)
             );
 
+            $(document).on('filterMethods.Narrative',
+                $.proxy(function(e, filterString) {
+                    if (filterString) {
+                        this.$searchDiv.show();
+                        this.$searchInput.val(filterString);
+                    }
+                }, this)
+            );
+
             this.addButton($('<button>')
                            .addClass('btn btn-xs btn-default')
                            .append('<span class="fa fa-search"></span>')

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -289,15 +289,16 @@
             );
 
             $.when(methodProm, appProm, catProm).done($.proxy(function(a, b, c) {
-                console.log([this.appSpecs, this.methodSpecs, this.categories]);
+                // console.log([this.appSpecs, this.methodSpecs, this.categories]);
                 this.parseMethodsAndApps(this.categories, this.methodSpecs, this.appSpecs);
                 this.showFunctionPanel();
             }, this));
 
-            $.when(methodProm, appProm).fail(function(err) {
+            $.when(methodProm, appProm).fail($.proxy(function(error) {
                 console.log("error'd!")
-                console.log(err);
-            });
+                console.log(error);
+                this.showError(error);
+            }, this));
         },
 
         parseMethodsAndApps: function(catSet, methSet, appSet) {
@@ -348,7 +349,7 @@
             this.id2Elem['app'] = appRender[1];
 
             this.$methodList.empty().append($appPanel).append($methodPanel);
-            console.log([Object.keys(this.appSpecs).length, Object.keys(this.methodSpecs).length]);
+            //console.log([Object.keys(this.appSpecs).length, Object.keys(this.methodSpecs).length]);
         },
 
         /**
@@ -586,7 +587,7 @@
                               .attr('type', 'button')
                               .addClass('btn btn-default')
                               .append(method.title)
-                              .click(function(event) { console.log(method); self.trigger('function_clicked.Narrative', method); });
+                              .click(function(event) { self.trigger('function_clicked.Narrative', method); });
 
             var $helpButton = $('<span>')
                               .addClass('glyphicon glyphicon-question-sign')
@@ -998,8 +999,8 @@
         },
 
         updateOverlayPosition: function() {
-        console.log("ME IS ", this.$elem);
-        console.log("HE IS", this.$elem.closest('.kb-side-panel'));
+        // console.log("ME IS ", this.$elem);
+        // console.log("HE IS", this.$elem.closest('.kb-side-panel'));
             this.$overlay.position({my: 'left top', at: 'right top', of: this.$elem.closest('.kb-side-panel')});
             this.$narrativeDimmer.position({my: 'left top', at: 'right top', of: this.$elem.closest('.kb-side-panel')});
         },

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -258,7 +258,7 @@
             IPython.notebook.kernel.execute(code, callbacks, {silent: true});
         },
 
-        buildAppCell: function(appInfo) {
+        buildAppCell: function(appSpec) {
             var cell = IPython.notebook.insert_cell_below('markdown');
             this.removeCellEditFunction(cell);
 
@@ -267,28 +267,29 @@
             cell.rendered = false;
             cell.render();
 
-            this.methClient.get_app_spec({'ids': [appInfo.id]}, 
-                $.proxy(function(appSpec) {
-                    this.setAppCell(cell, appSpec[0]);
-                    var cellIndex = IPython.notebook.ncells() - 1;
-                    var cellId = 'kb-cell-' + cellIndex + '-' + this.uuidgen();
+            // this.methClient.get_app_spec({'ids': [appInfo.id]}, 
+            //     $.proxy(function(appSpec) {
+            this.setAppCell(cell, appSpec);
+            var cellIndex = IPython.notebook.ncells() - 1;
+            var cellId = 'kb-cell-' + cellIndex + '-' + this.uuidgen();
 
-                    // The various components are HTML STRINGS, not jQuery objects.
-                    // This is because the cell expects a text input, not a jQuery input.
-                    // Yeah, I know it's ugly, but that's how it goes.
-                    var cellContent = "<div id='" + cellId + "'></div>" +
-                                      "\n<script>" +
-                                      "$('#" + cellId + "').kbaseNarrativeAppCell({'appSpec' : '" + this.safeJSONStringify(appSpec[0]) + "', 'cellId' : '" + cellId + "'});" +
-                                      "</script>";
-                    cell.set_text(cellContent);
-                    cell.rendered = false;
-                    cell.render();
+            // The various components are HTML STRINGS, not jQuery objects.
+            // This is because the cell expects a text input, not a jQuery input.
+            // Yeah, I know it's ugly, but that's how it goes.
+            console.log(appSpec);
+            var cellContent = "<div id='" + cellId + "'></div>" +
+                              "\n<script>" +
+                              "$('#" + cellId + "').kbaseNarrativeAppCell({'appSpec' : '" + this.safeJSONStringify(appSpec) + "', 'cellId' : '" + cellId + "'});" +
+                              "</script>";
+            cell.set_text(cellContent);
+            cell.rendered = false;
+            cell.render();
 
-                }, this),
-                $.proxy(function(error) {
+                // }, this),
+                // $.proxy(function(error) {
 
-                }, this)
-            );
+                // }, this)
+//            );
         },
 
         runAppCell: function(data) {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -267,8 +267,6 @@
             cell.rendered = false;
             cell.render();
 
-            // this.methClient.get_app_spec({'ids': [appInfo.id]}, 
-            //     $.proxy(function(appSpec) {
             this.setAppCell(cell, appSpec);
             var cellIndex = IPython.notebook.ncells() - 1;
             var cellId = 'kb-cell-' + cellIndex + '-' + this.uuidgen();
@@ -276,7 +274,6 @@
             // The various components are HTML STRINGS, not jQuery objects.
             // This is because the cell expects a text input, not a jQuery input.
             // Yeah, I know it's ugly, but that's how it goes.
-            console.log(appSpec);
             var cellContent = "<div id='" + cellId + "'></div>" +
                               "\n<script>" +
                               "$('#" + cellId + "').kbaseNarrativeAppCell({'appSpec' : '" + this.safeJSONStringify(appSpec) + "', 'cellId' : '" + cellId + "'});" +
@@ -284,12 +281,6 @@
             cell.set_text(cellContent);
             cell.rendered = false;
             cell.render();
-
-                // }, this),
-                // $.proxy(function(error) {
-
-                // }, this)
-//            );
         },
 
         runAppCell: function(data) {


### PR DESCRIPTION
This mainly addresses Issue #102 
* Remove code and text cell buttons

Not addressed yet, until #90 gets fixed
* Search button in style (should be title?) bar

Done
* Clicking search button should toggle search text box

Done
* Search text box should be fixed position

Done
* Design iteration on ‘more’ button (turn +/- to …)

Done
* click anywhere except for icon/title to pulldown

Done
* Add filter based on data input/output type (e.g. “type:KBaseGenomes.Genome”)

Done. Entering "type:XXX" searches among all parameters for each method and app for "XXX" in their allowed types. If present, that method/app passes, if not, then it gets filtered out. It actually searches for "XXX" somewhere within the type string itself. So, if the type is "KBaseBiochem.Media", then "media" matches, "biochem" matches, and "kbasebiochem.media" matches. It's a little fuzzy, but I would more expect users to search for "media" or "genome" instead of the full name.

This also comes with an event that can be triggered to run the filter. So if a user clicks on a data object (or somewhere else that knows how to trigger), the filtering can be activated automatically. To do this, use the statement:

    $elem.trigger('filterMethod.Narrative', stringToFilter);

where $elem is a jQuery node element (e.g. all widgets - from within a widget you can do this.trigger(....))
and stringToFilter is the string that gets inserted into the filter itself - to filter by type, you'll need to include the 'type:' prefix.

There should be some more info given on what's being filtered and why - just 'type:XXX' might be unclear to a new user. But this PR captures the main functionality needed.