### PR TITLE
Add debug mode for app jobs

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -25,6 +25,7 @@
     }, 
     "git_commit_hash": "bfbb9a8", 
     "git_commit_time": "Wed Nov 12 15:34:42 2014 -0800", 
+    "mode": "debug",
     "name": "KBase Narrative", 
     "prod": {
         "awe": "http://140.221.67.185:7080", 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -383,7 +383,8 @@
                             git_commit_hash: configJSON['git_commit_hash'],
                             git_commit_time: configJSON['git_commit_time'],
                             landing_page_map: landingPageMap,
-                            release_notes: configJSON['release_notes']
+                            release_notes: configJSON['release_notes'],
+                            mode: configJSON['mode']
                           };
     </script>
     <script src="{{ static_url("kbase/js/api/kbase-api.js") }}" type="text/javascript" charset="utf-8"></script>

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -35,7 +35,7 @@
                             stackTrace = metadata['kb-cell']['stackTrace'];
                         console.log(stackTrace);
                         var cell = IPython.notebook.insert_cell_below('code');
-                        cell.set_text('trace=' + stackTrace[3] + '\ntrace');
+                        cell.set_text('job_info=' + stackTrace[3] + '\njob_info');
                         IPython.notebook.get_selected_cell().execute();
                     }
                 });

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -24,6 +24,23 @@
                                 'margin' : '0'
                          });
 
+            if (window.kbconfig && window.kbconfig.mode === "debug") {
+                this.addMenuItem({
+                    icon: 'fa fa-code',
+                    text: 'View Stack Trace',
+                    action: function() {
+                        var metadata = IPython.notebook.get_selected_cell().metadata;
+                        var stackTrace = [];
+                        if (metadata['kb-cell'] && metadata['kb-cell']['stackTrace'])
+                            stackTrace = metadata['kb-cell']['stackTrace'];
+                        console.log(stackTrace);
+                        var cell = IPython.notebook.insert_cell_below('code');
+                        cell.set_text('from pprint import pprint\ntrace=' + stackTrace[3] + '\npprint(trace)');
+                        IPython.notebook.get_selected_cell().execute();
+                    }
+                });
+            }
+
             this.addMenuItem({
                 icon: 'fa fa-arrow-up',
                 text: 'Move Cell Up',

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -27,7 +27,7 @@
             if (window.kbconfig && window.kbconfig.mode === "debug") {
                 this.addMenuItem({
                     icon: 'fa fa-code',
-                    text: 'View Stack Trace',
+                    text: 'View Job Submission',
                     action: function() {
                         var metadata = IPython.notebook.get_selected_cell().metadata;
                         var stackTrace = [];

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -35,7 +35,7 @@
                             stackTrace = metadata['kb-cell']['stackTrace'];
                         console.log(stackTrace);
                         var cell = IPython.notebook.insert_cell_below('code');
-                        cell.set_text('from pprint import pprint\ntrace=' + stackTrace[3] + '\npprint(trace)');
+                        cell.set_text('trace=' + stackTrace[3] + '\ntrace');
                         IPython.notebook.get_selected_cell().execute();
                     }
                 });

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -1578,7 +1578,7 @@
                     buffer = buffer.substr(offs, buffer.length - offs);
                 }
                 if (result.length > 0) {
-                    if (showOutput === "app") {
+                    if (showOutput === "app" && window.kbconfig && window.kbconfig.mode === "debug") {
                         if (!cell.metadata[this.KB_CELL].stackTrace)
                             cell.metadata[this.KB_CELL].stackTrace = [];
                         // try to parse the result as JSON - if so, then it's a final result and we just

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -293,11 +293,11 @@
             var self = this;
             var callbacks = {
                 'execute_reply' : function(content) { self.handleExecuteReply(data.cell, content); },
-                'output' : function(msgType, content) { self.handleOutput(data.cell, msgType, content); },
+                'output' : function(msgType, content) { self.handleOutput(data.cell, msgType, content, "app"); },
                 'clear_output' : function(content) { self.handleClearOutput(data.cell, content); },
                 'set_next_input' : function(text) { self.handleSetNextInput(data.cell, content); },
                 'input_request' : function(content) { self.handleInputRequest(data.cell, content); },
-            }
+            };
 
             var code = this.buildAppCommand(data.appSpec, data.methodSpecs, data.parameters);
             IPython.notebook.kernel.execute(code, callbacks, {silent: true});
@@ -1577,8 +1577,24 @@
                     // if we found progress markers, trim processed prefix from buffer
                     buffer = buffer.substr(offs, buffer.length - offs);
                 }
-                if (result.length > 0 && showOutput) {
-                    this.createOutputCell(cell, result);
+                if (result.length > 0) {
+                    if (showOutput === "app") {
+                        if (!cell.metadata[this.KB_CELL].stackTrace)
+                            cell.metadata[this.KB_CELL].stackTrace = [];
+                        // try to parse the result as JSON - if so, then it's a final result and we just
+                        // need the 'data' field
+                        try {
+                            var data = JSON.parse(result);
+                            if (data && typeof data === 'object')
+                                cell.metadata[this.KB_CELL].stackTrace.push(data.data);
+                        }
+                        catch (err) {
+                            // it's NOT JSON, and we should just append it.
+                            cell.metadata[this.KB_CELL].stackTrace.push(result);
+                        }
+                    }
+                    else if (showOutput)
+                        this.createOutputCell(cell, result);
                 }
             }
         },


### PR DESCRIPTION
This adds a couple of things, related to issue #116.

The first is a 'mode' configuration in config.json (currently set to debug).

The second is an additional cell menu option that appears in debug mode - at the top of the menu is a 'View Job Submission' option. Now, when an app job is run in debug mode, all of the results of that initial set up (all communication from the kernel) is stored in that app cell's metadata. Clicking that new menu item will do two things:
  1. This will dump the contents of that info into the Javascript console (including a few message strings)
  2. Create and run a code cell that contains the job info that gets returned on a successful job submission. Having this cell auto run registers that object as a variable, and prints it out in a nice way (it's a substantial hunk of JSON, usually).

That job info object has three main properties: 'app' is the document that gets sent to the NJS, 'app_state' is the initial state object that gets returned, and 'job_id' is the job id that gets registered with the Narrative.

Hopefully this will make some debugging easier until a more elegant debugger can be assembled.