### PR TITLE
Narrative metadata update

### DIFF
--- a/src/biokbase/narrative/kbasewsmanager.py
+++ b/src/biokbase/narrative/kbasewsmanager.py
@@ -389,27 +389,35 @@ class KBaseWSNotebookManager(NotebookManager):
             }
         }
         """
-        cell_types = {'method' : {}, 'app' : {}, 'ipython' : {'markdown': 0, 'code': 0}}
+        cell_types = {'method' : {}, 
+                      'app' : {}, 
+                      'output': 0,
+                      'ipython' : {'markdown': 0, 'code': 0}}
         for wksheet in nb.get('worksheets'):
             for cell in wksheet.get('cells'):
                 meta = cell['metadata']
                 if 'kb-cell' in meta:  
                     t = None
                     # It's a KBase cell! So, either an app or method.
-                    if 'app' in meta['kb-cell']:
-                        t = 'app'
-                    elif 'method' in meta['kb-cell']:
-                        t = 'method'
+                    if 'type' in meta['kb-cell'] and meta['kb-cell']['type'] == 'function_output':
+                        cell_types['output'] = cell_types['output'] + 1
                     else:
-                        continue
-                    try:
-                        count = 1
-                        app_id = meta['kb-cell'][t]['info']['id']
-                        if app_id in cell_types[t]:
-                            count = cell_types[t][app_id] + 1
-                        cell_types[t][app_id] = count
-                    except KeyError:
-                        continue
+                        if 'app' in meta['kb-cell']:
+                            t = 'app'
+                        elif 'method' in meta['kb-cell']:
+                            t = 'method'
+                        else:
+                            # that should cover our cases
+                            continue
+                        if t is not None:
+                            try:
+                                count = 1
+                                app_id = meta['kb-cell'][t]['info']['id']
+                                if app_id in cell_types[t]:
+                                    count = cell_types[t][app_id] + 1
+                                cell_types[t][app_id] = count
+                            except KeyError:
+                                continue
                 else:
                     t = cell['cell_type']
                     cell_types['ipython'][t] = cell_types['ipython'][t] + 1

--- a/src/biokbase/narrative/tests/test_kbasewsmanager.py
+++ b/src/biokbase/narrative/tests/test_kbasewsmanager.py
@@ -271,12 +271,17 @@ class NarrDocumentTestCase(NarrBaseTestCase):
         ret_id = self.mgr.write_notebook_object(nb, notebook_id=self.nb_id)
         self.assertEquals(ret_id, self.nb_id)
 
+    # Without an id, we would expect it to create a new narrative object in the
+    # same workspace that Notebook knows about from its metadata
     def test_write_notebook_object_valid_without_id(self):
         self.login()
         (last_modified, nb) = self.mgr.read_notebook_object(self.nb_id)
         ret_id = self.mgr.write_notebook_object(nb)
         # we haven't changed the notebook's name, so it should be the same
-        self.assertEquals(ret_id, self.nb_id)
+        self.assertNotEquals(ret_id, self.nb_id)
+        # Do a little specific cleanup here.
+        if (ret_id is not self.nb_id):
+            self.mgr.delete_notebook(ret_id)
 
     def test_write_notebook_object_invalid(self):
         self.login()

--- a/src/biokbase/narrative/ws_util.py
+++ b/src/biokbase/narrative/ws_util.py
@@ -84,7 +84,7 @@ def get_wsid(wsclient, workspace):
             raise e
     return( ws_meta[0])
 
-def alter_workspace_metadata(wsclient, ref, new_metadata={}):
+def alter_workspace_metadata(wsclient, ref, new_metadata={}, ws_id=None):
     """
     This is just a wrapper for the workspace get_objects call.
 
@@ -99,12 +99,15 @@ def alter_workspace_metadata(wsclient, ref, new_metadata={}):
     if type is not specified then an extra lookup for object metadata
     is required, this can be shortcut by passing in the object type
     """
-    match = ws_regex.match( ref)
-    if not match:
-        raise BadWorkspaceID("%s does not match workspace ID format ws.{workspace id}.obj.{object id}" % ws_id)
-    ws = match.group(1)
+    if ws_id is None and ref is not None:
+        match = ws_regex.match(ref)
+        if not match:
+            raise BadWorkspaceID("%s does not match workspace ID format ws.{workspace id}.obj.{object id}" % ws_id)
+        ws_id = match.group(1)
+    elif ws_id is None and ref is None:
+        raise BadWorkspaceID("No workspace id or object reference given!")
     
-    wsclient.alter_workspace_metadata({'wsi':{'id':ws}, 'new':new_metadata})
+    wsclient.alter_workspace_metadata({'wsi':{'id':ws_id}, 'new':new_metadata})
     
     
 def get_wsobj(wsclient, ws_id, objtype=None):

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -149,7 +149,10 @@
          * @public
          */
         getParameters: function() {
-            return this.$inputWidget.getParameters();
+            if (this.$inputWidget)
+                return this.$inputWidget.getParameters();
+            else
+                return null;
         },
 
         /**


### PR DESCRIPTION
This adds a count of each cell type to the Narrative object's metadata. For app and method cells, it keeps a count of which app and method was used. This all gets shuffled together as a dictionary like this (as an example):
<pre><code>{
    'method': {
        'my_method_id': 2,
        'my_other_method': 3,
    },
    'app': {
        'an_app_id' : 1,
        'another_app_id' : 2,
    },
    'output' : 0,
    'ipython' : {
        'code' : 6,
        'markdown' : 3
    }
}</code></pre>

The numbers are just the counts of those cell types.

This also contains a small bugfix for an error that happens if a job tries to update a cell that's been deleted.