### PR TITLE
Issue #91: Show cell menubar when new code/markdown cells are created

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -221,7 +221,6 @@ narrative.init = function() {
                                                     .append($firstShutdownBtn))
                                             .append($reallyShutdownPanel))));
 
-//    var $versionBtn = $('<a href="#">About</a>')
     $('#kb-about-btn').click(function(event) {
                           event.preventDefault();
                           event.stopPropagation();
@@ -231,7 +230,6 @@ narrative.init = function() {
                           }
                       });
 
-//    $('#kb-version-stamp').empty().append($versionBtn);
     $('#notebook').append($versionModal);
     $('[data-toggle="tooltip"]').tooltip()
     /*
@@ -241,6 +239,14 @@ narrative.init = function() {
 
     var curCell = null;
     $([IPython.events]).on('select.Cell', function(event, data) {
+        if (curCell && data.cell != this.curCell)
+            curCell.celltoolbar.hide();
+        curCell = data.cell;
+        if (!curCell.metadata['kb-cell'])
+            curCell.celltoolbar.show();
+    });
+
+    $([IPython.events]).on('create.Cell', function(event, data) {
         if (curCell && data.cell != this.curCell)
             curCell.celltoolbar.hide();
         curCell = data.cell;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -238,20 +238,22 @@ narrative.init = function() {
     var $sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
 
     var curCell = null;
-    $([IPython.events]).on('select.Cell', function(event, data) {
-        if (curCell && data.cell != this.curCell)
+    var showIPythonCellToolbar = function(cell) {
+        // hide the previously selected cell's toolbar
+        if (curCell && cell != curCell)
             curCell.celltoolbar.hide();
-        curCell = data.cell;
+        curCell = cell;
+        // show the new one
         if (!curCell.metadata['kb-cell'])
-            curCell.celltoolbar.show();
+            curCell.celltoolbar.show();        
+    };
+
+    $([IPython.events]).on('select.Cell', function(event, data) {
+        showIPythonCellToolbar(data.cell);
     });
 
     $([IPython.events]).on('create.Cell', function(event, data) {
-        if (curCell && data.cell != this.curCell)
-            curCell.celltoolbar.hide();
-        curCell = data.cell;
-        if (!curCell.metadata['kb-cell'])
-            curCell.celltoolbar.show();
+        showIPythonCellToolbar(data.cell);
     });
 
     /*

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -200,6 +200,8 @@
          */
         buildMethodCell: function(method) {
             var cell = IPython.notebook.insert_cell_below('markdown');
+            cell.celltoolbar.hide();
+            
             // make this a function input cell, as opposed to an output cell
             this.setMethodCell(cell, method);
 
@@ -266,6 +268,7 @@
 
         buildAppCell: function(appSpec) {
             var cell = IPython.notebook.insert_cell_below('markdown');
+            cell.celltoolbar.hide();
             this.removeCellEditFunction(cell);
 
             var tempContent = '<img src="' + this.options.loadingImage + '">';
@@ -327,6 +330,7 @@
          */
         buildFunctionCell: function(method) {
             var cell = IPython.notebook.insert_cell_below('markdown');
+            cell.celltoolbar.hide();
             // make this a function input cell, as opposed to an output cell
             this.setFunctionCell(cell, method);
 
@@ -1817,7 +1821,7 @@
          */
         addOutputCell: function(currentIndex, widget) {
             var cell = IPython.notebook.insert_cell_below('markdown', currentIndex);
-
+            cell.celltoolbar.hide();
             this.setOutputCell(cell, widget);
             this.removeCellEditFunction(cell);
 
@@ -1826,6 +1830,7 @@
 
         addErrorCell: function(currentIndex) {
             var cell = IPython.notebook.insert_cell_below('markdown', currentIndex);
+            cell.celltoolbar.hide();
             this.setErrorCell(cell);
             this.removeCellEditFunction(cell);
             return cell;


### PR DESCRIPTION
This should fix that issue. It's a little bit of a hack in places, since we don't want those to appear over KBase cells (app/method/output/error). However, the best way to tell when a new cell is created is to catch the create.Cell IPython event.

Now, when a KBase-ish cell is created, that menubar is explicitly hidden, but shown when any other cell is made.