### PR TITLE
Better job management/canceling support, Fixes to App and Method cells to deal with cancellations

### DIFF
--- a/src/biokbase/narrative/common/kbjob_manager.py
+++ b/src/biokbase/narrative/common/kbjob_manager.py
@@ -163,7 +163,7 @@ class KBjobManager():
         workspace = os.environ['KB_WORKSPACE_ID']
         return _method_get_state(workspace, token, URLS, self, method_info[0], method_info[1], method_job_id)
 
-    def delete_jobs(self, job_list):
+    def delete_jobs(self, job_list, as_json=False):
         """
         Delete all jobs in the list. They may belong to different services based on their prefix, currently
         either 'njs', 'method', or 'ujs'.
@@ -189,4 +189,7 @@ class KBjobManager():
                 if (not status == 'success') and ('was marked for deletion' not in status):
                     is_deleted = False
             deletion_status[job_id] = is_deleted
-        return json.dumps(deletion_status)
+        if as_json:
+            import json
+            deletion_status = json.dumps(deletion_status)
+        return deletion_status

--- a/src/biokbase/narrative/common/kbjob_manager.py
+++ b/src/biokbase/narrative/common/kbjob_manager.py
@@ -86,7 +86,7 @@ class KBjobManager():
         Polls a list of job ids on behalf of the narrativejoblistener
         account and returns the results
         """
-        job_states = list()
+        job_states = dict()
         ujs_proxy = self.__proxy_client()
 
         for job in jobs:
@@ -96,16 +96,16 @@ class KBjobManager():
 
             if job_id.startswith('method:'):
                 try:
-                    job_states.append(self.get_method_state(job, job_id))
+                    job_states[job_id] = self.get_method_state(job, job_id)
                 except Exception as e:
                     import traceback
-                    job_states.append({'job_id' : job_id, 'job_state' : 'error', 'error' : e.__str__(), 'traceback' : traceback.format_exc()})
+                    job_states[job_id] = {'job_id' : job_id, 'job_state' : 'error', 'error' : e.__str__(), 'traceback' : traceback.format_exc()}
             elif job_id.startswith('njs:'):
                 try:
-                    job_states.append(self.get_app_state(job, job_id))
+                    job_states[job_id] = self.get_app_state(job, job_id)
                 except Exception as e:
                     import traceback
-                    job_states.append({'job_id' : job_id, 'job_state' : 'error', 'error' : e.__str__(), 'traceback' : traceback.format_exc()})
+                    job_states[job_id] = {'job_id' : job_id, 'job_state' : 'error', 'error' : e.__str__(), 'traceback' : traceback.format_exc()}
             else:
                 try:
                     # 0  job_id job,
@@ -136,10 +136,10 @@ class KBjobManager():
                         job['error'] = ujs_job[4]
                     elif ujs_job[10] == 1:
                         job['widget_outputs'] = self.get_method_state(method_info, job_id)
-                    job_states.append(job)
+                    job_states[job_id] = job
                 except Exception as e:
                     import traceback
-                    job_states.append({'job_id' : job_id, 'job_state' : 'error', 'error' : e.__str__(), 'traceback' : traceback.format_exc()})
+                    job_states[job_id] = {'job_id' : job_id, 'job_state' : 'error', 'error' : e.__str__(), 'traceback' : traceback.format_exc()}
         if as_json:
             import json
             job_states = json.dumps(job_states)

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -74,43 +74,6 @@
 })();
 
 /**
- * A fun little idea... but it doesn't really work. We need an actual way to poke at endpoints to see if they're alive.
- * But I'm leaving this in here for now. --Bill
- */
-var EndpointTester = function(url, target) {
-    this.loadingImage = 'static/kbase/images/ajax-loader.gif';
-    this.okayText = 'ok';
-    this.downText = 'down';
-    this.url = url;
-    this.$target = target;
-};
-
-EndpointTester.prototype.test = function(url) {
-    this.$target.html('<img src="' + this.loadingImage + '">');
-    var postTestParams = {
-        type: 'POST',
-        data: '{"params":{}, "version":"1.1", "method":"", "id":"' + Math.random() + '"}',
-        url: this.url,
-        success: $.proxy(function() { this.$target.html(this.okayText); }, this),
-        error: $.proxy(function(error) {
-            console.log('error!');
-            console.log(error);
-            this.$target.html(this.downText);
-        }, this),
-    };
-    var getTestParams = {
-        type: 'GET',
-        url: this.url,
-        success: $.proxy(function() { this.$target.html(this.okayText); }, this),
-        error: $.proxy(function(error) {
-            $.ajax(postTestParams);
-            this.$target.html(this.downText);
-        }, this),
-    }
-    $.ajax(getTestParams);
-};
-
-/**
  * Error logging for detectable failure conditions.
  * Logs go through the kernel and thus are sent to the
  * main KBase logging facility (Splunk, as of this writing).
@@ -301,18 +264,6 @@ narrative.init = function() {
             curCell.celltoolbar.show();
     };
 
-    $([IPython.events]).on('select.Cell', function(event, data) {
-        showIPythonCellToolbar(data.cell);
-    });
-
-    $([IPython.events]).on('create.Cell', function(event, data) {
-        showIPythonCellToolbar(data.cell);
-    });
-
-    $([IPython.events]).on('delete.Cell', function(event, data) {
-        showIPythonCellToolbar(IPython.notebook.get_selected_cell());
-    });
-
     /*
      * Once everything else is loaded and the Kernel is idle,
      * Go ahead and fill in the rest of the Javascript stuff.
@@ -320,6 +271,18 @@ narrative.init = function() {
     $([IPython.events]).one('status_started.Kernel', function() {
         // NAR-271 - Firefox needs to be told where the top of the page is. :P
         window.scrollTo(0,0);
+
+        $([IPython.events]).on('select.Cell', function(event, data) {
+            showIPythonCellToolbar(data.cell);
+        });
+
+        $([IPython.events]).on('create.Cell', function(event, data) {
+            showIPythonCellToolbar(data.cell);
+        });
+
+        $([IPython.events]).on('delete.Cell', function(event, data) {
+            showIPythonCellToolbar(IPython.notebook.get_selected_cell());
+        });
 
         IPython.notebook.set_autosave_interval(0);
         IPython.CellToolbar.activate_preset("KBase");
@@ -351,6 +314,7 @@ narrative.init = function() {
                 }
             });
 
+            $([IPython.events]).trigger('select.Cell', {cell: IPython.notebook.get_selected_cell()});
         }
         if (ws_name) {
             /* It's ON like DONKEY KONG! */

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -260,7 +260,7 @@ narrative.init = function() {
             curCell.celltoolbar.hide();
         curCell = cell;
         // show the new one
-        if (!curCell.metadata['kb-cell'])
+        if (curCell && !curCell.metadata['kb-cell'])
             curCell.celltoolbar.show();
     };
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -194,9 +194,6 @@ narrative.init = function() {
         if (window.kbconfig.release_notes)
             $versionDiv.append('<br>View release notes on <a href="' + window.kbconfig.release_notes + '" target="_blank">Github</a>');
 
-        // not used, but left in as legacy if we go back to it.
-        // $versionInfo = window.kbconfig.name + '<br>' + window.kbconfig.version;
-
         if (window.kbconfig.urls) {
             var urlList = Object.keys(window.kbconfig.urls).sort();
             var $versionTable = $('<table>')
@@ -210,8 +207,6 @@ narrative.init = function() {
                         $versionTable.append($('<tr>')
                                              .append($('<td>').append(val))
                                              .append($('<td>').append(url)));
-                        //                      .append($testTarget));
-                        // endpointTesters.push(new EndpointTester(url, $testTarget));
                     }
                 }
             );

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -734,6 +734,7 @@
             var source = jobInfo.state.source;
             var jobType = this.jobTypeFromId(jobInfo.state.id)
 
+            // console.log(['UPDATE_CELL', job, jobInfo]);
             var state = '';
             if (job.job_state)
                 state = job.job_state.toLowerCase();
@@ -841,6 +842,10 @@
                 else if (jobStatus.error) {
                     errorText = $('<div class="kb-jobs-error-modal">').append(jobStatus.error);
                     errorType = "Runtime";
+                }
+                else if (btnText === 'Deleted') {
+                    errorText = "This job has already been deleted from KBase Servers.";
+                    errorType = "Invalid Job";
                 }
                 else if (Object.keys(jobStatus.step_errors).length !== 0) {
                     errorType = "Runtime";

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -451,8 +451,8 @@
                     this.jobStates[jobId].status = 'error';
             }
 
-            console.log(['REFRESH: looking up ' + jobParamList.length]);
-            console.log(['REFRESH: jobstates:', this.jobStates]);
+            // console.log(['REFRESH: looking up ' + jobParamList.length]);
+            // console.log(['REFRESH: jobstates:', this.jobStates]);
 
             var pollJobsCommand = 'from biokbase.narrative.common.kbjob_manager import KBjobManager\n' +
                                   'job_manager = KBjobManager()\n' +
@@ -552,7 +552,7 @@
                 return;
             }
 
-            console.log(['POPULATE_JOBS_PANEL', fetchedJobStatus, jobInfo]);
+            // console.log(['POPULATE_JOBS_PANEL', fetchedJobStatus, jobInfo]);
 
             // var storedIds = {};
             // for (var i=0; i<IPython.notebook.metadata.job_ids.methods.length; i++) {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -14,6 +14,24 @@
         $appsList: null,
         $methodsList: null,
 
+        /* when populated, should have the structure:
+         * {
+         *    jobId: { id: <str>,
+                       status : <str>, 
+                       source : <id of source cell>,
+                       $elem : element of rendered job info,
+                       timestamp: <str> }
+         * }
+         */
+        jobStates: {},
+
+        /* when populated should have structure:
+         * {
+         *    sourceId : jobId
+         * }
+         */
+        source2Job: {},
+
         refreshTimer: null,
         refreshInterval: 10000,
 
@@ -41,14 +59,15 @@
             $(document).on('cancelJobCell.Narrative', $.proxy(
                 function(e, cellId, showPrompt, callback) {
                     // Find job based on cellId
-                    var job = this.findJobFromSource(cellId);
+                    var job = this.source2Job[cellId];
+
                     console.log(['found job', job]);
 
                     // If we can't find the job, then it's not being tracked, so we
                     // should just assume it's gone already and return true to the callback.
-                    if (job === null && callback)
+                    if (job === undefined && callback)
                         callback(true);
-                    else if (job !== null) {
+                    else if (job !== undefined) {
                         if (showPrompt)
                             this.openJobDeletePrompt(job.id, null, callback);
                         else 
@@ -132,34 +151,151 @@
                        .append(this.$loadingPanel)
                        .append(this.$errorPanel);
 
-            this.refresh();
-
-            if (this.options.autopopulate === true) {
+            if (this.options.autopopulate) {
+                this.initJobStates();
                 this.refresh();
             }
+
 
             return this;
         },
 
         /**
-         * If there is a job (method or app) associated with the given
-         * cell id (it's source), then this will find it.
-         * Returns the job object from the Narrative's metadata, or null
-         * if nothing is found.
-         * @private
          * @method
+         * Initializes the jobStates object that the panel knows about.
+         * We treat the IPython.notebook.metadata.job_ids as a (more or less) read-only 
+         * object for the purposes of loading and refreshing.
+         * 
+         * At load time, that gets adapted into the jobStates object, which is used to
+         * keep track of the job state.
          */
-        findJobFromSource: function(cellId) {
-            if (IPython.notebook.metadata.job_ids) {
-                for (var type in IPython.notebook.metadata.job_ids) {
-                    var jobList = IPython.notebook.metadata.job_ids[type];
-                    for (var i=0; i<jobList.length; i++) {
-                        if (jobList[i].source === cellId)
-                            return jobList[i];
+        initJobStates: function() {
+            if (IPython.notebook && IPython.notebook.metadata && IPython.notebook.metadata.job_ids) {
+                // this is actually like: ['apps': [list of app jobs], 'methods':[list of method jobs]
+                var jobIds = IPython.notebook.metadata.job_ids;
+
+                for (var jobType in jobIds) {
+                    if (!(jobIds[jobType] instanceof Array))
+                        continue;
+                    for (var i=0; i<jobIds[jobType].length; i++) {
+                        var job = jobIds[jobType][i];
+                        this.jobStates[job.id] = $.extend({}, job, { 'status' : null, '$elem' : null, 'id' : job.id });
+                        this.source2Job[job.source] = job.id;
                     }
                 }
             }
-            return null;
+        },
+
+        /**
+         * @method
+         * Opens a delete prompt for this job, with a 'Delete' and 'Cancel' button.
+         * If the user clicks 'Cancel', then it shouldn't do anything besides close.
+         * If the user clicks 'Delete', then it tries to delete the job through the backend, 
+         * then clears the job info from the front end and refreshes.
+         * 
+         * Under the covers, since we're using kbasePrompt and those buttons are a little
+         * disconnected from everything else, this sets widget variables 'removeId' and 'deleteCallback'.
+         * The 'removeId' is the id of the job to delete, and 'deleteCallback' is invoked 
+         * after the deletion is done.
+         *
+         * @param {object} jobId
+         * @param {object} jobState
+         * @param {function} callback - a callback to invoke when finished.
+         */
+        openJobDeletePrompt: function(jobId, jobState, callback) {
+            if (!jobId)
+                return;
+
+            var removeText = "Deleting this job will remove it from your Narrative. Any already generated data will be retained. Continue?";
+            var warningText = "";
+
+            if (jobState) {
+                jobState = jobState.toLowerCase();
+                var jobState = jobState.toLowerCase();
+                if (jobState === 'queued' || jobState === 'running' || jobState === 'in-progress') {
+                    warningText = "This job is currently running on KBase servers! Removing it will attempt to stop the running job.";
+                }
+                else if (jobState === 'completed') {
+                    warningText = "This job has completed running. You may safely remove it without affecting your Narrative.";
+                }
+            }
+            this.$jobsModalBody.empty().append(warningText + '<br><br>' + removeText);
+            this.$jobsModalTitle.empty().html('Remove Job?');
+            this.removeId = jobId;
+
+            this.deleteCallback = callback;
+            this.$jobsModal.openPrompt();
+        },
+
+        /**
+         * Attempts to delete a job in the backend (by making a kernel call - this lets the kernel decide
+         * what kind of job it is and how to stop/delete it).
+         * When it gets a response, it then clears the job from the Jobs list.
+         */
+        deleteJob: function(jobId, callback) {
+            var deleteJobCmd = 'from biokbase.narrative.common.kbjob_manager import KBjobManager\n' +
+                               'jm = KBjobManager()\n' +
+                               'print jm.delete_jobs(["' + jobId + '"])\n';
+
+            var callbacks = {
+                'output' : $.proxy(function(msgType, content) {
+                    var response = this.deleteResponse(msgType, content, jobId);
+                    if (callback)
+                        callback(response);
+                }, this),
+                'execute_reply' : $.proxy(function(content) { 
+                    this.handleCallback('execute_reply', content); 
+                }, this),
+                'clear_output' : $.proxy(function(content) { 
+                    this.handleCallback('clear_output', content); 
+                }, this),
+                'set_next_input' : $.proxy(function(content) { 
+                    this.handleCallback('set_next_input', content); 
+                }, this),
+                'input_request' : $.proxy(function(content) { 
+                    this.handleCallback('input_request', content); 
+                }, this)
+            };
+
+            IPython.notebook.kernel.execute(deleteJobCmd, callbacks, {store_history: false, silent: true});
+        },
+
+        deleteResponse: function(msgType, content, jobId) {
+            if (msgType != 'stream') {
+                console.error('An error occurred while trying to delete a job');
+                return;
+            }
+            var result = content.data;
+            try {
+                result = JSON.parse(result);
+            }
+            catch(err) {
+                // ignore and return. assume it failed.
+                return false;
+            }
+
+            if (result[jobId] === true) {
+                // successfully nuked it on the back end, now wipe it out on the front end.
+
+                // first, wipe the metadata
+                var appIds = IPython.notebook.metadata.job_ids.apps;
+                appIds = appIds.filter(function(val) { return val.id !== jobId });
+                IPython.notebook.metadata.job_ids.apps = appIds;
+
+                // ...and from the method list
+                var methodIds = IPython.notebook.metadata.job_ids.methods;
+                methodIds = methodIds.filter(function(val) { return val.id !== jobId });
+                IPython.notebook.metadata.job_ids.methods = methodIds;
+
+                // remove it from the 'cache' in this jobs panel
+                delete this.source2Job[this.jobStates[jobId]];
+                delete this.jobStates[jobId];
+                this.refresh(false);
+
+                // nuke the removeId
+                this.removeId = null;
+            }
+            return result[jobId];
         },
 
         /**
@@ -214,6 +350,9 @@
 
             var type = isApp ? 'apps' : 'methods';
             IPython.notebook.metadata.job_ids[type].push(jobInfo);
+            // put a stub in the job states
+            this.jobStates[jobInfo.id] = {'status' : null, $elem : 'null', 'sourceCell' : jobInfo.source};
+            this.source2Job[jobInfo.source] = jobInfo.id;
             this.refresh();
             IPython.notebook.save_checkpoint();
         },
@@ -234,11 +373,14 @@
         /**
          * @method
          */
-        refresh: function(hideLoadingMessage) {
+        refresh: function(hideLoadingMessage, initStates) {
+            if (initStates)
+                this.initJobStates();
+
             // if there's no timer, set one up - this should only happen the first time.
             if (this.refreshTimer === null) {
                 this.refreshTimer = setInterval(
-                    $.proxy(function() { this.refresh(true); }, this),
+                    $.proxy(function() { this.refresh(true, false); }, this),
                     this.refreshInterval
                 );
             }
@@ -251,7 +393,9 @@
 
             // If we don't have any job ids, or it's length is zero, just show a 
             // message and return.
-            if (!IPython.notebook.metadata.job_ids || IPython.notebook.metadata.job_ids.length === 0) {
+            if (!IPython.notebook.metadata.job_ids || 
+                IPython.notebook.metadata.job_ids.length === 0 ||
+                Object.keys(this.jobStates).length === 0) {
                 this.populateJobsPanel();
                 return;
             }
@@ -259,57 +403,65 @@
             if (!hideLoadingMessage)
                 this.showLoadingMessage('Loading running jobs...');
 
-            // Get a unique list of jobs
-            // XXX - this'll change to method vs. app jobs, soonish.
-            var jobs = IPython.notebook.metadata.job_ids;
-            var uniqueJobs = {};
+            // This contains all the job info like this:
+            // { jobId: {spec: {}, state: {}}}
+            var jobInfo = {};
+            // This contains the list of lookup parameters for each job.
+            // We pass back all specs/parameters so the back end can munge them into the right 
+            // output structures.
+            var jobParamList = [];
 
-            var jobList = [];
-            var allJobs = jobs.methods.concat(jobs.apps);
-            for (var i=0; i<allJobs.length; i++) {
-                var jobInfo = allJobs[i];
-                if (uniqueJobs.hasOwnProperty(jobInfo.id) || !jobInfo.source)
+            for (var jobId in this.jobStates) {
+                var jobState = this.jobStates[jobId];
+
+                jobInfo[jobId] = {'state' : jobState};
+                // get specs. we need them to render, regardless
+                // ...but if we don't have a source cell, we have to skip it.
+                if (!jobState.source)
                     continue;
-                var jobType = this.jobTypeFromId(jobInfo.id);
-                uniqueJobs[jobInfo.id] = { 'job' : jobInfo };
-                var $sourceCell = $('#' + jobInfo.source);
+
+                // if the job's incomplete, we have to go get it.
+                var jobIncomplete = (jobState.status !== 'complete' && jobState.status !== 'error' && jobState.status !== 'done')
+                // 2. The type dictates what cell it came from and how to deal with the inputs.
+                var jobType = this.jobTypeFromId(jobId);
+                var $sourceCell = $('#' + jobState.source);
                 var specInfo = null;
-                if ($sourceCell.length > 0) {
+                if ($sourceCell.length > 0) {  // if the source cell is there (kind of a jQuery trick).
+                    // if it's an NJS job, then it's an App cell, so fetch all that info.
                     if (jobType === "njs") {
                         specInfo = $sourceCell.kbaseNarrativeAppCell('getSpecAndParameterInfo');
-                        if (specInfo) {
-                            jobList.push("['" + jobInfo.id + "', " +
-                                         "'" + this.safeJSONStringify(specInfo.appSpec) + "', " +
-                                         "'" + this.safeJSONStringify(specInfo.methodSpecs) + "', " +
-                                         "'" + this.safeJSONStringify(specInfo.parameterValues) + "']");
+                        if (specInfo && jobIncomplete) {
+                            jobParamList.push("['" + jobId + "', " +
+                                              "'" + this.safeJSONStringify(specInfo.appSpec) + "', " +
+                                              "'" + this.safeJSONStringify(specInfo.methodSpecs) + "', " +
+                                              "'" + this.safeJSONStringify(specInfo.parameterValues) + "']");
                         }
                     }
+                    // otherwise, it's a method cell, so fetch info that way.
                     else {
                         specInfo = $sourceCell.kbaseNarrativeMethodCell('getSpecAndParameterInfo');
-                        if (specInfo) {
-                            jobList.push("['" + jobInfo.id + "', " +
-                                         "'" + this.safeJSONStringify(specInfo.methodSpec) + "', " +
-                                         "'" + this.safeJSONStringify(specInfo.parameterValues) + "']");
-                        }
-                        else {
-                            jobList.push("['" + jobInfo.id + "']");
+                        if (jobIncomplete) {
+                            if (specInfo) {
+                                jobParamList.push("['" + jobId + "', " +
+                                                  "'" + this.safeJSONStringify(specInfo.methodSpec) + "', " +
+                                                  "'" + this.safeJSONStringify(specInfo.parameterValues) + "']");
+                            }
+                            else {
+                                jobParamList.push("['" + jobId + "']");
+                            }
                         }
                     }
-                    uniqueJobs[jobInfo.id]['spec'] = specInfo;
+                    jobInfo[jobId]['spec'] = specInfo;
                 }
             }
 
-            if (allJobs.length === 0) {
-                // no jobs! skip the kernel noise and cut to the rendering!
-                this.populateJobsPanel();
-                return;
-            }
+
             var pollJobsCommand = 'from biokbase.narrative.common.kbjob_manager import KBjobManager\n' +
                                   'job_manager = KBjobManager()\n' +
-                                  'print job_manager.poll_jobs([' + jobList + '], as_json=True)\n'; //meth_jobs=[' + methJobList + '], app_jobs=[' + appJobList + '], as_json=True)\n';
+                                  'print job_manager.poll_jobs([' + jobParamList + '], as_json=True)\n';
             var callbacks = {
                 'output' : $.proxy(function(msgType, content) { 
-                    this.parseKernelResponse(msgType, content, uniqueJobs); 
+                    this.parseKernelResponse(msgType, content, jobInfo); 
                 }, this),
                 'execute_reply' : $.proxy(function(content) { 
                     this.handleCallback('execute_reply', content); 
@@ -325,10 +477,14 @@
                 }, this),
             };
 
-            //console.debug('JOBS PANEL: refresh');
             var msgid = IPython.notebook.kernel.execute(pollJobsCommand, callbacks, {silent: true, store_history: false});
         },
 
+        /**
+         * @method
+         * convenience to stringify a structure while escaping everything that needs it.
+         * @private
+         */
         safeJSONStringify: function(method) {
             var esc = function(s) { 
                 return s.replace(/'/g, "&apos;")
@@ -339,22 +495,29 @@
             });
         },
 
-        parseKernelResponse: function(msgType, content, jobRef) {
+        /**
+         * @method
+         * Get the kernel response and render it if it's valid.
+         */
+        parseKernelResponse: function(msgType, content, jobInfo) {
             // if it's not a datastream, display some kind of error, and return.
-            // console.debug('JOBS PANEL: parseKernelResponse');
             if (msgType != 'stream') {
                 this.showError('Sorry, an error occurred while loading the job list.');
                 return;
             }
             var buffer = content.data;
             if (buffer.length > 0) {
-                var jobInfo = JSON.parse(buffer);
-                this.populateJobsPanel(jobInfo, jobRef);
+                var jobStatus = JSON.parse(buffer);
+                this.populateJobsPanel(jobStatus, jobInfo);
             }
             this.$loadingPanel.hide();
             this.$jobsPanel.show();
         },
 
+        /** 
+         * @method
+         * Generic callback handler for the IPython kernel.
+         */
         handleCallback: function(call, content) {
             if (content.status === 'error') {
                 this.showError(content);
@@ -366,29 +529,54 @@
             }
         },
 
-        populateJobsPanel: function(jobStatus, jobInfo) {
-            if (!jobStatus || jobStatus.length === 0) {
+        /**
+         * @method
+         * Here we go, the first part of the rendering routine.
+         * @param {object} fetchedJobStatus - the results of the jobs looked up through the kernel. This has the job status objects from NJS, etc.
+         * @param {object} jobInfo - the specs (and status) of ALL jobs, not just those looked up through the kernel. 
+         * The specs and state are used to decorate both the job renderings and the cells with results, etc.
+         * 
+         * Here's the flow:
+         * 1. Get a sorted list of *all* jobs from the this.jobStates buffer
+         * 2. All of those are getting rendered one way or another. Iterate on through.
+         * 3. When we get to one that has an update from the server, then we need to update this.jobStates, render that job info, and update the cell
+         * (possibly).
+         * 4. That's it. All should be refreshed! Update the DOM node that holds all job info.
+         *
+         * XXX - it would probably be faster to re-render all jobs in place iff they need it (e.g., probably just the time since start field).
+         * But it's Friday night at 8:30 before the big build meeting, so that might not happen yet. In all reality, I have a hard time seeing a 
+         * case where there's more than, say, 20 job elements at once in any given Narrative.
+         * We should also expire jobs in a reasonable time, at least from the Narrative.
+         */
+        populateJobsPanel: function(fetchedJobStatus, jobInfo) {
+            if (!this.jobStates || Object.keys(this.jobStates).length === 0) {
                 this.showMessage('No running jobs!');
                 return;
             }
 
-            var storedIds = {};
-            for (var i=0; i<IPython.notebook.metadata.job_ids.methods.length; i++) {
-                storedIds[IPython.notebook.metadata.job_ids.methods[i].id] = IPython.notebook.metadata.job_ids.methods[i];
-            }
-            for (var i=0; i<IPython.notebook.metadata.job_ids.apps.length; i++) {
-                storedIds[IPython.notebook.metadata.job_ids.apps[i].id] = IPython.notebook.metadata.job_ids.apps[i];
-            }
+            console.log([fetchedJobStatus, jobInfo]);
 
+            // var storedIds = {};
+            // for (var i=0; i<IPython.notebook.metadata.job_ids.methods.length; i++) {
+            //     storedIds[IPython.notebook.metadata.job_ids.methods[i].id] = IPython.notebook.metadata.job_ids.methods[i];
+            // }
+            // for (var i=0; i<IPython.notebook.metadata.job_ids.apps.length; i++) {
+            //     storedIds[IPython.notebook.metadata.job_ids.apps[i].id] = IPython.notebook.metadata.job_ids.apps[i];
+            // }
+
+            // Instantiate a shiny new panel to hold job info.
             var $jobsList = $('<div>').addClass('kb-jobs-items');
 
-            if (jobStatus.length === 0 && Object.keys(storedIds).length === 0) {
-                $jobsList.append($('<div class="kb-data-loading">').append('No running jobs!'));                
+            // If we don't have any running jobs, just leave a message.
+            if (Object.keys(this.jobStates).length === 0) {
+                $jobsList.append($('<div class="kb-data-loading">').append('No running jobs!'));
             }
             else {
-                jobStatus.sort(function(a, b) {
-                    var aTime = jobInfo[a.job_id].job.timestamp;
-                    var bTime = jobInfo[b.job_id].job.timestamp;
+                // sort our set of jobs.
+                var sortedJobs = Object.keys(this.jobStates);
+                sortedJobs.sort(function(a, b) {
+                    var aTime = this.jobStates[a].timestamp;
+                    var bTime = this.jobStates[b].timestamp;
                     // if we have timestamps for both, compare them
                     if (aTime && bTime)
                         return (new Date(aTime) < new Date(bTime)) ? 1 : -1;
@@ -397,86 +585,57 @@
                     else            // if aTime is null, but bTime isn't, (OR they're both null), then put b first
                         return -1;
                 });
-                for (var i=0; i<jobStatus.length; i++) {
-                    var job = jobStatus[i];
-                    var info = jobInfo[job.job_id];
-                    $jobsList.append(this.renderJob(job, info));
-                    this.updateCell(job, info);
-                    delete storedIds[job.job_id];
-                }
-                for (var missingId in storedIds) {
-                    if (storedIds.hasOwnProperty(missingId)) {
-                        $jobsList.append(this.renderJob(null, {'job': storedIds[missingId]}));
+
+                for (var i=0; i<sortedJobs.length; i++) {
+                    var jobId = sortedJobs[i];
+                    var info = jobInfo[jobId];
+
+                    // if the id shows up in the "render me!" list:
+                    if (fetchedJobStatus[jobId]) {
+                        // update the state and cell
+                        this.jobStates[jobId].status = fetchedJobStatus[jobId].job_state;
+                        this.updateCell(fetchedJobStatus[jobId], jobInfo[jobId]);
                     }
+                    // updating the given state first allows us to just pass the id and the status set to
+                    // the renderer. If the status set doesn't exist (e.g. we didn't look it up in the 
+                    // kernel), then that's just undefined and the renderer can deal.
+                    $jobsList.append(this.renderJob(jobInfo[jobId], fetchedJobStatus[jobId]));
                 }
             }
             this.$jobsPanel.empty().append($jobsList);
+
+
+
+
+            //     jobStatus.sort(function(a, b) {
+            //         var aTime = jobInfo[a.job_id].job.timestamp;
+            //         var bTime = jobInfo[b.job_id].job.timestamp;
+            //         // if we have timestamps for both, compare them
+            //         if (aTime && bTime)
+            //             return (new Date(aTime) < new Date(bTime)) ? 1 : -1;
+            //         else if (aTime) // if we only have one for a, sort for a
+            //             return 1;
+            //         else            // if aTime is null, but bTime isn't, (OR they're both null), then put b first
+            //             return -1;
+            //     });
+            //     for (var i=0; i<jobStatus.length; i++) {
+            //         var job = jobStatus[i];
+            //         var info = jobInfo[job.job_id];
+            //         $jobsList.append(this.renderJob(job, info));
+            //         this.updateCell(job, info);
+            //         delete storedIds[job.job_id];
+            //     }
+            //     for (var missingId in storedIds) {
+            //         if (storedIds.hasOwnProperty(missingId)) {
+            //             $jobsList.append(this.renderJob(null, {'job': storedIds[missingId]}));
+            //         }
+            //     }
+            // }
+            // this.$jobsPanel.empty().append($jobsList);
         },
 
-        /**
-         * Attempts to delete a job in the backend (by making a kernel call - this lets the kernel decide
-         * what kind of job it is and how to stop/delete it).
-         * When it gets a response, it then clears the job from the Jobs list.
-         */
-        deleteJob: function(jobId, callback) {
-            var deleteJobCmd = 'from biokbase.narrative.common.kbjob_manager import KBjobManager\n' +
-                               'jm = KBjobManager()\n' +
-                               'print jm.delete_jobs(["' + jobId + '"])\n';
 
-            var callbacks = {
-                'output' : $.proxy(function(msgType, content) {
-                    var response = this.deleteResponse(msgType, content, jobId);
-                    if (callback)
-                        callback(response);
-                }, this),
-                'execute_reply' : $.proxy(function(content) { 
-                    this.handleCallback('execute_reply', content); 
-                }, this),
-                'clear_output' : $.proxy(function(content) { 
-                    this.handleCallback('clear_output', content); 
-                }, this),
-                'set_next_input' : $.proxy(function(content) { 
-                    this.handleCallback('set_next_input', content); 
-                }, this),
-                'input_request' : $.proxy(function(content) { 
-                    this.handleCallback('input_request', content); 
-                }, this)
-            };
-
-            IPython.notebook.kernel.execute(deleteJobCmd, callbacks, {store_history: false, silent: true});
-        },
-
-        deleteResponse: function(msgType, content, jobId) {
-            if (msgType != 'stream') {
-                console.error('An error occurred while trying to delete a job');
-                return;
-            }
-            var result = content.data;
-            try {
-                result = JSON.parse(result);
-            }
-            catch(err) {
-                // ignore and return. assume it failed.
-                return false;
-            }
-
-            if (result[jobId] === true) {
-                // successfully nuked it on the back end, now wipe it out on the front end.
-                var appIds = IPython.notebook.metadata.job_ids.apps;
-                appIds = appIds.filter(function(val) { return val.id !== jobId });
-                IPython.notebook.metadata.job_ids.apps = appIds;
-
-                var methodIds = IPython.notebook.metadata.job_ids.methods;
-                methodIds = methodIds.filter(function(val) { return val.id !== jobId });
-                IPython.notebook.metadata.job_ids.methods = methodIds;
-
-                this.refresh(false);
-                this.removeId = null;
-            }
-            return result[jobId];
-        },
-
-        renderJob: function(job, jobInfo) {
+        renderJob: function(jobInfo, job) {
             var getStepSpec = function(id, spec) {
                 for (var i=0; i<spec.steps.length; i++) {
                     if (id === spec.steps[i].step_id)
@@ -500,14 +659,15 @@
              * 3. have no job
              *    - just return null. nothing invokes this like that, anyway
              */
-
-            var jobType = this.jobTypeFromId(jobInfo.job.id);
+            var jobId = "Unknown Job Id";
+            if (jobInfo && jobInfo.state)
+                jobId = jobInfo.state.id;
+            var jobType = this.jobTypeFromId(jobInfo.state.id);
 
             var $jobDiv = $('<div>')
                           .addClass('kb-data-list-obj-row');
-
             // jobinfo: {
-            //     job: { id, source, target, timestamp },
+            //     state: { id, source, target, timestamp, $elem, status },
             //     spec: { appSpec?, methodSpec?, methodSpecs?, parameterValues }
             //     type=njs: appSpec, methodSpecs
             //     type=method: methodSpec
@@ -526,18 +686,15 @@
             }
 
             var jobName = "Unknown " + ((jobType === 'njs') ? "App" : "Method");
-            var jobId = "Unknown Job Id";
             if (jobInfo && jobInfo.spec && jobInfo.spec[specType] && jobInfo.spec[specType].info)
                 jobName = jobInfo.spec[specType].info.name;
-            if (jobInfo && jobInfo.job && jobInfo.job.id)
-                jobId = jobInfo.job.id;
 
             var $jobInfoDiv = $('<div class="kb-data-list-name">')
                                .append(jobName);
             var $jobControlDiv = $('<span class="pull-right">')
-                                 .append(this.makeJobClearButton(job, jobInfo))
+                                 .append(this.makeJobClearButton(jobId, jobInfo.state.status))
                                  .append('<br>')
-                                 .append(this.makeScrollToButton(job, jobInfo));
+                                 .append(this.makeScrollToButton(jobInfo.state.source));
             $jobInfoDiv.append($jobControlDiv)
                        .append($('<div style="font-size:75%">')
                                .append(jobId));
@@ -560,6 +717,8 @@
             else {
                 if (job.job_state) {
                     status = job.job_state.charAt(0).toUpperCase() + job.job_state.substring(1);
+                    // UPDATE this.jobStates HERE
+                    this.jobStates[jobId].status = job.job_state;
                 }
                 if (jobType === "njs") {
                     var stepId = job.running_step_id;
@@ -571,8 +730,8 @@
                 if (job.position && job.position > 0)
                     position = job.position;
             }
-            if (jobInfo && jobInfo.job && jobInfo.job.timestamp) {
-                started = this.makePrettyTimestamp(jobInfo.job.timestamp);
+            if (jobInfo && jobInfo.state && jobInfo.state.timestamp) {
+                started = this.makePrettyTimestamp(jobInfo.state.timestamp);
             }
             var $infoTable = $('<table class="kb-jobs-info-table">')
                              .append(this.makeInfoRow('Status', status));
@@ -590,13 +749,14 @@
 
         /**
          * @method
-         * Updates the status of the cell the given job is associated with.
+         * Updates the status of the cell the given job is associated with. This figures out
+         * which cell type it needs to talk to, then sends a message to that cell.
          * 'job' = the response from the server about the job. Contains info from the job service
          * 'jobInfo' = the info we know about the running job: its id, associated cell, etc.
          */
         updateCell: function(job, jobInfo) {
-            var source = jobInfo.job.source;
-            var jobType = this.jobTypeFromId(jobInfo.job.id)
+            var source = jobInfo.state.source;
+            var jobType = this.jobTypeFromId(jobInfo.state.id)
 
             var state = '';
             if (job.job_state)
@@ -653,6 +813,10 @@
             }
         },
 
+        /**
+         * @method
+         * Dummy convenience method to make a little table row.
+         */
         makeInfoRow: function(heading, info) {
             return $('<tr>').append($('<th>')
                                     .append(heading + ':'))
@@ -660,6 +824,16 @@
                                     .append(info));
         },
 
+        /**
+         * @method
+         * @private
+         * Makes an error button for a job.
+         * This invokes the JobPanel's popup error modal, so most of the logic here is figuring out what
+         * should appear in that modal.
+         * @param {object} jobStatus - the job status object 
+         * @param {object} jobInfo - the job info object - main keys are 'state' and 'specs'
+         * @param {string} btnText - the text of the button. If empty or null, the button just gets a /!\ icon.
+         */
         makeJobErrorButton: function(jobStatus, jobInfo, btnText) {
             var removeText = "Deleting this job will remove it from your Narrative. Any generated data will be retained. Continue?";
             var headText = "An error has been detected in this job!";
@@ -671,7 +845,7 @@
             if (btnText)
                 $errBtn.append(' ' + btnText);
             $errBtn.click($.proxy(function(e) {
-                this.removeId = jobInfo.job.id;
+                this.removeId = jobInfo.state.id;
                 this.$jobsModalTitle.html('Job Error');
                 /* error types:
                  * 1. jobStatus.error is a real string. Just cough it up.
@@ -680,11 +854,11 @@
                  * 4. jobInfo is still partly missing (e.g., dont' know what cell it should point to)
                  */
                 if (!jobStatus && jobInfo) {
-                    if (!jobInfo.job.source) {
+                    if (!jobInfo.state.source) {
                         errorText = "This job is not associated with an App Cell.";
                         errorType = "Unknown App Cell";
                     }
-                    else if ($('#' + jobInfo.job.source).length === 0) {
+                    else if ($('#' + jobInfo.state.source).length === 0) {
                         errorText = "The App Cell associated with this job can no longer be found in your Narrative.";
                         errorType = "Missing App Cell";
                     }
@@ -701,7 +875,7 @@
                             // contort that into the method name
                             // gotta search for it in the spec for the method id, first.
                             var methodName = "Unknown method: " + stepId;
-                            if (this.jobTypeFromId(jobInfo.job.id) === "njs") {
+                            if (this.jobTypeFromId(jobInfo.state.id) === "njs") {
                                 var methodId = null;
                                 for (var i=0; i<jobInfo.spec.appSpec.steps.length; i++) {
                                     if (stepId === jobInfo.spec.appSpec.steps[i].step_id) {
@@ -722,7 +896,7 @@
                 }
  
                 var $errorTable = $('<table class="table table-bordered">')
-                                  .append(this.makeInfoRow('Id', jobInfo.job.id))
+                                  .append(this.makeInfoRow('Id', jobInfo.state.id))
                                   .append(this.makeInfoRow('Type', errorType))
                                   .append(this.makeInfoRow('Error', errorText));
  
@@ -735,157 +909,40 @@
             return $errBtn;
         },
 
-        openJobDeletePrompt: function(jobId, jobState, callback) {
-            if (!jobId)
-                return;
 
-            var removeText = "Deleting this job will remove it from your Narrative. Any already generated data will be retained. Continue?";
-            var warningText = "This job appears to have fallen into an error state and is no longer running on KBase servers.";
-
-            if (jobState) {
-                jobState = jobState.toLowerCase();
-                var jobState = jobState.toLowerCase();
-                if (jobState === 'queued' || jobState === 'running' || jobState === 'in-progress') {
-                    warningText = "This job is currently running on KBase servers! Removing it will attempt to stop the running job.";
-                }
-                else if (jobState === 'completed') {
-                    warningText = "This job has completed running. You may safely remove it without affecting your Narrative.";
-                }
-            }
-            this.$jobsModalBody.empty().append(warningText + '<br><br>' + removeText);
-            this.$jobsModalTitle.empty().html('Remove Job?');
-            this.removeId = jobId;
-
-            this.deleteCallback = callback;
-            this.$jobsModal.openPrompt();
-        },
-
-        makeJobClearButton: function(jobStatus, jobInfo) {
+        /**
+         * @method
+         * @private
+         * Makes a little 'x' button to delete a job.
+         * @param {string} jobId
+         * @param {string} jobStatus 
+         */
+        makeJobClearButton: function(jobId, jobStatus) {
             return $('<span data-toggle="tooltip" title="Remove Job" data-placement="left">')
                    .addClass('btn-xs kb-data-list-more-btn pull-right fa fa-times')
                    .css({'cursor':'pointer'})
                    .click($.proxy(function() {
-                       /* cases for communication!
-                        * 1. we don't know what the job's linked to - either jobStatus is null, or jobInfo is 
-                        *    missing things.
-                        * 2. the job is well formed, and complete.
-                        * 3. the job is in an error state.
-                        * 4. the job is running
-                        */
-                       this.openJobDeletePrompt(jobStatus.job_id, jobStatus.job_state);
+                       this.openJobDeletePrompt(jobId, jobStatus);
                    }, this))
                    .tooltip();
         },
 
-        makeScrollToButton: function(job, jobInfo) {
+        /**
+         * @method
+         * @private
+         * Makes a little arrow button to scroll from a job to the associated app/method cell
+         */
+        makeScrollToButton: function(sourceId) {
             return $('<span data-toggle="tooltip" title="Scroll To App" data-placement="left">')
                    .addClass('btn-xs kb-data-list-more-btn pull-right fa fa-location-arrow')
                    .css({'cursor':'pointer'})
                    .click(function(e) {
-                       var sourceId = jobInfo.job.source;
                        if (sourceId) {
                            $('html, body').animate({ scrollTop: $('#' + sourceId).offset().top-85 }, 1000);
                            $('#' + sourceId).click();
                        }
                    })
                    .tooltip();
-        },
-
-        makeJobDetailButton: function(job, jobInfo) {
-            var showDetailModal = function(job, sourceId) {
-                var $modalBody = $('<div>');
-                var buttonList = [
-                    {
-                        name : 'Close',
-                        type : 'primary',
-                        callback : function(e, $prompt) {
-                            $prompt.closePrompt();
-                        },
-                    }
-                ];
-
-                if (sourceId) {
-                    buttonList.push({
-                        name : 'Scroll To',
-                        type : 'primary',
-                        callback : function(e, $prompt) {
-                            $prompt.closePrompt();
-                            $('#' + sourceId).click();
-                            $('html, body').animate({ scrollTop: $('#' + sourceId).offset().top-160 }, 1000);
-                        }
-                    });
-                }
-                else {
-                    buttonList.push({
-                        name : 'Unknown source',
-                        type : 'default disabled'
-                    });
-                }
-                $('<div>').kbasePrompt(
-                    {
-                        title : 'Job Details',
-                        body : $modalBody,
-                        controls : buttonList
-                    }
-                ).openPrompt();
-                $modalBody.kbaseJobWatcher({ jobInfo : job });
-            };
-
-            var sourceId = jobInfo.source ? jobInfo.source : "";
-
-            var $btn = $('<span>')
-                       .addClass('glyphicon glyphicon-info-sign kb-function-help')
-                       .click(function(e) {
-                           showDetailModal(job, sourceId);
-                       });
-
-            return $btn;
-        },
-
-        /**
-         * @method makeStatusElement
-         * Builds the HTML for a Status element based on the given job object.
-         * Cases:
-         * 1. Job complete - return 'complete + status message'
-         * 2. Error - return 'error' as a clickable link - opens a modal with the error message.
-         * 3. not complete OR error = in progress.
-         *    Show 3 rows. First = status + progress text ('x / y' or 'z%'). Second = progress bar. Bottom = time remaining div.
-         *
-         * This is all returned wrapped in a div element.
-         * @param job - the job to build a status element around.
-         * @return a div element containing the job's status.
-         * @private
-         */
-        makeStatusElement: function(job) {
-            var status = '<div job-id="' + job[0] + '">';
-            var deleteSpan = '<span class="pull-right glyphicon glyphicon-remove kbujs-delete-job" data-toggle="tooltip" title="Delete Job"></span>';
-
-            if (job[11] === 1)
-                status += '<span class="kbujs-error-cell kbujs-error" error-job-id="' + job[0] + '">' +
-                              '<span class="glyphicon glyphicon-exclamation-sign"></span>' +
-                              '&nbsp;Error: ' +
-                              job[4] +
-                          '</span>' +
-                          deleteSpan;
-            else if (job[10] === 1)
-                status += '<span>Complete: ' + job[4] + '</span>' + deleteSpan;
-            else {
-                status = '<div>' + job[4];
-                var progressType = job[8].toLowerCase();
-                var progress = job[6];
-                var max = job[7];
-
-                if (progressType === 'percent') {
-                    status += ' (' + progress + '%)</div>';
-                }
-                if (progressType === 'task') {
-                    status += ' (' + progress + ' / ' + max + ')</div>';
-                }
-                if (progressType !== 'none') {
-                    status +=  '<div class="pull-right" style="width: 75%">' + this.makeProgressBarElement(job, false) + '</div></div>';
-                }
-            }
-            return status + '</div>';
         },
 
         /**
@@ -955,63 +1012,6 @@
             this.$jobsPanel.hide();
             this.$loadingPanel.hide();
             this.$errorPanel.show();
-        },
-
-        parseStage: function(stage) {
-            if (stage.toLowerCase() === 'error') {
-                var $btn = $('<span/>')
-                           .addClass('kbujs-error')
-                           .append($('<span/>')
-                                   .addClass('glyphicon glyphicon-exclamation-sign'))
-                           .append(' Error');
-
-                return $('<div>')
-                       .addClass('kbujs-error-cell')
-                       .append($btn);
-            }
-            return stage;
-        },
-
-        /**
-         * @method makeProgressBarElement
-         * Makes a Bootstrap 3 Progress bar from the given job object.
-         *
-         * @param job - the job object
-         * @param showNumber - if truthy, includes the numberical portion of what's being shown in the progressbar, separately.
-         * @return A div containing a Bootstrap 3 progressbar, and, optionally, text describing the numbers in progress.
-         * @private
-         */
-        makeProgressBarElement: function(job, showNumber) {
-            var type = job[8].toLowerCase();
-            var max = job[7] || 0;
-            var progress = job[6] || 0;
-
-            if (type === 'percent') {
-                var bar = '';
-                if (showNumber)
-                    bar += progress + '%';
-
-                return bar + '<div class="progress" style="margin-bottom: 0; pull-right;">' + 
-                               '<div class="progress-bar" role="progressbar" aria-valuenow="' + 
-                                 progress + '" aria-valuemin="0" aria-valuemax="100" style="width: ' + 
-                                 progress + '%;">' +
-                                 '<span class="sr-only">' + progress + '% Complete</span>' +
-                               '</div>' +
-                             '</div>';
-            }
-            else {
-                var bar = '';
-                if (showNumber)
-                    bar += progress + ' / ' + max;
-                return bar + '<div class="progress" style="margin-bottom: 0">' + 
-                           '<div class="progress-bar" role="progressbar" aria-valuenow="' + 
-                           progress + '" aria-valuemin="0" aria-valuemax="' + max + '" style="width: ' + 
-                           (progress / max * 100) + '%;">' +
-                               '<span class="sr-only">' + progress + ' / ' + max + '</span>' +
-                           '</div>' +
-                       '</div>';
-            }
-            return '<div></div>';
         },
 
         /**
@@ -1159,6 +1159,7 @@
                 return d;
             }
         },
-    });
 
+
+    });
 })( jQuery );

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -420,7 +420,7 @@
                 jobInfo[jobId] = {'state' : jobState};
 
                 // if the job's incomplete, we have to go get it.
-                var jobIncomplete = (jobState.status !== 'completed' && jobState.status !== 'error' && jobState.status !== 'done')
+                var jobIncomplete = (jobState.status !== 'completed' && jobState.status !== 'error' && jobState.status !== 'done' && jobState.status !== 'deleted')
                 // 2. The type dictates what cell it came from and how to deal with the inputs.
                 var jobType = this.jobTypeFromId(jobId);
                 var specInfo = null;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -351,7 +351,10 @@
             var type = isApp ? 'apps' : 'methods';
             IPython.notebook.metadata.job_ids[type].push(jobInfo);
             // put a stub in the job states
-            this.jobStates[jobInfo.id] = {'status' : null, $elem : 'null', 'sourceCell' : jobInfo.source};
+            this.jobStates[jobInfo.id] = {'status' : null, 
+                                          '$elem' : 'null', 
+                                          'source' : jobInfo.source,
+                                          'id' : jobInfo.id };
             this.source2Job[jobInfo.source] = jobInfo.id;
             this.refresh();
             IPython.notebook.save_checkpoint();
@@ -574,7 +577,7 @@
             else {
                 // sort our set of jobs.
                 var sortedJobs = Object.keys(this.jobStates);
-                sortedJobs.sort(function(a, b) {
+                sortedJobs.sort($.proxy(function(a, b) {
                     var aTime = this.jobStates[a].timestamp;
                     var bTime = this.jobStates[b].timestamp;
                     // if we have timestamps for both, compare them
@@ -584,7 +587,7 @@
                         return 1;
                     else            // if aTime is null, but bTime isn't, (OR they're both null), then put b first
                         return -1;
-                });
+                }, this));
 
                 for (var i=0; i<sortedJobs.length; i++) {
                     var jobId = sortedJobs[i];
@@ -683,13 +686,17 @@
                 status = this.makeJobErrorButton(fetchedJobStatus, jobInfo, 'Error');
                 $jobDiv.addClass('kb-jobs-error');
             }
+            else if (status === 'Deleted') {
+                status = this.makeJobErrorButton(fetchedJobStatus, jobInfo, 'Deleted');
+                $jobDiv.addClass('kb-jobs-error');                
+            }
             else if (fetchedJobStatus && fetchedJobStatus.step_errors && Object.keys(fetchedJobStatus.step_errors).length !== 0) {
                 var $errBtn = this.makeJobErrorButton(fetchedJobStatus, jobInfo);
                 status = $('<span>').append(status + ' ')
                                     .append($errBtn);
             }
             else {
-                if (jobType === "njs") {
+                if (jobType === "njs" && fetchedJobStatus) {
                     var stepId = fetchedJobStatus.running_step_id;
                     if (stepId) {
                         var stepSpec = getStepSpec(stepId, jobInfo.spec.appSpec);

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -81,18 +81,16 @@
                               .css({'margin-right':'5px'})
                               .click(
                                   $.proxy(function(event) {
-                                      self.stopRunning();
+                                      this.stopRunning();
                                   }, this)
                               )
                               .hide();
 
             var $buttons = $('<div>')
                            .addClass('buttons pull-left')
-                           // .append(this.$deleteButton)
-                           .append(this.$submitted)
                            .append(this.$runButton)
-                           .append(this.$stopButton);
-
+                           .append(this.$stopButton)
+                           .append(this.$submitted);
 
             var $progressBar = $('<div>')
                                .attr('id', 'kb-func-progress')
@@ -143,7 +141,6 @@
                               .append($('<div>')
                                       .addClass('panel-footer')
                                       .css({'overflow' : 'hidden'})
-                                      .append($progressBar)
                                       .append($buttons));
 
             $menuSpan.kbaseNarrativeCellMenu();
@@ -238,7 +235,7 @@
                         this.$elem.find('.kb-app-panel').removeClass('kb-app-error');
                         this.$submitted.html(this.submittedText).show();
                         this.$runButton.hide();
-                        this.$stopButton.show();
+                        this.$stopButton.hide();
                         this.$inputWidget.lockInputs();
                         break;
                     case 'complete':
@@ -271,6 +268,7 @@
                         this.$elem.find('.kb-app-panel').removeClass('kb-app-error');
                         this.$submitted.hide();
                         this.$runButton.show();
+                        this.$stopButton.hide();
                         this.$inputWidget.unlockInputs();
                         break;
                 }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -272,7 +272,7 @@
             this.initOverlay();
 
             this.$methodsWidget.refreshFromService();
-            setTimeout($.proxy(function() { this.$jobsWidget.refresh(); }, this), 750);
+            setTimeout($.proxy(function() { this.$jobsWidget.refresh(false, true); }, this), 750);
 
         },
 
@@ -282,781 +282,781 @@
          * I'm throwing this here because I have no idea how to
          * bind a sidepanel to a specific widget, since all the other panels "inherit" these widgets.
          */
-        dataImporter: function() {
-            var maxObjFetch = 300000;
-
-            var narWSName;
-            $(document).on('setWorkspaceName.Narrative', function(e, info){
-                narWSName = info.wsId;
-            })
-
-            var self = this;
-            var user = $("#signin-button").kbaseLogin('session', 'user_id');
-
-            var body = this.$overlayBody;
-            var footer = this.$overlayFooter;
-
-            // models
-            var myData = [],
-                sharedData = [],
-                publicData = [];
-
-            var myWorkspaces = [],
-                sharedWorkspaces = [];
-
-            // model for selected objects to import
-            var mineSelected = [],
-                sharedSelected = [],
-                publicSelected = [];
-
-            var types = ["KBaseGenomes.Genome",
-                         "KBaseSearch.GenomeSet",
-                         "KBaseFBA.FBA",
-                         "KBaseExpression.ExpressionSample",
-                         "KBaseFBA.FBAModel",
-                         "KBaseFBA.ModelTemplate",
-                         "KBaseFBA.ReactionSensitivityAnalysis",
-                         "KBaseNarrative.Narrative",
-                         "KBaseGenomes.Pangenome",
-                         "KBaseGenomes.ContigSet",
-                         "KBaseGenomes.MetagenomeAnnotation",
-                         "KBaseAssembly.AssemblyInput",
-                         "Communities.SequenceFile",
-                         "KBaseFBA.PromConstraint",
-                         "KBaseExpression.ExpressionSeries",
-                         "KBasePhenotypes.PhenotypeSimulationSet",
-                         "KBasePhenotypes.PhenotypeSet",
-                         "KBaseBiochem.Media",
-                         "KBaseTrees.Tree",
-                         "KBaseGenomes.GenomeComparison",
-                         "GenomeComparison.ProteomeComparison",
-                         "KBaseRegulation.Regulome",
-                         "KBaseGenomes.GenomeDomainData"];
-
-            // tab panels
-            var minePanel = $('<div class="kb-import-content kb-import-mine">'),
-                sharedPanel = $('<div class="kb-import-content kb-import-shared">'),
-                publicPanel = $('<div class="kb-import-content kb-import-public">'),
-                importPanel = $('<div class="kb-import-content kb-import-import" style="margin: 0px">'),
-                examplePanel = $('<div class="kb-import-content">');
-
-            // add tabs
-            var $tabs = this.buildTabs([
-                    {tabName: '<small>My Data</small>', content: minePanel},
-                    {tabName: '<small>Shared With Me</small>', content: sharedPanel},
-                    {tabName: '<small>Public</small>', content: publicPanel},
-                    {tabName: '<small>Example</small>', content: examplePanel},
-                    {tabName: '<small>Import</small>', content: importPanel},
-                ]);
-
-            var btn = $('<button class="btn btn-primary pull-right" disabled>Add to Narrative</button>');
-            var selectedPublicItems = [];
-
-            publicPanel.kbaseNarrativeSidePublicTab({addToNarrativeButton: btn, selectedItems: selectedPublicItems});
-            importPanel.kbaseNarrativeSideImportTab({});
-            examplePanel.kbaseNarrativeExampleDataTab({});
-
-            body.addClass('kb-side-panel');
-            body.append($tabs.header, $tabs.body);
-
-            // It is silly to invoke a new object for each widget
-            var auth = {token: $("#signin-button").kbaseLogin('session', 'token')}
-            var ws = new Workspace(this.options.workspaceURL, auth);
-
-            // add footer status container and buttons
-            var importStatus = $('<div class="pull-left kb-import-status">');
-            footer.append(importStatus)
-            var closeBtn = $('<button class="btn btn-default pull-right">Close</button>');
-
-            closeBtn.click(function() { self.hideOverlay(); })
-            footer.append(btn, closeBtn);
-
-            // start with my data, then fetch other data
-            // this is because data sets can be large and
-            // makes things more fluid
-            minePanel.loading();
-            sharedPanel.loading();
-            updateView('mine').done(function() {
-                updateView('shared')
-            });
-
-            // some placeholder for the public panel
-            //publicView();
-
-            // events for changing tabs
-            $($tabs.header.find('.kb-side-header')).click(function() {
-                // reset selected models when changing tabs, if that's what is wanted
-                if ($(this).index() == 0)
-                    mineSelected = [], btn.show();
-                else if ($(this).index() == 1)
-                    sharedSelected = [], btn.show();
-                else if ($(this).index() == 2)
-                    publicSelected = [], btn.show();
-                else
-                    btn.hide();
-
-                // reset checkboxs... for any tabs.
-                var checkboxes = body.find('.kb-import-checkbox');
-                checkboxes.removeClass('fa-check-square-o')
-                          .addClass('fa-square-o');
-                btn.prop('disabled', true);
-            })
-
-            var narrativeNameLookup={};
-
-            function updateView(view) {
-                var p;
-                if (view == 'mine') p = getMyWS();
-                else if (view == 'shared') p = getSharedWS();
-
-                return $.when(p).done(function(workspaces) {
-                    if (view == 'mine') prom = getMyData(workspaces);
-                    else if (view == 'shared') prom = getSharedData(workspaces);
-                    $.when(prom).done(function() {
-                        if (view == 'mine') {
-                            minePanel.rmLoading();
-                            addMyFilters();
-                        } else if(view == 'shared') {
-                            sharedPanel.rmLoading();
-                            addSharedFilters();
-                        }
-                    });
-                });
-            }
-
-            // function used to update my data list
-            function getMyData(workspaces, type, ws_name) {
-                var params = {};
-                if (!ws_name) {
-                    var ws_ids = [], obj_count = 0;
-                    for (var i in workspaces) {
-                        ws_ids.push(workspaces[i].id);
-                        obj_count = workspaces[i].count + obj_count;
-                    }
-
-                    params.ids = ws_ids;
-                } else
-                    params.workspaces = [ws_name];
-
-                if (type) params.type = type;
-
-                if (obj_count > maxObjFetch)
-                    console.error("user's object count for owned workspaces was", obj_count);
-
-                //console.log('total owned data is', obj_count)
-
-                var req_count = Math.ceil(obj_count/10000);
-
-                var proms = [];
-                proms.push( ws.list_objects(params) );
-                for (var i=1; i < req_count; i++) {
-                    params.skip = 10000 * i;
-                    proms.push( ws.list_objects(params) );
-                }
-
-                var p = ws.list_objects(params);
-                return $.when(p).then(function(d) {
-                    // update model
-                    myData = [].concat.apply([], arguments);
-                    render(myData, minePanel, mineSelected);
-                });
-            }
-
-
-            // function used to update shared with me data list
-            function getSharedData(workspaces, type, ws_name) {
-                var params = {};
-                if (!ws_name) {
-                    var ws_ids = [], obj_count = 0;
-                    for (var i in workspaces) {
-                        ws_ids.push(workspaces[i].id);
-                        obj_count = workspaces[i].count + obj_count;
-                    }
-
-                    params.ids = ws_ids;
-                } else
-                    params.workspaces = [ws_name];
-
-                if (type) params.type = type;
-
-                if (obj_count > maxObjFetch)
-                    console.error("user's object count for shared workspaces was", obj_count);
-
-                //console.log('total shared data', obj_count);
-
-                var req_count = Math.ceil(obj_count/10000);
-
-                var proms = [];
-                proms.push( ws.list_objects(params) );
-                for (var i=1; i < req_count; i++) {
-                    params.skip = 10000 * i;
-                    proms.push( ws.list_objects(params) );
-                }
-
-                return $.when.apply($, proms).then(function() {
-                    // update model
-                    sharedData = [].concat.apply([], arguments);
-                    render(sharedData, sharedPanel, sharedSelected);
-                })
-            }
-
-            // function used to update shared with me data list
-            function getPublicData(workspace, template) {
-                var obj_count = workspace[4],
-                    ws_name = workspace[1];
-
-                if (obj_count > maxObjFetch)
-                    console.error("object count for public workspace",
-                                    ws_name, "was", obj_count);
-
-                //console.log('total public data is', obj_count)
-
-                var req_count = Math.ceil(obj_count/10000);
-
-                var params = {workspaces: [ws_name]};
-
-                var proms = [];
-                proms.push( ws.list_objects(params) );
-                for (var i=1; i < req_count; i++) {
-                    params.skip = 10000 * i;
-                    proms.push( ws.list_objects(params) );
-                }
-
-                return $.when.apply($,proms).then(function(d) {
-                    // update model
-                    publicData = [].concat.apply([], arguments);
-                    render(publicData, publicPanel, publicSelected, template);
-                })
-            }
-
-
-            // This function takes data to render and
-            // a container to put data in.
-            // It produces a scrollable dataset
-            function render(data, container, selected, template) {
-                var start = 0, end = 9;
-
-                // remove items from only current container being rendered
-                container.find('.kb-import-items').remove();
-
-                if (data.length == 0){
-                    container.append('<div class="kb-import-items text-muted">No data found</div>');
-                    return
-                } else if (data.length-1 < end)
-                    end = data.length;
-
-                var rows = buildMyRows(data, start, end, template);
-                container.append(rows);
-                events(container, selected);
-
-                // infinite scroll
-                container.unbind('scroll');
-                container.on('scroll', function() {
-                    if($(this).scrollTop() + $(this).innerHeight() >= this.scrollHeight) {
-                        var rows = buildMyRows(data, start, end, template);
-                        container.append(rows);
-                    }
-                    events(container, selected);
-                });
-            }
-
-            function getMyWS() {
-                return ws.list_workspace_info({owners: [user]})
-                        .then(function(d) {
-                            var workspaces = [];
-                            for (var i in d) {
-                                 if (d[i][8].is_temporary) {
-                                    if (d[i][8].is_temporary === 'true') { continue; }
-                                }
-                                var displayName = d[i][1];
-                                if (d[i][8].narrative_nice_name) {
-                                    displayName = d[i][8].narrative_nice_name;
-                                }
-                                // todo: should skip temporary narratives
-                                workspaces.push({id: d[i][0],
-                                                 name: d[i][1],
-                                                 displayName: displayName,
-                                                 count: d[i][4]});
-                                narrativeNameLookup[d[i][1]] = displayName;
-                            }
-
-                            // add to model for filter
-                            myWorkspaces = workspaces;
-                            return workspaces;
-                        })
-            }
-
-            function getSharedWS() {
-                return ws.list_workspace_info({excludeGlobal: 1})
-                        .then(function(d) {
-                            var workspaces = [];
-                            for (var i in d) {
-                                // skip owned workspaced
-                                if (d[i][2] == user) {
-                                    continue;
-                                }
-                                if (d[i][8].is_temporary) {
-                                    if (d[i][8].is_temporary === 'true') { continue; }
-                                }
-                                var displayName = d[i][1];
-                                if (d[i][8].narrative_nice_name) {
-                                    displayName = d[i][8].narrative_nice_name;
-                                }
-                                // todo: should skip temporary narratives
-                                workspaces.push({id: d[i][0],
-                                                 name: d[i][1],
-                                                 displayName:displayName,
-                                                 count: d[i][4]});
-                                narrativeNameLookup[d[i][1]] = displayName;
-                            }
-
-                            // add to model for filter
-                            sharedWorkspaces = workspaces;
-                            return workspaces;
-                        })
-            }
-
-            function typeList(data) {
-                var types = [];
-
-                for (var i in data) {
-                    var mod_type = data[i][2].split('-')[0];
-                    // update model for types dropdown
-                    if (types.indexOf(mod_type) == -1) types.push(mod_type);
-                }
-                return types;
-            }
-
-            function copyObjects(objs, nar_ws_name) {
-                importStatus.html('Adding <i>'+objs.length+'</i> objects to narrative...');
-
-                var proms = [];
-                for (var i in objs) {
-                    var ref = objs[i].ref;
-                    var name = objs[i].name;
-                    console.log('copying ', ref, 'to', nar_ws_name);
-                    proms.push( ws.copy_object({to: {workspace: nar_ws_name, name: name},
-                                                from: {ref: ref} }) );
-                }
-                return proms;
-            }
-
-
-            function events(panel, selected) {
-                panel.find('.kb-import-item').unbind('click');
-                panel.find('.kb-import-item').click(function(){
-                    var item = $(this);
-                    var ref = item.data('ref').replace(/\./g, '/');
-                    var name = item.data('obj-name');
-
-                    var checkbox = $(this).find('.kb-import-checkbox');
-                    checkbox.toggleClass('fa-check-square-o')
-                            .toggleClass('fa-square-o');
-
-                    // update model for selected items
-                    if (checkbox.hasClass('fa-check-square-o') ) {
-                        selected.push({ref: ref, name: name});
-                    }
-                    else {
-                        for (var i=0; i<selected.length; i++) {
-                            if (selected[i].ref == ref)
-                                selected.splice(i, 1);
-                        }
-                    }
-
-                    // disable/enable button
-                    if (selected.length > 0) btn.prop('disabled', false);
-                    else btn.prop('disabled', true);
-
-                    // import items on button click
-                    btn.unbind('click');
-                    btn.click(function() {
-                        if (selected.length == 0) return;
-
-                        //uncheck all checkboxes, disable add button
-                        $('.kb-import-checkbox').removeClass('fa-check-square-o', false);
-                        $('.kb-import-checkbox').addClass('fa-square-o', false);
-                        $(this).prop('disabled', true);
-
-                        var proms = copyObjects(selected, narWSName);
-                        $.when.apply($, proms).done(function(data) {
-                            importStatus.html('');
-                            var status = $('<span class="text-success">done.</span>');
-                            importStatus.append(status);
-                            status.delay(1000).fadeOut();
-
-                            // update sidebar data list
-                            self.trigger('updateDataList.Narrative');
-                        });
-
-                        selected = [];
-
-                        // um... reset events until my rendering issues are solved
-                        events(panel, selected)
-                    });
-                });
-
-                panel.find('.kb-import-item').unbind('hover');
-                panel.find('.kb-import-item').hover(function() {
-                    $(this).find('hr').css('visibility', 'hidden');
-                    $(this).prev('.kb-import-item').find('hr').css('visibility', 'hidden');
-                    $(this).find('.kb-import-checkbox').css('opacity', '.8');
-                }, function() {
-                    $(this).find('hr').css('visibility', 'visible');
-                    $(this).prev('.kb-import-item').find('hr').css('visibility', 'visible');
-                    $(this).find('.kb-import-checkbox').css('opacity', '.4');
-                })
-
-                // prevent checking when clicking link
-                panel.find('.kb-import-item a').unbind('click');
-                panel.find('.kb-import-item a').click(function(e) {
-                    e.stopPropagation();
-                })
-
-            }
-
-            function filterData(data, f) {
-                if (data.length == 0) return [];
-
-                var filteredData = [];
-                // add each item to view
-                for (var i=0; i<data.length; i< i++) {
-                    var obj = data[i];
-
-                    var mod_type = obj[2].split('-')[0],
-                        ws = obj[7],
-                        name = obj[1];
-                    var kind = mod_type.split('.')[1];
-
-                    // filter conditions
-                    if (f.query && name.toLowerCase().indexOf(f.query.toLowerCase()) == -1)
-                        continue;
-                    if (f.type && f.type.split('.')[1] != kind)
-                        continue;
-                    if (f.ws && f.ws != ws)
-                        continue;
-
-
-                    filteredData.push(obj);
-
-                }
-                return filteredData;
-            }
-
-
-            function buildMyRows(data, start, end, template) {
-
-                // add each set of items to container to be added to DOM
-                var rows = $('<div class="kb-import-items">');
-
-                for (var i=start; i< (start+end); i++) {
-                    var obj = data[i];
-
-                    var mod_type = obj[2].split('-')[0];
-                    var item = {id: obj[0],
-                                name: obj[1],
-                                mod_type: mod_type,
-                                version: obj[4],
-                                kind: mod_type.split('.')[1],
-                                module: mod_type.split('.')[0],
-                                wsID: obj[6],
-                                ws: obj[7],
-                                relativeTime: kb.ui.relativeTime( Date.parse(obj[3]) ) }
-
-                    if (template)
-                        var item = template(item);
-                    else
-                        var item = rowTemplate(item);
-
-                    rows.append(item);
-                }
-
-                return rows;
-            }
-
-
-            function addMyFilters() {
-                //var types = typeList(myData);
-                var wsList = myWorkspaces;
-
-                // possible filters via input
-                var type, ws, query;
-
-                // create workspace filter
-                var wsInput = $('<select class="form-control kb-import-filter">');
-                wsInput.append('<option>All narratives...</option>');
-                for (var i=1; i < wsList.length-1; i++) {
-                    wsInput.append('<option data-id="'+[i].id+'" data-name="'+wsList[i].name+'">'+
-                                          wsList[i].displayName+
-                                   '</option>');
-                }
-                var wsFilter = $('<div class="col-sm-4">').append(wsInput);
-
-                // event for type dropdown
-                wsInput.change(function() {
-                    ws = $(this).children('option:selected').data('name');
-
-                    // request again with filted type
-                    minePanel.find('.kb-import-items').remove();
-                    minePanel.loading();
-                    getMyData(myWorkspaces, type, ws).done(function() {
-                        minePanel.rmLoading();
-                    })
-                })
-
-                // create type filter
-                var typeInput = $('<select class="form-control kb-import-filter">');
-                typeInput.append('<option>All types...</option>');
-                for (var i=1; i < types.length-1; i++) {
-                    typeInput.append('<option data-type="'+types[i]+'">'+
-                                          types[i].split('.')[1]+
-                                     '</option>');
-                }
-                var typeFilter = $('<div class="col-sm-3">').append(typeInput);
-
-                // event for type dropdown
-                typeInput.change(function() {
-                    type = $(this).children('option:selected').data('type');
-
-                    // request again with filted type
-                    minePanel.find('.kb-import-items').remove();
-                    minePanel.loading();
-                    getMyData(myWorkspaces, type, ws).done(function() {
-                        minePanel.rmLoading();
-                    })
-                })
-
-
-                // create filter (search)
-                var filterInput = $('<input type="text" class="form-control kb-import-search" placeholder="Filter data">');
-                var searchFilter = $('<div class="col-sm-4">').append(filterInput);
-
-                // event for filter (search)
-                filterInput.keyup(function(e){
-                    query = $(this).val();
-
-                    var filtered = filterData(myData, {type: type, ws:ws, query:query})
-                    render(filtered, minePanel, mineSelected);
-                });
-
-
-                // add search, type, ws filter to dom
-                var row = $('<div class="row">').append(searchFilter, typeFilter, wsFilter);
-                minePanel.prepend(row);
-            }
-
-            function addSharedFilters() {
-                //var types = typeList(sharedData);
-                var wsList = sharedWorkspaces
-
-                // possible filters via input
-                var type, ws, query;
-
-                // create workspace filter
-                var wsInput = $('<select class="form-control kb-import-filter">');
-                wsInput.append('<option>All narratives...</option>');
-                for (var i=1; i < wsList.length-1; i++) {
-                    wsInput.append('<option data-id="'+wsList[i].id+'" data-name="'+wsList[i].name+'">'+
-                                          wsList[i].displayName+
-                                    '</option>');
-                }
-                var wsFilter = $('<div class="col-sm-4">').append(wsInput);
-
-                // event for type dropdown
-                wsInput.change(function() {
-                    ws = $(this).children('option:selected').data('name');
-
-                    // request again with filted type
-                    sharedPanel.find('.kb-import-items').remove();
-                    sharedPanel.loading();
-                    getSharedData(sharedWorkspaces, type, ws).done(function() {
-                        sharedPanel.rmLoading();
-                    })
-                })
-
-
-                // create type filter
-                var typeInput = $('<select class="form-control kb-import-filter">');
-                typeInput.append('<option>All types...</option>');
-                for (var i=1; i < types.length-1; i++) {
-                    typeInput.append('<option data-type="'+types[i]+'">'+
-                                          types[i].split('.')[1]+
-                                     '</option>');
-                }
-                var typeFilter = $('<div class="col-sm-3">').append(typeInput);
-
-                // event for type dropdown
-                typeInput.change(function() {
-                    type = $(this).children('option:selected').data('type');
-
-                    // request again with filted type
-                    sharedPanel.find('.kb-import-items').remove();
-                    sharedPanel.loading();
-                    getSharedData(sharedWorkspaces, type, ws).done(function() {
-                        sharedPanel.rmLoading();
-                    })
-                })
-
-
-                // create filter (search)
-                var filterInput = $('<input type="text" class="form-control kb-import-search" placeholder="Filter objects">');
-                var searchFilter = $('<div class="col-sm-4">').append(filterInput);
-
-                // event for filter (search)
-                filterInput.keyup(function(e){
-                    query = $(this).val();
-
-                    var filtered = filterData(sharedData, {type: type, ws:ws, query:query})
-                    render(filtered, sharedPanel, sharedSelected);
-                });
-
-                // add search, type, ws filter to dom
-                var row = $('<div class="row">').append(searchFilter, typeFilter, wsFilter);
-                sharedPanel.prepend(row);
-            }
-
-
-
-            function rowTemplate(obj) {
-                var item = $('<div class="kb-import-item">')
-                                .data('ref', obj.wsID+'.'+obj.id)
-                                .data('obj-name', obj.name);
-                item.append('<i class="fa fa-square-o pull-left kb-import-checkbox">');
-                item.append('<a class="h4" href="'+
-                                objURL(obj.module, obj.kind, obj.ws, obj.name)+
-                                '" target="_blank">'+obj.name+'</a>'+
-                            '<span class="kb-data-list-version">v'+obj.version+'</span>');
-
-                item.append('<br>');
-
-                item.append('<div class="kb-import-info">'+
-                                '<span>TYPE</span><br>'+
-                                '<b>'+obj.kind+'</b>'+
-                            '</div>');
-                var narName = obj.ws;
-                if (narrativeNameLookup[obj.ws]) {
-                    narName = narrativeNameLookup[obj.ws];
-                }
-                item.append('<div class="kb-import-info">'+
-                                '<span>NARRATIVE</span><br>'+
-                                '<b>'+narName+'<b>'+   //<a class="" href="'+wsURL(obj.ws)+'">'
-                            '</div>');
-                item.append('<div class="kb-import-info">'+
-                                '<span>LAST MODIFIED</span><br>'+
-                                '<b>'+obj.relativeTime+'</b>'+
-                            '</div>');
-                item.append('<br><hr>')
-
-                return item;
-            }
-
-            function publicTemplate(obj) {
-                var item = $('<div class="kb-import-item">')
-                                .data('ref', obj.wsID+'.'+obj.id)
-                                .data('obj-name', obj.name);
-                item.append('<i class="fa fa-square-o pull-left kb-import-checkbox">');
-                item.append('<a class="h4" href="'+
-                                objURL(obj.module, obj.kind, obj.ws, obj.name)+
-                                '" target="_blank">'+obj.name+'</a>'+
-                            '<span class="kb-data-list-version">v'+obj.version+'</span>');
-
-                item.append('<br>');
-
-                item.append('<div class="kb-import-info">'+
-                                '<span>TYPE</span><br>'+
-                                '<b>'+obj.kind+'</b>'+
-                            '</div>');
-                var narName = obj.ws;
-                if (narrativeNameLookup[obj.ws]) {
-                    narName = narrativeNameLookup[obj.ws];
-                }
-
-                item.append('<div class="kb-import-info">'+
-                                '<span>LAST MODIFIED</span><br>'+
-                                '<b>'+obj.relativeTime+'</b>'+
-                            '</div>');
-                item.append('<br><hr>')
-
-                return item;
-            }
-
-
-
-            function objURL(module, type, ws, name) {
-                var mapping = window.kbconfig.landing_page_map;
-                if (mapping[module])
-                    return self.options.landingPageURL+mapping[module][type]+'/'+ws+'/'+name;
-                else
-                    console.error('could not find a landing page mapping for', module);
-            }
-
-            function wsURL(ws) {
-                return self.options.landingPageURL+'ws/'+ws;
-            }
-
-
-            function publicView() {
-                var publicList = [{type: 'Genomes', ws: 'KBasePublicGenomesV4'},
-                                  {type: 'Media', ws: 'KBaseMedia'},
-                                  {type: 'Models', ws: 'KBasePublicModelsV4'},
-                                  {type: 'RNA Seqs', ws: 'KBasePublicRNASeq'}];
-                var selected = publicList[0];
-
-                // get initial public data;
-                ws.get_workspace_info({workspace: selected.ws})
-                  .done(function(d){
-                      getPublicData(d, publicTemplate);
-                  })
-
-                // filter for public objects
-                var wsInput = $('<select class="form-control kb-import-filter">');
-                for (var i=0; i < publicList.length; i++) {
-                    wsInput.append('<option data-type="'+publicList[i].type+
-                                         '" data-name="'+publicList[i].ws+'">'+
-                                          publicList[i].type+
-                                   '</option>');
-                }
-                var wsFilter = $('<div class="col-sm-4">').append(wsInput);
-
-                // search filter
-                var filterInput = $('<input type="text" class="form-control kb-import-search" placeholder="Filter '+
-                                    selected.type+'">');
-                var searchFilter = $('<div class="col-sm-4">').append(filterInput);
-
-                // event for filter (search)
-                filterInput.keyup(function(e){
-                    query = $(this).val();
-
-                    var filtered = filterData(publicData, {query:query})
-                    render(filtered, publicPanel, publicSelected);
-                });
-
-                var row = $('<div class="row">').append(searchFilter, wsFilter);
-                publicPanel.append(row);
-
-
-                // event for type (workspace) dropdown
-                wsInput.change(function() {
-                    var active = $(this).children('option:selected');
-                    var type = active.data('type'),
-                        workspace = active.data('name');
-
-                    filterInput.attr('placeholder', 'Filter '+type);
-
-                    // request again with filted type
-                    publicPanel.find('.kb-import-items').remove();
-                    publicPanel.loading();
-
-                    ws.get_workspace_info({workspace: workspace})
-                      .done(function(d){
-                            getPublicData(d, publicTemplate).done(function() {
-                                publicPanel.rmLoading();
-                            })
-                      })
-                });
-
-            }
-
-        }
+        // dataImporter: function() {
+        //     var maxObjFetch = 300000;
+
+        //     var narWSName;
+        //     $(document).on('setWorkspaceName.Narrative', function(e, info){
+        //         narWSName = info.wsId;
+        //     })
+
+        //     var self = this;
+        //     var user = $("#signin-button").kbaseLogin('session', 'user_id');
+
+        //     var body = this.$overlayBody;
+        //     var footer = this.$overlayFooter;
+
+        //     // models
+        //     var myData = [],
+        //         sharedData = [],
+        //         publicData = [];
+
+        //     var myWorkspaces = [],
+        //         sharedWorkspaces = [];
+
+        //     // model for selected objects to import
+        //     var mineSelected = [],
+        //         sharedSelected = [],
+        //         publicSelected = [];
+
+        //     var types = ["KBaseGenomes.Genome",
+        //                  "KBaseSearch.GenomeSet",
+        //                  "KBaseFBA.FBA",
+        //                  "KBaseExpression.ExpressionSample",
+        //                  "KBaseFBA.FBAModel",
+        //                  "KBaseFBA.ModelTemplate",
+        //                  "KBaseFBA.ReactionSensitivityAnalysis",
+        //                  "KBaseNarrative.Narrative",
+        //                  "KBaseGenomes.Pangenome",
+        //                  "KBaseGenomes.ContigSet",
+        //                  "KBaseGenomes.MetagenomeAnnotation",
+        //                  "KBaseAssembly.AssemblyInput",
+        //                  "Communities.SequenceFile",
+        //                  "KBaseFBA.PromConstraint",
+        //                  "KBaseExpression.ExpressionSeries",
+        //                  "KBasePhenotypes.PhenotypeSimulationSet",
+        //                  "KBasePhenotypes.PhenotypeSet",
+        //                  "KBaseBiochem.Media",
+        //                  "KBaseTrees.Tree",
+        //                  "KBaseGenomes.GenomeComparison",
+        //                  "GenomeComparison.ProteomeComparison",
+        //                  "KBaseRegulation.Regulome",
+        //                  "KBaseGenomes.GenomeDomainData"];
+
+        //     // tab panels
+        //     var minePanel = $('<div class="kb-import-content kb-import-mine">'),
+        //         sharedPanel = $('<div class="kb-import-content kb-import-shared">'),
+        //         publicPanel = $('<div class="kb-import-content kb-import-public">'),
+        //         importPanel = $('<div class="kb-import-content kb-import-import" style="margin: 0px">'),
+        //         examplePanel = $('<div class="kb-import-content">');
+
+        //     // add tabs
+        //     var $tabs = this.buildTabs([
+        //             {tabName: '<small>My Data</small>', content: minePanel},
+        //             {tabName: '<small>Shared With Me</small>', content: sharedPanel},
+        //             {tabName: '<small>Public</small>', content: publicPanel},
+        //             {tabName: '<small>Example</small>', content: examplePanel},
+        //             {tabName: '<small>Import</small>', content: importPanel},
+        //         ]);
+
+        //     var btn = $('<button class="btn btn-primary pull-right" disabled>Add to Narrative</button>');
+        //     var selectedPublicItems = [];
+
+        //     publicPanel.kbaseNarrativeSidePublicTab({addToNarrativeButton: btn, selectedItems: selectedPublicItems});
+        //     importPanel.kbaseNarrativeSideImportTab({});
+        //     examplePanel.kbaseNarrativeExampleDataTab({});
+
+        //     body.addClass('kb-side-panel');
+        //     body.append($tabs.header, $tabs.body);
+
+        //     // It is silly to invoke a new object for each widget
+        //     var auth = {token: $("#signin-button").kbaseLogin('session', 'token')}
+        //     var ws = new Workspace(this.options.workspaceURL, auth);
+
+        //     // add footer status container and buttons
+        //     var importStatus = $('<div class="pull-left kb-import-status">');
+        //     footer.append(importStatus)
+        //     var closeBtn = $('<button class="btn btn-default pull-right">Close</button>');
+
+        //     closeBtn.click(function() { self.hideOverlay(); })
+        //     footer.append(btn, closeBtn);
+
+        //     // start with my data, then fetch other data
+        //     // this is because data sets can be large and
+        //     // makes things more fluid
+        //     minePanel.loading();
+        //     sharedPanel.loading();
+        //     updateView('mine').done(function() {
+        //         updateView('shared')
+        //     });
+
+        //     // some placeholder for the public panel
+        //     //publicView();
+
+        //     // events for changing tabs
+        //     $($tabs.header.find('.kb-side-header')).click(function() {
+        //         // reset selected models when changing tabs, if that's what is wanted
+        //         if ($(this).index() == 0)
+        //             mineSelected = [], btn.show();
+        //         else if ($(this).index() == 1)
+        //             sharedSelected = [], btn.show();
+        //         else if ($(this).index() == 2)
+        //             publicSelected = [], btn.show();
+        //         else
+        //             btn.hide();
+
+        //         // reset checkboxs... for any tabs.
+        //         var checkboxes = body.find('.kb-import-checkbox');
+        //         checkboxes.removeClass('fa-check-square-o')
+        //                   .addClass('fa-square-o');
+        //         btn.prop('disabled', true);
+        //     })
+
+        //     var narrativeNameLookup={};
+
+        //     function updateView(view) {
+        //         var p;
+        //         if (view == 'mine') p = getMyWS();
+        //         else if (view == 'shared') p = getSharedWS();
+
+        //         return $.when(p).done(function(workspaces) {
+        //             if (view == 'mine') prom = getMyData(workspaces);
+        //             else if (view == 'shared') prom = getSharedData(workspaces);
+        //             $.when(prom).done(function() {
+        //                 if (view == 'mine') {
+        //                     minePanel.rmLoading();
+        //                     addMyFilters();
+        //                 } else if(view == 'shared') {
+        //                     sharedPanel.rmLoading();
+        //                     addSharedFilters();
+        //                 }
+        //             });
+        //         });
+        //     }
+
+        //     // function used to update my data list
+        //     function getMyData(workspaces, type, ws_name) {
+        //         var params = {};
+        //         if (!ws_name) {
+        //             var ws_ids = [], obj_count = 0;
+        //             for (var i in workspaces) {
+        //                 ws_ids.push(workspaces[i].id);
+        //                 obj_count = workspaces[i].count + obj_count;
+        //             }
+
+        //             params.ids = ws_ids;
+        //         } else
+        //             params.workspaces = [ws_name];
+
+        //         if (type) params.type = type;
+
+        //         if (obj_count > maxObjFetch)
+        //             console.error("user's object count for owned workspaces was", obj_count);
+
+        //         //console.log('total owned data is', obj_count)
+
+        //         var req_count = Math.ceil(obj_count/10000);
+
+        //         var proms = [];
+        //         proms.push( ws.list_objects(params) );
+        //         for (var i=1; i < req_count; i++) {
+        //             params.skip = 10000 * i;
+        //             proms.push( ws.list_objects(params) );
+        //         }
+
+        //         var p = ws.list_objects(params);
+        //         return $.when(p).then(function(d) {
+        //             // update model
+        //             myData = [].concat.apply([], arguments);
+        //             render(myData, minePanel, mineSelected);
+        //         });
+        //     }
+
+
+        //     // function used to update shared with me data list
+        //     function getSharedData(workspaces, type, ws_name) {
+        //         var params = {};
+        //         if (!ws_name) {
+        //             var ws_ids = [], obj_count = 0;
+        //             for (var i in workspaces) {
+        //                 ws_ids.push(workspaces[i].id);
+        //                 obj_count = workspaces[i].count + obj_count;
+        //             }
+
+        //             params.ids = ws_ids;
+        //         } else
+        //             params.workspaces = [ws_name];
+
+        //         if (type) params.type = type;
+
+        //         if (obj_count > maxObjFetch)
+        //             console.error("user's object count for shared workspaces was", obj_count);
+
+        //         //console.log('total shared data', obj_count);
+
+        //         var req_count = Math.ceil(obj_count/10000);
+
+        //         var proms = [];
+        //         proms.push( ws.list_objects(params) );
+        //         for (var i=1; i < req_count; i++) {
+        //             params.skip = 10000 * i;
+        //             proms.push( ws.list_objects(params) );
+        //         }
+
+        //         return $.when.apply($, proms).then(function() {
+        //             // update model
+        //             sharedData = [].concat.apply([], arguments);
+        //             render(sharedData, sharedPanel, sharedSelected);
+        //         })
+        //     }
+
+        //     // function used to update shared with me data list
+        //     function getPublicData(workspace, template) {
+        //         var obj_count = workspace[4],
+        //             ws_name = workspace[1];
+
+        //         if (obj_count > maxObjFetch)
+        //             console.error("object count for public workspace",
+        //                             ws_name, "was", obj_count);
+
+        //         //console.log('total public data is', obj_count)
+
+        //         var req_count = Math.ceil(obj_count/10000);
+
+        //         var params = {workspaces: [ws_name]};
+
+        //         var proms = [];
+        //         proms.push( ws.list_objects(params) );
+        //         for (var i=1; i < req_count; i++) {
+        //             params.skip = 10000 * i;
+        //             proms.push( ws.list_objects(params) );
+        //         }
+
+        //         return $.when.apply($,proms).then(function(d) {
+        //             // update model
+        //             publicData = [].concat.apply([], arguments);
+        //             render(publicData, publicPanel, publicSelected, template);
+        //         })
+        //     }
+
+
+        //     // This function takes data to render and
+        //     // a container to put data in.
+        //     // It produces a scrollable dataset
+        //     function render(data, container, selected, template) {
+        //         var start = 0, end = 9;
+
+        //         // remove items from only current container being rendered
+        //         container.find('.kb-import-items').remove();
+
+        //         if (data.length == 0){
+        //             container.append('<div class="kb-import-items text-muted">No data found</div>');
+        //             return
+        //         } else if (data.length-1 < end)
+        //             end = data.length;
+
+        //         var rows = buildMyRows(data, start, end, template);
+        //         container.append(rows);
+        //         events(container, selected);
+
+        //         // infinite scroll
+        //         container.unbind('scroll');
+        //         container.on('scroll', function() {
+        //             if($(this).scrollTop() + $(this).innerHeight() >= this.scrollHeight) {
+        //                 var rows = buildMyRows(data, start, end, template);
+        //                 container.append(rows);
+        //             }
+        //             events(container, selected);
+        //         });
+        //     }
+
+        //     function getMyWS() {
+        //         return ws.list_workspace_info({owners: [user]})
+        //                 .then(function(d) {
+        //                     var workspaces = [];
+        //                     for (var i in d) {
+        //                          if (d[i][8].is_temporary) {
+        //                             if (d[i][8].is_temporary === 'true') { continue; }
+        //                         }
+        //                         var displayName = d[i][1];
+        //                         if (d[i][8].narrative_nice_name) {
+        //                             displayName = d[i][8].narrative_nice_name;
+        //                         }
+        //                         // todo: should skip temporary narratives
+        //                         workspaces.push({id: d[i][0],
+        //                                          name: d[i][1],
+        //                                          displayName: displayName,
+        //                                          count: d[i][4]});
+        //                         narrativeNameLookup[d[i][1]] = displayName;
+        //                     }
+
+        //                     // add to model for filter
+        //                     myWorkspaces = workspaces;
+        //                     return workspaces;
+        //                 })
+        //     }
+
+        //     function getSharedWS() {
+        //         return ws.list_workspace_info({excludeGlobal: 1})
+        //                 .then(function(d) {
+        //                     var workspaces = [];
+        //                     for (var i in d) {
+        //                         // skip owned workspaced
+        //                         if (d[i][2] == user) {
+        //                             continue;
+        //                         }
+        //                         if (d[i][8].is_temporary) {
+        //                             if (d[i][8].is_temporary === 'true') { continue; }
+        //                         }
+        //                         var displayName = d[i][1];
+        //                         if (d[i][8].narrative_nice_name) {
+        //                             displayName = d[i][8].narrative_nice_name;
+        //                         }
+        //                         // todo: should skip temporary narratives
+        //                         workspaces.push({id: d[i][0],
+        //                                          name: d[i][1],
+        //                                          displayName:displayName,
+        //                                          count: d[i][4]});
+        //                         narrativeNameLookup[d[i][1]] = displayName;
+        //                     }
+
+        //                     // add to model for filter
+        //                     sharedWorkspaces = workspaces;
+        //                     return workspaces;
+        //                 })
+        //     }
+
+        //     function typeList(data) {
+        //         var types = [];
+
+        //         for (var i in data) {
+        //             var mod_type = data[i][2].split('-')[0];
+        //             // update model for types dropdown
+        //             if (types.indexOf(mod_type) == -1) types.push(mod_type);
+        //         }
+        //         return types;
+        //     }
+
+        //     function copyObjects(objs, nar_ws_name) {
+        //         importStatus.html('Adding <i>'+objs.length+'</i> objects to narrative...');
+
+        //         var proms = [];
+        //         for (var i in objs) {
+        //             var ref = objs[i].ref;
+        //             var name = objs[i].name;
+        //             console.log('copying ', ref, 'to', nar_ws_name);
+        //             proms.push( ws.copy_object({to: {workspace: nar_ws_name, name: name},
+        //                                         from: {ref: ref} }) );
+        //         }
+        //         return proms;
+        //     }
+
+
+        //     function events(panel, selected) {
+        //         panel.find('.kb-import-item').unbind('click');
+        //         panel.find('.kb-import-item').click(function(){
+        //             var item = $(this);
+        //             var ref = item.data('ref').replace(/\./g, '/');
+        //             var name = item.data('obj-name');
+
+        //             var checkbox = $(this).find('.kb-import-checkbox');
+        //             checkbox.toggleClass('fa-check-square-o')
+        //                     .toggleClass('fa-square-o');
+
+        //             // update model for selected items
+        //             if (checkbox.hasClass('fa-check-square-o') ) {
+        //                 selected.push({ref: ref, name: name});
+        //             }
+        //             else {
+        //                 for (var i=0; i<selected.length; i++) {
+        //                     if (selected[i].ref == ref)
+        //                         selected.splice(i, 1);
+        //                 }
+        //             }
+
+        //             // disable/enable button
+        //             if (selected.length > 0) btn.prop('disabled', false);
+        //             else btn.prop('disabled', true);
+
+        //             // import items on button click
+        //             btn.unbind('click');
+        //             btn.click(function() {
+        //                 if (selected.length == 0) return;
+
+        //                 //uncheck all checkboxes, disable add button
+        //                 $('.kb-import-checkbox').removeClass('fa-check-square-o', false);
+        //                 $('.kb-import-checkbox').addClass('fa-square-o', false);
+        //                 $(this).prop('disabled', true);
+
+        //                 var proms = copyObjects(selected, narWSName);
+        //                 $.when.apply($, proms).done(function(data) {
+        //                     importStatus.html('');
+        //                     var status = $('<span class="text-success">done.</span>');
+        //                     importStatus.append(status);
+        //                     status.delay(1000).fadeOut();
+
+        //                     // update sidebar data list
+        //                     self.trigger('updateDataList.Narrative');
+        //                 });
+
+        //                 selected = [];
+
+        //                 // um... reset events until my rendering issues are solved
+        //                 events(panel, selected)
+        //             });
+        //         });
+
+        //         panel.find('.kb-import-item').unbind('hover');
+        //         panel.find('.kb-import-item').hover(function() {
+        //             $(this).find('hr').css('visibility', 'hidden');
+        //             $(this).prev('.kb-import-item').find('hr').css('visibility', 'hidden');
+        //             $(this).find('.kb-import-checkbox').css('opacity', '.8');
+        //         }, function() {
+        //             $(this).find('hr').css('visibility', 'visible');
+        //             $(this).prev('.kb-import-item').find('hr').css('visibility', 'visible');
+        //             $(this).find('.kb-import-checkbox').css('opacity', '.4');
+        //         })
+
+        //         // prevent checking when clicking link
+        //         panel.find('.kb-import-item a').unbind('click');
+        //         panel.find('.kb-import-item a').click(function(e) {
+        //             e.stopPropagation();
+        //         })
+
+        //     }
+
+        //     function filterData(data, f) {
+        //         if (data.length == 0) return [];
+
+        //         var filteredData = [];
+        //         // add each item to view
+        //         for (var i=0; i<data.length; i< i++) {
+        //             var obj = data[i];
+
+        //             var mod_type = obj[2].split('-')[0],
+        //                 ws = obj[7],
+        //                 name = obj[1];
+        //             var kind = mod_type.split('.')[1];
+
+        //             // filter conditions
+        //             if (f.query && name.toLowerCase().indexOf(f.query.toLowerCase()) == -1)
+        //                 continue;
+        //             if (f.type && f.type.split('.')[1] != kind)
+        //                 continue;
+        //             if (f.ws && f.ws != ws)
+        //                 continue;
+
+
+        //             filteredData.push(obj);
+
+        //         }
+        //         return filteredData;
+        //     }
+
+
+        //     function buildMyRows(data, start, end, template) {
+
+        //         // add each set of items to container to be added to DOM
+        //         var rows = $('<div class="kb-import-items">');
+
+        //         for (var i=start; i< (start+end); i++) {
+        //             var obj = data[i];
+
+        //             var mod_type = obj[2].split('-')[0];
+        //             var item = {id: obj[0],
+        //                         name: obj[1],
+        //                         mod_type: mod_type,
+        //                         version: obj[4],
+        //                         kind: mod_type.split('.')[1],
+        //                         module: mod_type.split('.')[0],
+        //                         wsID: obj[6],
+        //                         ws: obj[7],
+        //                         relativeTime: kb.ui.relativeTime( Date.parse(obj[3]) ) }
+
+        //             if (template)
+        //                 var item = template(item);
+        //             else
+        //                 var item = rowTemplate(item);
+
+        //             rows.append(item);
+        //         }
+
+        //         return rows;
+        //     }
+
+
+        //     function addMyFilters() {
+        //         //var types = typeList(myData);
+        //         var wsList = myWorkspaces;
+
+        //         // possible filters via input
+        //         var type, ws, query;
+
+        //         // create workspace filter
+        //         var wsInput = $('<select class="form-control kb-import-filter">');
+        //         wsInput.append('<option>All narratives...</option>');
+        //         for (var i=1; i < wsList.length-1; i++) {
+        //             wsInput.append('<option data-id="'+[i].id+'" data-name="'+wsList[i].name+'">'+
+        //                                   wsList[i].displayName+
+        //                            '</option>');
+        //         }
+        //         var wsFilter = $('<div class="col-sm-4">').append(wsInput);
+
+        //         // event for type dropdown
+        //         wsInput.change(function() {
+        //             ws = $(this).children('option:selected').data('name');
+
+        //             // request again with filted type
+        //             minePanel.find('.kb-import-items').remove();
+        //             minePanel.loading();
+        //             getMyData(myWorkspaces, type, ws).done(function() {
+        //                 minePanel.rmLoading();
+        //             })
+        //         })
+
+        //         // create type filter
+        //         var typeInput = $('<select class="form-control kb-import-filter">');
+        //         typeInput.append('<option>All types...</option>');
+        //         for (var i=1; i < types.length-1; i++) {
+        //             typeInput.append('<option data-type="'+types[i]+'">'+
+        //                                   types[i].split('.')[1]+
+        //                              '</option>');
+        //         }
+        //         var typeFilter = $('<div class="col-sm-3">').append(typeInput);
+
+        //         // event for type dropdown
+        //         typeInput.change(function() {
+        //             type = $(this).children('option:selected').data('type');
+
+        //             // request again with filted type
+        //             minePanel.find('.kb-import-items').remove();
+        //             minePanel.loading();
+        //             getMyData(myWorkspaces, type, ws).done(function() {
+        //                 minePanel.rmLoading();
+        //             })
+        //         })
+
+
+        //         // create filter (search)
+        //         var filterInput = $('<input type="text" class="form-control kb-import-search" placeholder="Filter data">');
+        //         var searchFilter = $('<div class="col-sm-4">').append(filterInput);
+
+        //         // event for filter (search)
+        //         filterInput.keyup(function(e){
+        //             query = $(this).val();
+
+        //             var filtered = filterData(myData, {type: type, ws:ws, query:query})
+        //             render(filtered, minePanel, mineSelected);
+        //         });
+
+
+        //         // add search, type, ws filter to dom
+        //         var row = $('<div class="row">').append(searchFilter, typeFilter, wsFilter);
+        //         minePanel.prepend(row);
+        //     }
+
+        //     function addSharedFilters() {
+        //         //var types = typeList(sharedData);
+        //         var wsList = sharedWorkspaces
+
+        //         // possible filters via input
+        //         var type, ws, query;
+
+        //         // create workspace filter
+        //         var wsInput = $('<select class="form-control kb-import-filter">');
+        //         wsInput.append('<option>All narratives...</option>');
+        //         for (var i=1; i < wsList.length-1; i++) {
+        //             wsInput.append('<option data-id="'+wsList[i].id+'" data-name="'+wsList[i].name+'">'+
+        //                                   wsList[i].displayName+
+        //                             '</option>');
+        //         }
+        //         var wsFilter = $('<div class="col-sm-4">').append(wsInput);
+
+        //         // event for type dropdown
+        //         wsInput.change(function() {
+        //             ws = $(this).children('option:selected').data('name');
+
+        //             // request again with filted type
+        //             sharedPanel.find('.kb-import-items').remove();
+        //             sharedPanel.loading();
+        //             getSharedData(sharedWorkspaces, type, ws).done(function() {
+        //                 sharedPanel.rmLoading();
+        //             })
+        //         })
+
+
+        //         // create type filter
+        //         var typeInput = $('<select class="form-control kb-import-filter">');
+        //         typeInput.append('<option>All types...</option>');
+        //         for (var i=1; i < types.length-1; i++) {
+        //             typeInput.append('<option data-type="'+types[i]+'">'+
+        //                                   types[i].split('.')[1]+
+        //                              '</option>');
+        //         }
+        //         var typeFilter = $('<div class="col-sm-3">').append(typeInput);
+
+        //         // event for type dropdown
+        //         typeInput.change(function() {
+        //             type = $(this).children('option:selected').data('type');
+
+        //             // request again with filted type
+        //             sharedPanel.find('.kb-import-items').remove();
+        //             sharedPanel.loading();
+        //             getSharedData(sharedWorkspaces, type, ws).done(function() {
+        //                 sharedPanel.rmLoading();
+        //             })
+        //         })
+
+
+        //         // create filter (search)
+        //         var filterInput = $('<input type="text" class="form-control kb-import-search" placeholder="Filter objects">');
+        //         var searchFilter = $('<div class="col-sm-4">').append(filterInput);
+
+        //         // event for filter (search)
+        //         filterInput.keyup(function(e){
+        //             query = $(this).val();
+
+        //             var filtered = filterData(sharedData, {type: type, ws:ws, query:query})
+        //             render(filtered, sharedPanel, sharedSelected);
+        //         });
+
+        //         // add search, type, ws filter to dom
+        //         var row = $('<div class="row">').append(searchFilter, typeFilter, wsFilter);
+        //         sharedPanel.prepend(row);
+        //     }
+
+
+
+        //     function rowTemplate(obj) {
+        //         var item = $('<div class="kb-import-item">')
+        //                         .data('ref', obj.wsID+'.'+obj.id)
+        //                         .data('obj-name', obj.name);
+        //         item.append('<i class="fa fa-square-o pull-left kb-import-checkbox">');
+        //         item.append('<a class="h4" href="'+
+        //                         objURL(obj.module, obj.kind, obj.ws, obj.name)+
+        //                         '" target="_blank">'+obj.name+'</a>'+
+        //                     '<span class="kb-data-list-version">v'+obj.version+'</span>');
+
+        //         item.append('<br>');
+
+        //         item.append('<div class="kb-import-info">'+
+        //                         '<span>TYPE</span><br>'+
+        //                         '<b>'+obj.kind+'</b>'+
+        //                     '</div>');
+        //         var narName = obj.ws;
+        //         if (narrativeNameLookup[obj.ws]) {
+        //             narName = narrativeNameLookup[obj.ws];
+        //         }
+        //         item.append('<div class="kb-import-info">'+
+        //                         '<span>NARRATIVE</span><br>'+
+        //                         '<b>'+narName+'<b>'+   //<a class="" href="'+wsURL(obj.ws)+'">'
+        //                     '</div>');
+        //         item.append('<div class="kb-import-info">'+
+        //                         '<span>LAST MODIFIED</span><br>'+
+        //                         '<b>'+obj.relativeTime+'</b>'+
+        //                     '</div>');
+        //         item.append('<br><hr>')
+
+        //         return item;
+        //     }
+
+        //     function publicTemplate(obj) {
+        //         var item = $('<div class="kb-import-item">')
+        //                         .data('ref', obj.wsID+'.'+obj.id)
+        //                         .data('obj-name', obj.name);
+        //         item.append('<i class="fa fa-square-o pull-left kb-import-checkbox">');
+        //         item.append('<a class="h4" href="'+
+        //                         objURL(obj.module, obj.kind, obj.ws, obj.name)+
+        //                         '" target="_blank">'+obj.name+'</a>'+
+        //                     '<span class="kb-data-list-version">v'+obj.version+'</span>');
+
+        //         item.append('<br>');
+
+        //         item.append('<div class="kb-import-info">'+
+        //                         '<span>TYPE</span><br>'+
+        //                         '<b>'+obj.kind+'</b>'+
+        //                     '</div>');
+        //         var narName = obj.ws;
+        //         if (narrativeNameLookup[obj.ws]) {
+        //             narName = narrativeNameLookup[obj.ws];
+        //         }
+
+        //         item.append('<div class="kb-import-info">'+
+        //                         '<span>LAST MODIFIED</span><br>'+
+        //                         '<b>'+obj.relativeTime+'</b>'+
+        //                     '</div>');
+        //         item.append('<br><hr>')
+
+        //         return item;
+        //     }
+
+
+
+        //     function objURL(module, type, ws, name) {
+        //         var mapping = window.kbconfig.landing_page_map;
+        //         if (mapping[module])
+        //             return self.options.landingPageURL+mapping[module][type]+'/'+ws+'/'+name;
+        //         else
+        //             console.error('could not find a landing page mapping for', module);
+        //     }
+
+        //     function wsURL(ws) {
+        //         return self.options.landingPageURL+'ws/'+ws;
+        //     }
+
+
+        //     function publicView() {
+        //         var publicList = [{type: 'Genomes', ws: 'KBasePublicGenomesV4'},
+        //                           {type: 'Media', ws: 'KBaseMedia'},
+        //                           {type: 'Models', ws: 'KBasePublicModelsV4'},
+        //                           {type: 'RNA Seqs', ws: 'KBasePublicRNASeq'}];
+        //         var selected = publicList[0];
+
+        //         // get initial public data;
+        //         ws.get_workspace_info({workspace: selected.ws})
+        //           .done(function(d){
+        //               getPublicData(d, publicTemplate);
+        //           })
+
+        //         // filter for public objects
+        //         var wsInput = $('<select class="form-control kb-import-filter">');
+        //         for (var i=0; i < publicList.length; i++) {
+        //             wsInput.append('<option data-type="'+publicList[i].type+
+        //                                  '" data-name="'+publicList[i].ws+'">'+
+        //                                   publicList[i].type+
+        //                            '</option>');
+        //         }
+        //         var wsFilter = $('<div class="col-sm-4">').append(wsInput);
+
+        //         // search filter
+        //         var filterInput = $('<input type="text" class="form-control kb-import-search" placeholder="Filter '+
+        //                             selected.type+'">');
+        //         var searchFilter = $('<div class="col-sm-4">').append(filterInput);
+
+        //         // event for filter (search)
+        //         filterInput.keyup(function(e){
+        //             query = $(this).val();
+
+        //             var filtered = filterData(publicData, {query:query})
+        //             render(filtered, publicPanel, publicSelected);
+        //         });
+
+        //         var row = $('<div class="row">').append(searchFilter, wsFilter);
+        //         publicPanel.append(row);
+
+
+        //         // event for type (workspace) dropdown
+        //         wsInput.change(function() {
+        //             var active = $(this).children('option:selected');
+        //             var type = active.data('type'),
+        //                 workspace = active.data('name');
+
+        //             filterInput.attr('placeholder', 'Filter '+type);
+
+        //             // request again with filted type
+        //             publicPanel.find('.kb-import-items').remove();
+        //             publicPanel.loading();
+
+        //             ws.get_workspace_info({workspace: workspace})
+        //               .done(function(d){
+        //                     getPublicData(d, publicTemplate).done(function() {
+        //                         publicPanel.rmLoading();
+        //                     })
+        //               })
+        //         });
+
+        //     }
+
+        // }
     })
 })( jQuery );

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -283,6 +283,7 @@
             else if ((data.method.behavior.kb_service_method && data.method.behavior.kb_service_name) ||
                      (data.method.behavior.script_module && data.method.behavior.script_name)) {
                 code = this.buildGenericRunCommand(data);
+                showOutput = false;
             }
             else {
                 // something else!


### PR DESCRIPTION
This has a number of changes to how App and Method cells behave. Now:
  - Running Apps and Methods have a "Cancel" button associated with them. Clicking that will restore the cell to its input state, and cancel (and delete) the running job
  - Deleting App/Method cells now prompts to delete, warning the user that it'll kill any running job (if they've been run before)
  - Deleting jobs now triggers the call to the right back end services to delete the running job itself.
  - Deleting a job from a running cell now unlocks that cell so its inputs can be used again.
  - Added new error checking for different states
    - A dangling job with no associated cell should properly error.
    - A dangling job on the front end that's been deleted on the back should properly error.
    - A job in an error state (not the above, but a runtime error) should now reflect an error on its associated cell (if present)
  - Fixed an error where running a method automatically made an output cell connected to incomplete data.
  - Refactored Jobs panel to only look up jobs that are incomplete (e.g. not 'error', 'completed', 'done', or 'deleted')

This pull request also has a couple of cosmetic changes:
  - Toolbars should only appear over IPython cells now (KBase cells have their own menus)
  - Styled app/method control buttons to be closer to the style guide / mockup.