### PR TITLE
Fix jobs panel

### DIFF
--- a/src/biokbase/narrative/services/generic_service_calls.py
+++ b/src/biokbase/narrative/services/generic_service_calls.py
@@ -84,8 +84,8 @@ def _method_call(meth, method_spec_json, param_values_json):
         steps = []
         methodId = methodSpec['info']['id']
         app = { 'name' : 'App wrapper for method ' + methodId,'steps' : steps }
-        meth.debug(json.dumps(app))
         steps.append(create_app_step(workspace, token, wsClient, methodSpec, paramValues, methodId, True))
+        meth.debug(json.dumps(app))
         njsClient = NarrativeJobService(service.URLS.job_service, token = token)
         appState = njsClient.run_app(app)
         jobId = "method:" + appState["job_id"]

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseNarrativeError.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseNarrativeError.js
@@ -79,10 +79,10 @@
                 if (err.traceback === undefined) {
                     s += "No traceback available.\n";
                 }
-                else {
+                else if (err.traceback instanceof Array) {
                     s += "Traceback (most recent call last):\n";
                     var tb = err.traceback;
-                    for (var i= 0, ctr=0; i < tb.length; i++) {
+                    for (var i=0, ctr=0; i < tb.length; i++) {
                         var entry = tb[i];
                         if (entry.function == "__call__")
                             continue;  // ignore wrapper
@@ -95,6 +95,14 @@
                         txt += entry.text;
                         s += ind + txt + "\n";
                     }
+                }
+                else if (err.traceback instanceof Object) {
+                    for (var i in err.traceback) {
+                        s += JSON.stringify(err.traceback[i]);
+                    }
+                }
+                else {
+                    s += err.traceback;
                 }
                 return s;
             };

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -697,7 +697,7 @@
                         widget: widgetName,
                         data: output,
                         type: 'app',
-                        title: 'Output',
+                        title: this.methodSpecs[this.inputStepLookup[stepId].methodId].info.name,
                         showMenu: false,
                         time: new Date().getTime()
                     });

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -661,6 +661,7 @@
                         }
                     }
                     catch (err) {
+                        KBError("App::" + this.appSpec.info.name, "failed to render output widget: '" + widgetName);
                         $outputWidget[this.OUTPUT_ERROR_WIDGET]({'error': {
                             'msg': 'An error occurred while showing your output:',
                             'method_name': 'kbaseNarrativeAppCell.setStepOutput',

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -38,6 +38,8 @@
         $errorModal: null,
         $errorModalContent:null,
 
+        OUTPUT_ERROR_WIDGET: 'kbaseNarrativeError',
+
         state: null,
 
         /**
@@ -649,12 +651,25 @@
                     var widgetName = this.inputStepLookup[stepId].outputWidgetName;
                     var $outputWidget = $('<div>');
                     var widget;
-                    if (widgetName !== "kbaseDefaultNarrativeOutput")
-                        widget = $outputWidget[widgetName](output);
-                    else
-                        widget = $outputWidget[widgetName]({data:output});
-                    if (state) {
-                        widget.loadState(state);
+                    try {
+                        if (widgetName !== "kbaseDefaultNarrativeOutput")
+                            widget = $outputWidget[widgetName](output);
+                        else
+                            widget = $outputWidget[widgetName]({data:output});                
+                        if (state) {
+                            widget.loadState(state);
+                        }
+                    }
+                    catch (err) {
+                        $outputWidget[this.OUTPUT_ERROR_WIDGET]({'error': {
+                            'msg': 'An error occurred while showing your output:',
+                            'method_name': 'kbaseNarrativeAppCell.setStepOutput',
+                            'type': 'Output',
+                            'severity': '',
+                            'traceback': 'Failed while trying to show a "' + widgetName + '"\n' +
+                                         'With inputs ' + JSON.stringify(output) + '\n\n' + 
+                                         err.message
+                        }});
                     }
 
                     var header = '<span class="kb-out-desc">Output</span><span class="pull-right kb-func-timestamp">' +

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -649,43 +649,65 @@
                     this.inputStepLookup[stepId].$stepContainer.removeClass("kb-app-step-running");
 
                     var widgetName = this.inputStepLookup[stepId].outputWidgetName;
-                    var $outputWidget = $('<div>');
-                    var widget;
-                    try {
-                        if (widgetName !== "kbaseDefaultNarrativeOutput")
-                            widget = $outputWidget[widgetName](output);
-                        else
-                            widget = $outputWidget[widgetName]({data:output});                
-                        if (state) {
-                            widget.loadState(state);
-                        }
+
+
+
+                    // var header = '<span class="kb-out-desc">Output</span>' +
+                    //              '<span class="pull-right kb-func-timestamp">' +
+                    //                  this.readableTimestamp(new Date().getTime()) +
+                    //              '</span>';
+
+                    // var $outputWidget = $('<div>');
+                    // var widget;
+                    // try {
+                    //     if (widgetName !== "kbaseDefaultNarrativeOutput")
+                    //         widget = $outputWidget[widgetName](output);
+                    //     else
+                    //         widget = $outputWidget[widgetName]({data:output});                
+                    //     if (state) {
+                    //         widget.loadState(state);
+                    //     }
+                    // }
+                    // catch (err) {
+                    //     KBError("App::" + this.appSpec.info.name, "failed to render output widget: '" + widgetName);
+                    //     $outputWidget[this.OUTPUT_ERROR_WIDGET]({'error': {
+                    //         'msg': 'An error occurred while showing your output:',
+                    //         'method_name': 'kbaseNarrativeAppCell.setStepOutput',
+                    //         'type': 'Output',
+                    //         'severity': '',
+                    //         'traceback': 'Failed while trying to show a "' + widgetName + '"\n' +
+                    //                      'With inputs ' + JSON.stringify(output) + '\n\n' + 
+                    //                      err.message
+                    //     }});
+                    //     header = header.replace(/\-out\-/, '-err-');
+                    // }
+
+                    // var $outputCell = $("<div>")
+                    //                   .addClass("kb-cell-output")
+                    //                   .css({"padding-top":"5px","padding-bottom":"5px"})
+                    //                   .append(
+                    //                         $('<div>')
+                    //                         .addClass("panel panel-default")
+                    //                         .append($('<div>').addClass("panel-heading").append(header))
+                    //                         .append($('<div>').addClass("panel-body").append($outputWidget))
+                    //                   );
+
+                    var $outputWidget = $('<div>').css({'padding':'5px 0'});
+                    $outputWidget.kbaseNarrativeOutputCell({
+                        widget: widgetName,
+                        data: output,
+                        type: 'app',
+                        title: 'Output',
+                        showMenu: false,
+                        time: new Date().getTime()
+                    });
+                    if (state) {
+                        $outputWidget.loadState(state);
                     }
-                    catch (err) {
-                        KBError("App::" + this.appSpec.info.name, "failed to render output widget: '" + widgetName);
-                        $outputWidget[this.OUTPUT_ERROR_WIDGET]({'error': {
-                            'msg': 'An error occurred while showing your output:',
-                            'method_name': 'kbaseNarrativeAppCell.setStepOutput',
-                            'type': 'Output',
-                            'severity': '',
-                            'traceback': 'Failed while trying to show a "' + widgetName + '"\n' +
-                                         'With inputs ' + JSON.stringify(output) + '\n\n' + 
-                                         err.message
-                        }});
-                    }
+                    this.inputStepLookup[stepId].$outputPanel.append($outputWidget);
+//                    this.inputStepLookup[stepId].$outputPanel.append($outputCell);
 
-                    var header = '<span class="kb-out-desc">Output</span><span class="pull-right kb-func-timestamp">' +
-                                    this.readableTimestamp(new Date().getTime()) +
-                                    '</span>';
-
-                    var $outputCell = $("<div>").addClass("kb-cell-output").css({"padding-top":"5px","padding-bottom":"5px"}).append(
-                                            $('<div>').addClass("panel panel-default")
-                                                .append($('<div>').addClass("panel-heading").append(header))
-                                                .append($('<div>').addClass("panel-body").append($outputWidget))
-                                            );
-
-                    this.inputStepLookup[stepId].$outputPanel.append($outputCell);
-
-                    this.inputStepLookup[stepId].outputWidget = widget;
+                    this.inputStepLookup[stepId].outputWidget = $outputWidget;
                     var objCopy = $.extend(true, {}, output);
                     this.state.step[stepId].outputState = {
                         output: objCopy
@@ -697,8 +719,15 @@
         setStepError: function(stepId, error) {
             if (this.inputStepLookup) {
                 if(this.inputStepLookup[stepId]) {
-                    this.inputStepLookup[stepId].$outputPanel.html(error);
+//                    this.inputStepLookup[stepId].$outputPanel.html(error);
                     // todo: actually render with the error widget
+                    this.inputStepLookup[stepId].kbaseNarrativeOutputCell({
+                        widget: this.OUTPUT_ERROR_WIDGET,
+                        data: error,
+                        type: 'error',
+                        showMenu: false,
+                        time: new Date().getTime()
+                    });
                 }
             }
         },

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -420,7 +420,6 @@
                 jobInfo[jobId] = {'state' : jobState};
 
                 // if the job's incomplete, we have to go get it.
-                console.log('job status: ' + jobState.status);
                 var jobIncomplete = (jobState.status !== 'completed' && 
                                      jobState.status !== 'error' && 
                                      jobState.status !== 'done' && 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -420,7 +420,12 @@
                 jobInfo[jobId] = {'state' : jobState};
 
                 // if the job's incomplete, we have to go get it.
-                var jobIncomplete = (jobState.status !== 'completed' && jobState.status !== 'error' && jobState.status !== 'done' && jobState.status !== 'deleted')
+                console.log('job status: ' + jobState.status);
+                var jobIncomplete = (jobState.status !== 'completed' && 
+                                     jobState.status !== 'error' && 
+                                     jobState.status !== 'done' && 
+                                     jobState.status !== 'deleted' &&
+                                     jobState.status !== 'suspend')
                 // 2. The type dictates what cell it came from and how to deal with the inputs.
                 var jobType = this.jobTypeFromId(jobId);
                 var specInfo = null;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -351,10 +351,7 @@
             var type = isApp ? 'apps' : 'methods';
             IPython.notebook.metadata.job_ids[type].push(jobInfo);
             // put a stub in the job states
-            this.jobStates[jobInfo.id] = {'status' : null, 
-                                          '$elem' : 'null', 
-                                          'source' : jobInfo.source,
-                                          'id' : jobInfo.id };
+            this.jobStates[jobInfo.id] = $.extend({}, jobInfo, {'status' : null, '$elem' : 'null'});
             this.source2Job[jobInfo.source] = jobInfo.id;
             this.refresh();
             IPython.notebook.save_checkpoint();

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -767,12 +767,22 @@
                 if (jobType === 'njs') {
                     for (var key in job.widget_outputs) {
                         if (job.widget_outputs.hasOwnProperty(key)) {
-                            $cell.kbaseNarrativeAppCell('setStepOutput', key, job.widget_outputs[key]);
+                            try {
+                                $cell.kbaseNarrativeAppCell('setStepOutput', key, job.widget_outputs[key]);
+                            }
+                            catch (err) {
+                                console.log(["ERROR'D APP OUTPUT", err]);
+                            }
                         }
                     }
                 }
                 else {
-                    $cell.kbaseNarrativeMethodCell('setOutput', { 'cellId' : source, 'result' : job.widget_outputs });
+                    try {
+                        $cell.kbaseNarrativeMethodCell('setOutput', { 'cellId' : source, 'result' : job.widget_outputs });
+                    }
+                    catch (err) {
+                        console.log(["ERROR'D METHOD OUTPUT", err]);
+                    }
                 }
             }
             // if it's an error, then we need to signal the cell

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -11,6 +11,7 @@
             title: 'Output',
             time: '',
         },
+        OUTPUT_ERROR_WIDGET: 'kbaseNarrativeError',
 
         init: function(options) {
             this._super(options);
@@ -111,7 +112,21 @@
 
             this.$elem.append($body);
 
-            this.$outWidget = $body.find('.panel-body > div')[widget](widgetData);
+            try {
+                this.$outWidget = $body.find('.panel-body > div')[widget](widgetData);
+            }
+            catch (err) {
+                KBError("Output::" + this.options.title, "failed to render output widget: '" + widget);
+                $outputWidget[this.OUTPUT_ERROR_WIDGET]({'error': {
+                    'msg': 'An error occurred while showing your output:',
+                    'method_name': 'kbaseNarrativeOutputCell.renderCell',
+                    'type': 'Output',
+                    'severity': '',
+                    'traceback': 'Failed while trying to show a "' + widget + '"\n' +
+                                 'With inputs ' + JSON.stringify(widgetData) + '\n\n' + 
+                                 err.message
+                }});
+            }
         },
 
         getState: function() {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -10,6 +10,7 @@
             type: 'error',
             title: 'Output',
             time: '',
+            showMenu: true
         },
         OUTPUT_ERROR_WIDGET: 'kbaseNarrativeError',
 
@@ -84,8 +85,11 @@
                 this.$timestamp.append($('<span>')
                                        .append(this.readableTimestamp(this.options.time)));
             }
-            var $menuSpan = $('<span style="margin-left:5px">');
-            this.$timestamp.append($menuSpan);
+            if (this.options.showMenu) {
+                var $menuSpan = $('<span style="margin-left:5px">');
+                this.$timestamp.append($menuSpan);
+                $menuSpan.kbaseNarrativeCellMenu();
+            }
 
             var $headerLabel = $('<span>')
                                .addClass('label label-info')
@@ -107,26 +111,36 @@
                                 .append($('<div>')
                                         .addClass('panel-body')
                                         .append($('<div>'))));
-
-            $menuSpan.kbaseNarrativeCellMenu();
-
-            this.$elem.append($body);
-
             try {
                 this.$outWidget = $body.find('.panel-body > div')[widget](widgetData);
+                this.$elem.append($body);
             }
             catch (err) {
                 KBError("Output::" + this.options.title, "failed to render output widget: '" + widget);
-                $outputWidget[this.OUTPUT_ERROR_WIDGET]({'error': {
+                this.options.title = 'App Error';
+                this.options.data = {'error': {
                     'msg': 'An error occurred while showing your output:',
                     'method_name': 'kbaseNarrativeOutputCell.renderCell',
                     'type': 'Output',
                     'severity': '',
                     'traceback': 'Failed while trying to show a "' + widget + '"\n' +
                                  'With inputs ' + JSON.stringify(widgetData) + '\n\n' + 
-                                 err.message
-                }});
+                                 err.message                    
+                }};
+                this.options.widget = this.OUTPUT_ERROR_WIDGET;
+                this.renderErrorOutputCell();
+
+                // this.$outWidget = $body.find('.panel-body > div')[this.OUTPUT_ERROR_WIDGET]({'error': {
+                //     'msg': 'An error occurred while showing your output:',
+                //     'method_name': 'kbaseNarrativeOutputCell.renderCell',
+                //     'type': 'Output',
+                //     'severity': '',
+                //     'traceback': 'Failed while trying to show a "' + widget + '"\n' +
+                //                  'With inputs ' + JSON.stringify(widgetData) + '\n\n' + 
+                //                  err.message
+                // }});
             }
+
         },
 
         getState: function() {


### PR DESCRIPTION
Addresses the following issues:
- KBASE-1199 "time stamp issues - annotation"
Newly registered jobs weren't having their timestamps rendered right, though this gets fixed after a refresh. It should work now.

- KBASE-1210
Debug info for methods wasn't being properly sent to the console. Now it should be. **This doesn't actually fix the issue, but it helps diagnose what's happening**

- NAR-400 "Jobs not loading in jobs panel"
- KBASE-1202 "Running jobs list doesn't update correctly"
- KBASE-1192 "jobs view not updating"
- KBASE-1191 "assemble and annotate"

The root cause for these - especially with the jobs panel locking up - was that a completed job was trying to render an output widget that didn't exist. This caused a small chain of uncaught exceptions that resulted in the jobs panel failing. These are now caught and should result in an "error" widget being shown. It could probably use a little love, still, but it's a start. 

The main problem with how it displays is that if a widget throws an exception while rendering (i.e. just propagates a problem instead of rendering some error message), that error is usually kind of a nonsense string. In this case, it's simply "undefined is not a function", meaning the widget invocation command "$.kbaseAssemblyView" didn't actually exist. Now, the error widget should show what widget it tried to render and with what data. It also now logs the error.