### PR TITLE
Improved handling of corrupt narratives

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
@@ -2045,6 +2045,12 @@ div[class="tooltip-inner"] {
     color:#444;
 }
 
+.kb-data-list-narrative-error {
+    color:#F44336;
+    font-size: 10pt;
+    margin: 2px;
+}
+
 .kb-data-list-narrative {
     color:#777;
     font-size: 10pt;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
@@ -25,7 +25,6 @@
         
         render: function() {
             var self = this;
-            console.log(this.spec);
             var spec = self.spec;
             
             // check if we need to allow multiple values


### PR DESCRIPTION
Fixes NAR-441

When narratives are deleted outside of the narrative interface, without deleting the containing workspace, that workspace is corrupted, throwing an error and causing other narratives not to render.

This fix detects this case in the narrative manage panel, shows existing and corrupt narratives, and provides an option to delete the corrupt narrative.