### PR TITLE
NAR-465 fix

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -369,6 +369,14 @@
     <script src="{{ static_url("components/bootstrap-3/js/bootstrap.min.js") }}" type="text/javascript" charset="utf-8"></script>
 
     <script>
+        // Dumb thing to get the workspace ID just like the back end does - from the URL at startup.
+        // This snippet keeps the workspace ID local, so it shouldn't be changed if some knucklehead pokes at the URL
+        // before trying to fetch it again.
+        var workspaceId = null;
+        var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
+        if (m && m.length > 0)
+            workspaceId = m[1];
+
         var configJSON = $.parseJSON(
             $.ajax({
                 url: "{{ static_url('kbase/config.json') }}",
@@ -399,6 +407,7 @@
                             release_notes: configJSON['release_notes'],
                             mode: configJSON['mode'],
                             data_icons: dataIcons,
+                            workspaceId: workspaceId
                           };
     </script>
     <script src="{{ static_url("kbase/js/api/kbase-api.js") }}" type="text/javascript" charset="utf-8"></script>

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -375,7 +375,7 @@
         var workspaceId = null;
         var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
         if (m && m.length > 0)
-            workspaceId = m[1];
+            workspaceId = parseInt(m[1]);
 
         var configJSON = $.parseJSON(
             $.ajax({

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -374,7 +374,7 @@
         // before trying to fetch it again.
         var workspaceId = null;
         var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-        if (m && m.length > 0)
+        if (m && m.length > 1)
             workspaceId = parseInt(m[1]);
 
         var configJSON = $.parseJSON(

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -7,16 +7,6 @@
 "use strict";
 
 (function() {
-
-    // Dumb thing to get the workspace ID just like the back end does - from the URL at startup.
-    // This snippet keeps the workspace ID local, so it shouldn't be changed if some knucklehead pokes at the URL
-    // before trying to fetch it again.
-    var workspaceId = null;
-    var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-    if (m && m.length > 0)
-        workspaceId = m[1];
-    window.kbconfig.workspaceId = workspaceId;
-    
     $(document).on('workspaceIdQuery.Narrative', function(e, callback) {
         if (callback) {
             callback(workspaceId);

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/create_metagenome_set.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/create_metagenome_set.js
@@ -10,7 +10,7 @@
         version: "1.0.0",
         token: null,
         options: {},
-        ws_id: null,
+        ws_id: window.kbconfig.workspaceId,
         ws_url: window.kbconfig.urls.workspace,
         loading_image: "static/kbase/images/ajax-loader.gif",
 
@@ -22,8 +22,7 @@
          */
         init: function(options) {
             this._super(options);
-            var ws_id = window.kbconfig.workspaceId;
-            this.ws_id = parseInt(ws_id, 10);
+            this.ws_id = parseInt(this.ws_id, 10);
             return this;
         },
 


### PR DESCRIPTION
This puts the current workspace id in the global namespace as soon as the page starts. Should avoid any issues with widgets trying to instantiate that variable on page load.