### PR TITLE
Updated Narrative login widget to point to the user's profile page when ...

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/kbaseLoginFuncSite.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/kbaseLoginFuncSite.js
@@ -303,6 +303,11 @@
                                                     .attr('target', '_blank')
                                                     .css('padding-right', '0px')
                                                     .css('padding-left', '0px')
+                                                    .bind('click',
+                                                        $.proxy( function(e) {
+                                                            this.data('login-dropdown-menu').hide();
+                                                        }, this)
+                                                    )
                                             )
                                         )
                                 )
@@ -335,10 +340,11 @@
 
             this.registerLogin =
                 function(args) {
-
                     if ( args.success ) {
                         this.data("loginlink").hide();
-                        this.data('loggedinuser_id').text(args.name);
+                        this.data('loggedinuser_id').text(args.name)
+                                                    .attr('href', '/functional-site/#/people/' + args.user_id)
+                                                    .click();
                         this.data("userdisplay").show();
                         this.data('loginDialog').closePrompt();
                     }


### PR DESCRIPTION
...logged in. This only affects the link under the dropdown menu.

This also means that there should either be another direct link to Globus Online for password, etc., management, or it should be handled from the profile page. But that's another ticket.