### PR TITLE
Dev msneddon

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
@@ -90,7 +90,7 @@
                                 .append($('<div>').css({"display":"inline-block"}).append($feedbackTip));
                 var $hintCol  = $('<div>').addClass(hintColClass).addClass("kb-method-parameter-hint")
                                 .append(spec.short_hint);
-                if (spec.description) {
+                if (spec.description && spec.short_hint !== spec.description) {
                     $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
                                     .tooltip({title:spec.description, html:true}));
                 }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
@@ -106,7 +106,7 @@
                                 .append($('<div>').css({"display":"inline-block"}).append($feedbackTip));
                 var $hintCol  = $('<div>').addClass(hintColClass).addClass("kb-method-parameter-hint")
                                 .append(spec.short_hint);
-                if (spec.description) {
+                if (spec.description && spec.short_hint !== spec.description) {
                     $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
                                     .tooltip({title:spec.description, html:true}));
                 }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
@@ -41,11 +41,22 @@
                 // just one field, phew, this one should be easy    
                 var d = spec.default_values;
                 self.required= true;
+                if (spec.optional===1) {
+                    self.required = false;
+                }
                 
                 var defaultValue = (d[0] !== "" && d[0] !== undefined) ? d[0] : "";
                 var form_id = spec.id;
                 var $dropdown= $('<select id="'+form_id+'">').css({width:"100%"})
                                 .on("change",function() { self.isValid() });
+                
+                if (d && d.length>0 && d[0]==="" && !self.required) {
+                    // we assume that if there is a single value set as empty, and this is optional, we allow an
+                    // empty selection which ends up getting omitted from the params on the backend
+                    // annoying select two removes my option if it is left blank!! must disguise it!
+                    $dropdown.append($('<option value="">').append('-'));
+                }
+                
                 
                 var foundOptions = false;
                 /* HOW IT SHOULD BE!!! */
@@ -285,6 +296,9 @@
          */
         getParameterValue: function() {
             var value = this.$elem.find("#"+this.spec.id).val();
+            if (value==="") {
+                return null;
+            }
             return value;
         }
         

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
@@ -140,7 +140,7 @@
             	.append($('<div>').css({"display":"inline-block", "height": "34px", "vertical-align":"top"}).append($feedbackTip));
             var $hintCol = $('<div>').addClass(hintColClass).addClass("kb-method-parameter-hint")
             	.append(spec.short_hint);
-	    if (spec.description) {
+	    if (spec.description && spec.short_hint !== spec.description) {
                 $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
                                     .tooltip({title:spec.description, html:true}));
             }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
@@ -186,7 +186,7 @@
             var uuidForRemoval = self.genUUID(); var $removalButton=null;
             if(showHint) {
                 $hintCol.append(spec.short_hint);
-                if (spec.description) {
+                if (spec.description && spec.short_hint !== spec.description) {
                     $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
                                     .tooltip({title:spec.description, html:true}));
                 }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
@@ -86,7 +86,7 @@
                                 .append($('<div>').css({"display":"inline-block"}).append($feedbackTip));
                 var $hintCol  = $('<div>').addClass(hintColClass).addClass("kb-method-parameter-hint")
                                 .append(spec.short_hint);
-		if (spec.description) {
+		if (spec.description && spec.short_hint !== spec.description) {
 		    $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
 					.tooltip({title:spec.description, html:true}));
 		}


### PR DESCRIPTION
also removes the 'info' icon on parameter hints if the long description is the same as the short description.  For now we have few, if any, long descriptions for parameters.

fixes https://atlassian.kbase.us/browse/NAR-470