### PR TITLE
Websocket text change

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/js/notificationarea.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/js/notificationarea.js
@@ -13,6 +13,10 @@ var IPython = (function (IPython) {
     "use strict";
     var utils = IPython.utils;
 
+    var websocketDisconnectMsg = "<p>Your Narrative's connection to KBase has been lost.</p>" +
+                                 "<p>You will not be able to run KBase apps, use code cells, or save any changes.</p>" +
+                                 "<p>Please check your network connection and click 'Reconnect' to try again</p>" +
+                                 "<p>If this persists, try restarting your browser, or notify <a href='mailto:help@kbase.us' target='_blank'>help@kbase.us</a>.</p>";
 
     var NotificationArea = function (selector) {
         this.selector = selector;
@@ -127,11 +131,13 @@ var IPython = (function (IPython) {
                 return;
             }
             console.log('WebSocket connection failed: ', ws_url)
-            msg = "A WebSocket connection to could not be established." +
-                " You will NOT be able to run code. Check your" +
-                " network connection or notebook server configuration.";
+            // msg = "A WebSocket connection to could not be established." +
+            //     " You will NOT be able to run code. Check your" +
+            //     " network connection or notebook server configuration.";
+            msg = websocketDisconnectMsg;
+
             IPython.dialog.modal({
-                title: "WebSocket connection failed",
+                title: "Narrative connection lost!",
                 body: msg,
                 buttons : {
                     "OK": {},

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/js/notificationarea.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/js/notificationarea.js
@@ -13,9 +13,13 @@ var IPython = (function (IPython) {
     "use strict";
     var utils = IPython.utils;
 
+    var oldWebsocketMsg = "A WebSocket connection to could not be established." +
+                          " You will NOT be able to run code. Check your" +
+                          " network connection or notebook server configuration.";
+
     var websocketDisconnectMsg = "<p>Your Narrative's connection to KBase has been lost.</p>" +
                                  "<p>You will not be able to run KBase apps, use code cells, or save any changes.</p>" +
-                                 "<p>Please check your network connection and click 'Reconnect' to try again</p>" +
+                                 "<p>Please check your network connection and click 'Reconnect' to try again.</p>" +
                                  "<p>If this persists, try restarting your browser, or notify <a href='mailto:help@kbase.us' target='_blank'>help@kbase.us</a>.</p>";
 
     var NotificationArea = function (selector) {
@@ -131,16 +135,12 @@ var IPython = (function (IPython) {
                 return;
             }
             console.log('WebSocket connection failed: ', ws_url)
-            // msg = "A WebSocket connection to could not be established." +
-            //     " You will NOT be able to run code. Check your" +
-            //     " network connection or notebook server configuration.";
             msg = websocketDisconnectMsg;
 
             IPython.dialog.modal({
                 title: "Narrative connection lost!",
                 body: msg,
                 buttons : {
-                    "OK": {},
                     "Reconnect": {
                         click: function () {
                             knw.set_message('Reconnecting WebSockets', 1000);


### PR DESCRIPTION
The IPython websocket error doesn't have the same meaning in the KBase Narrative, and needed to be updated. This PR does so, and removes the 'OK' button (since that doesn't really have meaning either - it's not like the user can just reboot their instance and reconnect to it).