### PR TITLE
Styling changes and a bugfix

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -324,6 +324,7 @@
                     <div class="fa fa-save"></div>
                     <div class="kb-nav-btn-txt">save</div>
                 </button>
+                <span style="margin-right: 10px"></span>
                 <span id="signin-button"></span>
             </div>
         </div>

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -280,8 +280,7 @@
                         <li><a id="kb-jira-btn" href="" target="_blank">Submit JIRA ticket</a></li>
                         <li role="presentation" class="divider"></li>
                         <li><a id="kb-about-btn">About</a></li>
-<!--                         <li><a href="#">Help</a></li>
- -->                        <li><a target="_blank" href="https://staging.kbase.us/narrative-guide/">Narrative Tutorial</a></li>
+                        <li><a target="_blank" href="https://staging.kbase.us/narrative-guide/">Narrative Tutorial</a></li>
                         <li><a target="_blank" href="mailto:help@kbase.us">Email help@kbase.us</a></li>
                     </ul>
                 </div>
@@ -325,19 +324,7 @@
                     <div class="fa fa-save"></div>
                     <div class="kb-nav-btn-txt">save</div>
                 </button>
-<!--                 <button id="kb-del-btn" class="btn btn-default navbar-btn kb-nav-btn">
-                    <div class="fa fa-trash-o"></div>
-                    <div class="kb-nav-btn-txt">delete cell</div>
-                </button>
-                <button id="kb-about-btn" class="btn btn-default navbar-btn kb-nav-btn">
-                    <div class="fa fa-info"></div>
-                    <div class="kb-nav-btn-txt">about</div>
-                </button>
-                <button id="kb-help-btn" class="btn btn-default navbar-btn kb-nav-btn" data-toggle="tooltip" data-placement="bottom" Title="Not yet!">
-                    <div class="fa fa-question"></div>
-                    <div class="kb-nav-btn-txt">help</div>
-                </button>
- -->                <span id="signin-button"></span>
+                <span id="signin-button"></span>
             </div>
         </div>
     </nav>

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
@@ -1672,8 +1672,14 @@ div#notebook_panel {
    margin-top:20px;
 }
 
+.kb-app-step-error {
+    border: 3px solid #D14836;
+    border-radius: 5px;
+    z-index: auto;
+}
+
 .kb-app-step-running {
-    border: 3px solid #d14836;
+    border: 3px solid #2196F3;
     border-radius: 5px;
     z-index: auto;
     /*animation: pulse 1s ease infinite;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
@@ -919,7 +919,7 @@ div#notebook_panel {
     font-family: "OxygenBold", Arial, sans-serif;
     text-transform: uppercase;
     color: #2e618d;
-    border-bottom: 1px solid #CECECE;
+    /*border-bottom: 1px solid #CECECE;*/
 }
 
 /* From user and job state service */

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
@@ -52,25 +52,16 @@ body {
 }
 
 header[role="banner"] {
-/*  overflow: auto;
-    padding: 7px 0 2px 0;
-    border-bottom: 1px solid #C0C0C0;
-    -moz-box-shadow: inset 0 0 2px #c2c2c2;
-    -webkit-box-shadow: inset 0 0 2px #c2c2c2;
-    box-shadow: inset 0 0 2px #c2c2c2; */
     position: absolute;
     top: 0;
     width: 100%;
     background-color: #fff;
-    border-bottom: 1px solid #E0E0E0;
-    /*-webkit-box-shadow: 0 1px 10px rgba(0,0,0,.1);
-    -moz-box-shadow: 0 1px 10px rgba(0,0,0,.1);
-    box-shadow: 0 1px 10px rgba(0,0,0,.1);*/
+    border-bottom: 1px solid #CECECE;
     z-index: 999;
 
 }
 
-nav[role="navigation"] ul{
+nav[role="navigation"] ul {
     margin: 1.2em 0 .5em 0;
     /*text-align: center;*/
     padding-left: 0;
@@ -140,7 +131,7 @@ div#notebook {
 }
 
 .navbar-kbase {
-    border-bottom: 5px solid #E0E0E0 !important;
+    border-bottom: 5px solid #CECECE !important;
     padding: 8px;
 }
 
@@ -376,7 +367,7 @@ p#site-title {
 #left-column {
     width: 380px;
     position: fixed;
-    border-right: 5px solid #e0e0e0;
+    border-right: 5px solid #CECECE;
     top: 70px;
     bottom: 0;
     overflow-y: auto;
@@ -442,6 +433,10 @@ p#site-title {
     border-bottom: 6px solid orange;
     color: #fff;
     cursor: auto;
+}
+
+.kb-side-separator {
+    border-bottom: 5px solid #CECECE;
 }
 
 .kb-side-tab {
@@ -924,7 +919,7 @@ div#notebook_panel {
     font-family: "OxygenBold", Arial, sans-serif;
     text-transform: uppercase;
     color: #2e618d;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid #CECECE;
 }
 
 /* From user and job state service */

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
@@ -356,7 +356,7 @@ p#site-title {
     border-top: 1px solid #aaa;
 }
 
-#bottom-tabs p a{
+#bottom-tabs p a {
     border: 1px solid #018841;
     background-color: #fff;
     padding: 14px 20px;
@@ -375,7 +375,7 @@ p#site-title {
 
 .kb-side-overlay-container {
     width: 700px;  /* I would advise fixing this for UX sake */
-    border : 1px solid #ababab;
+    border : 1px solid #CECECE;
     z-index : 1030;
     background : white;
     position : fixed;
@@ -383,7 +383,7 @@ p#site-title {
 
 .kb-side-overlay-header {
     width: 100%;
-    background-color: #428bca;
+    background-color: #2196F3;
     color: #fff;
     padding: 6px;
     font-size: 12pt;
@@ -409,10 +409,11 @@ p#site-title {
     display: inline-block;
     font-size: 12pt;
     text-align: center;
-    border: 6px solid #428bca;
-    background-color: #428bca;
+    border-bottom: 6px solid #2196F3;
+    border-top: 6px solid #2196F3;
+    background-color: #2196F3;
     padding: 6px;
-    color: #b3d1ea;
+    color: #BBDEFB;
     font-weight: bold;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -426,11 +427,11 @@ p#site-title {
 }
 
 .kb-side-header:hover {
-    border-bottom: 6px solid orange;
+    border-bottom: 6px solid #10CE34;
 }
 
 .kb-side-header.active {
-    border-bottom: 6px solid orange;
+    border-bottom: 6px solid #10CE34;
     color: #fff;
     cursor: auto;
 }
@@ -2012,7 +2013,8 @@ div[class="tooltip-inner"] {
     box-shadow: #CECECE 2px 2px 1px;
     height: 40px;
     width: 40px;
-    background-color: rgba(128,128,128,0.5);
+    background-color: #2196F3;
+    opacity: 0.5;
 }
 #kb-add-code-cell { right: 100px; }
 #kb-add-md-cell { margin-right: 20px; }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
@@ -1427,9 +1427,12 @@ div#notebook_panel {
 }
 
 /** output cell styling */
+.kb-cell-output .panel {
+    border-radius: 0px;
+}
+
 .kb-cell-output .panel .panel-heading {
     padding: 5px 10px;
-    border-radius: 1px;
 }
 
 .rendered_html .kb-cell-output ul {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseStylesheet.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseStylesheet.css
@@ -68,7 +68,7 @@
     font-style: normal;
 
 }
- 
+
 h1 {
 	font: 1.75em/2em 'RobotoBlack', Arial, sans-serif;
 	letter-spacing: 0; 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -210,7 +210,9 @@ Narrative.prototype.initUpgradeDialog = function() {
                                             .addClass('modal-body')
                                             .append($('<span>').append('Your current version of the Narrative is <b>' + this.currentVersion + '</b>. Version '))
                                             .append($newVersion)
-                                            .append($('<span>').append(' is now available. Click "Update and Reload" to reload with the latest version!<br><br>' + 
+                                            .append($('<span>').append(' is now available.<br><br>' + 
+                                                                       'See <a href="' + window.kbconfig.release_notes + '" target="_blank">here</a> for current release notes.<br>' +
+                                                                       'Click "Update and Reload" to reload with the latest version!<br><br>' + 
                                                                        '<b>Any unsaved data in any open Narrative in any window WILL BE LOST!</b>')))
                                     .append($('<div>')
                                             .addClass('modal-footer')

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -732,8 +732,15 @@
 
         setRunningState: function(state) {
             state = state.toLowerCase();
-            if (state === 'error')
+            if (state === 'error') {
                 this.setErrorState(true);
+                for (var i=0; i<this.inputSteps.length; i++) {
+                    if (this.inputSteps[i].$stepContainer.hasClass('kb-app-step-running')) {
+                        this.inputSteps[i].$stepContainer.removeClass('kb-app-step-running');
+                        this.inputSteps[i].$stepContainer.addClass('kb-app-step-error');
+                    }
+                }
+            }
             else if (state === 'complete') {
                 for (var i=0; i<this.inputSteps.length; i++) {
                     this.inputSteps[i].$stepContainer.removeClass('kb-app-step-running');

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -1,5 +1,7 @@
 /**
  * @author Bill Riehl <wjriehl@lbl.gov>
+ * @author Michael Sneddon <mwsneddon@lbl.gov>
+ * @author Dan Gunter <dkgunter@lbl.gov>
  * @public
  * This is a generalized class for an input cell that sits in an IPython markdown cell.
  * It handles all of its rendering here (no longer in HTML in markdown), and invokes
@@ -85,9 +87,9 @@
         },
 
         fetchMethodInfo: function() {
-          if (!this.appSpec.steps || this.appSpec.steps.length === 0) {
-            KBError("App::" + this.appSpec.info.name, "has no steps");
-            this.showError('App "' + this.appSpec.info.name + '" has no steps!');
+            if (!this.appSpec.steps || this.appSpec.steps.length === 0) {
+                KBError("App::" + this.appSpec.info.name, "has no steps");
+                this.showError('App "' + this.appSpec.info.name + '" has no steps!');
             }
             // get the list of method ids
             var methodIds = [];
@@ -210,18 +212,17 @@
                               .hide();
             // Reset the inputs and prepare for another "run"
             this.$resetButton = $('<button>')
-              .attr('type', 'button')
-              .attr('value', 'Reset')
-              .addClass('kb-app-run kb-app-reset')
-              .append('Reset')
-              .css({'margin-right':'5px'})
-              .click(
-                $.proxy(function(event) {
-                  self.resetAppRun(true);
+                .attr('type', 'button')
+                .attr('value', 'Reset')
+                .addClass('kb-app-run kb-app-reset')
+                .append('Reset')
+                .css({'margin-right':'5px'})
+                .click(
+                    $.proxy(function(event) {
+                    self.resetAppRun(true);
                 }, this)
-              )
+            )
             .hide();
-
 
             this.$submitted = $('<span>').addClass("kb-func-timestamp").hide();
 
@@ -300,26 +301,26 @@
             this.panel_minimized = false;
             var self = this;
             $controlsSpan.click(function() {
-              if (self.panel_minimized) {
-                console.debug("restore full panel");
-                $mintarget.find(".panel-body").slideDown();
-                $mintarget.find(".panel-footer").show();
-                $minimizeControl.removeClass("glyphicon-chevron-right")
-                                .addClass("glyphicon-chevron-down");
-                // restore original padding (20px)
-                $mintarget.find(".app-panel-heading").css({padding: "20px"});
-                self.panel_minimized = false;
-              }
-              else {
-                console.debug("minimize panel");
-                $mintarget.find(".panel-footer").hide();
-                $mintarget.find(".panel-body").slideUp();
-                $minimizeControl.removeClass("glyphicon-chevron-down")
-                                .addClass("glyphicon-chevron-right");
-                // reduce padding so it lines up
-                $mintarget.find(".app-panel-heading").css({padding: "5px"});
-                self.panel_minimized = true;
-              }
+                if (self.panel_minimized) {
+                    console.debug("restore full panel");
+                    $mintarget.find(".panel-body").slideDown();
+                    $mintarget.find(".panel-footer").show();
+                    $minimizeControl.removeClass("glyphicon-chevron-right")
+                                    .addClass("glyphicon-chevron-down");
+                    // restore original padding (20px)
+                    $mintarget.find(".app-panel-heading").css({padding: "20px"});
+                    self.panel_minimized = false;
+                }
+                else {
+                    console.debug("minimize panel");
+                    $mintarget.find(".panel-footer").hide();
+                    $mintarget.find(".panel-body").slideUp();
+                    $minimizeControl.removeClass("glyphicon-chevron-down")
+                                    .addClass("glyphicon-chevron-right");
+                    // reduce padding so it lines up
+                    $mintarget.find(".app-panel-heading").css({padding: "5px"});
+                    self.panel_minimized = true;
+                }
             });
 
             // finally, we refresh so that our drop down or other boxes can be populated
@@ -327,11 +328,11 @@
         },
 
         minimizePanel: function() {
-          console.debug("minimize panel");
+            console.debug("minimize panel");
         },
 
         showFullPanel: function() {
-          console.debug("restore panel to full size");
+            console.debug("restore panel to full size");
         },
 
         // given a method spec, returns a jquery div that is rendered but not added yet to the dom
@@ -351,12 +352,6 @@
             var $methodInfo = $('<div>')
                               .addClass('kb-func-desc')
                               .append('<h1><b>' + stepHeading +'&nbsp&nbsp-&nbsp '+ stepSpec.info.name + '</b></h1>')
-                              /*.append($('<button>')
-                                      .addClass('btn btn-default btn-xs')
-                                      .attr('type', 'button')
-                                      .attr('data-toggle', 'collapse')
-                                      .attr('data-target', '#' + methodId)
-                                      .append(buttonLabel))*/
                               .append($('<div>')
                                       .attr('id', methodId)
                                       //.addClass('collapse')
@@ -526,39 +521,39 @@
          * Reset parameters and allow to re-run
          */
         resetAppRun: function(clear_inputs) {
-          this.displayRunning(false);
-          // buttons
-          this.$stopButton.hide();
-          this.$resetButton.hide();
-          this.$submitted.hide();
-          // clear inputs
-          if (this.inputSteps) {
-            for(var i=0; i<this.inputSteps.length; i++) {
-              this.inputSteps[i].widget.unlockInputs();
-              this.inputSteps[i].$stepContainer.removeClass('kb-app-step-running');
-              // If invoked from "Reset" button, then clear_inputs will be
-              // true and we need to get back to the original state.
-              // If invoked from "Cancel" button we skip this step and
-              // allow the user to Reset later.
-              if (clear_inputs) {
-                var c = this.inputSteps[i].$stepContainer;
-                // clear text fields
-                c.find("span.kb-parameter-data-selection").text("");
-                // remove old output
-                c.find(".kb-cell-output").remove();
-              }
+            this.displayRunning(false);
+            // buttons
+            this.$stopButton.hide();
+            this.$resetButton.hide();
+            this.$submitted.hide();
+            // clear inputs
+            if (this.inputSteps) {
+                for(var i=0; i<this.inputSteps.length; i++) {
+                    this.inputSteps[i].widget.unlockInputs();
+                    this.inputSteps[i].$stepContainer.removeClass('kb-app-step-running');
+                    // If invoked from "Reset" button, then clear_inputs will be
+                    // true and we need to get back to the original state.
+                    // If invoked from "Cancel" button we skip this step and
+                    // allow the user to Reset later.
+                    if (clear_inputs) {
+                        var c = this.inputSteps[i].$stepContainer;
+                        // clear text fields
+                        c.find("span.kb-parameter-data-selection").text("");
+                        // remove old output
+                        c.find(".kb-cell-output").remove();
+                    }
+                }
             }
-          }
-          if (clear_inputs) {
-            this.setErrorState(false);
-            this.state.runningState.appRunState = "input";
-            this.$runButton.show();
-          }
-          else {
-            this.state.runningState.appRunState = "canceled"; // XXX?
-            this.$runButton.hide();
-            this.$resetButton.show();
-          }
+            if (clear_inputs) {
+                this.setErrorState(false);
+                this.state.runningState.appRunState = "input";
+                this.$runButton.show();
+            }
+            else {
+                this.state.runningState.appRunState = "canceled"; // XXX?
+                this.$runButton.hide();
+                this.$resetButton.show();
+            }
         },
 
         /* unlocks inputs and updates display properties to reflect the not running state */
@@ -573,20 +568,6 @@
                   self.resetAppRun(false);
 
                 }
-/*  Moved to resetAppRun:
-                  this.$stopButton.hide();
-                    this.$runButton.show();
-                    if (this.inputSteps) {
-                        for(var i=0; i<this.inputSteps.length; i++) {
-                            this.inputSteps[i].widget.unlockInputs();
-                            this.inputSteps[i].$stepContainer.removeClass('kb-app-step-running');
-                        }
-                    }
-                    this.setErrorState(false);
-                    this.$submitted.hide();
-                    this.state.runningState.appRunState = "input";
-                }
-*/
             }, this)]);
         },
 
@@ -754,33 +735,33 @@
         },
 
         getNextSteps: function() {
-          console.debug("Find next steps for app",this.appSpec);
-          var method_ids = [ ], app_ids = [ ];
-          // add one or more next steps
-          // XXX: replace this with something much smarter
-          switch (this.appSpec.info.id) {
-            case "genome_assembly":
-              app_ids.push("genome_comparison");
-              app_ids.push("build_fba_model");
-              method_ids.push("insert_genome_into_species_tree_generic");
-              method_ids.push("compare_two_metabolic_models_generic");
-              break;
-            case "build_fba_model":
-              app_ids.push("community_fba_modeling");
-              // ?? Translate Model to New Genome
-              break;
-            case "build_species_tree":
-              method_ids.push("compute_pangenome");
-              break;
-          }
-          // Fetch function specs now because we need the real, human-readable
-          // name of the spec and all we have is the id.
-          var result = {};
-          var params = {apps: app_ids, methods: method_ids};
-          this.trigger('getFunctionSpecs.Narrative', [params, function(specs) {
-            result.specs = specs;
-          }]);
-          return result.specs;
+            console.debug("Find next steps for app",this.appSpec);
+            var method_ids = [ ], app_ids = [ ];
+            // add one or more next steps
+            // XXX: replace this with something much smarter
+            switch (this.appSpec.info.id) {
+                case "genome_assembly":
+                    app_ids.push("genome_comparison");
+                    app_ids.push("build_fba_model");
+                    method_ids.push("insert_genome_into_species_tree_generic");
+                    method_ids.push("compare_two_metabolic_models_generic");
+                    break;
+                case "build_fba_model":
+                    app_ids.push("community_fba_modeling");
+                    // ?? Translate Model to New Genome
+                    break;
+                case "build_species_tree":
+                    method_ids.push("compute_pangenome");
+                    break;
+            }
+            // Fetch function specs now because we need the real, human-readable
+            // name of the spec and all we have is the id.
+            var result = {};
+            var params = {apps: app_ids, methods: method_ids};
+            this.trigger('getFunctionSpecs.Narrative', [params, function(specs) {
+                result.specs = specs;
+            }]);
+            return result.specs;
         },
 
         /*
@@ -814,49 +795,6 @@
                     this.inputStepLookup[stepId].$stepContainer.removeClass("kb-app-step-running");
 
                     var widgetName = this.inputStepLookup[stepId].outputWidgetName;
-
-
-
-                    // var header = '<span class="kb-out-desc">Output</span>' +
-                    //              '<span class="pull-right kb-func-timestamp">' +
-                    //                  this.readableTimestamp(new Date().getTime()) +
-                    //              '</span>';
-
-                    // var $outputWidget = $('<div>');
-                    // var widget;
-                    // try {
-                    //     if (widgetName !== "kbaseDefaultNarrativeOutput")
-                    //         widget = $outputWidget[widgetName](output);
-                    //     else
-                    //         widget = $outputWidget[widgetName]({data:output});
-                    //     if (state) {
-                    //         widget.loadState(state);
-                    //     }
-                    // }
-                    // catch (err) {
-                    //     KBError("App::" + this.appSpec.info.name, "failed to render output widget: '" + widgetName);
-                    //     $outputWidget[this.OUTPUT_ERROR_WIDGET]({'error': {
-                    //         'msg': 'An error occurred while showing your output:',
-                    //         'method_name': 'kbaseNarrativeAppCell.setStepOutput',
-                    //         'type': 'Output',
-                    //         'severity': '',
-                    //         'traceback': 'Failed while trying to show a "' + widgetName + '"\n' +
-                    //                      'With inputs ' + JSON.stringify(output) + '\n\n' +
-                    //                      err.message
-                    //     }});
-                    //     header = header.replace(/\-out\-/, '-err-');
-                    // }
-
-                    // var $outputCell = $("<div>")
-                    //                   .addClass("kb-cell-output")
-                    //                   .css({"padding-top":"5px","padding-bottom":"5px"})
-                    //                   .append(
-                    //                         $('<div>')
-                    //                         .addClass("panel panel-default")
-                    //                         .append($('<div>').addClass("panel-heading").append(header))
-                    //                         .append($('<div>').addClass("panel-body").append($outputWidget))
-                    //                   );
-
                     var $outputWidget = $('<div>').css({'padding':'5px 0'});
                     $outputWidget.kbaseNarrativeOutputCell({
                         widget: widgetName,
@@ -870,8 +808,6 @@
                         $outputWidget.loadState(state);
                     }
                     this.inputStepLookup[stepId].$outputPanel.append($outputWidget);
-//                    this.inputStepLookup[stepId].$outputPanel.append($outputCell);
-
                     this.inputStepLookup[stepId].outputWidget = $outputWidget;
                     var objCopy = $.extend(true, {}, output);
                     this.state.step[stepId].outputState = {
@@ -884,8 +820,6 @@
         setStepError: function(stepId, error) {
             if (this.inputStepLookup) {
                 if(this.inputStepLookup[stepId]) {
-//                    this.inputStepLookup[stepId].$outputPanel.html(error);
-                    // todo: actually render with the error widget
                     this.inputStepLookup[stepId].kbaseNarrativeOutputCell({
                         widget: this.OUTPUT_ERROR_WIDGET,
                         data: error,

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -474,7 +474,6 @@
                     // if it's an NJS job, then it's an App cell, so fetch all that info.
                     if (jobType === "njs") {
                         specInfo = $sourceCell.kbaseNarrativeAppCell('getSpecAndParameterInfo');
-                        console.log(specInfo);
                         if (specInfo && jobIncomplete) {
                             jobParamList.push("['" + jobId + "', " +
                                               "'" + this.safeJSONStringify(specInfo.appSpec) + "', " +
@@ -496,7 +495,7 @@
                             }
                         }
                     }
-                    jobInfo[jobId] = {'spec': specInfo}; //['spec'] = specInfo;
+                    jobInfo[jobId] = { 'spec': specInfo };
                 }
                 else
                     this.jobStates[jobId].status = 'error';
@@ -598,6 +597,7 @@
          * We should also expire jobs in a reasonable time, at least from the Narrative.
          */
         populateJobsPanel: function(fetchedJobStatus, jobInfo) {
+            console.log(fetchedJobStatus, jobInfo);
             if (!this.jobStates || Object.keys(this.jobStates).length === 0) {
                 this.showMessage('No running jobs!');
                 this.setJobCounter(0);

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -804,7 +804,7 @@
                 return;
 
             var $cell = $('#' + source);
-            // don't do anything if we can't find the running cell, either.
+            // don't do anything if we know what the source should be, but we can't find it.
             if (!$cell)
                 return;
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -766,7 +766,7 @@
                         task = jobInfo.spec.methodSpecs[stepSpec.method_id].info.name;
                     }
                 }
-                if (jobState.state && jobState.state.position !== undefined && jobState.state.position !== null)
+                if (jobState.state && jobState.state.position !== undefined && jobState.state.position !== null && jobState.state.position > 0)
                     position = jobState.state.position;
             }
             if (jobState.timestamp) {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -26,7 +26,7 @@
                        timestamp: <str> }
          * }
          */
-        jobStates: {},
+        jobStates: null,
 
         /* when populated should have structure:
          * {
@@ -179,6 +179,8 @@
          * keep track of the job state.
          */
         initJobStates: function() {
+            if (this.jobStates === null)
+                this.jobStates = {};
             if (IPython.notebook && IPython.notebook.metadata && IPython.notebook.metadata.job_ids) {
                 // this is actually like: ['apps': [list of app jobs], 'methods':[list of method jobs]
                 var jobIds = IPython.notebook.metadata.job_ids;
@@ -422,7 +424,7 @@
          * @method
          */
         refresh: function(hideLoadingMessage, initStates) {
-            if (initStates)
+            if (this.jobStates === null || initStates)
                 this.initJobStates();
 
             // if there's no timer, set one up - this should only happen the first time.
@@ -472,6 +474,7 @@
                     // if it's an NJS job, then it's an App cell, so fetch all that info.
                     if (jobType === "njs") {
                         specInfo = $sourceCell.kbaseNarrativeAppCell('getSpecAndParameterInfo');
+                        console.log(specInfo);
                         if (specInfo && jobIncomplete) {
                             jobParamList.push("['" + jobId + "', " +
                                               "'" + this.safeJSONStringify(specInfo.appSpec) + "', " +

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -328,7 +328,7 @@
                         break;
                     case 'error':
                         this.$submitted.html(this.submittedText).show();
-                        this.$cellPanel.addClass('kb-app-step-running');
+                        this.$cellPanel.addClass('kb-app-step-error');
                         this.$runButton.hide();
                         this.$stopButton.show();
                         this.$inputWidget.lockInputs();

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -254,7 +254,8 @@
             for (var i=0; i<widgets.length; i++) {
                 var widgetInfo = widgets[i];
                 var $widgetDiv = $('<div>')
-                                 .css({'height' : height + '%', 'border-bottom' : '5px solid #e0e0e0'});
+                                 .addClass('kb-side-separator')
+                                 .css({'height' : height + '%'});
 
                 retObj[widgetInfo.name] = $widgetDiv[widgetInfo.name](widgetInfo.params);
                 $panelSet.append($widgetDiv);
@@ -267,8 +268,6 @@
             this.initOverlay();
 
             this.$methodsWidget.refreshFromService();
-            setTimeout($.proxy(function() { this.$jobsWidget.refresh(false, true); }, this), 750);
-
         }
 
     })

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -99,6 +99,7 @@
                         this.refreshFunctionInputs(!this.inputsRendered);
                         if (!this.inputsRendered) {
                             this.loadAllRecentCellStates();
+                            this.trigger('refreshJobs.Narrative');
                         }
 
                         this.inputsRendered = true;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/css/override.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/css/override.css
@@ -17,4 +17,7 @@ pre { outline: none; }
 
 .celltoolbar {
     height: auto;
+    background: none;
+    border: none;
+    border-bottom: none;
 }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/css/override.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/css/override.css
@@ -21,3 +21,13 @@ pre { outline: none; }
     border: none;
     border-bottom: none;
 }
+
+div.input_area {
+    border: 1px solid #CECECE;
+    border-radius: 0px;
+}
+
+div.text_cell_input {
+    border: 1px solid #CECECE;
+    border-radius: 0px;
+}


### PR DESCRIPTION
This adjusts a number of style rules to meet issue #161. This also relates to the following tickets:
- https://atlassian.kbase.us/browse/KBASE-1304 - this was a race condition where job lookup attempts happen before a cell's parameters are loaded. When this happens, the job lookup can't map between what are supposed to be user-provided output parameters and what's supposed to be autogenerated by the job result.
- https://atlassian.kbase.us/browse/KBASE-1196 - using red for a running state makes it look like an error. This was changed to blue
- https://atlassian.kbase.us/browse/NAR-421 - removed the styling from code and markdown cell toolbars.

Finally, it removes rounded borders from a few elements that shouldn't have them, so we can keep a little more consistent.