### PR TITLE
Fixed problem where lots of data panel refreshes were attempted and fail...

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -39,9 +39,9 @@
 
             parentControlPanel: null
         },
-
         // private variables
         mainListPanelHeight : '340px',
+        refreshTimer: null,
 
         ws_name: null,
         ws: null,
@@ -123,16 +123,13 @@
             this.data_icons = window.kbconfig.icons.data;
             this.icon_colors = window.kbconfig.icons.colors;
 
-
-
             if (this._attributes.auth) {
                 this.ws = new Workspace(this.options.ws_url, this._attributes.auth);
             }
-            setInterval(function(){self.refresh();}, this.options.refresh_interval); // check if there is new data every X ms
 
             // listener for refresh
             $(document).on('updateDataList.Narrative', function() {
-                self.refresh()
+                self.refresh();
             })
 
             this.showLoading();
@@ -154,6 +151,12 @@
 
         refresh: function() {
             var self = this;
+
+            // Set the refresh timer on the first refresh. From  here, it'll refresh itself
+            // every this.options.refresh_interval (30000) ms
+            if (self.refreshTimer === null) {
+                self.refreshTimer = setInterval(function(){self.refresh();}, this.options.refresh_interval); // check if there is new data every X ms
+            }
             if (self.ws_name && self.ws) {
                 self.ws.get_workspace_info({
                         workspace: this.ws_name
@@ -189,13 +192,13 @@
                     });
             }
             else {
-              var where = "kbaseNarrativeDataList.refresh";
-              if (!self.ws) {
-                KBFatal(where, "Workspace not connected");
-              }
-              else {
-                KBFatal(where, "Workspace name is empty");
-              }
+                var where = "kbaseNarrativeDataList.refresh";
+                if (!self.ws) {
+                    KBFatal(where, "Workspace not connected");
+                }
+                else {
+                    KBFatal(where, "Workspace name is empty");
+                }
             }
         },
 
@@ -1313,7 +1316,8 @@
             //this.user_profile = new UserProfile(this.options.user_profile_url, auth);
             this.my_user_id = auth.user_id;
             this.isLoggedIn = true;
-            this.refresh();
+            if (this.ws_name)
+                this.refresh();
             return this;
         },
 
@@ -1327,7 +1331,8 @@
             this.ws = null;
             this.isLoggedIn = false;
             this.my_user_id = null;
-            this.refresh();
+            if (this.ws_name)
+                this.refresh();
             return this;
         },
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -162,7 +162,8 @@
         loggedInCallback: function(event, auth) {
             this.wsClient = new Workspace(this.options.workspaceURL, auth);
             this.isLoggedIn = true;
-            this.refresh();
+            if (this.ws_name)
+                this.refresh();
             return this;
         },
 
@@ -175,13 +176,15 @@
         loggedOutCallback: function(event, auth) {
             this.wsClient = null;
             this.isLoggedIn = false;
-            this.refresh();
+            this.ws_name = null;
+            // this.refresh();
             return this;
         },
 
         setWorkspace: function(ws_name) {
             this.ws_name = ws_name;
-            this.refresh();
+            if (this.wsClient)
+                this.refresh();
         },
 
         /**
@@ -206,7 +209,7 @@
          * @public
          */
         refresh: function() {
-            this.dataListWidget.refresh();
+//            this.dataListWidget.refresh();
             return;
         },
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -21,10 +21,11 @@
         init: function(options) {
             this._super(options);
 
-            // make sure we pick up the proper config urls
-            if (window.kbconfig && window.kbconfig.urls) {
-                this.options.workspaceURL = window.kbconfig.urls.workspace;
+            if (!window.kbconfig || !window.kbconfig.urls || !window.kbconfig.urls.workspace) {
+                KBFatal('kbaseNarrativeSidePanel.init', 'Failed to load base configuration');
+                return this;
             }
+            this.options.workspaceURL = window.kbconfig.urls.workspace;
 
             var analysisWidgets = this.buildPanelSet([
                 {
@@ -266,7 +267,6 @@
 
         render: function() {
             this.initOverlay();
-
             this.$methodsWidget.refreshFromService();
         }
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -181,9 +181,10 @@
             );
 
             $(document).on('showNextSteps.Narrative',
-              $.proxy(function(event, obj) {
-                this.showNextSteps(obj);
-              }, this));
+                $.proxy(function(event, obj) {
+                    this.showNextSteps(obj);
+                }, this)
+            );
 
             $(document).on('createViewerCell.Narrative',
                 $.proxy(function(event, data) {
@@ -2086,7 +2087,7 @@
             this.loadAllRecentCellStates();
             // Check for older version of data dependencies
             // update them if necessary.
-            this.trigger('updateData.Narrative');
+            // this.trigger('updateData.Narrative');
 
             return this;
         },


### PR DESCRIPTION
...ed noisily on page load.

To refresh, the data list needs both an authenticated workspace client, and the valid workspace to pull from. If it has neither of those, it doesn't try to refresh.

Also, removed a case where both the kbaseNarrativeSidePanel and kbaseNarrativeWorkspace (still ought to be named "kbaseNarrativeController") try to manually refresh the data list on render - that should be done later when the workspace name is set.