### PR TITLE
removed button to open the gallery

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -210,12 +210,12 @@ kb_require(['kbaseMethodGallery'],
                            .click($.proxy(function(event) {
                                this.$searchDiv.slideToggle(400);
                            }, this)));
-            this.addButton($('<button>')
+            /*this.addButton($('<button>')
                            .addClass('btn btn-xs btn-default')
                            .append('<span class="fa fa-arrow-right"></span>')
                            .click($.proxy(function(event) {
                                this.trigger('toggleSidePanelOverlay.Narrative', this.$methodGallery);
-                           }, this)));
+                           }, this)));*/
 
             if (!NarrativeMethodStore) {
                 this.showError('Unable to connect to KBase Method Store!');


### PR DESCRIPTION
We're going to hold off on deploying the gallery until we get more icons and screenshots, so this just drops the button to open it from the UI.

Widgets, etc. still exist for future deployment.