### PR TITLE
Fix for bug in firefox search in data list

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1093,6 +1093,7 @@
                 } else {
                     self.$filterTypeSelect.prepend($('<option value="">').append("Show All Types ("+runningCount+" objects)"));
                 }
+                self.$filterTypeSelect.val("");
             }
         },
 


### PR DESCRIPTION
Apparently dropdowns in firefox pick the first option that has a non-empty value as the default, while in chrome/safari the first option is always selected.  Thus in firefox a type filter was always set at first, but the data isn't filtered as such until another filter event is triggered.  So on search, this causes strange behavior because it looks like everything is there, but then when a search starts the type filter is immediately checked and applied making it seem like some data disappeared when really a hidden filter was on!

Arg!!!!