### PR TITLE
Data panel no longer hides data on network interrupt

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -149,7 +149,7 @@
             this.refresh();
         },
 
-        refresh: function() {
+        refresh: function(showError) {
             var self = this;
 
             // Set the refresh timer on the first refresh. From  here, it'll refresh itself
@@ -182,13 +182,14 @@
                         }
                     },
                     function(error) {
-                        console.error(error);
-
-                        self.$mainListDiv.show();
-                        self.$mainListDiv.empty();
-                        self.$mainListDiv.append($('<div>').css({'color':'#F44336','margin':'10px'})
-                                                 .append('Error: '+error.error.message));
-                        self.hideLoading();
+                        console.error('DataList: when checking for updates:',error);
+                        if (showError) {
+                            self.$mainListDiv.show();
+                            self.$mainListDiv.empty();
+                            self.$mainListDiv.append($('<div>').css({'color':'#F44336','margin':'10px'})
+                                                     .append('Error: Unable to connect to KBase data.'));
+                            self.hideLoading();
+                        }
                     });
             }
             else {


### PR DESCRIPTION
When refreshing narrative data in the background, if the WS cannot be connected, an error doesn't hide the existing view of data.

addresses: https://atlassian.kbase.us/browse/KBASE-1477