### PR TITLE
Adjusted job rendering when there's a non-error status, but an error is ...

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -772,7 +772,7 @@
                 status = this.makeJobErrorButton(jobId, jobInfo, 'Network Error');
             }
             else if (jobState.state && jobState.state.step_errors && Object.keys(jobState.state.step_errors).length !== 0) {
-                var $errBtn = this.makeJobErrorButton(jobId, jobInfo, status);
+                var $errBtn = this.makeJobErrorButton(jobId, jobInfo);
                 status = $('<span>').append(status + ' ')
                                     .append($errBtn);
             }


### PR DESCRIPTION
...present. Now it shows the '!' icon next to the status, as it should.