### PR TITLE
Removed 'viewers' widgets from view, changed default page title

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -7,7 +7,7 @@
 <head>
     <meta charset="utf-8">
 
-    <title>{% block title %}User Testing Narrative{% endblock %}</title>
+    <title>{% block title %}KBase Narrative{% endblock %}</title>
     <link rel="shortcut icon" type="image/x-icon" href="{{static_url("kbase/images/KBase_favicon.ico") }}">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <link rel="stylesheet" href="{{static_url("components/jquery-ui/themes/smoothness/jquery-ui.min.css") }}" type="text/css" />

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -22,7 +22,7 @@ kb_require(['kbaseMethodGallery'],
             methodStoreURL: 'http://dev19.berkeley.kbase.us/narrative_method_store',
             methodHelpLink: '/functional-site/#/narrativestore/method/',
         },
-        ignoreCategories: { 'inactive' : 1, 'importers' : 1 },
+        ignoreCategories: { 'inactive' : 1, 'importers' : 1, 'viewers' : 1 },
         id2Elem: {},
         methodSpecs: {},  // id -> spec
         appSpecs: {},     // id -> spec


### PR DESCRIPTION
Two semi-crucial things here:
1. Hide all non-specified 'viewer' widgets That functionality is duplicated by clicking the data object or doing a drag-and-drop with it.
2. Set the page title from a slightly incorrect User Testing Narrative to KBase Narrative in preparation for production.
