### PR TITLE
Updated release notes, version 1.0.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,15 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the IPython Notebook (more notes will follow).
 
+### Version 1.0.3
+__Changes__
+- JIRA KBASE-1672 - updated text in upload dialogs
+- Added initial Selenium test scripts
+- Updated root README
+
+__Bugfixes__
+- Fixed issue where duplicated results can appear in the Public Data tab
+
 ### Version 1.0.2 - 2/19/2015
 __Bugfixes__
 - JIRA NAR-491 - modified public data panel to get metagenomes of the correct type from the updated search interface

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'mongonbmanager', 'ws_util', 'common', 'kbasewsmanager', 'services']
 
 from semantic_version import Version
-__version__ = Version("1.0.2")
+__version__ = Version("1.0.3")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -66,5 +66,5 @@
         "ws_browser": "https://narrative.kbase.us/functional-site/#/ws"
     }, 
     "release_notes": "https://github.com/kbase/narrative/blob/staging/RELEASE_NOTES.md", 
-    "version": "1.0.2"
+    "version": "1.0.3"
 }


### PR DESCRIPTION
Preliminary 1.0.3 release notes that capture a few minor changes and bugfixes. There will probably be more before the production 1.0.3 deployment, but doing this now to ease the process of testing on narrative-dev.