### PR TITLE
NAR-783 Change update button text

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -232,7 +232,7 @@
                 <span class="kb-navbar-buttons">
                     <button id="kb-update-btn" class="btn btn-default navbar-btn kb-nav-btn kb-nav-btn-upgrade">
                         <div class="fa fa-refresh fa-spin"></div>
-                        <div class="kb-nav-btn-txt">New Version Available!</div>
+                        <div class="kb-nav-btn-txt">Get new version!</div>
                     </button>
                     <div class="btn-group">
                         <button id="kb-ipy-menu" class="btn btn-default navbar-btn kb-nav-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -340,9 +340,6 @@ Narrative.prototype.checkVersion = function($newVersion) {
         error: function(err) {
             console.error('Error while checking for a version update: ' + err);
             KBError('Narrative.checkVersion', 'Unable to check for a version update!');
-            var ver = {"git_hash":"b3908de","version":"1.0.3b"};
-            $newVersion.empty().append('<b>' + ver.version + '</b>');
-            $('#kb-update-btn').fadeIn('fast'); 
         },
     });
 };

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -337,9 +337,13 @@ Narrative.prototype.checkVersion = function($newVersion) {
                 $('#kb-update-btn').fadeIn('fast'); 
             }
         },
-        fail: function(err) {
-            console.log('err');
-        }
+        error: function(err) {
+            console.error('Error while checking for a version update: ' + err);
+            KBError('Narrative.checkVersion', 'Unable to check for a version update!');
+            var ver = {"git_hash":"b3908de","version":"1.0.3b"};
+            $newVersion.empty().append('<b>' + ver.version + '</b>');
+            $('#kb-update-btn').fadeIn('fast'); 
+        },
     });
 };
 


### PR DESCRIPTION
This changes the update button text to read "Get new version!" which is more actionable, and clearly prompts the user to click there, as opposed to the more passive "New Version Available!" text.