### PR TITLE
Modify save error messaging.

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -454,9 +454,9 @@ Narrative.prototype.init = function() {
         // currently - 4/6/2015 - there's a hard limit of 4MB per KBase Narrative.
         // Any larger object will throw a 413 error, and we need to show some text.
         if (data.xhr.status === 413) {
-            errorText = 'Due to current system constraints, a Narrative may not exceed 4 MB of text.<br>' +
-                        'Errors of this sort are usually due to excessive size of outputs from code cells, ' +
-                        'or from '
+            errorText = 'Due to current system constraints, a Narrative may not exceed 4 MB of text.<br><br>' +
+                        'Errors of this sort are usually due to excessive size of outputs from Code Cells, ' +
+                        'or from large objects embedded in Markdown Cells.<br><br>' +
                         'Please decrease the document size and try to save again.';
         }
         else if (data.xhr.responseText) {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -232,6 +232,7 @@ var KBFatal = function(where, what) {
  * specific piece of functionality. See Narrative.prototype.saveNarrative below.
  */
 var Narrative = function() {
+    this.maxNarrativeSize = "4 MB";
     this.narrController = null;
     this.readonly = false; /* whether whole narrative is read-only */
     this.authToken = null;
@@ -454,9 +455,11 @@ Narrative.prototype.init = function() {
         // currently - 4/6/2015 - there's a hard limit of 4MB per KBase Narrative.
         // Any larger object will throw a 413 error, and we need to show some text.
         if (data.xhr.status === 413) {
-            errorText = 'Due to current system constraints, a Narrative may not exceed 4 MB of text.<br><br>' +
-                        'Errors of this sort are usually due to excessive size of outputs from Code Cells, ' +
-                        'or from large objects embedded in Markdown Cells.<br><br>' +
+            errorText = 'Due to current system constraints, a Narrative may not exceed ' + 
+                        this.maxNarrativeSize + ' of text.<br><br>' +
+                        'Errors of this sort are usually due to excessive size ' + 
+                        'of outputs from Code Cells, or from large objects ' + 
+                        'embedded in Markdown Cells.<br><br>' +
                         'Please decrease the document size and try to save again.';
         }
         else if (data.xhr.responseText) {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -443,6 +443,67 @@ Narrative.prototype.init = function() {
     this.initAboutDialog();
     this.initUpgradeDialog();
 
+    // Override the base IPython event that happens when a notebook fails to save.
+    $([IPython.events]).on('notebook_save_failed.Notebook', function(event, data) {
+        IPython.save_widget.set_save_status('Narrative save failed!');
+        console.log(event);
+        console.log(data);
+
+        var errorText;
+        // 413 means that the Narrative is too large to be saved.
+        // currently - 4/6/2015 - there's a hard limit of 4MB per KBase Narrative.
+        // Any larger object will throw a 413 error, and we need to show some text.
+        if (data.xhr.status === 413) {
+            errorText = 'Due to current system constraints, a Narrative may not exceed 4 MB of text.<br>' +
+                        'Errors of this sort are usually due to excessive size of outputs from code cells, ' +
+                        'or from '
+                        'Please decrease the document size and try to save again.';
+        }
+        else if (data.xhr.responseText) {
+            var $error = $($.parseHTML(data.xhr.responseText));
+            errorText = $error.find('#error-message > h3').text();
+
+            if (errorText) {
+                /* gonna throw in a special case for workspace permissions issues for now.
+                 * if it has this pattern:
+                 * 
+                 * User \w+ may not write to workspace \d+
+                 * change the text to something more sensible.
+                 */
+
+                var res = /User\s+(\w+)\s+may\s+not\s+write\s+to\s+workspace\s+(\d+)/.exec(errorText);
+                if (res) {
+                    errorText = "User " + res[1] + " does not have permission to save to workspace " + res[2] + ".";
+                }
+            }
+        }
+        else {
+            errorText = 'An unknown error occurred!';
+        }
+
+        IPython.dialog.modal({
+            title: "Narrative save failed!",
+            body: $('<div>').append(errorText),
+            buttons : {
+                "OK": {
+                    class: "btn-primary",
+                    click: function () {
+                    }
+                }
+            },
+            open : function (event, ui) {
+                var that = $(this);
+                // Upon ENTER, click the OK button.
+                that.find('input[type="text"]').keydown(function (event, ui) {
+                    if (event.which === utils.keycodes.ENTER) {
+                        that.find('.btn-primary').first().click();
+                    }
+                });
+                that.find('input[type="text"]').focus();
+            }
+        });
+    });
+
     $('[data-toggle="tooltip"]').tooltip();
     /*
      * Before we get everything loading, just grey out the whole %^! page

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -445,7 +445,7 @@ Narrative.prototype.init = function() {
     this.initUpgradeDialog();
 
     // Override the base IPython event that happens when a notebook fails to save.
-    $([IPython.events]).on('notebook_save_failed.Notebook', function(event, data) {
+    $([IPython.events]).on('notebook_save_failed.Notebook', $.proxy(function(event, data) {
         IPython.save_widget.set_save_status('Narrative save failed!');
         console.log(event);
         console.log(data);
@@ -505,7 +505,7 @@ Narrative.prototype.init = function() {
                 that.find('input[type="text"]').focus();
             }
         });
-    });
+    }, this));
 
     $('[data-toggle="tooltip"]').tooltip();
     /*

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/js/savewidget.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/notebook/js/savewidget.js
@@ -46,58 +46,7 @@ var IPython = (function (IPython) {
             that.update_document_title();
         });
         $([IPython.events]).on('notebook_save_failed.Notebook', function (event, data) {
-            that.set_save_status('Narrative save failed!');
-            console.log(event);
-            console.log(data);
-
-            var errorText;
-            if (data.xhr.responseText) {
-                var $error = $($.parseHTML(data.xhr.responseText));
-                errorText = $error.find('#error-message > h3').text();
-
-                /* gonna throw in a special case for workspace permissions issues for now.
-                 * if it has this pattern:
-                 * 
-                 * User \w+ may not write to workspace \d+
-                 * change the text to something more sensible.
-                 */
-
-                var res = /User\s+(\w+)\s+may\s+not\s+write\s+to\s+workspace\s+(\d+)/.exec(errorText);
-                if (res) {
-                    errorText = "User " + res[1] + " does not have permission to save to workspace " + res[2] + ".";
-                }
-
-            }
-            else {
-                errorText = 'An unknown error occurred!';
-            }
-
-            IPython.dialog.modal({
-                title: "Narrative save failed!",
-                body: $('<div>').append(errorText),
-                buttons : {
-                    "OK": {
-                        class: "btn-primary",
-                        click: function () {
-                        }
-                    }
-                },
-                open : function (event, ui) {
-
-
-                    var that = $(this);
-                    // Upon ENTER, click the OK button.
-                    that.find('input[type="text"]').keydown(function (event, ui) {
-                        if (event.which === utils.keycodes.ENTER) {
-                            that.find('.btn-primary').first().click();
-                        }
-                    });
-                    that.find('input[type="text"]').focus();
-                }
-            });
-
-
-
+            that.set_save_status('Autosave Failed!');
         });
         $([IPython.events]).on('checkpoints_listed.Notebook', function (event, data) {
             that.set_last_checkpoint(data[0]);


### PR DESCRIPTION
This change does two things.

1. It pulls out some hacky things that were injected into the IPython notebooks savewidget.js, and puts them where they belong.

2. It addresses a special error condition we've come across (https://atlassian.kbase.us/browse/KBASE-1843) where a Narrative object that is too large gets rejected by Nginx with a 413 error (Request entity too large). Currently, the maximum Narrative object size is set to 4 MB, which is pretty substantial, but we should have a discussion to decide what's actually reasonable. The Workspace can handle objects of nearly any size - several megabytes is no big deal - but this does create a performance cost on the front end.

Partly, I'm of the "caveat emptor" mindset that we should let the user do what they like and absorb the consequences, but this might also put undue pressure on the rest of the system to be performant in a way that isn't fair. For example, it might make sense to append large TIFF images of slides or tissue sections (for example), or videos of colony growth, but those should probably not be part of the Narrative object itself.

Likewise, if a user fetches a large data object via the API and looks at it in a code cell (the method I used to replicate the error and deal with it), that should probably not be saved separately. Then again, users will be able to do all sorts of things with code cells and shouldn't really be stopped by maximum Narrative sizes.

I think it's still up for discussion what an appropriate max size should be for a Narrative object, but these code changes will support it. Currently, this is set as an Nginx parameter and needs to be configured in kbaseNarrative.js. The next PR will factor that out into an external configuration. I think it's worth refactoring the config file itself all together, which is why that's not part of this.