### PR TITLE
Base image fix

### DIFF
--- a/buildNarrativeContainer.sh
+++ b/buildNarrativeContainer.sh
@@ -5,7 +5,7 @@ DS=$( date +%Y%m%d%H%M )
 
 # This is the name for now, as this is what the Lua provisioner looks for to fire up a Narrative.
 NAR_NAME="kbase/narrative"
-NAR_BASE="base2.0"
+NAR_BASE="base3.0"
 
 # Update the git submodule(s)
 git submodule init

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -24,23 +24,49 @@ RUN mkdir -p /kb/deployment/services/narrative /tmp/narrative
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
 RUN echo 'deb http://cran.cnr.berkeley.edu/bin/linux/ubuntu trusty/' | tee /etc/apt/sources.list.d/cran.list
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y mesa-common-dev libglu1-mesa-dev
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y r-recommended
-
 # There are a bunch of packages that are related to kernel operation
 # which we can't upgrade within a container. Mark them for "hold" before
 # running the upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-mark hold udev initscripts plymouth initramfs-tools procps busybox-initramfs
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+apt-mark hold udev initscripts plymouth initramfs-tools procps busybox-initramfs
 RUN DEBIAN_FRONTEND=noninteractive apt-get -f upgrade -y
 
 # Install the stuff we actually need
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y perl-base perl-modules make
-
-# Maybe this will get all the necessary dependencies!
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python-qt4 python-pip python-setuptools ipython-notebook python-matplotlib python-dev python-scipy python-numpy python-lxml python-sklearn python-sympy python-pandas python-rpy2 python-virtualenv python-thrift python-yaml python-paramiko
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libfreetype6-dev libcairo2-dev texlive-latex-base texlive-fonts-recommended curl libcurl4-gnutls-dev git-core libzmq-dev libreadline6-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+perl-base \
+perl-modules \
+make \
+python-qt4 \
+python-pip \
+python-setuptools \
+ipython-notebook \
+python-matplotlib \
+python-dev \
+python-scipy \
+python-numpy \
+python-lxml \
+python-sklearn \
+python-sympy \
+python-pandas \
+python-rpy2 \
+python-virtualenv \
+python-thrift \
+python-yaml \
+python-paramiko \
+libfreetype6-dev \
+libcairo2-dev \
+texlive-latex-base \
+texlive-fonts-recommended \
+curl \
+libcurl4-gnutls-dev \
+git-core \
+libzmq-dev \
+libreadline6-dev \
+libreadline-dev \
+libssl-dev \
+libxml2-dev \
+libxslt1-dev
 
 # Pip is currently broken when installed through Ubuntu. Upgrade it with easy_install 
 RUN easy_install -U pip

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -22,7 +22,7 @@ RUN mkdir -p /kb/deployment/services/narrative /tmp/narrative
 
 # Add the R CRAN repo - add this back in when the 3.1-beta issue is resolved
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-RUN echo 'deb http://cran.cnr.berkeley.org/bin/linux/ubuntu trusty/' | tee /etc/apt/sources.list.d/cran.list
+RUN echo 'deb http://cran.cnr.berkeley.edu/bin/linux/ubuntu trusty/' | tee /etc/apt/sources.list.d/cran.list
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 
@@ -39,11 +39,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -f upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y perl-base perl-modules make
 
 # Maybe this will get all the necessary dependencies!
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python-qt4 python-pip python-setuptools ipython-notebook python-matplotlib python-dev python-scipy python-numpy python-lxml python-sklearn python-sympy python-pandas python-rpy2 python-virtualenv
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python-qt4 python-pip python-setuptools ipython-notebook python-matplotlib python-dev python-scipy python-numpy python-lxml python-sklearn python-sympy python-pandas python-rpy2 python-virtualenv python-thrift python-yaml python-paramiko
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libfreetype6-dev libcairo2-dev texlive-latex-base texlive-fonts-recommended curl libcurl4-gnutls-dev git-core libzmq-dev libreadline6-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev
 
 # There's a bug in the current repository deployment of python requests - do an easy_install of v2.3.0, or pip will fail
-RUN easy_install requests==2.3.0
+# <testing if this is still necessary>
+# RUN easy_install requests==2.3.0
+
+# Pip is currently broken when installed through Ubuntu. Upgrade it with easy_install 
+RUN easy_install -U pip
 
 # install R packages that seem to be handy
 RUN R --vanilla < /root/r-packages.R

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -42,10 +42,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y perl-base perl-modules mak
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python-qt4 python-pip python-setuptools ipython-notebook python-matplotlib python-dev python-scipy python-numpy python-lxml python-sklearn python-sympy python-pandas python-rpy2 python-virtualenv python-thrift python-yaml python-paramiko
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libfreetype6-dev libcairo2-dev texlive-latex-base texlive-fonts-recommended curl libcurl4-gnutls-dev git-core libzmq-dev libreadline6-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev
 
-# There's a bug in the current repository deployment of python requests - do an easy_install of v2.3.0, or pip will fail
-# <testing if this is still necessary>
-# RUN easy_install requests==2.3.0
-
 # Pip is currently broken when installed through Ubuntu. Upgrade it with easy_install 
 RUN easy_install -U pip
 

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -11,7 +11,7 @@
 # Made available under the KBase Open Source License
 #
 
-FROM kbase/narrative:base2.0
+FROM kbase/narrative:base3.0
 MAINTAINER Bill Riehl wjriehl@lbl.gov
 
 EXPOSE 8888
@@ -21,8 +21,6 @@ ADD ./narrative/docker/sources.list /etc/apt/sources.list
 # Copy in the narrative repo
 ADD ./narrative /kb/dev_container/narrative
 ADD ./narrative/kbase-logdb.conf /tmp/kbase-logdb.conf
-RUN apt-get update
-RUN apt-get install -y python-virtualenv python-thrift python-yaml python-paramiko
 RUN cd /kb/dev_container/narrative; /bin/bash old-install.sh -p /kb/deployment/services narrative
 RUN cd /tmp/narrative
 

--- a/docker/Dockerfile.update
+++ b/docker/Dockerfile.update
@@ -16,8 +16,6 @@ MAINTAINER Bill Riehl wjriehl@lbl.gov
 
 EXPOSE 8888
 
-ADD ./narrative/docker/sources.list /etc/apt/sources.list
-
 # Copy in the narrative repo
 ADD ./narrative /kb/dev_container/narrative
 ADD ./narrative/kbase-logdb.conf /tmp/kbase-logdb.conf


### PR DESCRIPTION
This addresses https://atlassian.kbase.us/browse/NAR-391 where the base Docker image was failing to build. There were a couple of main errors going on here:

1. The R repository used was set to .org instead of .edu, so it was defaulting to Ubuntu, meaning that most packages were out of date.
2. The automatic pip installation through apt (apt-get install python-pip) results in an unusable pip. Updating it with easy_install fixes it for now, will revert once the official Ubuntu fix is made.
3. An earlier bug (that was actually fixed! but masked by the above two) was fixed. The public ANL Ubuntu mirror was taken down - this was replaced by the PNL mirror.