### PR TITLE
Fix error text when a narrative is unavailable

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/notfound.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/notfound.html
@@ -19,14 +19,12 @@
         }
     </style>
 
-    <h1>Narrative object (<small>{{ narr_id }}</small>) not found, or you do not have permissions to read
+    <h1>Narrative object (<small>{{ narr_id }}</small>) not found, or you do not have permission to read
         it.</h1>
     <p>Please click the back button to return to the previous page, or
-      <a href="{{base_project_url}}">click here</a> to go to the home page.
+      <a href="/">click here</a> to go to the home page.
     </p>
     <br/>
-    <p>If you think this is an error, please notify <a href="mailto:help@kbase.us"
-      target="_blank">help@kbase.us</a>.
-
+    <p>If you think this is an error, please <a href="http://kbase.us/contact-us/">contact us</a>.
     </p>
 {% endblock %}


### PR DESCRIPTION
See https://atlassian.kbase.us/browse/KBASE-2042

When a Narrative is unavailable - whether it doesn't exist, or a user doesn't have permission to see it - this template is displayed. This fixes a typo and a couple out of date links on that page.