### PR TITLE
Added Travis-CI and Coveralls badges to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kbase/narrative?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+| Branch | Status |
+| :--- | :--- |
+| master | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=master)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=master)](https://coveralls.io/r/kbase/narrative?branch=master) |
+| staging | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=staging)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=staging)](https://coveralls.io/r/kbase/narrative?branch=staging) |
+| develop | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=develop)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=develop)](https://coveralls.io/r/kbase/narrative?branch=develop)|
+
 This is the repository for the KBase Narrative Interface.
 
 ## About


### PR DESCRIPTION
Minor fix. Now that Travis and Coveralls are set up to deal with the Narrative, this adds a status badge for each of the branches of note - develop, staging, and master.