### PR TITLE
Config change in docker.lua

### DIFF
--- a/docker/docker.lua
+++ b/docker/docker.lua
@@ -31,7 +31,7 @@ local function config()
 		    Dns = json.util.null,
 		    Image = "base",
 		    Volumes = {},
-		    VolumesFrom = "",
+		    VolumesFrom = json.util.null,
 		    WorkingDir = ""
 		 }
    config.Volumes['/dev/log'] = {}


### PR DESCRIPTION
There may have been a change in how the VolumesFrom config option is interpreted by the lua code.  It used to be that an empty string would work, but the variable is supposed to be an array, and the empty string is now an error.  json.util.null populates VolumesFrom with an empty array.