### PR TITLE
Nar 804 race condition

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/custom/custom.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/custom/custom.js
@@ -47,7 +47,7 @@
  */
 
 console.log('Loading KBase Narrative setup routine.');
-$([IPython.events]).on('app_initialized.NotebookApp', function() {
+$([IPython.events]).one('notebook_loaded.Notebook', function() {
     console.log('Performing narrative startup');
     require(['kbaseNarrative'], function(Narrative) {
         IPython.narrative = new Narrative();

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -308,7 +308,7 @@ Narrative.prototype.init = function() {
      * Once everything else is loaded and the Kernel is idle,
      * Go ahead and fill in the rest of the Javascript stuff.
      */
-    $([IPython.events]).one('status_idle.Kernel', $.proxy(function() {
+    // $([IPython.events]).one('status_idle.Kernel', $.proxy(function() {
         /*
          * Before we get everything loading, just grey out the whole %^! page
          */
@@ -364,7 +364,7 @@ Narrative.prototype.init = function() {
         else {
             KBFatal("Narrative.init", "Unable to locate workspace name from the Narrative object!");
         }
-    }, this));
+    // }, this));
 };
 
 Narrative.prototype.updateVersion = function() {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -8,8 +8,12 @@
  */
 "use strict";
 
-define(['jquery', 'kbaseNarrativeSidePanel', 
-        'kbaseNarrativeOutputCell', 'kbaseNarrativeWorkspace'], 
+define(['jquery', 
+        'kbaseNarrativeSidePanel', 
+        'kbaseNarrativeOutputCell', 
+        'kbaseNarrativeWorkspace',
+        'kbaseNarrativePrestart',
+        'bootstrap'], 
         function($) {
 
 /**
@@ -308,63 +312,61 @@ Narrative.prototype.init = function() {
      * Once everything else is loaded and the Kernel is idle,
      * Go ahead and fill in the rest of the Javascript stuff.
      */
-    // $([IPython.events]).one('status_idle.Kernel', $.proxy(function() {
+
+    // NAR-271 - Firefox needs to be told where the top of the page is. :P
+    window.scrollTo(0,0);
+    
+    IPython.notebook.set_autosave_interval(0);
+    require(['ipythonCellMenu'], function() {
+        IPython.CellToolbar.activate_preset("KBase");
+    });
+
+    this.ws_name = null;
+    if (IPython && IPython.notebook && IPython.notebook.metadata) {
+        this.ws_name = IPython.notebook.metadata.ws_name;
+        var narrname = IPython.notebook.notebook_name;
+        var username = IPython.notebook.metadata.creator;
+        $('#kb-narr-name #name').text(narrname);
+        $('#kb-narr-creator').text(username);
+        $('.kb-narr-namestamp').css({'display':'block'});
+
+        var token = null;
+        if (window.kb && window.kb.token)
+            token = window.kb.token;
+
+        $.ajax({
+            type: 'GET',
+            url: 'https://kbase.us/services/genome_comparison/users?usernames=' + username + '&token=' + token,
+            dataType: 'json',
+            crossDomain: true,
+            success: function(data, res, jqXHR) {
+                if (username in data.data && data.data[username].fullName) {
+                    var fullName = data.data[username].fullName;
+                    $('#kb-narr-creator').text(fullName + ' (' + username + ')');
+                }
+            }
+        });
+
+        // This puts the cell menu in the right place.
+        $([IPython.events]).trigger('select.Cell', {cell: IPython.notebook.get_selected_cell()});
+    }
+    if (this.ws_name) {
+        /* It's ON like DONKEY KONG! */
+        $('a#workspace-link').attr('href', $('a#workspace-link').attr('href') + 'objects/' + this.ws_name);
+        this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({
+            loadingImage: "/static/kbase/images/ajax-loader.gif",
+            ws_id: IPython.notebook.metadata.ws_name
+        });
         /*
          * Before we get everything loading, just grey out the whole %^! page
          */
         var $sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
-
-        // NAR-271 - Firefox needs to be told where the top of the page is. :P
-        window.scrollTo(0,0);
-        
-        IPython.notebook.set_autosave_interval(0);
-        require(['ipythonCellMenu'], function() {
-            IPython.CellToolbar.activate_preset("KBase");
-        });
-
-        this.ws_name = null;
-        if (IPython && IPython.notebook && IPython.notebook.metadata) {
-            this.ws_name = IPython.notebook.metadata.ws_name;
-            var narrname = IPython.notebook.notebook_name;
-            var username = IPython.notebook.metadata.creator;
-            $('#kb-narr-name #name').text(narrname);
-            $('#kb-narr-creator').text(username);
-            $('.kb-narr-namestamp').css({'display':'block'});
-
-            var token = null;
-            if (window.kb && window.kb.token)
-                token = window.kb.token;
-
-            $.ajax({
-                type: 'GET',
-                url: 'https://kbase.us/services/genome_comparison/users?usernames=' + username + '&token=' + token,
-                dataType: 'json',
-                crossDomain: true,
-                success: function(data, res, jqXHR) {
-                    if (username in data.data && data.data[username].fullName) {
-                        var fullName = data.data[username].fullName;
-                        $('#kb-narr-creator').text(fullName + ' (' + username + ')');
-                    }
-                }
-            });
-
-            // This puts the cell menu in the right place.
-            $([IPython.events]).trigger('select.Cell', {cell: IPython.notebook.get_selected_cell()});
-        }
-        if (this.ws_name) {
-            /* It's ON like DONKEY KONG! */
-            $('a#workspace-link').attr('href', $('a#workspace-link').attr('href') + 'objects/' + this.ws_name);
-            this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({
-                loadingImage: "/static/kbase/images/ajax-loader.gif",
-                ws_id: IPython.notebook.metadata.ws_name
-            });
-            $sidePanel.render();
-            $(document).trigger('setWorkspaceName.Narrative', {'wsId' : this.ws_name, 'narrController': this.narrController});
-        }
-        else {
-            KBFatal("Narrative.init", "Unable to locate workspace name from the Narrative object!");
-        }
-    // }, this));
+        $sidePanel.render();
+        $(document).trigger('setWorkspaceName.Narrative', {'wsId' : this.ws_name, 'narrController': this.narrController});
+    }
+    else {
+        KBFatal("Narrative.init", "Unable to locate workspace name from the Narrative object!");
+    }
 };
 
 Narrative.prototype.updateVersion = function() {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeLogin.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeLogin.js
@@ -5,7 +5,9 @@
  * @author Bill Riehl wjriehl@lbl.gov
  */
 
-define(['jquery', 'kbaseLogin'], function($) {
+define(['jquery', 
+        'kbaseLogin', 
+        'kbapi'], function($) {
 // (function( $, undefined ) {
 
     $(function() {


### PR DESCRIPTION
This addresses NAR-804 - a race condition failure that sometimes happens on Narrative startup.

The issue is that the KBase code is loaded asynchronously, but still requires that IPython code is present, and certain events are fired at the right time. Specifically, it was set that the Narrative code waited for the first status_idle.Kernel event to be kicked off before starting up. This ensured that everything was in place before starting, including auth info and workspace info.

This PR fixes the problem by doing two things.
1. Load the KBase startup code in custom.js before running the IPython main function. This registers the needed event listeners at the right time.
2. Use the notebook_loaded.Notebook event, which is fired once when the notebook is successfully loaded.

This will all be obsolete when the upgrade to IPython 3 is complete, since that loads everything asynchronously and allows the dependencies to be much more explicit. But this should patch things for a release.