### PR TITLE
Adjust load order and configuration loading.

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -60,8 +60,6 @@
     <script src="{{ static_url("kbase/js/ui-common/ext/requirejs/2.1.9/require.js") }}" data-main="{{ static_url("narrative_paths") }}"></script>
     <!-- endbuild -->
 
-    <!-- // <script src="{{ static_url("kbase/js/ui-common/ext/requirejs/2.1.9/require.js") }}" data-main="{{ static_url("narrative_paths") }}"></script> -->
-    <!-- // <script src="{{ static_url("kbase/js/ui-common/ext/requirejs/2.1.9/require.js") }}" data-main="{{ static_url("dist/kbase-narrative-built") }}"></script> -->
     <script>
         var kb_use_require = true;
         var kb_norequire = function(deps, callback) {
@@ -228,46 +226,46 @@
 
 
     <script>
-        // Dumb thing to get the workspace ID just like the back end does - from the URL at startup.
-        // This snippet keeps the workspace ID local, so it shouldn't be changed if someone pokes at the URL
-        // before trying to fetch it again.
-        var workspaceId = null;
-        var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-        if (m && m.length > 1)
-            workspaceId = parseInt(m[1]);
+        // // Dumb thing to get the workspace ID just like the back end does - from the URL at startup.
+        // // This snippet keeps the workspace ID local, so it shouldn't be changed if someone pokes at the URL
+        // // before trying to fetch it again.
+        // var workspaceId = null;
+        // var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
+        // if (m && m.length > 1)
+        //     workspaceId = parseInt(m[1]);
 
-        var configJSON = $.parseJSON(
-            $.ajax({
-                url: "{{ static_url('kbase/config.json') }}",
-                async: false,
-                dataType: 'json',
-                cache: false
-            }).responseText
-        );
-        var landingPageMap = {}; 
-        /*
-        we no longer use the crazy landing page map, but keep the variable here
-        so things we don't know about don't break
-        */
-        var icons = $.parseJSON(
-          $.ajax({
-            url: "{{ static_url('kbase/icons.json') }}",
-            async: false,
-            dataType: 'json',
-            cache: false
-          }).responseText
-        );
-        window.kbconfig = { urls: configJSON[configJSON['config']],
-                            version: configJSON['version'],
-                            name: configJSON['name'],
-                            git_commit_hash: configJSON['git_commit_hash'],
-                            git_commit_time: configJSON['git_commit_time'],
-                            landing_page_map: landingPageMap,
-                            release_notes: configJSON['release_notes'],
-                            mode: configJSON['mode'],
-                            icons: icons,
-                            workspaceId: workspaceId
-                          };
+        // var configJSON = $.parseJSON(
+        //     $.ajax({
+        //         url: "{{ static_url('kbase/config.json') }}",
+        //         async: false,
+        //         dataType: 'json',
+        //         cache: false
+        //     }).responseText
+        // );
+        // var landingPageMap = {}; 
+        // /*
+        // we no longer use the crazy landing page map, but keep the variable here
+        // so things we don't know about don't break
+        // */
+        // var icons = $.parseJSON(
+        //   $.ajax({
+        //     url: "{{ static_url('kbase/icons.json') }}",
+        //     async: false,
+        //     dataType: 'json',
+        //     cache: false
+        //   }).responseText
+        // );
+        // window.kbconfig = { urls: configJSON[configJSON['config']],
+        //                     version: configJSON['version'],
+        //                     name: configJSON['name'],
+        //                     git_commit_hash: configJSON['git_commit_hash'],
+        //                     git_commit_time: configJSON['git_commit_time'],
+        //                     landing_page_map: landingPageMap,
+        //                     release_notes: configJSON['release_notes'],
+        //                     mode: configJSON['mode'],
+        //                     icons: icons,
+        //                     workspaceId: workspaceId
+        //                   };
     </script>
 
     <script src="{{ static_url("base/js/namespace.js") }}" type="text/javascript" charset="utf-8"></script>

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -6,15 +6,27 @@
  *
  * To set global variables, use: IPython.narrative.<name> = value
  */
-"use strict";
 
-define(['jquery', 
-        'kbaseNarrativeSidePanel', 
-        'kbaseNarrativeOutputCell', 
-        'kbaseNarrativeWorkspace',
-        'kbaseNarrativePrestart',
-        'bootstrap'], 
-        function($) {
+define([
+    'jquery', 
+    'kbaseNarrativeSidePanel', 
+    'kbaseNarrativeOutputCell', 
+    'kbaseNarrativeWorkspace',
+    'kbaseNarrativeMethodCell',
+    'narrativeLogin',
+    'kbase-client-api',
+    'kbaseNarrativePrestart',
+    'ipythonCellMenu'
+], function($, 
+            kbaseNarrativeSidePanel,
+            kbaseNarrativeOutputCell,
+            kbaseNarrativeWorkspace,
+            kbaseNarrativeMethodCell,
+            narrativeLogin,
+            kbaseClient,
+            kbaseNarrativePrestart,
+            kbaseCellToolbar) {
+    "use strict";
 
 /**
  * @constructor

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeConfig.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeConfig.js
@@ -1,0 +1,66 @@
+/**
+ * Loads the required narrative configuration files.
+ * This returns a Promise that will eventually hold the results.
+ * This should mainly be invoked by the starting app, then
+ * that result should be injected where necessary.
+ *
+ * @author Bill Riehl <wjriehl@lbl.gov>
+ * @class narrativeConfig
+ * @module Narrative
+ * @static
+ */
+define(['jquery'], function($) {
+    "use strict";
+
+    var deferred = new $.Deferred();
+
+    // Dumb thing to get the workspace ID just like the back end does - from the URL at startup.
+    // This snippet keeps the workspace ID local, so it shouldn't be changed if someone pokes at the URL
+    // before trying to fetch it again.
+    var workspaceId = null;
+    var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
+    if (m && m.length > 1)
+        workspaceId = parseInt(m[1]);
+
+    var configProm = $.ajax({
+        url: '/static/kbase/config.json',
+        dataType: 'json',
+        cache: false
+    });
+    var iconsProm = $.ajax({
+        url: '/static/kbase/icons.json',
+        dataType: 'json',
+        cache: false
+    });
+
+    $.when(configProm, iconsProm).done(
+        // configRes and iconsRes are the arguments resolved from their respective lookups.
+        // they are both arrays with the structure [data, statustext, jqXHR]
+        function loadedConfig(configRes, iconsRes) {
+            var configSet = configRes[0];
+            var iconsSet = iconsRes[0];
+            var config = {
+                urls:            configSet[configSet['config']],
+                version:         configSet['version'],
+                name:            configSet['name'],
+                git_commit_hash: configSet['git_commit_hash'],
+                git_commit_time: configSet['git_commit_time'],
+                // landing_page_map:landingPageMap,
+                release_notes:   configSet['release_notes'],
+                mode:            configSet['mode'],
+                icons:           iconsSet,
+                workspaceId:     workspaceId,
+                loading_gif:     configSet['loading_gif']
+            }
+            deferred.resolve(config);
+        }
+    ).fail(
+        function failedConfig(configFail, iconFail) {
+            console.err('Fatal error - unable to load configuration.');
+            // include other fatal error stuff here - should log the error.
+            deferred.reject(null);
+        }
+    );
+
+    return deferred.promise();
+});

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeMain.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeMain.js
@@ -1,0 +1,59 @@
+/**
+ * A little wrapper script for making sure that Narrative code 
+ * is injected at the right time before loading the Notebook running
+ * code.
+ * 
+ * Mainly, we need to load up a configuration, then make
+ * sure that the other Narrative JS widgets are loaded *first*, 
+ * because they're referenced from within Markdown cells at Notebook
+ * load time.
+ * 
+ * I'm not thrilled about this, but if this isn't done, then our GUI
+ * method/app/output widget cells are replaced by ReferenceErrors.
+ *
+ * Once this step is complete, the notebook main is run, and the
+ * actual KBase Narrative startup code is instantiated in custom.js,
+ * where is all ought to be. This is a ***temporary*** solution, 
+ * until we migrate our Frankenstein'd markdown cells to proper
+ * output cells.
+ *
+ * @author Bill Riehl <wjriehl@lbl.gov>
+ * @module narrative
+ * @class narrativeMain
+ * @static
+ */
+
+require([
+    'jquery',
+    'narrative_paths',
+], function($) {
+    "use strict";
+    console.log('Loading KBase Narrative setup routine.');
+
+    require(['narrativeConfig'], function(configDefer) {
+        // The config returns a Deferrered. When that's
+        // finished, inject the config into the global namespace.
+        //
+        // TODO: bail out if the config isn't available.
+        configDefer.then(function(config) {
+            if (config === null) {
+                console.err('fatal error! gotta bail out here.');
+                // TODO: change the view to an error/error popup/etc.
+                return;
+            }
+            console.log('Got KBase config');
+            window.kbconfig = config;
+            // Gotta have the Narrative code in place first, specifically
+            // the following:
+            // kbaseNarrativeAppCell,
+            // kbaseNarrativeMethodCell,
+            // kbaseNarrativeOutputCell,
+            // loading up the kbaseNarrative module pulls those in, and 
+            // is generally cleaner.
+            require(['kbaseNarrative', 'IPythonCustom'], function(Narrative) {
+                console.log('Starting IPython main');
+                require(['IPythonMain']);
+            });
+        });
+    });
+});

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
@@ -18,6 +18,8 @@ require.config({
         'jquery_cookie'                         : 'components/jquery-extensions/js/jquery.cookie.min',
         'select2'                               : 'select2-v3.5.2/select2.min',
 
+        'narrativeConfig'                       : 'kbase/js/narrativeConfig',
+        'narrativeMain'                         : 'kbase/js/narrativeMain',
         'kbaseLogin'                            : 'kbase/js/widgets/kbaseLoginFuncSite',
         'narrativeLogin'                        : 'kbase/js/narrativeLogin',
         'kbaseTabs'                             : 'kbase/js/widgets/kbaseTabs',
@@ -396,17 +398,21 @@ require.config({
     }
 });
 
-// Make sure all the proper things get loaded. IPython does the rest.
-require(['domReady!', 'kbwidget', 'kbapi', 'kbase-client-api'], function() {
-    require(['kbaseNarrativePrestart', 
-             'kbaseLogging', 
-             'narrativeLogin', 
-             'kbaseNarrativeOutputCell', 
-             'kbaseNarrativeAppCell',
-             'kbaseNarrativeMethodCell',
-             'IPythonCustom', 
-             ], function() {
-        console.log('Done with code loading, Starting IPython...');
-        require(['IPythonMain']);
-    });
+require(['domReady!', 'kbapi', 'kbase-client-api'], function() {
+    require(['narrativeMain']);
 });
+
+// // Make sure all the proper things get loaded. IPython does the rest.
+// require(['domReady!', 'kbwidget', 'kbapi', 'kbase-client-api'], function() {
+//     require(['kbaseNarrativePrestart', 
+//              'kbaseLogging', 
+//              'narrativeLogin', 
+//              'kbaseNarrativeOutputCell', 
+//              'kbaseNarrativeAppCell',
+//              'kbaseNarrativeMethodCell',
+//              'IPythonCustom', 
+//              ], function() {
+//         console.log('Done with code loading, Starting IPython...');
+//         require(['IPythonMain']);
+//     });
+// });


### PR DESCRIPTION
This adjusts the configuration management to load it all asynchronously, and it more tightly controls the load order of JS modules for the Narrative.

The goal here is to combat a race condition that popped up in the last PR (which was only discoverable once deployed on narrative-ci) where Narrative files were populated in the interface before required Javascript was loaded. This meant that strange behavior was seen, including broken app and method cells since their interface code wasn't loaded.

I worked through this problem while starting to upgrade to IPython 3 (upcoming WIP PR today), and applied the same solutions here.

At the same time, this makes a discrete configuration loading module that loads the config and icons files asynchronously in a separate script, not in the main page.