### PR TITLE
Adjustment to load order, fix compilation step

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/Gruntfile.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/Gruntfile.js
@@ -27,7 +27,10 @@ module.exports = function(grunt) {
                     generateSourceMaps: true,
                     preserveLicenseComments: false,
                     name: "narrative_paths",
-                    out: "static/dist/kbase-narrative-min.js"
+                    out: "static/dist/kbase-narrative-min.js",
+                    paths : {
+                        "IPythonMain": "empty:",
+                    },
                 }
             }
         },

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/page.html
@@ -224,50 +224,6 @@
 
     <div id="app" class="wrapper" ui-view></div>
 
-
-    <script>
-        // // Dumb thing to get the workspace ID just like the back end does - from the URL at startup.
-        // // This snippet keeps the workspace ID local, so it shouldn't be changed if someone pokes at the URL
-        // // before trying to fetch it again.
-        // var workspaceId = null;
-        // var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-        // if (m && m.length > 1)
-        //     workspaceId = parseInt(m[1]);
-
-        // var configJSON = $.parseJSON(
-        //     $.ajax({
-        //         url: "{{ static_url('kbase/config.json') }}",
-        //         async: false,
-        //         dataType: 'json',
-        //         cache: false
-        //     }).responseText
-        // );
-        // var landingPageMap = {}; 
-        // /*
-        // we no longer use the crazy landing page map, but keep the variable here
-        // so things we don't know about don't break
-        // */
-        // var icons = $.parseJSON(
-        //   $.ajax({
-        //     url: "{{ static_url('kbase/icons.json') }}",
-        //     async: false,
-        //     dataType: 'json',
-        //     cache: false
-        //   }).responseText
-        // );
-        // window.kbconfig = { urls: configJSON[configJSON['config']],
-        //                     version: configJSON['version'],
-        //                     name: configJSON['name'],
-        //                     git_commit_hash: configJSON['git_commit_hash'],
-        //                     git_commit_time: configJSON['git_commit_time'],
-        //                     landing_page_map: landingPageMap,
-        //                     release_notes: configJSON['release_notes'],
-        //                     mode: configJSON['mode'],
-        //                     icons: icons,
-        //                     workspaceId: workspaceId
-        //                   };
-    </script>
-
     <script src="{{ static_url("base/js/namespace.js") }}" type="text/javascript" charset="utf-8"></script>
     <script src="{{ static_url("base/js/page.js") }}" type="text/javascript" charset="utf-8"></script>
     <script src="{{ static_url("auth/js/loginwidget.js") }}" type="text/javascript" charset="utf-8"></script>

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/custom/custom.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/custom/custom.js
@@ -46,9 +46,9 @@
  * @static
  */
 
-console.log('Loading KBase Narrative setup routine.');
+console.log('Loading KBase Narrative setup routine from IPython.custom.js.');
 $([IPython.events]).one('notebook_loaded.Notebook', function() {
-    console.log('Performing narrative startup');
+    console.log('Performing narrative startup after Notebook loading.');
     require(['kbaseNarrative'], function(Narrative) {
         IPython.narrative = new Narrative();
         IPython.narrative.init();

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/kbaseNarrative.js
@@ -16,7 +16,6 @@ define([
     'narrativeLogin',
     'kbase-client-api',
     'kbaseNarrativePrestart',
-    'ipythonCellMenu'
 ], function($, 
             kbaseNarrativeSidePanel,
             kbaseNarrativeOutputCell,
@@ -24,8 +23,7 @@ define([
             kbaseNarrativeMethodCell,
             narrativeLogin,
             kbaseClient,
-            kbaseNarrativePrestart,
-            kbaseCellToolbar) {
+            kbaseNarrativePrestart) {
     "use strict";
 
 /**

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeConfig.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeConfig.js
@@ -23,12 +23,12 @@ define(['jquery'], function($) {
         workspaceId = parseInt(m[1]);
 
     var configProm = $.ajax({
-        url: '/static/kbase/config.json',
+        url: 'static/kbase/config.json',
         dataType: 'json',
         cache: false
     });
     var iconsProm = $.ajax({
-        url: '/static/kbase/icons.json',
+        url: 'static/kbase/icons.json',
         dataType: 'json',
         cache: false
     });

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeMain.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/narrativeMain.js
@@ -25,7 +25,6 @@
 
 require([
     'jquery',
-    'narrative_paths',
 ], function($) {
     "use strict";
     console.log('Loading KBase Narrative setup routine.');
@@ -37,11 +36,11 @@ require([
         // TODO: bail out if the config isn't available.
         configDefer.then(function(config) {
             if (config === null) {
-                console.err('fatal error! gotta bail out here.');
+                console.error('fatal error! gotta bail out here.');
                 // TODO: change the view to an error/error popup/etc.
                 return;
             }
-            console.log('Got KBase config');
+            console.log('Successfully got KBase config');
             window.kbconfig = config;
             // Gotta have the Narrative code in place first, specifically
             // the following:
@@ -50,9 +49,12 @@ require([
             // kbaseNarrativeOutputCell,
             // loading up the kbaseNarrative module pulls those in, and 
             // is generally cleaner.
-            require(['kbaseNarrative', 'IPythonCustom'], function(Narrative) {
-                console.log('Starting IPython main');
-                require(['IPythonMain']);
+
+            require(['kbapi'], function() {
+                require(['kbaseNarrative', 'IPythonCustom'], function(Narrative) {
+                    console.log('Starting IPython main');
+                    require(['IPythonMain']);
+                });
             });
         });
     });

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
@@ -398,7 +398,7 @@ require.config({
     }
 });
 
-require(['domReady!', 'kbapi', 'kbase-client-api'], function() {
+require(['domReady!'], function() {
     require(['narrativeMain']);
 });
 


### PR DESCRIPTION
This fixes an issue where a file (IPython's notebook/js/main.js) that should not be compiled during the JS minification process was getting added. Because it is not an AMD itself, that means that as soon as the minified file was loaded, that script was run, which was done very much out of order.

This PR removes that file from the build step, so it is only properly downloaded and executed at the right time.