### PR TITLE
Duplicate a narrative method with parameter values

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -99,18 +99,16 @@ define(['jquery', 'kbwidget'], function($) {
                             // so we have to wait and check when that is done.  When it is, we can update state
                             var newCell = IPython.notebook.get_selected_cell();
                             var newWidget = $('#'+$(newCell.get_text())[0].id).kbaseNarrativeMethodCell();
-                            currentState.runningState.submittedText = "";
-                            currentState.runningState.runState = "";
                             var updateState = function(state) {
                                 if(newWidget.$inputWidget) {
-                                    // if the $inputWidget is not null, we are good to go, so set the state (ignoring the run state)
-                                    newWidget.loadState(state);
+                                    // if the $inputWidget is not null, we are good to go, so set the state
+                                    newWidget.loadState(currentState.params);
                                 } else {
                                     // not ready yet, keep waiting
-                                    window.setTimeout(function() { updateState(currentState); },500);
+                                    window.setTimeout(updateState,500);
                                 }
                             };
-                            window.setTimeout(function() { updateState(currentState); },50);
+                            window.setTimeout(updateState,50);
 
                         }
                     }, this)

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -66,6 +66,8 @@
                     if (!this.checkMethodRun())
                         return;
 
+                    // todo: lookup current user here
+
                     this.submittedText = 'submitted on ' + this.readableTimestamp();
                     this.trigger('runCell.Narrative', {
                         cell: IPython.notebook.get_selected_cell(),
@@ -158,7 +160,7 @@
                                       .css({'overflow' : 'hidden'})
                                       .append($buttons));
 
-            this.cellMenu = $menuSpan.kbaseNarrativeCellMenu();
+            this.cellMenu = $menuSpan.kbaseNarrativeCellMenu({'kbWidget':this, 'kbWidgetType':'method'});
             this.$elem.append(this.$cellPanel);
 
             // Add minimize/restore actions.


### PR DESCRIPTION
I've been working out how to automatically create a method with parameter values set in the Narrative via the JS api, and have a potentially useful feature here to copy a narrative method including parameter values.

This could be useful because we can copy narrative methods even after they've been run.  So it allows a user to essentially rerun something without reentering all the parameters.

This could probably be done for apps too, but is slightly trickier because we need to find a way to ensure the the app input widgets are all fully loaded before we update state.

Thoughts on this feature?