### PR TITLE
API function for running a method cell

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -202,6 +202,19 @@
 
         /**
          * @method
+         * Invoke this method- basically the API way to click on the run button.
+         * @public
+         */
+        runMethod: function() {
+            if(this.$runButton) {
+                this.$runButton.click();
+            } else {
+                console.error('Attempting to run a method, but the method is not yet initialized/rendered.')
+            }
+        },
+
+        /**
+         * @method
          * Returns parameters from the contained input widget
          * @public
          */


### PR DESCRIPTION
This small change adds a runMethod function to kbaseNarrativeMethodCell so that we can run a method cell without user interaction.  This is a step towards being able to automatically create a method, set parameters, and run the method, which will be useful for some of the feature-value user stories.
