### PR TITLE
Minimize methods on run and add summary text

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/css/kbaseNarrative.css
@@ -1623,7 +1623,7 @@ div#notebook_panel {
 }
 
 .app-panel-heading {
-    padding-top: 20px;
+    padding-top: 10px;
 }
 
 .app-panel-heading h1 {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -178,7 +178,7 @@
                               .append('Run')
                               .click(
                                   $.proxy(function(event) {
-                                      var submittedText = "submitted on "+this.readableTimestamp(new Date().getTime());
+                                      var submittedText = "&nbsp;&nbsp; submitted on "+this.readableTimestamp(new Date().getTime());
                                       if(this.auth()) {
                                           if(this.auth().user_id)
                                               submittedText += ' by <a href="functional-site/#/people/'+this.auth().user_id
@@ -266,8 +266,10 @@
 
             var $appSubtitleDiv = $("<div>")
                                         .addClass('kb-app-panel-description')
-                                        .append(this.appSpec.info.subtitle)
+                                        .append('&nbsp;&nbsp;&nbsp;&nbsp;' + this.appSpec.info.subtitle)
                                         .append('&nbsp;&nbsp;<a href="'+this.options.appHelpLink+this.appSpec.info.id+'" target="_blank">more...</a>');
+            var $appSubmittedStamp = $("<div>");
+
 
             var headerCleaned = this.appSpec.info.header.replace(/&quot;/g, '"')
             var $appHeaderDiv = $("<div>")
@@ -291,7 +293,8 @@
                                         .append($('<div>').addClass('app-panel-heading')
                                                    .append($('<div>')
                                                            .append($('<h1><b>' + appInfo + '</b></h1>')))
-                                                   .append($appSubtitleDiv)))
+                                                   .append($appSubtitleDiv)
+                                                   .append($appSubmittedStamp)))
                              .append($('<div>')
                                      .addClass('panel-body')
                                      .append($appHeaderDiv))
@@ -320,6 +323,9 @@
             var self = this;
             $controlsSpan.click(function() {
                 if (self.panel_minimized) {
+                    $appSubmittedStamp.hide();
+                    $appSubtitleDiv.show();
+
                     $mintarget.children(".panel-body").slideDown();
                     $mintarget.children(".panel-footer").slideDown();
                     $minimizeControl.removeClass("glyphicon-chevron-right")
@@ -327,6 +333,11 @@
                     self.panel_minimized = false;
                 }
                 else {
+                    if(self.state.runningState.submittedText && !self.isAwaitingInput()) {
+                        $appSubmittedStamp.html($('<h2>').append("&nbsp;&nbsp;&nbsp;" +self.state.runningState.submittedText));
+                        $appSubmittedStamp.show();
+                        $appSubtitleDiv.hide();
+                    }
                     $mintarget.children(".panel-footer").slideUp();
                     $mintarget.children(".panel-body").slideUp();
                     $minimizeControl.removeClass("glyphicon-chevron-down")
@@ -619,6 +630,18 @@
             }
         },
 
+        isAwaitingInput: function() {
+            if(this.state) {
+              if(this.state.runningState) {
+                if(this.state.runningState.appRunState === "input") {
+                  return true;
+                }
+                return false;
+              }
+            }
+            return true;
+        },
+
         /*
          * Reset parameters and allow to re-run
          */
@@ -762,6 +785,7 @@
                 if (state.runningState.appRunState) {
                     if (state.runningState.submittedText) {
                         this.$submitted.html(state.runningState.submittedText);
+                        this.state.runningState.submittedText = state.runningState.submittedText;
                     }
                     if (state.runningState.appRunState === "running") {
                         if (state.runningState.runningStep) {

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -633,7 +633,8 @@
         isAwaitingInput: function() {
             if(this.state) {
               if(this.state.runningState) {
-                if(this.state.runningState.appRunState === "input") {
+                if(this.state.runningState.appRunState === "input" ||
+                    this.state.runningState.appRunState === "canceled") {
                   return true;
                 }
                 return false;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -650,10 +650,12 @@
             if (clear_inputs) {
                 this.setErrorState(false);
                 this.state.runningState.appRunState = "input";
+                this.setRunningStep(null);
                 this.$runButton.show();
             }
             else {
                 this.state.runningState.appRunState = "canceled"; // XXX?
+                this.setRunningStep(null);
                 this.$runButton.show();
                 this.$resetButton.hide();
             }
@@ -736,7 +738,6 @@
          * @public
          */
         loadState: function(state) {
-            console.log(state);
             if (!state) {
                 return;
             }
@@ -801,6 +802,7 @@
             if (this.inputSteps) {
                 for(var i=0; i<this.inputSteps.length; i++) {
                     this.inputSteps[i].$stepContainer.removeClass("kb-app-step-running");
+                    this.inputSteps[i].$stepContainer.removeClass("kb-app-step-error");
                     if (this.inputSteps[i].id === stepId) {
                         this.inputSteps[i].$stepContainer.addClass("kb-app-step-running");
                         this.state.runningState.runningStep = stepId;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -15,7 +15,7 @@
   require(['jquery', 'kbwidget'], function($) {
     $.KBWidget({
         name: "kbaseNarrativeAppCell",
-        parent: "kbaseWidget",
+        parent: "kbaseAuthenticatedWidget",
         version: "1.0.0",
         options: {
             app: null,
@@ -178,8 +178,13 @@
                               .append('Run')
                               .click(
                                   $.proxy(function(event) {
-                                      self.$submitted.html("submitted on "+this.readableTimestamp(new Date().getTime()));
-
+                                      var submittedText = "submitted on "+this.readableTimestamp(new Date().getTime());
+                                      if(this.auth()) {
+                                          if(this.auth().user_id)
+                                              submittedText += ' by <a href="functional-site/#/people/'+this.auth().user_id
+                                                                      +'" target="_blank">' + this.auth().user_id + "</a>";
+                                      }
+                                      this.$submitted.html(submittedText);
                                       var isGood = self.startAppRun();
                                       if (!isGood) { return; }
 
@@ -314,7 +319,6 @@
             var self = this;
             $controlsSpan.click(function() {
                 if (self.panel_minimized) {
-                    console.debug("restore full panel");
                     $mintarget.find(".panel-body").slideDown();
                     $mintarget.find(".panel-footer").show();
                     $minimizeControl.removeClass("glyphicon-chevron-right")
@@ -324,7 +328,6 @@
                     self.panel_minimized = false;
                 }
                 else {
-                    console.debug("minimize panel");
                     $mintarget.find(".panel-footer").hide();
                     $mintarget.find(".panel-body").slideUp();
                     $minimizeControl.removeClass("glyphicon-chevron-down")

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -231,7 +231,7 @@
                 .attr('value', 'Reset')
                 .addClass('kb-app-run kb-app-reset')
                 .append('Reset')
-                .css({'margin-right':'5px'})
+                .css({'margin-right':'5px', 'margin-left':'10px'})
                 .click(
                     $.proxy(function(event) {
                     self.resetAppRun(true);
@@ -250,6 +250,8 @@
             var inputStep = {};
             for (var i=0; i<stepSpecs.length; i++) {
                 var $stepPanel = this.renderStepDiv(this.appSpec.steps[i].step_id, stepSpecs[i], stepHeaderText + (i+1));
+
+
                 this.$methodPanel.append($stepPanel);
                 this.methodSpecs[stepSpecs[i].info.id] = stepSpecs[i];
             }
@@ -277,19 +279,19 @@
             // Controls (minimize)
             var $controlsSpan = $('<div>').addClass("pull-left");
             var $minimizeControl = $("<span class='glyphicon glyphicon-chevron-down'>")
-                        .css({color: "#888", fontSize: "14pt"});
+                        .css({color: "#888", fontSize: "14pt", cursor:'pointer', paddingTop: "7px", margin: "5px"});
             $controlsSpan.append($minimizeControl);
 
             var $cellPanel = $('<div>')
                              .addClass('panel kb-app-panel kb-cell-run')
-                             .append($menuSpan)
                              .append($controlsSpan)
+                             .append($menuSpan)
                              .append($('<div>')
-                                     .addClass('panel-heading app-panel-heading')
-                                     .append($('<div>')
-                                             .append($('<h1><b>' + appInfo + '</b></h1>'))
-                                             )
-                                     .append($appSubtitleDiv))
+                                        .addClass('panel-heading')
+                                        .append($('<div>').addClass('app-panel-heading')
+                                                   .append($('<div>')
+                                                           .append($('<h1><b>' + appInfo + '</b></h1>')))
+                                                   .append($appSubtitleDiv)))
                              .append($('<div>')
                                      .addClass('panel-body')
                                      .append($appHeaderDiv))
@@ -303,7 +305,6 @@
             require(['kbaseNarrativeCellMenu'], $.proxy(function() {
                 this.cellMenu = $menuSpan.kbaseNarrativeCellMenu();
             }, this));
-
 
 
             //now we link the step parameters together that are linked
@@ -320,20 +321,16 @@
             $controlsSpan.click(function() {
                 if (self.panel_minimized) {
                     $mintarget.find(".panel-body").slideDown();
-                    $mintarget.find(".panel-footer").show();
+                    $mintarget.find(".panel-footer").slideDown();
                     $minimizeControl.removeClass("glyphicon-chevron-right")
                                     .addClass("glyphicon-chevron-down");
-                    // restore original padding (20px)
-                    $mintarget.find(".app-panel-heading").css({padding: "20px"});
                     self.panel_minimized = false;
                 }
                 else {
-                    $mintarget.find(".panel-footer").hide();
+                    $mintarget.find(".panel-footer").slideUp();
                     $mintarget.find(".panel-body").slideUp();
                     $minimizeControl.removeClass("glyphicon-chevron-down")
                                     .addClass("glyphicon-chevron-right");
-                    // reduce padding so it lines up
-                    $mintarget.find(".app-panel-heading").css({padding: "5px"});
                     self.panel_minimized = true;
                 }
             });
@@ -360,30 +357,42 @@
             var $outputPanel = $('<div>');
 
 
+            // First setup the Input widget header
             var $inputWidgetDiv = $("<div>");
             var methodId = stepSpec.info.id + '-step-details-' + this.genUUID();
             var buttonLabel = 'details';
             var methodDesc = stepSpec.info.subtitle;
-            var $methodInfo = $('<div>')
-                              .addClass('kb-func-desc')
+            var $header = $('<div>').css({'margin-top':'4px'})
+                              .addClass('kb-func-desc');
+            var $staticMethodInfo = $('<div>')
                               .append('<h1><b>' + stepHeading +'&nbsp&nbsp-&nbsp '+ stepSpec.info.name + '</b></h1>')
-                              .append($('<div>')
+                              .append($('<h2>')
                                       .attr('id', methodId)
-                                      //.addClass('collapse')
-                                      .append($('<h2>')
-                                         .append(methodDesc +
-                                                 ' &nbsp&nbsp<a href="'+ this.options.methodHelpLink + stepSpec.info.id +
-                                                        '" target="_blank">more...</a>')));
+                                      .append(methodDesc +
+                                            ' &nbsp&nbsp<a href="'+ this.options.methodHelpLink + stepSpec.info.id +
+                                                '" target="_blank">more...</a>'
+                                      ));
+            $header.append($staticMethodInfo);
+            var $dynamicMethodSummary = $('<div>');
+            $header.append($dynamicMethodSummary);
+
+            // Next the min/max controls
+            var $controlsSpan = $('<div>').addClass("pull-left");
+            var $minimizeControl = $("<span class='glyphicon glyphicon-chevron-down'>")
+                                    .css({color: "#888", fontSize: "14pt", cursor:'pointer',
+                                          paddingTop: "7px", margin: "5px"});
+            $controlsSpan.append($minimizeControl);
 
             var $cellPanel = $('<div>')
                              .addClass('panel kb-func-panel kb-app-func-panel kb-cell-run')
+                             .append($controlsSpan)
                              //.attr('id', this.options.cellId)
                              .append($('<div>')
                                      .addClass('panel-heading')
-                                     .append($methodInfo))
+                                     .append($header))
                              .append($('<div>')
                                      .addClass('panel-body')
-                                     .append($inputWidgetDiv))
+                                     .append($inputWidgetDiv));
 
             $stepPanel.append($cellPanel);
             $stepPanel.append($statusPanel);
@@ -398,15 +407,85 @@
                 outputWidgetName = this.defaultOutputWidget;
             }
 
+            var stepIdx = this.inputSteps.length;
+            var self = this;
+            $controlsSpan.click(function() {
+                self.toggleStepMinimization(stepIdx);
+            });
+
+
             // todo, update input widget so that we don't have to stringify
             var inputWidget = $inputWidgetDiv[inputWidgetName]({ method: JSON.stringify(stepSpec) });
-            var inputStepData = {id:stepId ,methodId: stepSpec.info.id, widget:inputWidget, $stepContainer:$stepPanel, $statusPanel:$statusPanel, $outputPanel:$outputPanel, outputWidgetName:outputWidgetName }
+            var inputStepData = {
+              id:stepId ,methodId: stepSpec.info.id, 
+              widget:inputWidget,
+              $stepContainer:$stepPanel, 
+              $statusPanel:$statusPanel, 
+              $outputPanel:$outputPanel,
+              utputWidgetName:outputWidgetName,
+              minimized: false,
+              $minimizeControl:$minimizeControl
+            }
             this.inputSteps.push(inputStepData);
             this.inputStepLookup[stepId] = inputStepData;
 
             this.state.step[stepId] = { };
 
             return $stepPanel;
+        },
+
+        toggleStepMinimization: function(stepIdx) {
+            var self = this;
+            if(self.inputSteps[stepIdx].minimized) {
+                self.maximizeStepView(stepIdx);
+            } else {
+                self.minimizeStepView(stepIdx);
+            }
+        },
+
+        minimizeStepView: function(stepIdx, noAnimation) {
+            var self = this;
+            var $mintarget = self.inputSteps[stepIdx].$stepContainer;
+
+            //self.$staticMethodInfo.hide();
+
+            // create the dynamic summary based on the run state
+            //self.updateDynamicMethodSummaryHeader()
+            //self.$dynamicMethodSummary.show();
+            if(noAnimation) {
+                $mintarget.find(".panel-footer").hide();
+                $mintarget.find(".panel-body").hide();
+            } else {
+                $mintarget.find(".panel-footer").slideUp();
+                $mintarget.find(".panel-body").slideUp();
+            }
+            self.inputSteps[stepIdx].$minimizeControl.removeClass("glyphicon-chevron-down")
+                              .addClass("glyphicon-chevron-right");
+            self.inputSteps[stepIdx].minimized = true;
+        },
+
+        maximizeStepView: function(stepIdx) {
+            var self = this;
+            var $mintarget = self.inputSteps[stepIdx].$stepContainer;
+            $mintarget.find(".panel-body").slideDown();
+            $mintarget.find(".panel-footer").slideDown();
+            self.inputSteps[stepIdx].$minimizeControl.removeClass("glyphicon-chevron-right")
+                                .addClass("glyphicon-chevron-down");
+            //self.$dynamicMethodSummary.hide();
+            //self.$staticMethodInfo.show();
+            self.inputSteps[stepIdx].minimized = false;
+        },
+
+        minimizeAllSteps: function() {
+            for(var k=0; k<this.inputSteps.length; k++) {
+                this.minimizeStepView(k);
+            }
+        },
+
+        maximizeAllSteps: function() {
+            for(var k=0; k<this.inputSteps.length; k++) {
+                this.maximizeStepView(k);
+            }
         },
 
         linkStepsTogether: function() {
@@ -519,6 +598,7 @@
                     this.inputSteps[i].widget.lockInputs();
                 }
             }
+            this.minimizeAllSteps();
             this.state.runningState.appRunState = "running";
             this.displayRunning(true);
             return true;
@@ -548,6 +628,7 @@
             this.$stopButton.hide();
             this.$resetButton.hide();
             this.$submitted.hide();
+            this.maximizeAllSteps();
             // clear inputs
             if (this.inputSteps) {
                 for(var i=0; i<this.inputSteps.length; i++) {
@@ -573,8 +654,8 @@
             }
             else {
                 this.state.runningState.appRunState = "canceled"; // XXX?
-                this.$runButton.hide();
-                this.$resetButton.show();
+                this.$runButton.show();
+                this.$resetButton.hide();
             }
         },
 
@@ -588,7 +669,6 @@
             this.trigger('cancelJobCell.Narrative', [this.cellId, true, $.proxy(function(isCanceled) {
                 if (isCanceled) {
                   self.resetAppRun(false);
-
                 }
             }, this)]);
         },
@@ -656,6 +736,7 @@
          * @public
          */
         loadState: function(state) {
+            console.log(state);
             if (!state) {
                 return;
             }
@@ -676,17 +757,22 @@
 
             // if we were in the running state before, set the values
             if (state.runningState) {
-                if (state.runningState.runningStep) {
-                    this.setRunningStep(state.runningState.runningStep);
-                }
+                
                 if (state.runningState.appRunState) {
                     if (state.runningState.submittedText) {
                         this.$submitted.html(state.runningState.submittedText);
                     }
                     if (state.runningState.appRunState === "running") {
+                        if (state.runningState.runningStep) {
+                            this.setRunningStep(state.runningState.runningStep);
+                        }
                         this.startAppRun();
                     }
                     else if (state.runningState.appRunState === "done") {
+                        this.$submitted.show();
+                        this.$runButton.hide();
+                    }
+                    else if (state.runningState.appRunState === "complete") {
                         this.$submitted.show();
                         this.$runButton.hide();
                     }
@@ -737,6 +823,7 @@
         },
 
         setRunningState: function(state) {
+            //console.debug('app state!'); console.debug(state);
             state = state.toLowerCase();
             if (state === 'error') {
                 this.setErrorState(true);

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -320,15 +320,15 @@
             var self = this;
             $controlsSpan.click(function() {
                 if (self.panel_minimized) {
-                    $mintarget.find(".panel-body").slideDown();
-                    $mintarget.find(".panel-footer").slideDown();
+                    $mintarget.children(".panel-body").slideDown();
+                    $mintarget.children(".panel-footer").slideDown();
                     $minimizeControl.removeClass("glyphicon-chevron-right")
                                     .addClass("glyphicon-chevron-down");
                     self.panel_minimized = false;
                 }
                 else {
-                    $mintarget.find(".panel-footer").slideUp();
-                    $mintarget.find(".panel-body").slideUp();
+                    $mintarget.children(".panel-footer").slideUp();
+                    $mintarget.children(".panel-body").slideUp();
                     $minimizeControl.removeClass("glyphicon-chevron-down")
                                     .addClass("glyphicon-chevron-right");
                     self.panel_minimized = true;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -884,7 +884,7 @@ define(['jquery',
                 }
             }
             // if it's an error, then we need to signal the cell
-            if (status === "error") { // || (jobState.state.step_errors && Object.keys(jobState.state.step_errors).length !== 0)) {
+            if (status === "error" || status === "suspend") { // || (jobState.state.step_errors && Object.keys(jobState.state.step_errors).length !== 0)) {
                 if (jobType === 'njs') {
                     $cell.kbaseNarrativeAppCell('setRunningState', 'error');
                 }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -66,7 +66,7 @@
                     if (!this.checkMethodRun())
                         return;
 
-                    this.submittedText = 'submitted on ' + this.readableTimestamp();
+                    this.submittedText = '&nbsp;&nbsp; submitted on ' + this.readableTimestamp();
                     if(this.auth()) {
                         if(this.auth().user_id)
                             this.submittedText += ' by <a href="functional-site/#/people/'+this.auth().user_id

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -143,7 +143,7 @@
             // Controls (minimize)
             var $controlsSpan = $('<div>').addClass("pull-left");
             this.$minimizeControl = $("<span class='glyphicon glyphicon-chevron-down'>")
-                                    .css({color: "#888", fontSize: "14pt",
+                                    .css({color: "#888", fontSize: "14pt",  cursor:'pointer',
                                           paddingTop: "7px", margin: "5px"});
             $controlsSpan.append(this.$minimizeControl);
             this.panel_minimized = false;
@@ -502,7 +502,6 @@
             var self = this;
             self.$dynamicMethodSummary.empty();
 
-
             // First set the main text
             if(self.method.replacement_text && 
               self.submittedText && !self.isAwaitingInput()) {
@@ -518,9 +517,6 @@
                     self.$dynamicMethodSummary.append($('<h2>').append('Not yet submitted.'));
                 }
             }
-
-            
-
         },
 
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -259,6 +259,7 @@
                     'submittedText' : this.submittedText,
                     'outputState' : this.allowOutput
                 },
+                'minimized' : this.panel_minimized,
                 'params' : this.$inputWidget.getState()
             };
         },
@@ -279,11 +280,17 @@
             // That's new!
             // old one just has the state that should be passed to the input widget.
             // that'll be deprecated soonish.
-            if (state.hasOwnProperty('params') && state.hasOwnProperty('runningState')) {
+            console.debug('loading state!');
+            console.debug(state);
+            if (state.hasOwnProperty('params') 
+              && state.hasOwnProperty('runningState')) {
                 this.allowOutput = state.runningState.outputState;
                 this.$inputWidget.loadState(state.params);
                 this.submittedText = state.runningState.submittedText;
                 this.changeState(state.runningState.runState);
+                if(state.minimized) {
+                    this.minimizeView(true); // true so that we don't show slide animation
+                }
             }
             else
                 this.$inputWidget.loadState(state);
@@ -517,20 +524,22 @@
         },
 
 
-        minimizeView: function() {
+        minimizeView: function(noAnimation) {
             var self = this;
             var $mintarget = self.$cellPanel;
-
-            console.debug(self.method)
 
             self.$staticMethodInfo.hide();
 
             // create the dynamic summary based on the run state
             self.updateDynamicMethodSummaryHeader()
             self.$dynamicMethodSummary.show();
-
-            $mintarget.find(".panel-footer").slideUp();
-            $mintarget.find(".panel-body").slideUp();
+            if(noAnimation) {
+                $mintarget.find(".panel-footer").hide();
+                $mintarget.find(".panel-body").hide();
+            } else {
+                $mintarget.find(".panel-footer").slideUp();
+                $mintarget.find(".panel-body").slideUp();
+            }
             self.$minimizeControl.removeClass("glyphicon-chevron-down")
                               .addClass("glyphicon-chevron-right");
             self.panel_minimized = true;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -13,7 +13,7 @@
   require(['jquery', 'kbwidget'], function($) {
     $.KBWidget({
         name: "kbaseNarrativeMethodCell",
-        parent: "kbaseWidget",
+        parent: "kbaseAuthenticatedWidget",
         version: "1.0.0",
         options: {
             method: null,
@@ -66,9 +66,12 @@
                     if (!this.checkMethodRun())
                         return;
 
-                    // todo: lookup current user here
-
                     this.submittedText = 'submitted on ' + this.readableTimestamp();
+                    if(this.auth()) {
+                        if(this.auth().user_id)
+                            this.submittedText += ' by <a href="functional-site/#/people/'+this.auth().user_id
+                                +'" target="_blank">' + this.auth().user_id + "</a>";
+                    }
                     this.trigger('runCell.Narrative', {
                         cell: IPython.notebook.get_selected_cell(),
                         method: this.method,

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -169,11 +169,9 @@
             // These mess with the CSS on the cells!
             var self = this;
             $controlsSpan.click(function() {
-                var $mintarget = self.$cellPanel;
                 if (self.panel_minimized) {
                     self.maximizeView();
-                }
-                else {
+                } else {
                     self.minimizeView();
                 }
             });
@@ -280,8 +278,6 @@
             // That's new!
             // old one just has the state that should be passed to the input widget.
             // that'll be deprecated soonish.
-            console.debug('loading state!');
-            console.debug(state);
             if (state.hasOwnProperty('params') 
               && state.hasOwnProperty('runningState')) {
                 this.allowOutput = state.runningState.outputState;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -219,7 +219,6 @@
          * @public
          */
         getParameterMapForReplacementText: function() {
-
             if (this.$inputWidget) {
                 var paramMap = {};
                 var paramList = this.$inputWidget.getParameters();
@@ -232,12 +231,10 @@
                             this.method.parameters[k].text_options) {
                           if(this.method.parameters[k].text_options.valid_ws_types) {
                             if(this.method.parameters[k].text_options.valid_ws_types.length>0) {
-                              paramMap[this.method.parameters[k].id] = '<b><a>' + paramList[k] + '</a></b>';
-
+                              paramMap[this.method.parameters[k].id] = '<b><a style="cursor:default;">' + paramList[k] + '</a></b>';
                             }
                           }
                         }
-
                     }
                 }
                 return paramMap;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -376,9 +376,16 @@ define(['jquery',
                 // do the standard for now.
                 code = this.buildGenericRunCommand(data);
             }
+            var handleError = function() {
+                if(data.widget) {
+                    if(data.widget.changeState)
+                        data.widget.changeState('error');
+                }
+            };
+
             var callbacks = {
                 'execute_reply' : function(content) { self.handleExecuteReply(data.cell, content); },
-                'output' : function(msgType, content) { self.handleOutput(data.cell, msgType, content, showOutput); },
+                'output' : function(msgType, content) { self.handleOutput(data.cell, msgType, content, showOutput, handleError); },
                 'clear_output' : function(content) { self.handleClearOutput(data.cell, content); },
                 'set_next_input' : function(text) { self.handleSetNextInput(data.cell, content); },
                 'input_request' : function(content) { self.handleInputRequest(data.cell, content); }
@@ -1769,7 +1776,7 @@ define(['jquery',
         /**
          * @method _handle_output
          */
-        handleOutput: function (cell, msgType, content, showOutput) {
+        handleOutput: function (cell, msgType, content, showOutput, submissionErrorCallback) {
             // copied from outputarea.js
             var buffer = "";
             if (msgType === "stream") {
@@ -1814,6 +1821,7 @@ define(['jquery',
                                     case 'E': // Error while running
                                         var errorJson = matches[2];
                                         errorJson = errorJson.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\$/g, "&#36;");
+                                        if(submissionErrorCallback) { submissionErrorCallback(); }
                                         self.createOutputCell(cell, '{"error" :' + errorJson + '}', true);
                                         break;
 


### PR DESCRIPTION
This update consists of:

1) When a method is run, it is automatically collapsed, and 'replacement' text is shown that allows us to briefly summarized the step the user performed.  The replacement text is pulled from the replacement text field in the narrative method specification (for example, here: https://github.com/kbase/narrative_method_specs_ci/blob/master/methods/reannotate_microbial_genome/display.yaml#L14).  This was already a feature in the narrative method store, so it will just work if you update the specs.  The cool thing is that the replacement text uses http://handlebarsjs.com so you can include parameter values in the replacement text (and do things like have conditional expressions, show the length of an array input, etc)

2) When an app cell runs, the method input fields are collapsed.  I choose to not yet add the replacement text in the case of Apps, because the 'Steps' are displayed more prominently, but that is something we can easily add.  Thoughts on this?  Also, should we replace the App header when it is collapsed with some other information?

3) Added user names to the timestamp when methods and apps are run, so you can see who executed a particular method/app.  The user name links to the user profile page.  I think this small feature will be very useful when multiple people are editing a single narrative.

4) When working on the above, there was some minor bugs that I found in updating the error state of methods/apps which I fixed.  There are still issues here I think in connecting the jobs panel to the state of the apps/methods in the narrative cells, but at least now things are somewhat improved.
