### PR TITLE
Updated kbjob_manager to treat urllib2.URLErrors as network errors.

### DIFF
--- a/src/biokbase/narrative/common/kbjob_manager.py
+++ b/src/biokbase/narrative/common/kbjob_manager.py
@@ -151,8 +151,8 @@ class KBjobManager():
 
     def prepare_job_error_state(self, job_id, e):
         e_type = type(e).__name__
-        e_message = e.__str__()
-        e_trace = traceback.format_exc()
+        e_message = str(e).replace('<', '&lt;').replace('>', '&gt;')
+        e_trace = traceback.format_exc().replace('<', '&lt;').replace('>', '&gt;')
         job_state = 'error'
         if e_type == 'ConnectionError' or e_type == 'HTTPError':
             job_state = 'network_error'            # Network problem routing to NJS wrapper
@@ -167,6 +167,8 @@ class KBjobManager():
                 job_state = 'network_error'        # Network problem routing NJS
             elif '[awe error]' in e_message:
                 job_state = 'awe_error'
+        elif e_type == 'URLError':
+            job_state = 'network_error'
         return {
             'job_id' : job_id,
             'job_state' : job_state,


### PR DESCRIPTION
Occasionally, on CI, a UJS job lookup will fail because something spazzes out with the UJS/proxy client, and returns a (transient) URLError. This patch does two things.

1. Treats that error as a 'network_error', which is non-fatal, so it'll lookup the job info again on the next cycle.
2. Properly escapes any <> characters that the exception's message string contains so they can get rendered right. Silly HTML thinking angle brackets are always tags!