### PR TITLE
Added Narrative API call to create and autorun a method

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -193,9 +193,9 @@ define(['jquery', 'kbwidget', 'kbaseAccordion', 'kbaseNarrativeControlPanel'], f
              */
             $(document).on('getFunctionSpecs.Narrative',
                 $.proxy(function(e, specSet, callback) {
-                  console.debug("Trigger proxy: specSet=", specSet, "callback=", callback);
+                    //console.debug("Trigger proxy: specSet=", specSet, "callback=", callback);
                     if (callback) {
-                      console.debug("Trigger: specSet=",specSet);
+                        //console.debug("Trigger: specSet=",specSet);
                         callback(this.getFunctionSpecs(specSet));
                     }
                 }, this)
@@ -497,7 +497,7 @@ define(['jquery', 'kbwidget', 'kbaseAccordion', 'kbaseNarrativeControlPanel'], f
          * If a spec isn't found, then it won't appear in the return values.
          */
         getFunctionSpecs: function(specSet) {
-            console.debug("getFunctionSpecs(specSet=",specSet,")");
+            //console.debug("getFunctionSpecs(specSet=",specSet,")");
             var results = {};
             if (specSet.apps && specSet.apps instanceof Array) {
                 results.apps = {};
@@ -516,7 +516,7 @@ define(['jquery', 'kbwidget', 'kbaseAccordion', 'kbaseNarrativeControlPanel'], f
                 }
               */
             }
-            console.debug("getFunctionSpecs returning:",results);
+            //console.debug("getFunctionSpecs returning:",results);
             return results;
         },
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -2040,9 +2040,11 @@ define(['jquery',
             outputCell.rendered = false; // force a render
             outputCell.render();
             // If present, add list of "next steps"
-            if (result.next_steps.apps || result.next_steps.methods) {
-                var $body = $('#' + outCellId).find('.panel-body');
-                this.showNextSteps({elt: $body, next_steps: result.next_steps});
+            if(result.next_steps) {
+                if (result.next_steps.apps || result.next_steps.methods) {
+                    var $body = $('#' + outCellId).find('.panel-body');
+                    this.showNextSteps({elt: $body, next_steps: result.next_steps});
+                }
             }
             this.resetProgress(cell);
             if (IPython && IPython.narrative)

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -298,6 +298,7 @@ define(['jquery',
         },
 
         showDeleteCellModal: function(index, cell, message) {
+            this.initDeleteCellModal();
             if (cell && cell.metadata[this.KB_CELL]) {
                 this.cellToDelete = index;
                 if (message)

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -376,6 +376,7 @@ define(['jquery',
                 // do the standard for now.
                 code = this.buildGenericRunCommand(data);
             }
+
             var handleError = function() {
                 if(data.widget) {
                     if(data.widget.changeState)
@@ -385,7 +386,7 @@ define(['jquery',
 
             var callbacks = {
                 'execute_reply' : function(content) { self.handleExecuteReply(data.cell, content); },
-                'output' : function(msgType, content) { self.handleOutput(data.cell, msgType, content, showOutput, handleError); },
+                'output' : function(msgType, content) { self.handleOutput(data.cell, msgType, content, showOutput, handleError, data.widget); },
                 'clear_output' : function(content) { self.handleClearOutput(data.cell, content); },
                 'set_next_input' : function(text) { self.handleSetNextInput(data.cell, content); },
                 'input_request' : function(content) { self.handleInputRequest(data.cell, content); }
@@ -393,6 +394,9 @@ define(['jquery',
 
             $(data.cell.element).find('#kb-func-progress').css({'display': 'block'});
             IPython.notebook.kernel.execute(code, callbacks, {silent: true});
+
+
+                
         },
 
         buildAppCell: function(appSpec) {
@@ -1776,7 +1780,7 @@ define(['jquery',
         /**
          * @method _handle_output
          */
-        handleOutput: function (cell, msgType, content, showOutput, submissionErrorCallback) {
+        handleOutput: function (cell, msgType, content, showOutput, submissionErrorCallback, callingWidget) {
             // copied from outputarea.js
             var buffer = "";
             if (msgType === "stream") {
@@ -1880,8 +1884,15 @@ define(['jquery',
                             cell.metadata[this.KB_CELL].stackTrace.push(result);
                         }
                     }
-                    else if (showOutput)
+                    else if (showOutput) {
                         this.createOutputCell(cell, result);
+                        // if we create an output cell, and the callingWidget is defined, then make sure we say it
+                        // is complete (this is not updated for widgets with 'none' behavior otherwise)
+                        if(callingWidget) {
+                            if(callingWidget.changeState)
+                                callingWidget.changeState('complete');
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
This change allows us to add a method, populate parameters, and run it through an API call.  This is useful for widgets that need to trigger some additional narrative action, like computing some statistics on data selected in a widget using an existing narrative method, or calling a method to create say a FeatureSet based on features selected in a widget.

This is an important because it means we still get nice usability without having to create heavyweight widgets that do analysis internally, making it easier for people to see what is happening in a narrative.

You can test it out directly from the JS console like so:
```
var method_id = 'example_subdata';
var parameters = {
        'input_model':'model',
        'input_rxns':['rxn1','rxn2'],
        'input_cmpds' : 'cmpds1,cmpds2',
        'input_template' : ['something']
    };
IPython.narrative.createAndRunMethod(method_id, parameters);
```

Note that in the future we probably want to add a way for KBase widgets to notify when it is finished rendering/loading, so that we can update the state safely.  Since each widget potentially does something different and loads in multiple async steps, and because widgets can be arbitrarily nested, I'm not sure exactly how to do that.  Here I just keep checking until the method input widget is defined and ready, which worked properly for all the methods I tested with.

