### PR TITLE
No longer auto-quit when the Workspace service is unavailable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,11 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the IPython Notebook (more notes will follow).
 
+### Version 1.0.4
+__Changes__
+- Added widgets and methods to support feature-value analyses
+- JIRA KBASE-2626 - Narrative should no longer crash when the Workspace Service is unavailable, but it will produce a 404 error when trying to fetch a Narrative from that Workspace.
+
 ### Version 1.0.3
 __Changes__
 - JIRA KBASE-1672 - updated text in upload dialogs

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'mongonbmanager', 'ws_util', 'common', 'kbasewsmanager', 'services']
 
 from semantic_version import Version
-__version__ = Version("1.0.3")
+__version__ = Version("1.0.4")
 version = lambda: __version__
 
 # if run directly:

--- a/src/biokbase/narrative/kbasewsmanager.py
+++ b/src/biokbase/narrative/kbasewsmanager.py
@@ -117,7 +117,7 @@ class KBaseWSNotebookManager(NotebookManager):
             wsclient = self.wsclient()
             wsclient.ver()
         except Exception as e:
-            self.log.debug("Unable to connect to workspace service at {}: {}".format(self.kbasews_uri, e))
+            self.log.error("Unable to connect to workspace service at {}: {}".format(self.kbasews_uri, e))
 
         # Map Narrative ids to notebook names
         mapping = Dict()
@@ -687,7 +687,3 @@ for handlerstr in tgt_handlers:
     IPython.html.base.handlers.app_log.debug("Patching routes in %s.default_handler" % handlerstr)
     handler = importlib.import_module(handlerstr)
     handler_route_replace(handler.default_handlers, r'(?P<notebook_id>\w+-\w+-\w+-\w+-\w+)',r'(?P<notebook_id>ws\.\d+\.obj\.\d+)')
-
-# Load the plupload handler
-import upload_handler
-upload_handler.insert_plupload_handler()

--- a/src/biokbase/narrative/kbasewsmanager.py
+++ b/src/biokbase/narrative/kbasewsmanager.py
@@ -161,8 +161,9 @@ class KBaseWSNotebookManager(NotebookManager):
         try:
             all = ws_util.get_wsobj_meta(wsclient)
         except Exception, e:
-            return []            
-            # raise web.HTTPError(500, u"error'd!")
+            # Raising the exception here will cause the server to
+            # shut down, so don't crash, just return nothing.
+            return []
 
         self.mapping = {
             ws_id: "%s/%s" % (all[ws_id]['workspace'],all[ws_id]['meta'].get('name',"undefined"))
@@ -270,6 +271,8 @@ class KBaseWSNotebookManager(NotebookManager):
                 objmeta = ws_util.get_wsobj_meta(self.wsclient(), ws_id=m.group('wsid'))
             except ws_util.PermissionsError, err:
                 return False # XXX: kind of a lie!
+            except:
+                return False # Also kind of a lie... will be fixed with Jupyter 4 backend
             if notebook_id in objmeta:
                 self.mapping[notebook_id] = notebook_id
                 return True

--- a/src/biokbase/narrative/kbasewsmanager.py
+++ b/src/biokbase/narrative/kbasewsmanager.py
@@ -113,12 +113,12 @@ class KBaseWSNotebookManager(NotebookManager):
 
         # Verify we can poke the Workspace service at that URI by just checking its
         # version
-        try:
-            wsclient = self.wsclient()
-            wsclient.ver()
-        except Exception as e:
-            raise web.HTTPError(500, u"Unable to connect to workspace service"
-                                     u" at %s: %s " % (self.kbasews_uri, e))
+        # try:
+        #     wsclient = self.wsclient()
+        #     wsclient.ver()
+        # except Exception as e:
+        #     raise web.HTTPError(500, u"Unable to connect to workspace service"
+        #                              u" at %s: %s " % (self.kbasews_uri, e))
 
         # Map Narrative ids to notebook names
         mapping = Dict()
@@ -158,7 +158,11 @@ class KBaseWSNotebookManager(NotebookManager):
         self.log.debug("Listing Narratives")
         self.log.debug("kbase_session = %s" % str(self.kbase_session))
         wsclient = self.wsclient()
-        all = ws_util.get_wsobj_meta(wsclient)
+        try:
+            all = ws_util.get_wsobj_meta(wsclient)
+        except Exception, e:
+            return []            
+            # raise web.HTTPError(500, u"error'd!")
 
         self.mapping = {
             ws_id: "%s/%s" % (all[ws_id]['workspace'],all[ws_id]['meta'].get('name',"undefined"))

--- a/src/biokbase/narrative/kbasewsmanager.py
+++ b/src/biokbase/narrative/kbasewsmanager.py
@@ -113,12 +113,11 @@ class KBaseWSNotebookManager(NotebookManager):
 
         # Verify we can poke the Workspace service at that URI by just checking its
         # version
-        # try:
-        #     wsclient = self.wsclient()
-        #     wsclient.ver()
-        # except Exception as e:
-        #     raise web.HTTPError(500, u"Unable to connect to workspace service"
-        #                              u" at %s: %s " % (self.kbasews_uri, e))
+        try:
+            wsclient = self.wsclient()
+            wsclient.ver()
+        except Exception as e:
+            self.log.debug("Unable to connect to workspace service at {}: {}".format(self.kbasews_uri, e))
 
         # Map Narrative ids to notebook names
         mapping = Dict()

--- a/src/biokbase/narrative/magics.py
+++ b/src/biokbase/narrative/magics.py
@@ -20,9 +20,8 @@ from IPython.core.magic import (Magics, magics_class, line_magic,
 from IPython.display import HTML
 # KBase
 import biokbase.auth
-from biokbase.InvocationService.Client import \
-    InvocationService as InvocationClient
-import biokbase.narrative.upload_handler
+# from biokbase.InvocationService.Client import \
+#     InvocationService as InvocationClient
 from biokbase.narrative.common.url_config import URLS
 from biokbase.narrative.common.log_common import EVENT_MSG_SEP
 
@@ -618,42 +617,42 @@ else:
     # based heavily on method here:
     # http://dietbuddha.blogspot.com/2012/11/python-metaprogramming-dynamic-module.html
 
-    icmd = types.ModuleType('icmd', "Top level module for invocation command "
-                                    "helper functions")
-    sys.modules['icmd'] = icmd
+    # icmd = types.ModuleType('icmd', "Top level module for invocation command "
+    #                                 "helper functions")
+    # sys.modules['icmd'] = icmd
 
-    def mkfn(script):
-        def fn(*args):
-            args2 = [script]
-            args2 += list(args)
-            if inv_client is None:
-                ip.magic("inv_session")
-            stdout, stderr = inv_client.run_pipeline(inv_session," ".join(args2),[],200,'/')
-            if stderr:
-                user_msg("\n".join(stderr))
-            return stdout
-        return fn
+    # def mkfn(script):
+    #     def fn(*args):
+    #         args2 = [script]
+    #         args2 += list(args)
+    #         if inv_client is None:
+    #             ip.magic("inv_session")
+    #         stdout, stderr = inv_client.run_pipeline(inv_session," ".join(args2),[],200,'/')
+    #         if stderr:
+    #             user_msg("\n".join(stderr))
+    #         return stdout
+    #     return fn
 
-    # initialize an invocation session
-    ip.magic("inv_session")
-    cmds = inv_client.valid_commands()
-    for category in cmds:
-        catname = str(category['name']).replace('-','_')
-        m = types.ModuleType(catname,category['title'])
-        setattr(icmd,catname, m)
-        sys.modules['icmd.%s' % catname] = m
-        for item in category['items']:
-            script = str(item['cmd']).replace('-','_')
-            fn = mkfn(str(item['cmd']))
-            fn.__name__ = script
-            fn.__doc__ = "Runs the %s script via invocation service" % item['cmd']
-            setattr(m, script, fn)
-    ip.ex('import icmd')
-    try:
-        os.makedirs(workdir)
-    except OSError as exception:
-        if exception.errno != errno.EEXIST:
-            raise
-    os.chdir(workdir)
-    user_msg("Invocation service script helper functions have been loaded "
-             "under the icmd.* namespace")
+    # # initialize an invocation session
+    # ip.magic("inv_session")
+    # cmds = inv_client.valid_commands()
+    # for category in cmds:
+    #     catname = str(category['name']).replace('-','_')
+    #     m = types.ModuleType(catname,category['title'])
+    #     setattr(icmd,catname, m)
+    #     sys.modules['icmd.%s' % catname] = m
+    #     for item in category['items']:
+    #         script = str(item['cmd']).replace('-','_')
+    #         fn = mkfn(str(item['cmd']))
+    #         fn.__name__ = script
+    #         fn.__doc__ = "Runs the %s script via invocation service" % item['cmd']
+    #         setattr(m, script, fn)
+    # ip.ex('import icmd')
+    # try:
+    #     os.makedirs(workdir)
+    # except OSError as exception:
+    #     if exception.errno != errno.EEXIST:
+    #         raise
+    # os.chdir(workdir)
+    # user_msg("Invocation service script helper functions have been loaded "
+    #          "under the icmd.* namespace")

--- a/src/biokbase/narrative/magics.py
+++ b/src/biokbase/narrative/magics.py
@@ -177,23 +177,6 @@ class kbasemagics(Magics):
         return
         
     @line_magic
-    def uploader(self, line):
-        """
-        Bring up basic input form that allows you to upload files into /tmp/narrative
-        using PLUpload client libraries
-        Note that this is a demonstration prototype!
-        """
-        return HTML(biokbase.narrative.upload_handler.HTML_EXAMPLE)
-        
-    @line_magic
-    def jquploader(self, line):
-        """
-        Bring up an html cell with JQuery UI PLUpload widget that supports drag and drop
-        Note that this is a demonstration prototype!
-        """
-        return HTML(biokbase.narrative.upload_handler.JQUERY_UI_EXAMPLE)
-        
-    @line_magic
     def inv_session(self, line=None):
         """Return the current invocation session id, create one if necessary.
         Parameters are ignored

--- a/src/biokbase/narrative/monkeypatch.py
+++ b/src/biokbase/narrative/monkeypatch.py
@@ -20,6 +20,7 @@ import IPython.html.services.notebooks.handlers
 from IPython.html.notebook.handlers import web  # get Tornado hook
 import IPython
 from tornado import web
+import urllib2
 
 import biokbase.auth
 from biokbase.narrative.common.kblogging import get_logger, log_event
@@ -157,8 +158,15 @@ def do_patching(c):
     def write_error(self, status_code, exc_info=None, **kwargs):
         err_obj = exc_info[1]
         app_log.warn("Write error: {}".format(err_obj))
-        # handle  special not-found
-        if err_obj.log_message.startswith('Notebook does not exist'):
+        # handle special not-found
+
+        from pprint import pprint
+        pprint(exc_info)
+        if isinstance(err_obj, web.HTTPError) or isinstance(err_obj, urllib2.HTTPError):
+            app_log.warn("HTTP Error")
+            self.write(self.render_template('notfound.html', narr_id=kbase_env.narrative))
+            return
+        elif err_obj.log_message.startswith('Notebook does not exist'):
             app_log.warn("Not found error")
             self.write(self.render_template('notfound.html', narr_id=kbase_env.narrative))
             return

--- a/src/biokbase/narrative/ws_util.py
+++ b/src/biokbase/narrative/ws_util.py
@@ -87,6 +87,8 @@ def get_wsobj_meta(wsclient, objtype=ws_narrative_type, ws_id=None):
         if PermissionsError.is_permissions_error(err.message):
             raise PermissionsError(name=err.name, code=err.code,
                                    message=err.message, data=err.data)
+        else:
+            raise
     my_narratives = {}
     for obj in res:
         my_narratives["ws.%s.obj.%s" % (obj[obj_field['wsid']],obj[obj_field['objid']])] = dict(zip(list_objects_fields,obj))

--- a/src/config.json
+++ b/src/config.json
@@ -133,6 +133,6 @@
         "workspace": "https://ci.kbase.us/services/ws", 
         "ws_browser": "https://narrative.kbase.us/functional-site/#/ws"
     }, 
-   "release_notes": "https://github.com/kbase/narrative/blob/staging/RELEASE_NOTES.md", 
-    "version": "1.0.3"
+    "release_notes": "https://github.com/kbase/narrative/blob/staging/RELEASE_NOTES.md", 
+    "version": "1.0.4"
 }


### PR DESCRIPTION
See JIRA ticket: https://atlassian.kbase.us/browse/KBASE-2626

When the Workspace service is unavailable (due to misconfiguration, downtime, cosmic rays, etc.), a newly started Narrative will just bail out, and shut its IPython process right back down. A little annoying, maybe, but not really a problem unless you're running this as a process in a Docker container. Then it takes the container down with it, since the process finishes. Even worse, if you're provisioning a bunch of containers at once, and trying to maintain a queue of loaded containers, that'll cause some serious churn as they start up and shut down repeatedly.

This PR fixes that but inserting an error into the log, but it keeps IPython alive. Trying to fetch any narratives will likely result in a 404 (a restriction due to a number of reasons - mainly that this version of IPython doesn't deal with those types of errors very well. Fixed in the ease-dev-campaign branch that works against Jupyter 4.0), until the Workspace service comes back.

A follow up PR will amend the drop down in the browser to be able to shut down the browser. There's some finicky code restructuring that needs to take place to get that button to work without the rest of the Narrative apparatus being started up.