### PR TITLE
Small bug fix in Expression widgets

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionConditionsetBaseWidget.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionConditionsetBaseWidget.js
@@ -225,10 +225,10 @@ define(['jquery',
                         'index': desc.index,
                         'id': desc.id,
                         'name': desc.name ? desc.name : ' ',
-                        'min': stat.mins[i] === null? ' ' : stat.mins[i].toFixed(2),
-                        'max': stat.maxs[i] === null? ' ' : stat.maxs[i].toFixed(2),
-                        'avg': stat.avgs[i] === null? ' ' : stat.avgs[i].toFixed(2),
-                        'std': stat.stds[i] === null? ' ' : stat.stds[i].toFixed(2),
+                        'min': stat.mins[i] ? stat.mins[i].toFixed(2) : ' ',
+                        'max': stat.maxs[i] ? stat.maxs[i].toFixed(2) : ' ',
+                        'avg': stat.avgs[i] ? stat.avgs[i].toFixed(2) : ' ',
+                        'std': stat.stds[i] ? stat.stds[i].toFixed(2) : ' ',
                         'missing_values': stat.missing_values[i]
                     }
                 );

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionFeatureTableHeatmap.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionFeatureTableHeatmap.js
@@ -222,10 +222,10 @@
                     {
                         'id': desc.id,
                         'function' : gene_function ? gene_function : ' ',
-                        'min': stat.mins[ri] === null? ' ' : stat.mins[ri].toFixed(2),
-                        'max': stat.maxs[ri] === null? ' ' : stat.maxs[ri].toFixed(2),
-                        'avg': stat.avgs[ri] === null? ' ' : stat.avgs[ri].toFixed(2),
-                        'std': stat.stds[ri] === null? ' ' : stat.stds[ri].toFixed(2),
+                        'min': stat.mins[ri] ? stat.mins[ri].toFixed(2) : ' ',
+                        'max': stat.maxs[ri] ? stat.maxs[ri].toFixed(2) : ' ',
+                        'avg': stat.avgs[ri] ? stat.avgs[ri].toFixed(2) : ' ',
+                        'std': stat.stds[ri] ? stat.stds[ri].toFixed(2) : ' ',
                         'missing_values': stat.missing_values[ri],
                         'values': rowValues
                     }

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionGenesetBaseWidget.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionGenesetBaseWidget.js
@@ -222,10 +222,10 @@ define(['jquery',
                         'id': desc.id,
                         'name': desc.name ? desc.name : ' ',
                         'function' : gene_function ? gene_function : ' ',
-                        'min': stat.mins[i] === null? ' ' : stat.mins[i].toFixed(2),
-                        'max': stat.maxs[i] === null? ' ' : stat.maxs[i].toFixed(2),
-                        'avg': stat.avgs[i] === null? ' ' : stat.avgs[i].toFixed(2),
-                        'std': stat.stds[i] === null? ' ' : stat.stds[i].toFixed(2),
+                        'min': stat.mins[i] ? stat.mins[i].toFixed(2) : ' ',
+                        'max': stat.maxs[i] ? stat.maxs[i].toFixed(2) : ' ',
+                        'avg': stat.avgs[i] ? stat.avgs[i].toFixed(2) : ' ',
+                        'std': stat.stds[i] ? stat.stds[i].toFixed(2) : ' ',
                         'missing_values': stat.missing_values[i]
                     }
                 );

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -212,10 +212,10 @@ define(['jquery',
 						'index': desc.index,
 						'id': desc.id,
 						'name': desc.name,
-						'min': stat.min === null? ' ' : stat.min.toFixed(2),
-						'max': stat.max === null? ' ' : stat.max.toFixed(2),
-						'avg': stat.avg === null? ' ' : stat.avg.toFixed(2),
-						'std': stat.std === null? ' ' : stat.std.toFixed(2),
+						'min': stat.min ? stat.min.toFixed(2) : ' ',
+						'max': stat.max ? stat.max.toFixed(2) : ' ',
+						'avg': stat.avg ? stat.avg.toFixed(2) : ' ',
+						'std': stat.std ? stat.std.toFixed(2) : ' ',
 						'missing_values': stat.missing_values ? 'Yes' : 'No'
 					}
 				);
@@ -238,10 +238,10 @@ define(['jquery',
 						'id': desc.id,
 						'name': desc.name,
 						'function' : gene_function ? gene_function : ' ',
-						'min': stat.min === null? ' ' : stat.min.toFixed(2),
-						'max': stat.max === null? ' ' : stat.max.toFixed(2),
-						'avg': stat.avg === null? ' ' : stat.avg.toFixed(2),
-						'std': stat.std === null? ' ' : stat.std.toFixed(2),
+						'min': stat.min ? stat.min.toFixed(2) : ' ',
+						'max': stat.max ? stat.max.toFixed(2) : ' ',
+						'avg': stat.avg ? stat.avg.toFixed(2) : ' ',
+						'std': stat.std ? stat.std.toFixed(2) : ' ',
 						'missing_values': stat.missing_values ? 'Yes' : 'No'
 					}
 				);


### PR DESCRIPTION
In some cases if a particular expression data statistic is undefined (as opposed to null), the entire table will not render.  This PR fixes this bug.