### PR TITLE
Fix shared saving

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@ This is built on the IPython Notebook (more notes will follow).
 ### Version 1.0.5
 __Changes__
 - Fix for bugs in saving/loading App state and displaying App step output widgets.
+- Fix for a bug that prevented users with edit privileges from saving a shared narrative.
+- Fixed issue where FBA model comparison widget wasn't showing up properly.
 
 ### Version 1.0.4
 __Changes__

--- a/src/biokbase/narrative/kbasewsmanager.py
+++ b/src/biokbase/narrative/kbasewsmanager.py
@@ -516,7 +516,8 @@ class KBaseWSNotebookManager(NotebookManager):
             };
             ws_util.alter_workspace_metadata(wsclient, None, updated_metadata, ws_id=wsid)
         except Exception as e:
-            raise web.HTTPError(500, u'Error saving Narrative: %s, %s' % (e.__str__(), wsid))
+            pass
+            # raise web.HTTPError(500, u'Error saving Narrative: %s, %s' % (e.__str__(), wsid))
 
         # Now we can save the Narrative object.
         try:


### PR DESCRIPTION
This fixes a bug where shared narratives weren't always saving properly. If Alice makes a narrative and shares with Bob with edit (not share) rights, Bob wouldn't be able the narrative.

This just fixes that error so saving can occur.

However, due to how Narrative names get presented, altered names won't always appear right. The Narrative object in the NI might get a different name than what's shown on the Dashboard. This is more of a minor cosmetic bug, though, and will be put off until after the RSV.