### PR TITLE
Improved FeatureSet widget error handling

### DIFF
--- a/src/biokbase/narrative/common/generic_service_calls.py
+++ b/src/biokbase/narrative/common/generic_service_calls.py
@@ -163,7 +163,7 @@ def _app_get_state(workspace, token, URLS, job_manager, app_spec_json, method_sp
 
 def _method_get_state(workspace, token, URLS, job_manager, method_spec_json, param_values_json, method_job_id):
     methodSpec = json.loads(method_spec_json)
-    methodInputValues = json.loads(param_values_json)
+    methodInputValues = json.loads(correct_method_specs_json(param_values_json))
     njsClient = NarrativeJobService(URLS.job_service, token = token)
     wsClient = workspaceService(URLS.workspace, token = token)
     if method_job_id.startswith("method:"):


### PR DESCRIPTION
When features are not properly linked to a Genome, or cannot be found in a Genome, provide an error/warning per feature rather than an error that shows nothing.  This is useful for allowing the featureset object to still be inspected and for debugging.