### PR TITLE
Set of changes to fix malformatted tooltips on the data list panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,71 @@ kbase-extension/kbase_templates/old/
 kbase-extension/static/components/
 node_modules/
 install.log
+/nbproject/private/
+/src/build/
+/venvs/
+.projectKnowledge
+/nbproject/
+static/dist
+
+# From https://github.com/github/gitignore/blob/master/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "requirejs-json": "0.0.3",
     "requirejs-text": "2.0.14",
     "select2": "~3.5.2",
+    "select2-bootstrap-css": "^1.4.5",
     "underscore": "~1.8.3"
   }
 }

--- a/kbase-extension/kbase_templates/notebook.html
+++ b/kbase-extension/kbase_templates/notebook.html
@@ -18,7 +18,7 @@ window.mathjax_url = "{{mathjax_url}}";
 <link rel="stylesheet" href="{{ static_url("kbase/css/contigBrowserStyles.css") }}" type="text/css" />
 <link rel="stylesheet" href="{{ static_url("components/datatables/media/css/dataTables.bootstrap.min.css") }}" type="text/css" />
 <link rel="stylesheet" href="{{ static_url("components/select2/select2.css") }}" type="text/css" />
-<link rel="stylesheet" href="{{ static_url("components/select2/select2-bootstrap.css") }}" type="text/css" />
+<link rel="stylesheet" href="{{ static_url("components/select2-bootstrap-css/select2-bootstrap.css") }}" type="text/css" />
 
 <link rel="stylesheet" href="{{ static_url("notebook/css/override.css") }}" type="text/css" />
 <link rel="stylesheet" href=""  id='kernel-css'                             type="text/css" />

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1493,6 +1493,32 @@ div#notebook_panel {
 .kb-method-parameter-input input {
    font-weight: bold;
 }
+
+/*
+This set of styles is a to accomodate the required/satisfied icon which appears 
+between the select input control and the help text to the right of it. The 
+problem is that within the columns used for layout the select is set to 100% width
+and yet the icon is placed right next to it. The result is that the icon is shoved
+to the right of the select control and into the next column, overlapping the
+help text. The old method handling this was to scoot the help text far enough over 
+to accomodate the the icon intruding into its space. This technique makes space
+in the column in which the icon lives, and does this by shrinking the select
+control with padding, and then scooting the icon back into its column.
+*/
+.kb-method-parameter-input .select2-container {
+    /* allow space for the required (red arrow), satisfied (green checkbox) icon */
+    padding-right: 20px;
+}
+.kb-method-parameter-input .kb-method-parameter-accepted-glyph, 
+.kb-method-parameter-input .kb-method-parameter-required-glyph {
+    /* This scoots the icon inside */
+    margin-left: -15px;
+    font-size: 15px;
+}
+.kb-method-parameter-hint {
+    padding-left: 7px;
+}
+
 .kb-parameter-data-selection {
    font-weight: bold;
 }

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1737,40 +1737,40 @@ For data in KBase workspace
 }
 
 /* === Tooltips  === */
-
+/* see bootstrap styles, e.g. bootstrap.css, for the original definitions */
 div[class="tooltip-inner"] {
     max-width: 400px;
     white-space: pre-wrap;
     text-align: left;
 }
-.tooltip {
+.notebook_app .tooltip {
     z-index: 2000 !important;
 }
-.tooltip-inner {
+.notebook_app .tooltip-inner {
     background-color: #1B69B6;
 }
-.tooltip.top .tooltip-arrow {
+.notebook_app .tooltip.top .tooltip-arrow {
   border-top-color: #1B69B6;
 }
-.tooltip.top-left .tooltip-arrow {
+.notebook_app .tooltip.top-left .tooltip-arrow {
   border-top-color: #1B69B6;
 }
-.tooltip.top-right .tooltip-arrow {
+.notebook_app .tooltip.top-right .tooltip-arrow {
   border-top-color: #1B69B6;
 }
-.tooltip.right .tooltip-arrow {
+.notebook_app .tooltip.right .tooltip-arrow {
   border-right-color: #1B69B6;
 }
-.tooltip.left .tooltip-arrow {
+.notebook_app .tooltip.left .tooltip-arrow {
   border-left-color: #1B69B6;
 }
-.tooltip.bottom .tooltip-arrow {
+.notebook_app .tooltip.bottom .tooltip-arrow {
   border-bottom-color: #1B69B6;
 }
-.tooltip.bottom-left .tooltip-arrow {
+.notebook_app .tooltip.bottom-left .tooltip-arrow {
   border-bottom-color: #1B69B6;
 }
-.tooltip.bottom-right .tooltip-arrow {
+.notebook_app .tooltip.bottom-right .tooltip-arrow {
   border-bottom-color: #1B69B6;
 }
 

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1717,7 +1717,7 @@ button.kb-method-run {
     moz-box-shadow: 1px 1px 1px #ccc;
 }
 button.kb-method-run:hover {
-    background-color: #1E88E5;;
+    background-color: #1E88E5;
 }
 
 
@@ -1746,11 +1746,32 @@ div[class="tooltip-inner"] {
 .tooltip {
     z-index: 2000 !important;
 }
-.tooltip.top .tooltip-inner {
+.tooltip-inner {
     background-color: #1B69B6;
 }
 .tooltip.top .tooltip-arrow {
-    border-top-color: #1B69B6;
+  border-top-color: #1B69B6;
+}
+.tooltip.top-left .tooltip-arrow {
+  border-top-color: #1B69B6;
+}
+.tooltip.top-right .tooltip-arrow {
+  border-top-color: #1B69B6;
+}
+.tooltip.right .tooltip-arrow {
+  border-right-color: #1B69B6;
+}
+.tooltip.left .tooltip-arrow {
+  border-left-color: #1B69B6;
+}
+.tooltip.bottom .tooltip-arrow {
+  border-bottom-color: #1B69B6;
+}
+.tooltip.bottom-left .tooltip-arrow {
+  border-bottom-color: #1B69B6;
+}
+.tooltip.bottom-right .tooltip-arrow {
+  border-bottom-color: #1B69B6;
 }
 
 .kb-data-main-panel {
@@ -2010,7 +2031,7 @@ div[class="tooltip-inner"] {
     margin: 5px;
 }
 .kb-data-list-btn:hover {
-    background-color: #1E88E5;;
+    background-color: #1E88E5;
 }
 .kb-data-list-btn[disabled] {
     box-shadow: none;
@@ -2031,7 +2052,7 @@ div[class="tooltip-inner"] {
     margin: 5px;
 }
 .kb-data-list-cancel-btn:hover {
-    background-color: #CECECE;;
+    background-color: #CECECE;
 }
 
 .kb-data-list-row-hr {
@@ -2316,7 +2337,7 @@ div[class="tooltip-inner"] {
 }
 
 .kb-import-info {
-    font-weight:
+    font-weight: normal;
 }
 
 .kb-import-status {

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -341,8 +341,11 @@ define([
             });
         }, this));
 
-        $('[data-toggle="tooltip"]').tooltip();
-
+//        $('[data-toggle="tooltip"]').tooltip({
+//            placement: 'auto',
+//            delay: {show: 500, hide: 0}
+//        });
+        
         /*
          * Before we get everything loading, just grey out the whole %^! page
          */

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -1,7 +1,7 @@
 // Bind all page buttons right at startup.
 define(['jquery',
         'narrativeConfig', 
-        'jqueryui', 
+        'bootstrap', 
         'kbaseNarrativeSharePanel', 
         'bootstrap'], function($) {
     $(document).on('workspaceIdQuery.Narrative', function(e, callback) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -2,12 +2,13 @@
  * @author Michael Sneddon <mwsneddon@lbl.gov>
  * @public
  */
-define(['jquery', 
-        'jquery-nearest',
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseNarrativeDownloadPanel'], 
-        function($) {
+define([
+    'jquery', 
+    'jquery-nearest',
+    'kbwidget', 
+    'kbaseAuthenticatedWidget', 
+    'kbaseNarrativeDownloadPanel'
+], function($) {
     $.KBWidget({
         name: 'kbaseNarrativeDataList',
         parent: 'kbaseAuthenticatedWidget',
@@ -659,7 +660,7 @@ define(['jquery',
                     .hide()
                     .html($('<button class="btn btn-xs btn-default pull-right" aria-hidden="true">').append('<span class="fa fa-ellipsis-h" style="color:#888" />'));
             var toggleAdvanced = function() {
-                    if (self.selectedObject == object_info[0] && $moreRow.is(':visible')) {
+                    if (self.selectedObject === object_info[0] && $moreRow.is(':visible')) {
                         // assume selection handling occurs before this is called
                         // so if we are now selected and the moreRow is visible, leave it...
                         return;
@@ -752,7 +753,7 @@ define(['jquery',
                     // (a) find nearest cell using 'jquery-nearest'
                     var $near_elt = $($elt.nearest('.cell'));
                     var near_idx = 0;
-                    if ($near_elt == null || $near_elt.data() == null) {
+                    if ($near_elt === null || $near_elt.data() === null) {
                       // no cell found, so place at top
                     }
                     else {
@@ -782,9 +783,16 @@ define(['jquery',
 
             // Add tooltip to indicate this functionality
             $row.attr({'data-toggle': 'tooltip',
-                       'data-placement': 'top',
                         'title': 'Drag onto narrative &rarr;'});
-            $row.tooltip({delay: { show: 1500, hide: 0 }, html: true});
+            $row.tooltip({
+                delay: { show: 1000, hide: 0 }, 
+                placement: 'top auto', 
+                html: true, 
+                viewport: {
+                    selector: '#kb-side-panel .kb-narr-side-panel:nth-child(1) .kb-narr-panel-body',
+                    padding: 2
+                }
+            });
 
             return this;
         },

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -292,7 +292,7 @@ require.config({
             deps : ['jquery', 'jquery-svg']
         },
         'bootstrap' : {
-            deps : ['jquery']
+            deps : ['jquery', 'jqueryui']
         },
     }
 });


### PR DESCRIPTION
The main problem was that the jquery-ui tooltip plugin was being loaded after the bootstrap one, so tooltips, at least on the data list panel (I didn't check elsewhere), were rendered in the jquery-ui style, which was in the incorrect format and also did not place tooltip content as html, so character entities were displayed as plain text. 
The fix for this was to set jquery-ui as a dependency of bootstrap, and to load bootstrap in the main loading script rather than jquery-ui.
Secondarily, there were minor display problems with the data list tooltip. On the first item of the list, the tooltip would display above the item, and was mostly hidden inside containing element. The solution was to set the tooltip to try to display above the item, but if that would cause the tooltip to bump into the container, display it below. To enable this, the "viewport" property needed to be set to a selector which would match the container for the data list. Because there is no specific id on this container, the selector used is not very solid - it selects the first container within the left column, so if that order changes, or if the class names change, this will break. Seems like it will be solid for now, though.
Finally, since setting the tooltip to "auto" will lead to arbitrary locations for the tooltip, the style overrides (basically setting the background color to blue from the default black) needed to be extended to all the tooltip orientations. This was accomplished by copy/pasting the relevant bootstrap styles into the kbase stylesheet, removing extraneous styles, and overriding just the necessary colors. This is rather order-dependent (kbase after bootstrap), so I also added a specializer ancestor class (notebook_app on the body seems to be the most appropriate one).
A note -- I was confused at first because bootstrap is not made available through the stock stylesheets, rather a generically named "style.css" within jupiter. This does raise the issue of what might be different about it, and being able to keep this stylesheet, the bootstrap javascript which is loaded from a bower-installed package, and kbase-ui in sync.