### PR TITLE
Put in 're-run cell' button

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -79,12 +79,12 @@
 
             // initialize the state
             this.state = {
-                    runningState: {
-                        appRunState: "input", // could be 'input' || 'running' || 'error' || 'done', something else?
-                        runningStep: null
-                    },
-                    step: { }
-                };
+                runningState: {
+                    appRunState: "input", // could be 'input' || 'running' || 'error' || 'done', something else?
+                    runningStep: null
+                },
+                step: { }
+            };
             this.initErrorModal();
 
             this.fetchMethodInfo();
@@ -235,11 +235,11 @@
                 .attr('type', 'button')
                 .attr('value', 'Reset')
                 .addClass('kb-app-run kb-app-reset')
-                .append('Reset')
+                .append('Edit and Re-Run')
                 .css({'margin-right':'5px', 'margin-left':'10px'})
                 .click(
                     $.proxy(function(event) {
-                    self.resetAppRun(true);
+                    self.resetAppRun(false);
                 }, this)
             )
             .hide();
@@ -787,7 +787,6 @@
 
             // if we were in the running state before, set the values
             if (state.runningState) {
-                
                 if (state.runningState.appRunState) {
                     if (state.runningState.submittedText) {
                         this.$submitted.html(state.runningState.submittedText);
@@ -810,19 +809,11 @@
                             this.inputSteps[i].widget.lockInputs();
                         }
                     }
-                    else if (state.runningState.appRunState === "done") {
+                    else if (state.runningState.appRunState === "done" || state.runningState.appRunState === "complete") {
                         this.$submitted.show();
                         this.$runButton.hide();
+                        this.$resetButton.show();
                         // start minimized if done, todo: save minimization state of steps
-                        this.minimizeAllSteps();
-                        for(var i=0; i<this.inputSteps.length; i++) {
-                            this.inputSteps[i].widget.lockInputs();
-                        }
-                    }
-                    else if (state.runningState.appRunState === "complete") {
-                        this.$submitted.show();
-                        this.$runButton.hide();
-                        // start minimized if complete, todo: save minimization state of steps
                         this.minimizeAllSteps();
                         for(var i=0; i<this.inputSteps.length; i++) {
                             this.inputSteps[i].widget.lockInputs();
@@ -888,13 +879,16 @@
                     }
                 }
             }
-            else if (state === 'complete') {
+            else if (state === 'complete' || state === 'done') {
                 for (var i=0; i<this.inputSteps.length; i++) {
                     this.inputSteps[i].$stepContainer.removeClass('kb-app-step-running');
                 }
                 this.state.runningState.runningStep = null;
                 this.state.runningState.appRunState = state;
                 this.$stopButton.hide();
+                this.$resetButton.show();
+                this.displayRunning(false);
+
                 // Show the 'next-steps' to take, if there are any
                 this.getNextSteps(
                   $.proxy(function(next_steps) {
@@ -908,34 +902,35 @@
         },
 
 
-    /**
-    * Get next steps, and invoke `render_cb` to render
-    * the specs returned by the trigger:getFunctionSpecs.Narrative for
-    * each of the possible apps/methods.
-    */
-    getNextSteps: function(render_cb) {
-      var app = this.appSpec;
-      //console.debug("Find next steps for app", app);
-      // fetch full info, which contains suggested next steps
-      var params = {ids: [app.info.id]};
-      var result = {};
-      this.methClient.get_app_full_info(params,
-        $.proxy(function(info_list) {
-          //console.debug("Got full info for app:", info_list);
-          var sugg = info_list[0].suggestions;
-          //console.debug("Suggestions for app:", sugg);
-          var params = {apps: sugg.next_apps,methods: sugg.next_methods };
-          //console.debug("Getting function specs, params=", params);
-          // Pass callback to render each retrieved function spec
-          this.trigger('getFunctionSpecs.Narrative', [params, function(specs) {
-            render_cb(specs);
-          }]);
-        }, this),
-        $.proxy(function() {
-          KBError("kbaseNarrativeMethodCell.getNextSteps",
-          "Could not get full info for app:" + app.info.id);
-        }, this));
-      },
+        /**
+         * Get next steps, and invoke `render_cb` to render
+         * the specs returned by the trigger:getFunctionSpecs.Narrative for
+         * each of the possible apps/methods.
+         */
+        getNextSteps: function(render_cb) {
+            var app = this.appSpec;
+            //console.debug("Find next steps for app", app);
+            // fetch full info, which contains suggested next steps
+            var params = {ids: [app.info.id]};
+            var result = {};
+            this.methClient.get_app_full_info(params,
+                $.proxy(function(info_list) {
+                    //console.debug("Got full info for app:", info_list);
+                    var sugg = info_list[0].suggestions;
+                    //console.debug("Suggestions for app:", sugg);
+                    var params = {apps: sugg.next_apps,methods: sugg.next_methods };
+                    //console.debug("Getting function specs, params=", params);
+                    // Pass callback to render each retrieved function spec
+                    this.trigger('getFunctionSpecs.Narrative', [params, function(specs) {
+                        render_cb(specs);
+                    }]);
+                }, this),
+                $.proxy(function() {
+                    KBError("kbaseNarrativeMethodCell.getNextSteps",
+                        "Could not get full info for app:" + app.info.id);
+                }, this)
+            );
+        },
 
         /*
          * Handle error in app.
@@ -960,10 +955,10 @@
         setStepOutput: function(stepId, output, state, preventSave) {
             if (this.inputStepLookup) {
                 if(this.inputStepLookup[stepId]) {
-                    if (this.inputStepLookup[stepId].outputWidget) {
-                        //output is already set and cannot change, so we do not rerender
-                        return;
-                    }
+                    // if (this.inputStepLookup[stepId].outputWidget) {
+                    //     //output is already set and cannot change, so we do not rerender
+                    //     return;
+                    // }
                     // clear the output panel, and assume we are no longer running this step
                     this.inputStepLookup[stepId].$outputPanel.empty();
                     this.inputStepLookup[stepId].$stepContainer.removeClass("kb-app-step-running");

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -100,10 +100,24 @@
                               )
                               .hide();
 
+            this.$resetButton = $('<button>')
+                                .attr('type', 'button')
+                                .attr('value', 'Cancel')
+                                .addClass('kb-app-run')
+                                .append('Edit and Re-Run')
+                                .css({'margin-right':'5px'})
+                                .click(
+                                    $.proxy(function(event) {
+                                        this.stopRunning();
+                                    }, this)
+                                )
+                                .hide();
+
             var $buttons = $('<div>')
                            .addClass('buttons pull-left')
                            .append(this.$runButton)
                            .append(this.$stopButton)
+                           .append(this.$resetButton)
                            .append(this.$submitted);
 
             var $progressBar = $('<div>')
@@ -253,13 +267,13 @@
          */
         getState: function() {
             return {
-                'runningState' : {
-                    'runState' : this.runState,
-                    'submittedText' : this.submittedText,
-                    'outputState' : this.allowOutput
+                runningState : {
+                    runState : this.runState,
+                    submittedText : this.submittedText,
+                    outputState : this.allowOutput
                 },
-                'minimized' : this.panel_minimized,
-                'params' : this.$inputWidget.getState()
+                minimized : this.panel_minimized,
+                params : this.$inputWidget.getState()
             };
         },
 
@@ -351,7 +365,9 @@
                         this.$submitted.html(this.submittedText).show();
                         this.$runButton.hide();
                         this.$stopButton.hide();
+                        this.$resetButton.hide();
                         this.$inputWidget.lockInputs();
+                        this.allowOutput = true;
                         this.displayRunning(true);
                         break;
                     case 'complete':
@@ -360,6 +376,7 @@
                         this.$submitted.html(this.submittedText).show();
                         this.$runButton.hide();
                         this.$stopButton.hide();
+                        this.$resetButton.show();
                         this.$inputWidget.lockInputs();
                         this.displayRunning(false);
                         // maybe unlock? show a 'last run' box?
@@ -370,6 +387,7 @@
                         this.$cellPanel.addClass('kb-app-step-running');
                         this.$runButton.hide();
                         this.$stopButton.show();
+                        this.$resetButton.hide();
                         this.$inputWidget.lockInputs();
                         this.displayRunning(true);
                         break;
@@ -377,7 +395,8 @@
                         this.$submitted.html(this.submittedText).show();
                         this.$cellPanel.addClass('kb-app-step-error');
                         this.$runButton.hide();
-                        this.$stopButton.show();
+                        this.$stopButton.hide();
+                        this.$resetButton.show();
                         this.$inputWidget.lockInputs();
                         this.$elem.find('.kb-app-panel').addClass('kb-app-error');
                         this.displayRunning(false, true);
@@ -385,9 +404,11 @@
                     default:
                         this.$cellPanel.removeClass('kb-app-step-running');
                         this.$elem.find('.kb-app-panel').removeClass('kb-app-error');
+                        this.$cellPanel.removeClass('kb-app-step-error');
                         this.$submitted.hide();
                         this.$runButton.show();
                         this.$stopButton.hide();
+                        this.$resetButton.hide();
                         this.$inputWidget.unlockInputs();
                         this.displayRunning(false);
                         break;

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -2073,7 +2073,12 @@ define(['jquery',
         * Returns the <div> that was populated.
         */
         showNextSteps: function(obj) {
-          var $elt = obj.elt, next_steps = obj.next_steps;
+          var $elt = obj.elt;
+          // if the element already has a 'kb-app-next' div, don't add another one.
+          if ($elt.has('.kb-app-next').length)
+            return;
+
+          var next_steps = obj.next_steps;
           var $tgt = $('<div>').addClass('kb-app-next');
           var $title = $('<h3>').text('Suggested next steps:');
           $tgt.append($title);


### PR DESCRIPTION
This PR fixes JIRA issue KBASE-1360.
The re-run button had wandered off with recent changes. This replaces it with a few other state changes.

  1. When a method/app cell finishes running, the Cancel button is replaced by a 'Edit and Re-Run' button. Clicking this unlocks the input fields and re-enables running the cell.
  2. Fixes other state management problems - lingering run icons and lingering error state borders.
  3. In a method cell, the generated output is placed in a new cell. But in an app cell, the generated outputs are placed directly below each method. When re-running an app cell, the previously generated output viewers are removed. The data objects stay behind, however, and can be viewed by clicking on their names or dragging and dropping.
  4. After running, if next steps are available, they are only shown once. Previously, running a method/app cell multiple times might add the next steps block multiple times.
