### PR TITLE
Bumped version to 1.1.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,17 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the IPython Notebook (more notes will follow).
 
+### Version 1.1.0
+__Changes__
+- Updated 'filtered' in method panel to 'filtered out'.
+- Added uploaders for Feature-Value pair data.
+- Added viewers for BLAST output.
+- Added bokeh (Python) and Plot.ly (JS) dependencies.
+- Added KBase data_api methods.
+- Added a refresh button to the method panel.
+- Added support for method specs based on namespacing.
+- Added preliminary third party SDK support.
+
 ### Version 1.0.5
 __Changes__
 - Fix for bugs in saving/loading App state and displaying App step output widgets.

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'mongonbmanager', 'ws_util', 'common', 'kbasewsmanager', 'services']
 
 from semantic_version import Version
-__version__ = Version("1.0.5")
+__version__ = Version("1.1.0")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -143,5 +143,5 @@
         "ws_browser": "https://narrative.kbase.us/functional-site/#/ws"
     }, 
     "release_notes": "https://github.com/kbase/narrative/blob/staging/RELEASE_NOTES.md", 
-    "version": "1.0.5"
+    "version": "1.1.0"
 }


### PR DESCRIPTION
The new feature here is preliminary SDK support.

With any luck, this'll be the last release before upgrading the backend to Jupyter 4.0.6.