### PR TITLE
Changes/additions to support the SDK

### DIFF
--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/api/Catalog.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/api/Catalog.js
@@ -182,9 +182,9 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             [params], 1, _callback, _errorCallback);
     };
  
-     this.get_build_log = function (timestamp, _callback, _errorCallback) {
-        if (typeof timestamp === 'function')
-            throw 'Argument timestamp can not be a function';
+     this.get_build_log = function (registration_id, _callback, _errorCallback) {
+        if (typeof registration_id === 'function')
+            throw 'Argument registration_id can not be a function';
         if (_callback && typeof _callback !== 'function')
             throw 'Argument _callback must be a function if defined';
         if (_errorCallback && typeof _errorCallback !== 'function')
@@ -192,7 +192,135 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
         if (typeof arguments === 'function' && arguments.length > 1+2)
             throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
         return json_call_ajax("Catalog.get_build_log",
-            [timestamp], 1, _callback, _errorCallback);
+            [registration_id], 1, _callback, _errorCallback);
+    };
+ 
+     this.get_parsed_build_log = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.get_parsed_build_log",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.list_builds = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.list_builds",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.delete_module = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.delete_module",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
+     this.migrate_module_to_new_git_url = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.migrate_module_to_new_git_url",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
+     this.set_to_active = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.set_to_active",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
+     this.set_to_inactive = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.set_to_inactive",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
+     this.is_approved_developer = function (usernames, _callback, _errorCallback) {
+        if (typeof usernames === 'function')
+            throw 'Argument usernames can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.is_approved_developer",
+            [usernames], 1, _callback, _errorCallback);
+    };
+ 
+     this.list_approved_developers = function (_callback, _errorCallback) {
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 0+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(0+2)+')';
+        return json_call_ajax("Catalog.list_approved_developers",
+            [], 1, _callback, _errorCallback);
+    };
+ 
+     this.approve_developer = function (username, _callback, _errorCallback) {
+        if (typeof username === 'function')
+            throw 'Argument username can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.approve_developer",
+            [username], 0, _callback, _errorCallback);
+    };
+ 
+     this.revoke_developer = function (username, _callback, _errorCallback) {
+        if (typeof username === 'function')
+            throw 'Argument username can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.revoke_developer",
+            [username], 0, _callback, _errorCallback);
     };
   
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/api/NarrativeJobServiceWrapper.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/api/NarrativeJobServiceWrapper.js
@@ -1,0 +1,249 @@
+function NarrativeJobService(url, auth, auth_cb) {
+
+    this.url = url;
+    var _url = url;
+    var deprecationWarningSent = false;
+
+    function deprecationWarning() {
+        if (!deprecationWarningSent) {
+            deprecationWarningSent = true;
+            if (!window.console) return;
+            console.log(
+                "DEPRECATION WARNING: '*_async' method names will be removed",
+                "in a future version. Please use the identical methods without",
+                "the'_async' suffix.");
+        }
+    }
+
+    var _auth = auth ? auth : { 'token' : '', 'user_id' : ''};
+    var _auth_cb = auth_cb;
+
+
+    this.run_app = function (app, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.run_app",
+        [app], 1, _callback, _errorCallback);
+};
+
+    this.run_app_async = function (app, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.run_app", [app], 1, _callback, _error_callback);
+    };
+
+    this.check_app_state = function (job_id, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.check_app_state",
+        [job_id], 1, _callback, _errorCallback);
+};
+
+    this.check_app_state_async = function (job_id, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.check_app_state", [job_id], 1, _callback, _error_callback);
+    };
+
+    this.suspend_app = function (job_id, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.suspend_app",
+        [job_id], 1, _callback, _errorCallback);
+};
+
+    this.suspend_app_async = function (job_id, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.suspend_app", [job_id], 1, _callback, _error_callback);
+    };
+
+    this.resume_app = function (job_id, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.resume_app",
+        [job_id], 1, _callback, _errorCallback);
+};
+
+    this.resume_app_async = function (job_id, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.resume_app", [job_id], 1, _callback, _error_callback);
+    };
+
+    this.delete_app = function (job_id, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.delete_app",
+        [job_id], 1, _callback, _errorCallback);
+};
+
+    this.delete_app_async = function (job_id, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.delete_app", [job_id], 1, _callback, _error_callback);
+    };
+
+    this.list_config = function (_callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.list_config",
+        [], 1, _callback, _errorCallback);
+};
+
+    this.list_config_async = function (_callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.list_config", [], 1, _callback, _error_callback);
+    };
+
+    this.ver = function (_callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.ver",
+        [], 1, _callback, _errorCallback);
+};
+
+    this.ver_async = function (_callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.ver", [], 1, _callback, _error_callback);
+    };
+
+    this.status = function (_callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.status",
+        [], 1, _callback, _errorCallback);
+};
+
+    this.status_async = function (_callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.status", [], 1, _callback, _error_callback);
+    };
+
+    this.list_running_apps = function (_callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.list_running_apps",
+        [], 1, _callback, _errorCallback);
+};
+
+    this.list_running_apps_async = function (_callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.list_running_apps", [], 1, _callback, _error_callback);
+    };
+
+    this.run_job = function (params, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.run_job",
+        [params], 1, _callback, _errorCallback);
+};
+
+    this.run_job_async = function (params, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.run_job", [params], 1, _callback, _error_callback);
+    };
+
+    this.get_job_params = function (job_id, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.get_job_params",
+        [job_id], 2, _callback, _errorCallback);
+};
+
+    this.get_job_params_async = function (job_id, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.get_job_params", [job_id], 2, _callback, _error_callback);
+    };
+
+    this.add_job_logs = function (job_id, lines, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.add_job_logs",
+        [job_id, lines], 1, _callback, _errorCallback);
+};
+
+    this.add_job_logs_async = function (job_id, lines, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.add_job_logs", [job_id, lines], 1, _callback, _error_callback);
+    };
+
+    this.get_job_logs = function (params, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.get_job_logs",
+        [params], 1, _callback, _errorCallback);
+};
+
+    this.get_job_logs_async = function (params, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.get_job_logs", [params], 1, _callback, _error_callback);
+    };
+
+    this.finish_job = function (job_id, params, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.finish_job",
+        [job_id, params], 0, _callback, _errorCallback);
+};
+
+    this.finish_job_async = function (job_id, params, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.finish_job", [job_id, params], 0, _callback, _error_callback);
+    };
+
+    this.check_job = function (job_id, _callback, _errorCallback) {
+    return json_call_ajax("NarrativeJobService.check_job",
+        [job_id], 1, _callback, _errorCallback);
+};
+
+    this.check_job_async = function (job_id, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("NarrativeJobService.check_job", [job_id], 1, _callback, _error_callback);
+    };
+ 
+
+    /*
+     * JSON call using jQuery method.
+     */
+    function json_call_ajax(method, params, numRets, callback, errorCallback) {
+        var deferred = $.Deferred();
+
+        if (typeof callback === 'function') {
+           deferred.done(callback);
+        }
+
+        if (typeof errorCallback === 'function') {
+           deferred.fail(errorCallback);
+        }
+
+        var rpc = {
+            params : params,
+            method : method,
+            version: "1.1",
+            id: String(Math.random()).slice(2),
+        };
+
+        var beforeSend = null;
+        var token = (_auth_cb && typeof _auth_cb === 'function') ? _auth_cb()
+            : (_auth.token ? _auth.token : null);
+        if (token != null) {
+            beforeSend = function (xhr) {
+                xhr.setRequestHeader("Authorization", token);
+            }
+        }
+
+        var xhr = jQuery.ajax({
+            url: _url,
+            dataType: "text",
+            type: 'POST',
+            processData: false,
+            data: JSON.stringify(rpc),
+            beforeSend: beforeSend,
+            success: function (data, status, xhr) {
+                var result;
+                try {
+                    var resp = JSON.parse(data);
+                    result = (numRets === 1 ? resp.result[0] : resp.result);
+                } catch (err) {
+                    deferred.reject({
+                        status: 503,
+                        error: err,
+                        url: _url,
+                        resp: data
+                    });
+                    return;
+                }
+                deferred.resolve(result);
+            },
+            error: function (xhr, textStatus, errorThrown) {
+                var error;
+                if (xhr.responseText) {
+                    try {
+                        var resp = JSON.parse(xhr.responseText);
+                        error = resp.error;
+                    } catch (err) { // Not JSON
+                        error = "Unknown error - " + xhr.responseText;
+                    }
+                } else {
+                    error = "Unknown Error";
+                }
+                deferred.reject({
+                    status: 500,
+                    error: error
+                });
+            }
+        });
+
+        var promise = deferred.promise();
+        promise.xhr = xhr;
+        return promise;
+    }
+}

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
@@ -24,8 +24,7 @@ define(['jquery',
             catalogURL: 'https://ci.kbase.us/services/catalog',
 			loadingImage: "static/kbase/images/ajax-loader.gif"
 		},
-		// Prefix for all element ids
-		pref: null,
+
 		// Catalog client
 		catalogClient: null,
 
@@ -134,11 +133,11 @@ define(['jquery',
                         for(var k=self.log.length; k<log_length; k++) {
                             if(k>=skip) {
                                 self.log.push(build_info.log[k-skip]);
-                                self.appendLineToLog(build_info.log[k-skip].content,skip);
+                                self.appendLineToLog(build_info.log[k-skip].content);
                             } else {
                                 // odd- we're getting a chunk before an earlier chunk
                                 self.log.push({'content':'','is_error':0})
-                                self.appendLineToLog('',skip); // odd, we're 
+                                self.appendLineToLog(''); // odd, we're 
                             }
                         }
 
@@ -155,7 +154,7 @@ define(['jquery',
         },
 
 
-        appendLineToLog: function(line, skip) {
+        appendLineToLog: function(line) {
             self = this;
             self.$log_window.val(self.$log_window.val()+line)
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
@@ -27,8 +27,12 @@ define(['jquery',
 		// Catalog client
 		catalogClient: null,
 
+
+        log: null,
+
         init: function(options) {
             this._super(options);
+            this.registration_id = options.output;
             this.pref = this.uuid();
             if (window.kbconfig && window.kbconfig.urls)
                 this.options.catalogURL = window.kbconfig.urls.catalog;
@@ -36,6 +40,7 @@ define(['jquery',
             this.$messagePane = $("<div/>").addClass("kbwidget-message-pane kbwidget-hide-message");
             this.$elem.append(this.$messagePane);
             this.loading(true);
+            this.log = [];
             return this;
         },
 
@@ -61,105 +66,119 @@ define(['jquery',
             var self = this;
             var pref = this.pref;
             var container = this.$elem;
-            var table = $('<table class="table table-striped table-bordered" \
-                    style="margin-left: auto; margin-right: auto;" id="'+pref+'info-table"/>');
-            container.append(table);
+
+            var $table = $('<table class="table table-striped table-bordered" style="margin-left: auto; margin-right: auto;" />');
+
+            container.append($table);
             var width = "15%"
-            table.append('<tr><td width="'+width+'">Timestamp</td><td id="'+pref+'_timestamp"></td></tr>');
-            table.append('<tr><td width="'+width+'">Is active</td><td id="'+pref+'_active"></td></tr>');
-            table.append('<tr><td width="'+width+'">Release Approval</td><td id="'+pref+'_release_approval"></td></tr>');
-            table.append('<tr><td width="'+width+'">Release Review</td><td id="'+pref+'_review_message"></td></tr>');
-            table.append('<tr><td width="'+width+'">State</td><td id="'+pref+'_registration"></td></tr>');
-            table.append('<tr><td width="'+width+'">Error</td><td><textarea style="width:100%;" rows="2" readonly id="'+pref+'_error"/></td></tr>');
-            table.append('<tr><td width="'+width+'">Build-log</td><td><textarea style="width:100%;" rows="5" readonly id="'+pref+'_build_log"/></td></tr>');
-            self.refreshState();
+
+            $table.append('<tr><td width="'+width+'">Registration ID</td><td>'+self.registration_id+'</td></tr>');
+            //table.append('<tr><td width="'+width+'">Is active</td><td id="'+pref+'_active"></td></tr>');
+            //table.append('<tr><td width="'+width+'">Release Approval</td><td id="'+pref+'_release_approval"></td></tr>');
+            //table.append('<tr><td width="'+width+'">Release Review</td><td id="'+pref+'_review_message"></td></tr>');
+            self.$registration_state_td = $('<td></td>')
+            $table.append(
+                $('<tr>')
+                    .append($('<td width="'+width+'">Progress</td>'))
+                    .append(self.$registration_state_td));
+            //table.append('<tr><td width="'+width+'">Error Mssg</td><td><textarea style="width:100%;" rows="2" readonly id="'+pref+'_error"/></td></tr>');
+
+            self.$log_window = $('<textarea style="width:100%;font-family:Monaco,monospace;font-size:9pt;color:#555;" rows="20" readonly>')
+            container.append(self.$log_window);
+
+            self.$track_checkbox= $('<input type="checkbox">').prop('checked', true);;
+            var $checkboxContainer = $('<div>').addClass('checkbox').css({width:"100%"})
+                .append($('<label>')
+                    .append(self.$track_checkbox)
+                    .append('Track Log'));
+            
+            //$checkboxContainer.append($('<label>').append(self.$track_checkbox));
+            container.append($checkboxContainer)
+
+            self.getLogAndState(self.registration_id,0);
         },
         
 
         getState: function() {
-            var self = this;
-            if(self.state) return self.state
             return null;
         },
 
         loadState: function(state) {
+        },
+
+        getLogAndState: function(registration_id, skip) {
             var self = this;
-            if(state) {
-                self.state = state;
-                self.catalogClient.get_build_log(self.options.output, function(data2) {
-                    //console.log(data2);
-                    self.showData(state, data2);
-                }, function(error) {
-                    //console.log(error);
-                    self.showData(data, error.error.error);
-                });
+
+            var chunk_size = 10000
+            
+            self.catalogClient.get_parsed_build_log({
+                                            'registration_id':self.options.output,
+                                            'skip':skip,
+                                            'limit':chunk_size
+                                        },
+                    function(build_info) {
+
+                        // display the state
+                        self.updateBuildState(build_info.registration, build_info.error_message);
+
+                        // make sure our log array is big enough
+                        var log_length = skip+build_info.log.length;
+                        self.last_log_line = log_length;
+
+                        for(var k=self.log.length; k<log_length; k++) {
+                            if(k>=skip) {
+                                self.log.push(build_info.log[k-skip]);
+                                self.appendLineToLog(build_info.log[k-skip].content,skip);
+                            } else {
+                                // odd- we're getting a chunk before an earlier chunk
+                                self.log.push({'content':'','is_error':0})
+                                self.appendLineToLog('',skip); // odd, we're 
+                            }
+                        }
+
+                        // get the next chunk if there is more
+                        if(build_info.log.length == chunk_size) {
+                            setTimeout(self.getLogAndState(registration_id, skip+chunk_size), 50);
+                            self.getLogAndState(registration_id, skip+chunk_size);
+                        }
+
+                    }, function(error) {
+                        console.error(error);
+                        //self.showData(data, error.error.error);
+                    });
+        },
+
+
+        appendLineToLog: function(line, skip) {
+            self = this;
+            self.$log_window.val(self.$log_window.val()+line)
+
+            if(self.$track_checkbox.prop('checked')) {
+                self.$log_window.scrollTop(self.$log_window[0].scrollHeight); // scroll to bottom
             }
         },
 
-        showData : function(data, build_log) {
+        updateBuildState: function(state, error) {
             var self = this;
             self.loading(false);
-            var pref = this.pref;
-            var state = data.registration;
-            $('#'+pref+'_timestamp').html('' + self.options.output);
-            $('#'+pref+'_active').html(data.active ? ''+data.active : '[unknown]');
-            $('#'+pref+'_release_approval').html(data.release_approval ? data.release_approval : '[unknown]');
-            $('#'+pref+'_review_message').html(data.review_message ? data.review_message : '');
-            $('#'+pref+'_registration').html(state ? state : '[unknown]');
-            $('#'+pref+'_error').val(data.error_message ? data.error_message : '');
-            $('#'+pref+'_build_log').val('' + build_log);
-            $('#'+pref+'_build_log').scrollTop($('#'+pref+'_build_log')[0].scrollHeight); // scroll to bottom
+            self.$registration_state_td
             if (state === 'error') {
-                self.state = data
-                $('#'+pref+'_registration').empty()
+                self.$registration_state_td.empty()
                     .append($('<span>').addClass('label label-danger').append(state))
+                    .append('<br><br>')
+                    .append(error)
+
                 // now always show if something is in error field
                 //$('#'+pref+'_error').val(data.error_message);
             } else if (state !== 'complete') {
+                self.$registration_state_td.empty().append(state)
                 setTimeout(function(event) {
-                    self.refreshState();
+                    self.getLogAndState(self.registration_id, self.last_log_line);
                 }, 1000);
             } else {
-                $('#'+pref+'_registration').empty()
+                self.$registration_state_td.empty()
                     .append($('<span>').addClass('label label-success').append(state))
-                self.state = data
             }
-        },
-
-
-        refreshState: function() {
-            var self = this;
-            self.catalogClient.get_module_state({git_url: self.options.git_url},
-                function(data) {
-                    // If state was already defined, then it might have been set by the narrative, and
-                    // we just reload it.
-                    if(self.state) {
-                        self.loadState(self.state)
-                        return
-                    }
-                    //console.log(data);
-                    self.catalogClient.get_build_log(self.options.output, function(data2) {
-                        //console.log(data2);
-                        self.showData(data, data2);
-                    }, function(error) {
-                        //console.log(error);
-                        self.showData(data, error.error.error);
-                    });
-                },
-                function(error) {
-                    console.log(error);
-                    self.clientError(error);
-                }
-            );
-        },
-
-        getData: function() {
-            return {
-                type: 'RegisterRepoState',
-                id: this.options.expressionMatrixID,
-                workspace: this.options.workspaceID,
-                title: 'Repository State'
-            };
         },
 
         loading: function(isLoading) {
@@ -171,7 +190,6 @@ define(['jquery',
 
         showMessage: function(message) {
             var span = $("<span/>").append(message);
-
             this.$messagePane.append(span);
             this.$messagePane.show();
         },
@@ -179,19 +197,6 @@ define(['jquery',
         hideMessage: function() {
             this.$messagePane.hide();
             this.$messagePane.empty();
-        },
-
-        uuid: function() {
-            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, 
-                function(c) {
-                    var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
-                    return v.toString(16);
-                });
-        },
-
-        clientError: function(error){
-            this.loading(false);
-            this.showMessage(error.error.error);
-        }        
+        }     
     });
 });

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
@@ -88,14 +88,14 @@ define(['jquery',
                     .append(self.$registration_state_td));
             //table.append('<tr><td width="'+width+'">Error Mssg</td><td><textarea style="width:100%;" rows="2" readonly id="'+pref+'_error"/></td></tr>');
 
-            self.$log_window = $('<textarea style="width:100%;font-family:Monaco,monospace;font-size:9pt;color:#555;" rows="20" readonly>')
+            self.$log_window = $('<textarea style="width:100%;font-family:Monaco,monospace;font-size:9pt;color:#555;resize:vertical;" rows="20" readonly>')
             container.append(self.$log_window);
 
             self.$track_checkbox= $('<input type="checkbox">').prop('checked', true);;
             var $checkboxContainer = $('<div>').addClass('checkbox').css({width:"100%"})
                 .append($('<label>')
                     .append(self.$track_checkbox)
-                    .append('Track Log'));
+                    .append('Auto scroll to new log output'));
             
             //$checkboxContainer.append($('<label>').append(self.$track_checkbox));
             container.append($checkboxContainer)

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -1,0 +1,280 @@
+/**
+ * Basic viz for a basic report type.
+ * @public
+ */
+
+define(['jquery', 
+        'kbwidget', 
+        'kbaseAuthenticatedWidget', 
+        'jquery-dataTables',
+        'jquery-dataTables-bootstrap',        
+        'kbase-client-api'
+        ], function($) {
+    $.KBWidget({
+        name: 'kbaseReportView',
+        parent: 'kbaseAuthenticatedWidget',
+        version: '1.0.0',
+        options: {
+            workspace_name: null,
+            report_name: null,
+
+            report_window_line_height: 10,
+
+            wsURL: window.kbconfig.urls.workspace,
+            loadingImage: "static/kbase/images/ajax-loader.gif"
+        },
+
+        // workspace client
+        ws: null,
+
+        init: function(options) {
+            this._super(options);
+
+            if (window.kbconfig && window.kbconfig.urls) {
+                this.options.wsURL = window.kbconfig.urls.workspace;
+            }
+
+            // Create a message pane
+            this.$messagePane = $("<div/>").addClass("kbwidget-message-pane kbwidget-hide-message");
+            this.$elem.append(this.$messagePane);      
+
+            this.$mainPanel = $("<div>"); 
+            this.$elem.append(this.$mainPanel);
+
+            return this;
+        },
+
+        loggedInCallback: function(event, auth) {
+
+           // Build a client
+            this.ws = new Workspace(this.options.wsURL, auth);         
+
+            // Let's go...
+            this.loadAndRender();           
+            return this;
+        },
+
+        loggedOutCallback: function(event, auth) {
+            this.isLoggedIn = false;
+            return this;
+        },
+
+        reportData: null,
+
+        loadAndRender: function(){
+            var self = this;
+            self.loading(true);
+
+            var objIdentity = self.buildObjectIdentity(this.options.workspace_name, this.options.report_name, null, null);
+            self.ws.get_objects([objIdentity],
+                function(data) {
+                    self.reportData = data[0].data;
+                    self.render();
+                }, function(error) {
+                    self.clientError(error);
+                });
+        },
+
+        render: function(){
+            var self = this;
+
+            // Handle warnings?
+            if(self.reportData.warnings) {
+                if(self.reportData.warnings.length>0) {
+                    var $warningPanel = $('<div style="max-height:100px;overflow-y:auto;margin:0px 5px 5px 10px;">')
+                    var warnings = self.reportData.warnings;
+                    if(warnings.length>=5) {
+                        $warningPanel.append($('<div>').css('margin','5px').append('['+warnings.length+'Warnings]'))
+                    }
+                    for(var k=0; k<warnings.length; k++) {
+                        $warningPanel.append(
+                            $('<div>').css('margin','0px 5px 5px 10px').append(
+                                $('<span>').addClass('label label-warning')
+                                    .append(warnings[k])));
+                    }
+                    self.$mainPanel.append($warningPanel);
+                }
+            }
+
+            var $report_window = $('<textarea style="width:100%;font-family:Monaco,monospace;font-size:9pt;color:#555;resize:vertical;" rows="'+
+                                        self.options.report_window_line_height+'" readonly>')
+                                        .append(self.reportData.text_message);
+            self.$mainPanel.append($report_window);
+
+
+            if(self.reportData.objects_created) {
+                if(self.reportData.objects_created.length>0) {
+
+                    var objsCreated = self.reportData.objects_created;
+
+                    var objIds = []
+                    for(var i=0; i<objsCreated.length; i++) {
+                        objIds.push({'ref':objsCreated[i].ref})
+                    }
+                    self.ws.get_object_info_new({'objects':objIds},
+                        function(objInfo) {
+
+                            var displayData = [];
+                            for(var k=0; k<objInfo.length; k++) {
+
+                                //var nameHTML = $('<a>').append(objInfo[k][1])
+                                /* TODO: we need code something like this to show data objects on click
+                                var obj = _.findWhere(self.objectList, {key: key});
+                                var info = self.createInfoObject(obj.info);
+                                // Insert the narrative data cell into the div we just rendered
+                                //$('#' + cell_id).kbaseNarrativeDataCell({cell: cell, info: info});
+                                self.trigger('createViewerCell.Narrative', {
+                                    'nearCellIdx': near_idx,
+                                    'widget': 'kbaseNarrativeDataCell',
+                                    'info' : info
+                                });*/
+
+                                displayData.push({
+                                    'name':objInfo[k][1],
+                                    'type':objInfo[k][2].split('-')[0].split('.')[1],
+                                    'fullType':objInfo[k][2],
+                                    'description': objsCreated[k].description ? objsCreated[k].description : ''
+                                });
+                            }
+
+                            var iDisplayLength = 5;
+                            var sDom = "ft<ip>";
+                            var $tblDiv = $('<div>').css('margin-top','10px');
+                            self.$mainPanel.append($tblDiv);
+                            if(displayData.length<=iDisplayLength) { 
+                                var $objTable = $('<table class="table table-striped table-bordered" style="margin-left: auto; margin-right: auto;">');
+
+                                displayData.sort(function(a, b) {
+                                  return a.name < b.name;
+                                });
+                                var color = '#555';
+                                $objTable.append($('<tr>')
+                                        .append('<th style="width:30%;color:'+color+';"><b>Created Object Name</b></th>')
+                                        .append('<th style="width:20%;color:'+color+';"><b>Type</b></th>')
+                                        .append('<th style="color:'+color+';"><b>Description</b></th>'));
+                                for(var k=0; k<displayData.length; k++) {
+                                    $objTable.append($('<tr>')
+                                        .append('<td style="width:30%;color:'+color+';">'+displayData[k].name+'</td>')
+                                        .append('<td style="width:20%;color:'+color+';">'+displayData[k].type+'</td>')
+                                        .append('<td style="color:'+color+';">'+displayData[k].description+'</td>'));
+                                }
+                                $tblDiv.append($objTable)
+                            } else {
+                                var $tbl = $('<table cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin-left: 0px; margin-right: 0px;">')
+                                                .addClass("table table-bordered table-striped");
+                                $tblDiv.append($tbl);
+
+                                var sDom = "ft<ip>";
+
+                                var tblSettings = {
+                                    "sPaginationType": "full_numbers",
+                                    "iDisplayLength": iDisplayLength,
+                                    "sDom": sDom,
+                                    "aaSorting": [[ 0, "asc" ]],
+                                    "aoColumns": [
+                                                    { sTitle: "<b>Created Object Name</b>", mData: "name", sWidth: "30%"},
+                                                    { sTitle: "<b>Type</b>", mData:"type", sWidth: "20%"},
+                                                    { sTitle: "<b>Description</b>", mData:"description" }
+                                                ],
+                                                "aaData": [],
+                                                "oLanguage": {
+                                                    "sSearch": "Search: ",
+                                                    "sEmptyTable": "No created objects."
+                                                }
+                                    };
+                                var objTable = $tbl.dataTable(tblSettings);
+                                objTable.fnAddData(displayData);
+
+
+                                var $objTable = $('<table ' + 
+                                                    'class="table table-bordered table-striped" style="width:100%;margin-left:0px; margin-right:0px;">'+
+                                                        '</table>')
+                                                        .dataTable( {
+                                                            "sPaginationType": "full_numbers",
+                                                            "sDom": sDom,
+                                                            "iDisplayLength": iDisplayLength,
+                                                            "aaSorting": [[ 0, "asc" ], [1, "asc"]],
+                                                            "aaData": displayData,
+                                                            "aoColumns": [
+                                                                { sTitle: "Created Object Name", mData: "name", sWidth: "20%"},
+                                                                { sTitle: "Type", mData:"type", sWidth: "20%"},
+                                                                { sTitle: "Description", mData:"description" }
+                                                            ],
+                                                            "oLanguage": {
+                                                                        "sEmptyTable": "No objects specified!",
+                                                                        "sSearch": "Search Created Objects: "
+                                                            }
+                                                        } );
+                                //$tblDiv.append($objTable)
+                            }
+                        }, function(error) {
+                            console.error(error);
+                        });
+                }
+            }
+
+            this.loading(false);
+        },
+
+        loading: function(isLoading) {
+            if (isLoading)
+                this.showMessage("<img src='" + this.options.loadingImage + "'/>");
+            else
+                this.hideMessage();                
+        },
+
+        showMessage: function(message) {
+            var span = $("<span/>").append(message);
+            this.$messagePane.append(span);
+            this.$messagePane.show();
+        },
+
+        hideMessage: function() {
+            this.$messagePane.hide();
+            this.$messagePane.empty();
+        },
+
+        clientError: function(error){
+            this.loading(false);
+            var errString = "Unknown error.";
+            console.error(error);
+            if (typeof error === "string")
+                errString = error;
+            else if (error.error && error.error.message)
+                errString = error.error.message;
+            else if (error.error && error.error.error && typeof error.error.error==='string') {
+                errString = error.error.error;
+            }
+            
+            var $errorDiv = $("<div>")
+                            .addClass("alert alert-danger")
+                            .append("<b>Error:</b>")
+                            .append("<br>" + errString);
+            this.$elem.empty();
+            this.$elem.append($errorDiv);
+        },            
+
+        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
+            var obj = {};
+            if (wsRef) {
+                obj['ref'] = wsRef;
+            } else {
+                if (/^\d+$/.exec(workspaceID))
+                    obj['wsid'] = workspaceID;
+                else
+                    obj['workspace'] = workspaceID;
+
+                // same for the id
+                if (/^\d+$/.exec(objectID))
+                    obj['objid'] = objectID;
+                else
+                    obj['name'] = objectID;
+                
+                if (objectVer)
+                    obj['ver'] = objectVer;
+            }
+            return obj;
+        }
+
+    });
+});

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseViewLiveRunLog.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseViewLiveRunLog.js
@@ -73,14 +73,14 @@ define(['jquery',
                     .append($('<td width="'+width+'">State</td>'))
                     .append(self.$state_td));
 
-            self.$log_window = $('<textarea style="width:100%;font-family:Monaco,monospace;font-size:9pt;color:#555;" rows="20" readonly>')
+            self.$log_window = $('<textarea style="width:100%;font-family:Monaco,monospace;font-size:9pt;color:#555;resize:vertical;" rows="20" readonly>')
             container.append(self.$log_window);
 
             self.$track_checkbox= $('<input type="checkbox">').prop('checked', true);;
             var $checkboxContainer = $('<div>').addClass('checkbox').css({width:"100%"})
                 .append($('<label>')
                     .append(self.$track_checkbox)
-                    .append('Track Log'));
+                    .append('Auto scroll to new log output'));
             
             container.append($checkboxContainer)
 

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseViewLiveRunLog.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/kbase/js/widgets/function_output/kbaseViewLiveRunLog.js
@@ -1,0 +1,213 @@
+/**
+ * @public
+ */
+
+define(['jquery', 
+        'kbwidget', 
+        'kbaseAuthenticatedWidget', 
+        'njs-wrapper-client-api'
+        ], function($) {
+    $.KBWidget({
+        name: 'kbaseViewLiveRunLog',
+        parent: 'kbaseAuthenticatedWidget',
+        version: '1.0.0',
+        options: {
+            job_id: null,
+
+            // Service URL: should be in window.kbconfig.urls.
+            job_serviceURL: 'https://ci.kbase.us/services/njs_wrapper',
+            loadingImage: "static/kbase/images/ajax-loader.gif"
+        },
+        // Catalog client
+        job_service: null,
+
+
+        log: null,
+
+        init: function(options) {
+            this._super(options);
+            this.job_id = options.job_id;
+            if (window.kbconfig && window.kbconfig.urls)
+                this.options.job_serviceURL = window.kbconfig.urls.job_service;
+            // Create a message pane
+            this.$messagePane = $("<div/>").addClass("kbwidget-message-pane kbwidget-hide-message");
+            this.$elem.append(this.$messagePane);
+            this.loading(true);
+
+            this.log = [];
+            return this;
+        },
+
+        loggedInCallback: function(event, auth) {
+            // Build a client
+
+            this.jobServiceClient = new NarrativeJobService(this.options.job_serviceURL, auth);
+
+            if(!this.job_id) {
+                this.loading(false);
+                this.showMessage("No job_id provided or returned, so no build log can be shown.");
+            } else {
+                this.render();
+            }
+            return this;
+        },
+
+        loggedOutCallback: function(event, auth) {
+            this.isLoggedIn = false;
+            return this;
+        },
+
+        render: function() {
+            var self = this;
+            var container = this.$elem;
+
+            var $table = $('<table class="table table-striped table-bordered" style="margin-left: auto; margin-right: auto;" />');
+
+            container.append($table);
+            var width = "15%"
+
+            $table.append('<tr><td width="'+width+'">Job ID</td><td>'+self.job_id+'</td></tr>');
+            self.$state_td = $('<td></td>')
+            $table.append(
+                $('<tr>')
+                    .append($('<td width="'+width+'">State</td>'))
+                    .append(self.$state_td));
+
+            self.$log_window = $('<textarea style="width:100%;font-family:Monaco,monospace;font-size:9pt;color:#555;" rows="20" readonly>')
+            container.append(self.$log_window);
+
+            self.$track_checkbox= $('<input type="checkbox">').prop('checked', true);;
+            var $checkboxContainer = $('<div>').addClass('checkbox').css({width:"100%"})
+                .append($('<label>')
+                    .append(self.$track_checkbox)
+                    .append('Track Log'));
+            
+            container.append($checkboxContainer)
+
+            self.getLogAndState(0);
+        },
+        
+
+        getState: function() {
+            return null;
+        },
+
+        loadState: function(state) {
+        },
+
+        getLogAndState: function(skip) {
+            var self = this;
+            
+            self.jobServiceClient.check_job(self.job_id,
+                    function(build_state) {
+
+                        // display the state
+                        self.updateBuildState(build_state);
+
+                        self.jobServiceClient.get_job_logs({
+                                            'job_id':self.job_id,
+                                            'skip_lines':skip
+                                        },
+                                function(build_log) {
+
+                                    // make sure our log array is big enough
+                                    var log_length = skip+build_log.lines.length;
+                                    self.last_log_line = log_length;
+
+                                    for(var k=self.log.length; k<log_length; k++) {
+                                        if(k>=skip) {
+                                            self.log.push(build_log.lines[k-skip]);
+                                            self.appendLineToLog(build_log.lines[k-skip].line);
+                                        } else {
+                                            // odd- we're getting a chunk before an earlier chunk
+                                            self.log.push({'line':'','is_error':0})
+                                            self.appendLineToLog('');
+                                        }
+                                    }
+
+                                }, function(error) {
+                                    console.error(error);
+                                    self.hideMessage();
+                                    self.showMessage('Warning- unable to fetch log.  This Job may not have been run from an SDK module.')
+                                    self.$log_window.hide();
+                                });
+
+                    }, function(error) {
+                        console.error(error);
+                        self.hideMessage();
+                        self.showMessage('Error in fetching Job- The Job may have been deleted, or is too old, or the Job ID is incorrect.')
+                        self.$log_window.hide();
+                    });
+        },
+
+
+        appendLineToLog: function(line) {
+            self = this;
+            self.$log_window.val(self.$log_window.val()+line+'\n')
+
+            if(self.$track_checkbox.prop('checked')) {
+                self.$log_window.scrollTop(self.$log_window[0].scrollHeight); // scroll to bottom
+            }
+        },
+
+
+        /* build state=
+            typedef structure {
+                string job_id;
+                boolean finished;
+                string ujs_url;
+                UnspecifiedObject status;
+                UnspecifiedObject result;
+                JsonRpcError error;
+            } JobState;
+        */
+        updateBuildState: function(build_state) {
+            var self = this;
+            self.loading(false);
+
+            if(build_state.finished) {
+                self.$state_td.empty().append(build_state.status)
+            } else {
+                setTimeout(function(event) {
+                    self.getLogAndState(self.last_log_line);
+                }, 1000);
+            }
+
+            /*if (state === 'error') {
+                self.$registration_state_td.empty()
+                    .append($('<span>').addClass('label label-danger').append(state))
+                    .append('<br><br>')
+                    .append(error)
+
+                // now always show if something is in error field
+                //$('#'+pref+'_error').val(data.error_message);
+            } else if (state !== 'complete') {
+                self.$registration_state_td.empty().append(state)
+                setTimeout(function(event) {
+                    self.getLogAndState(self.registration_id, self.last_log_line);
+                }, 1000);
+            } else {
+                self.$registration_state_td.empty()
+                    .append($('<span>').addClass('label label-success').append(state))
+            }*/
+        },
+
+        loading: function(isLoading) {
+            if (isLoading)
+                this.showMessage("<img src='" + this.options.loadingImage + "'/>");
+            else
+                this.hideMessage();                
+        },
+
+        showMessage: function(message) {
+            var span = $("<span/>").append(message);
+            this.$messagePane.append(span);
+            this.$messagePane.show();
+        },
+
+        hideMessage: function() {
+            this.$messagePane.hide();
+            this.$messagePane.empty();
+        }     
+    });
+});

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
@@ -211,6 +211,7 @@ define([], function() {
 
             'kbaseRegisterRepoState'                : 'kbase/js/widgets/function_output/kbaseRegisterRepoState',
             'kbaseViewLiveRunLog'                   : 'kbase/js/widgets/function_output/kbaseViewLiveRunLog',
+            'kbaseReportView'                       : 'kbase/js/widgets/function_output/kbaseReportView',
 
             // unfinished ones
             /***

--- a/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
+++ b/src/notebook/ipython_profiles/profile_narrative/kbase_templates/static/narrative_paths.js
@@ -35,6 +35,7 @@ define([], function() {
             'kbase-client-api'                      : 'kbase/js/api/kbase-client-api.min',
             'kbaseFeatureValues-client-api'         : 'kbase/js/api/KBaseFeatureValues',
             'catalog-client-api'                    : 'kbase/js/api/Catalog',
+            'njs-wrapper-client-api'                : 'kbase/js/api/NarrativeJobServiceWrapper',
 
             /***
              * CORE NARRATIVE WIDGETS
@@ -209,6 +210,7 @@ define([], function() {
             'kbaseBlastOutput'                      : 'kbase/js/widgets/function_output/kbaseBlastOutput',
 
             'kbaseRegisterRepoState'                : 'kbase/js/widgets/function_output/kbaseRegisterRepoState',
+            'kbaseViewLiveRunLog'                   : 'kbase/js/widgets/function_output/kbaseViewLiveRunLog',
 
             // unfinished ones
             /***


### PR DESCRIPTION
This PR improves the register SDK module widget, updates the JS catalog and NJS wrapper clients, adds a method to show the live logs of running (or recently completed) SDK module jobs, and adds a simple widget for the new Report data type.