### PR TITLE
improve markdown cell behavior

### DIFF
--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -168,13 +168,16 @@ define(['jquery',
             var $cellNode = $(this.element);
             switch (this.getCellState('toggleState', 'unknown')) {
                 case 'closed':
-                    $cellNode.find('.inner_cell > div:nth-child(3)').hide();
+                    $cellNode.find('.inner_cell > div:nth-child(2)').css('display', 'none');
+                    $cellNode.find('.inner_cell > div:nth-child(3)').css('display', 'none');
                     break;
                 case 'open':
-                    $cellNode.find('.inner_cell > div:nth-child(3)').show();
+                    $cellNode.find('.inner_cell > div:nth-child(2)').css('display', '');
+                    $cellNode.find('.inner_cell > div:nth-child(3)').css('display', '');
                     break;
                 case 'unknown':
-                    $cellNode.find('.inner_cell > div:nth-child(3)').show();
+                    $cellNode.find('.inner_cell > div:nth-child(2)').css('display', '');
+                    $cellNode.find('.inner_cell > div:nth-child(3)').css('display', '');
                     break;
             }
         };
@@ -526,6 +529,17 @@ define(['jquery',
                 .on('toggle.cell', function (e) {
                     // Alas, it has no discriminating attributes!
                     cell.toggle();
+                });
+            // Use another hook on double click to toggle the cell open if it 
+            // was closed.
+            // Note that the base Cell bind_events already has a default
+            // double click behavior.
+            $(this.element)
+                .on('dblclick', function (e) {
+                    // if cell state is closed...
+                    if (cell.getCellState('toggleState', 'unknown') === 'closed') {
+                        cell.toggle();
+                    }
                 });
         };
 


### PR DESCRIPTION
double click expands closed cells - before it was putting the cell into edit mode without actually toggling the visibility, which was weird. this is accomplished in the double click event on the cell bind_events.
toggling no longer interferes with edit / render state - on the other hand toggling put the edit/render cell areas into unexpected states. this fixes that by avoiding jQuery hide/show, instead adding display="none" to hide, and simply removing it (and thus returning to unmodified state) to show. 
Will be nice to get this working consistently across cell types, but this was targeted to have double click work more or less for markdown cells, in which it already does something. I'm not sure double click does anything interesting elsewhere.