### PR TITLE
fix non-activation of cell toolbar buttons when cell selected due to cell deletion

### DIFF
--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -237,6 +237,15 @@ define(['jquery',
             return wasSelected;
         };
         
+        var original_select = cell.Cell.prototype.select;
+        cell.Cell.prototype.select = function () {
+            var wasSelected = original_select.apply(this);
+            if (wasSelected) {
+                $(this.element).trigger('selected.cell');
+            }
+            return wasSelected;
+        };
+        
         
         cell.Cell.prototype.getCellState = function (name, defaultValue) {
             if (!this.metadata.kbstate) {
@@ -533,7 +542,7 @@ define(['jquery',
             // Use another hook on double click to toggle the cell open if it 
             // was closed.
             // Note that the base Cell bind_events already has a default
-            // double click behavior.
+            // double click behavior
             $(this.element)
                 .on('dblclick', function (e) {
                     // if cell state is closed...

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -115,8 +115,6 @@ define([
             if (data.cell.metadata['kb-cell']) {
                 this.disableKeyboardManager();
             }
-            // data.cell.events.trigger('selected.cell');
-            $(data.cell.element).trigger('selected.cell');
         }, this));
 
         $([IPython.events]).on('create.Cell', $.proxy(function(event, data) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -1516,12 +1516,14 @@ define(['jquery',
                     if (cell.metadata[this.KB_CELL]) {
                         widget = null; // default is app cell
                         var state = 'input'; // default is input... also doubles as a proxy for output cells
-                        if (this.isFunctionCell(cell))
+                        if (this.isFunctionCell(cell)) {
                             widget = 'kbaseNarrativeMethodCell';
-                        else if (this.isAppCell(cell))
+                        } else if (this.isAppCell(cell)) {
                             widget = 'kbaseNarrativeAppCell';
-                        if (widget)
+                        }
+                        if (widget) {
                             state = $(cell.element).find('div[id^=kb-cell-]')[widget]('getRunningState');
+                        }
 
                         if (state === 'input') {
                             IPython.notebook.delete_cell(index);
@@ -1561,8 +1563,7 @@ define(['jquery',
                             //         break;
                             // }
                         }
-                    }
-                    else {
+                    } else {
                         IPython.notebook.delete_cell(index);
                     }
                 }


### PR DESCRIPTION
The trick here was to hinge the "selected.cell" jQuery event upon the extension of cell.select. Previously it was emitted from the "select.Cell" jupyter event. However, there are cases in which the cell.select is called directly, and no select.Cell event is emitted. This change covers all cases of cell selection.