### PR TITLE
Update makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install:
   - npm install -g grunt-cli
 install:
   - pip install -r src/requirements.txt
-script: make && make test
+script: make build-travis-narrative && make test

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,18 @@ TEST_INSTALL_LOC = .
 BACKEND_TEST_SCRIPT = scripts/narrative_backend_tests.sh
 FRONTEND_TEST_DIR = test
 
-default: build-narrative
+# Docker build script
+DOCKER_INSTALLER = ./scripts/build_narrative_container.sh
+
+
+default: build-narrative-container
+
+build-narrative-container:
+	sh $(DOCKER_INSTALLER)
 
 # runs the installer to locally build the Narrative in a
 # local venv.
-build-narrative:
+build-travis-narrative:
 	bower install && \
 	npm install && \
 	bash $(INSTALLER) --no-venv
@@ -77,6 +84,7 @@ test-frontend-e2e:
 	cd $(FRONTEND_TEST_DIR)
 	@echo "done"
 
+# no op
 deploy:
 
 


### PR DESCRIPTION
New directives:  
`make`: (default) run the Docker image build script
`make build-travis-narrative`: build the Narrative locally (without a venv) for testing on Travis-CI.