### PR TITLE
Fix cell selection issues

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -20,8 +20,8 @@ Last updated 1/14/2016, 2:36pm
   * ~~404 on Safari's "Click to enter narrative" space in the loading page.~~
   * .ver.## in URL seems to be ignored (probably for the best right now)
   * ~~Data Panel: Shared With Me refresh button has bad offset~~
-  * Method outputs can be inserted in seemingly random places
+  * ~~Method outputs can be inserted in seemingly random places~~
   * Data viewer with unknown type needs some TLC.
-  * Inserting new cells on click has changed due to cell selection changes / cell multi-select [NAR-835](https://atlassian.kbase.us/browse/NAR-835)
+  * ~~Inserting new cells on click has changed due to cell selection changes / cell multi-select [NAR-835](https://atlassian.kbase.us/browse/NAR-835)~~
   * Method/app cells should be drag/droppable like data cells.
   * Name change doesn't seem to change temporary state (should actually use temporary state instead of "Untitled" name)

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -24,3 +24,4 @@ Last updated 1/14/2016, 2:36pm
   * Data viewer with unknown type needs some TLC.
   * Inserting new cells on click has changed due to cell selection changes / cell multi-select [NAR-835](https://atlassian.kbase.us/browse/NAR-835)
   * Method/app cells should be drag/droppable like data cells.
+  * Name change doesn't seem to change temporary state (should actually use temporary state instead of "Untitled" name)

--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -69,6 +69,8 @@ div.cell {
 div.cell.selected {
     border: 1px solid #4BB856;
     border-left: 5px solid #4BB856;
+    padding: 6px 0 6px 0;
+    background: none;
 }
 
 input.raw_input {

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -20,7 +20,8 @@ define([
     'ipythonCellMenu',
     'base/js/events',
     'notebook/js/notebook',
-    'util/display'
+    'util/display',
+    'jquery-nearest'
 ], 
 function($,
          Promise,
@@ -87,11 +88,11 @@ function($,
      * code and markdown cells).
      * Updates the currently selected cell to be the one passed in.
      */
-    Narrative.prototype.showJupyterCellToolbar = function(cell) {
-        // tell the toolbar that it is selected. For now, the toolbar is in 
-        // charge.
-        $(cell.element).trigger('select.toolbar');
-    };
+    // Narrative.prototype.showJupyterCellToolbar = function(cell) {
+    //     // tell the toolbar that it is selected. For now, the toolbar is in 
+    //     // charge.
+    //     $(cell.element).trigger('select.toolbar');
+    // };
 
     /**
      * Registers Narrative responses to a few Jupyter events - mainly some
@@ -107,19 +108,11 @@ function($,
             $("#kb-kernel-icon").removeClass().addClass('fa fa-circle');
         });
 
-        $([Jupyter.events]).on('select.Cell', function(event, data) {
-            this.showJupyterCellToolbar(data.cell);
-            if (data.cell.metadata['kb-cell']) {
-                this.disableKeyboardManager();
-            }
-        }.bind(this));
-
         $([Jupyter.events]).on('create.Cell', function(event, data) {
-            this.showJupyterCellToolbar(data.cell);
+            // this.showJupyterCellToolbar(data.cell);
         }.bind(this));
 
         $([Jupyter.events]).on('delete.Cell', function(event, data) {
-            this.showJupyterCellToolbar(Jupyter.notebook.get_selected_cell());
             this.enableKeyboardManager();
         }.bind(this));
 
@@ -513,6 +506,21 @@ function($,
 
     Narrative.prototype.lookupUserProfile = function(username) {
         return displayUtil.lookupUserProfile(username);
+    };
+
+    /**
+     * A little bit of a riff on the Jupyter "find_cell_index". 
+     * Every KBase-ified cell (App, Method, Output) has a unique identifier.
+     * This can be used to find the closest cell element - its index is the 
+     * Jupyter cell index (inferred somewhat from find_cell_index which calls 
+     * get_cell_elements, which does this searching).
+     */
+    Narrative.prototype.getCellIndexByKbaseId = function(id) {
+        return $('#' + id).nearest('.cell').not('.cell .cell').index();
+    };
+
+    Narrative.prototype.getCellByKbaseId = function(id) {
+        return Jupyter.notebook.get_cell(this.getCellIndexByKbaseId(id));
     };
 
     return Narrative;

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseTree.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseTree.js
@@ -6,12 +6,14 @@
 
 define(['jquery', 
         'narrativeConfig',
+        'util/string',
         'kbwidget', 
         'kbaseAuthenticatedWidget', 
         'knhx', 
         'widgetMaxWidthCorrection'], 
 function($,
-         Config) {
+         Config,
+         StringUtil) {
     $.KBWidget({
         name: 'kbaseTree',
         parent: 'kbaseAuthenticatedWidget',
@@ -28,12 +30,11 @@ function($,
 
         pref: null,
         timer: null,
-        loadingImage: this.options.loadingImage,
         token: null,
 
         init: function(options) {
             this._super(options);
-            this.pref = this.uuid();
+            this.pref = StringUtil.uuid();
 
             this.$messagePane = $("<div/>").addClass("kbwidget-message-pane kbwidget-hide-message");
             this.$elem.append(this.$messagePane);
@@ -198,14 +199,6 @@ function($,
         hideMessage: function() {
             this.$messagePane.hide();
             this.$messagePane.empty();
-        },
-
-        uuid: function() {
-            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, 
-                function(c) {
-                    var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
-                    return v.toString(16);
-                });
         },
 
         loggedInCallback: function(event, auth) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -198,7 +198,7 @@
 
                                       event.preventDefault();
                                       this.trigger('runApp.Narrative', {
-                                          cell: Jupyter.notebook.get_selected_cell(),
+                                          cell: Jupyter.narrative.getCellByKbaseId(this.cellId),
                                           appSpec: this.appSpec,
                                           methodSpecs: this.methodSpecs,
                                           parameters: this.getParameters()

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -22,6 +22,9 @@ function($, Config) {
             var self = this;
             this._super(options);
 
+            this.$elem.on('mousedown', function () {
+                Jupyter.notebook.events.trigger('select.Cell', this.options.cell);
+            }.bind(this));
 
             var $deleteBtn = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Delete Cell">')
                 .append($('<span class="fa fa-trash-o" style="font-size:14pt; padding-left: 5px;">'))
@@ -66,21 +69,21 @@ function($, Config) {
                     icon: 'fa fa-code',
                     text: 'View Job Submission',
                     action: function () {
-                        var metadata = Jupyter.notebook.get_selected_cell().metadata,
+                        var metadata = this.options.cell.metadata,
                             stackTrace = [],
-                            cell = Jupyter.notebook.insert_cell_below('code');
+                            newCell = Jupyter.notebook.insert_cell_below('code', Jupyter.notebook.find_cell_index(this.options.cell));
                         if (metadata['kb-cell'] && metadata['kb-cell'].stackTrace) {
                             stackTrace = metadata['kb-cell'].stackTrace;
                         }
                         console.log(stackTrace);
                         if (stackTrace instanceof Array) {
-                            cell.set_text('job_info=' + stackTrace[stackTrace.length - 1] + '\njob_info');
-                            Jupyter.notebook.get_selected_cell().execute();
+                            newCell.set_text('job_info=' + stackTrace[stackTrace.length - 1] + '\njob_info');
+                            newCell.execute();
                         } else {
-                            cell.set_text('job_info=' + stackTrace);
+                            newCell.set_text('job_info=' + stackTrace);
                         }
                     }
-                });
+                }.bind(this));
             }
 
             this.addMenuItem({
@@ -147,29 +150,20 @@ function($, Config) {
                 });
             }
 
-            // if (this.options.cell && this.options.cell.metadata['kb-cell'] === undefined) {
-            //     this.addMenuItem({
-            //         icon: 'fa fa-terminal',
-            //         text: 'Toggle Cell Type',
-            //         action: function() {
-            //             if (this.options.cell.cell_type === "markdown") {
-            //                 Jupyter.notebook.to_code();
-            //             }
-            //             else {
-
-            //             }
-            //         },
-            //         disable: true
-            //     });
-            // }
-//
-//            this.addMenuItem({
-//                icon: 'fa fa-trash-o',
-//                text: 'Delete Cell',
-//                action: $.proxy(function () {
-//                    this.trigger('deleteCell.Narrative', Jupyter.notebook.get_selected_index());
-//                }, this)
-//            });
+            if (this.options.cell && this.options.cell.metadata['kb-cell'] === undefined) {
+                this.addMenuItem({
+                    icon: 'fa fa-terminal',
+                    text: 'Toggle Cell Type',
+                    action: function() {
+                        if (this.options.cell.cell_type === "markdown") {
+                            Jupyter.notebook.to_code();
+                        }
+                        else {
+                            Jupyter.notebook.to_markdown();
+                        }
+                    }.bind(this),
+                });
+            }
 
             var self = this;
             

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -22,22 +22,17 @@ function($, Config) {
             var self = this;
             this._super(options);
 
-            // console.log(['cell menu', this.options.cell]);
-//            var outputPane = this.$elem.closest('.cell').find('.inner_cell > div:nth-child(2)').get(0);
-//            if (!outputPane.id) {
-//                outputPane.id = this.genId();
-//            }
-//            this.$elem.data('ouputPaneId', outputPane.id);
 
             var $deleteBtn = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Delete Cell">')
                 .append($('<span class="fa fa-trash-o" style="font-size:14pt; padding-left: 5px;">'))
                 .click($.proxy(function () {
-                    this.trigger('deleteCell.Narrative', Jupyter.notebook.get_selected_index());
-                }, this)),
-                $menuBtn = $('<button type="button" data-toggle="dropdown" aria-haspopup="true" class="btn btn-default btn-xs">')
-                .append($('<span class="fa fa-cog" style="font-size:14pt">')),
-                // $collapseBtn = $('<button class="btn btn-default" role="button" data-toggle="collapse" href="#' + outputPane.id + '" aria-controls="' + $outputPane.id + '">Open</button>'),
-                $collapseBtn = $('<button type="button" class="btn btn-default btn-xs" role="button" data-button="toggle"><span class="fa fa-chevron-down"></button>')
+                    this.trigger('deleteCell.Narrative', Jupyter.notebook.find_cell_index(this.options.cell));
+                }, this));
+
+            var $menuBtn = $('<button type="button" data-toggle="dropdown" aria-haspopup="true" class="btn btn-default btn-xs">')
+                .append($('<span class="fa fa-cog" style="font-size:14pt">'));
+
+            var $collapseBtn = $('<button type="button" class="btn btn-default btn-xs" role="button" data-button="toggle"><span class="fa fa-chevron-down"></button>')
                 .on('click', function () {
                     self.$elem.trigger('toggle.toolbar');                    
                 });
@@ -48,9 +43,9 @@ function($, Config) {
              * Each cell type unfortunately has a different top level layout.
              * Not that it matters, but I don't see why there isn't a uniform layout 
              * for the primary layout areas - prompt, toolbar, body, as they exist
-             * now, and another nice one would be a message/notification are
+             * now, and another nice one would be a message/notification area.
              */
-            this.$elem.on('toggle.toolbar', function () {                
+            this.$elem.on('toggle.toolbar', function () {
                 var $cellNode = self.$elem.closest('.cell');
                 $cellNode
                     .trigger('toggle.cell');

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -87,7 +87,6 @@ function($,
             this.$runButton.click(
                 $.proxy(function(event) {
                     console.log('** clicked' + (new Date()).getTime());
-                    event.preventDefault();
 
                     if (!this.checkMethodRun())
                         return;
@@ -102,7 +101,7 @@ function($,
                     this.changeState('submitted');
                     this.minimizeView();
                     this.trigger('runCell.Narrative', {
-                        cell: Jupyter.notebook.get_selected_cell(),
+                        cell: Jupyter.narrative.getCellByKbaseId(this.cellId),
                         method: this.method,
                         parameters: this.getParameters(),
                         widget: this

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -190,15 +190,14 @@ function($,
 
             $(document).on('createOutputCell.Narrative',
                 $.proxy(function(event, data) {
-                    var cellIndex = $('#'+data.cellId).nearest('.cell').index();
+                    var cell = Jupyter.narrative.getCellByKbaseId(data.cellId);
                     var params = {'embed' : true,
                                   'data': StringUtil.safeJSONStringify(data.result)};
                     if (data.next_steps) {
                       // console.debug("adding next steps in create");
                       params.next_steps = data.next_steps;
                     }
-                    this.createOutputCell(Jupyter.notebook.get_cell(cellIndex),
-                                          params);
+                    this.createOutputCell(cell, params);
                 }, this)
             );
 


### PR DESCRIPTION
Clicking buttons on unselected cells (specifically the run buttons or the delete button) would often cause behavior to be based on the other selected cell. For example, a different cell would get deleted, or output cells would appear in the wrong place.

This fixes that by properly binding each KBase widget to the right cell. Instead of just assuming it's selected and calling `Jupyter.notebook.get_selected_cell()`, call  
`Jupyter.narrative.getCellByKbaseId(id)` or  
`Jupyter.narrative.getCellIndexByKbaseId(id)`.

The ids are in the $elem bound to the KBase widget.