### PR TITLE
Fix read only mode

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,7 +1,7 @@
 Last updated 1/14/2016, 2:36pm
 
   * Markdown cells render a little different. Previously headers could be made by "###text" on its own line, now a space is needed: "### text" on that line.
-  * The "view only" mode has a gigantic margin on the left side. [KBASE-3370](https://atlassian.kbase.us/browse/KBASE-3370)
+  * ~~The "view only" mode has a gigantic margin on the left side. [KBASE-3370](https://atlassian.kbase.us/browse/KBASE-3370)~~
   * All cells sit in a container that makes it easier to see what's selected or not, which brings up issues.
   * KBase cells (method, app, output, data viewer) appear as boxes in boxes with duplicated minimization. [KBASE-3335](https://atlassian.kbase.us/browse/KBASE-3335)
   * Markdown cells don't have any placeholder text (Jupyter feature) and their input boxes appear shrunken when inactive.

--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -171,6 +171,18 @@
             <div class="navbar-right">
                 <span class="kb-navbar-buttons">
                     <div id="kb-notify-area"><div id="notification_area"></div></div>
+
+
+                    <button id="kb-view-only-ctrl" class="btn btn-default navbar-btn kb-nav-btn hidden">
+                        <div class="fa fa-gear"></div>
+                        <div class="kb-nav-btn-txt">controls</div>
+                    </button>
+                    <button id="kb-view-only-copy" class="btn btn-default navbar-btn kb-nav-btn hidden">
+                        <div class="fa fa-copy"></div>
+                        <div class="kb-nav-btn-txt">copy</div>
+                    </button>
+                    <div id="kb-view-only-msg" class="label label-warning hidden">View-only mode</div>
+
                     <button id="kb-update-btn" class="btn btn-default navbar-btn kb-nav-btn kb-nav-btn-upgrade">
                         <div class="fa fa-refresh fa-spin"></div>
                         <div class="kb-nav-btn-txt">Get new version!</div>

--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -132,7 +132,7 @@
     </div>
     {% endblock %}
 
-    <nav class="navbar-kbase navbar-fixed-top" id="header">
+    <nav class="navbar-kbase navbar-static-top" id="header">
         <div class="container-fluid">
             <div class="navbar-header">
                 <div style="display:inline-block">

--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -94,11 +94,6 @@ span#notebook_name:hover {
     background-color: #e0e0e0;    
 }
 
-
-body {
-    padding-top: 70px !important;
-}
-
 .prompt {
     min-width: 10ex;
 }

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -254,20 +254,10 @@ p.clear{
     clear: both;
 }
 
-/*div#header {
-    border-bottom: 1px solid #AAA;
-    position: relative;
-    padding: 0 0 0 20px;
-    height: 56px;
-}*/
-
 body > #header {
-    position:fixed;
     display: block;
     box-sizing: border-box;
 }
-
-
 
 p#site-title {
     height: 46px;
@@ -2744,9 +2734,9 @@ div[class="tooltip-inner"] {
 }
 
 /* Override the default max-width of the narrative box */
-.container {
-    max-width: 2000px !important;
-}
+/*.container {*/
+    /*max-width: 2000px !important;*/
+/*}*/
 
 /* Styles for KNHX trees to remove its document.write nonsense that breaks asynchronous loading */
 #popdiv {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -77,7 +77,6 @@ function ($,
         $mainListDiv: null,
         mainListId: null,
         $loadingDiv: null,
-        methClient: null,
         objList: [],
         objData: {}, // old style - type_name : info
 
@@ -136,8 +135,6 @@ function ($,
             if (this.options.ws_name) {
                 this.ws_name = this.options.ws_name;
             }
-
-            this.methClient = new NarrativeMethodStore(this.options.methodStoreURL);
 
             return this;
         },

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -122,17 +122,7 @@ function($, Config) {
             // toggle off the jobs header
             // omg this is a hack, but i'm out of time.
             this.$tabs.header.find('div:nth-child(3).kb-side-header').toggle(!readOnly);
-            this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? '48%' : '33.333%')});
-
-            var $hide_btn = $('<div>')
-                            .attr({id: 'kb-view-mode-narr-hide'})
-                            .append($('<span>')
-                                    .addClass('fa fa-caret-up'))
-                            .css({'width':'4%'})
-                            .click(function() {
-                                minimizeFn();
-                            });
-            this.$tabs.header.prepend($hide_btn);
+            this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? '50%' : '33.333%')});
         },
 
         /**

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -837,6 +837,7 @@ function($,
          */
         readOnlyMode: function(delay) {
             // Hide side-panel
+            this.trigger('hideSidePanelOverlay.Narrative');
             if (!delay)
                 delay = 0;
             $('#left-column').hide('slide', {direction: 'left', easing: 'swing'}, delay);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -241,6 +241,10 @@ function($,
                 placement: 'bottom'
             });
 
+            if (this.isReadOnly) {
+                this.readOnlyMode(false);
+            }
+
             this.initDeleteCellModal();
             this.render();
             return this;
@@ -810,19 +814,29 @@ function($,
         readOnlyMode: function(from_user) {
             // console.debug('set_readonly_mode.begin from-user=' + from_user);
             // Hide side-panel
-            $('#left-column').hide();
+            console.log('is from user', from_user);
+            $('#left-column').hide('slide', {direction: 'left', easing: 'linear'}, from_user ? 500 : 0);
             // Move content flush left-ish
-            $('#content-column').css({'margin-left': '120px'});
+            $('#notebook-container').animate({left: 0}, {easing: 'linear', duration: (from_user ? 500 : 0)});
+
+            var $viewOnlyMsg = $('<div>').addClass('label label-warning').text('View-only mode');
             // Hide things
             _.map(this.getReadOnlySelectors(), function (id) {$(id).hide()});
             this.toggleRunButtons(false);
             this.toggleSelectBoxes(false);
-            if (from_user == true) {
-                $('.navbar-right').prepend(
-                  $('<div>').addClass("label label-warning")
-                    .text('View-only mode'));
-            }
-            else {
+            $('.navbar-right').prepend($viewOnlyMsg);
+
+            if (!from_user) {
+                $viewOnlyMsg.popover({
+                    html: true,
+                    placement: 'bottom',
+                    trigger: 'hover',
+                    content: 'You do not have permissions to modify ' +
+                    'this narrative. If you want to make your own ' +
+                    'copy that can be modified, use the ' +
+                    '"Copy" button.'
+                });
+
                 // Add copy button
                 if (!this.copyModal) {
                     this.copyModal = new BootstrapDialog({
@@ -853,23 +867,24 @@ function($,
                     }.bind(this))
                 );
                 // Add view-only info/badge
-                $('.navbar-right').prepend(
-                    $('<div>').addClass("label label-warning")
-                      .attr({'id': 'kb-ro-btn'})
-                      .text('View-only mode')
-                      .popover({
-                        html: true,
-                        placement: "bottom",
-                        trigger: 'hover',
-                        content: 'You do not have permissions to modify ' +
-                        'this narrative. If you want to make your own ' +
-                        'copy that can be modified, use the ' +
-                        '"Copy" button.'
-                    }));
+                // $('.navbar-right').prepend(
+                //     $('<div>').addClass("label label-warning")
+                //       .attr({'id': 'kb-ro-btn'})
+                //       .text('View-only mode')
+                //       .popover({
+                //         html: true,
+                //         placement: "bottom",
+                //         trigger: 'hover',
+                //         content: 'You do not have permissions to modify ' +
+                //         'this narrative. If you want to make your own ' +
+                //         'copy that can be modified, use the ' +
+                //         '"Copy" button.'
+                //     }));
                 // Add button to unhide the controls
+
                 $('#main-container').prepend(
                   $('<div>').attr({'id': 'kb-view-mode-narr'})
-                    .append($('<div>').css({cursor: 'pointer'})
+                    .append($('<div>').css({cursor: 'pointer', position: 'fixed', left:'0', top:'0'})
                       .append($('<span>')
                         .css({'padding-left':'1em'})
                         .text('Controls'))
@@ -911,9 +926,9 @@ function($,
             }
             $('.navbar-right > div')[0].remove();
             // Restore side-panel
-            $('#left-column').show();
             // Restore margin for content
-            $('#content-column').css({'margin-left': '380px'});
+            $('#notebook-container').animate({left: '380'}, {duration: 500, easing: 'linear'});
+            $('#left-column').show('slide', {'direction': 'left', 'easing': 'linear'}, 500);
             // Show hidden things
             _.map(this.getReadOnlySelectors(), function (id) {
                 $(id).show();
@@ -2297,11 +2312,6 @@ function($,
                 this.checkCellMetadata(cells[i]);
             }
             this.loadAllRecentCellStates();
-
-            if (this.isReadOnly) {
-                this.readOnlyMode(false);
-            }
-            // this.updateReadOnlyMode(this.ws_client, this.ws_id);
 
             return this;
         },

--- a/kbase-extension/static/narrativeMain.js
+++ b/kbase-extension/static/narrativeMain.js
@@ -41,7 +41,7 @@ require(['narrative_paths'], function(paths) {
             window.kbconfig = config;
             require(['kbaseNarrative'], function(Narrative) {
                 Login.init($('#signin-button'));
-                console.log('Starting IPython main');
+                console.log('Starting Jupyter main');
                 require(['notebook/js/main']);
             });
         });


### PR DESCRIPTION
The read only mode toggle button works again. it still remains in view only mode until page reload, even if share settings change while viewing the page.

Additionally, you can now slide the left control panel out and back. It might be worth decoupling that from read only mode and still allowing usage. Honestly nothing much would change there, except for allowing existing run buttons to be pressed, and keeping the "View-only mode" message from showing. The only work to be done there would be where and how to define the toggle button.