### PR TITLE
Methods Panel Update

### DIFF
--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -2262,10 +2262,11 @@ div[class="tooltip-inner"] {
     font-size: 10pt;
     margin: 2px;
     margin-left: 10px;
-    cursor: pointer;
+    /* Not a link anymore, so we disable for now
+    cursor: pointer;*/
 }
 .kb-data-list-narinfo:hover {
-    color:#444;
+    /*color:#444;*/
 }
 
 .kb-data-list-narrative-error {

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1264,13 +1264,13 @@ div#notebook_panel {
 }
 
 .kb-function-dim {
-    background-color: #aaa !important;
-    border-color: #aaa !important;
+    background-color: #eee !important;
+    /* border-color: #ddd !important; */
 }
 
 .kb-function-dim .panel-heading {
-    background-color: #444 !important;
-    border-color: #000 !important;
+    background-color: #eee !important;
+    /*border-color: #000 !important; */
 }
 
 .kb-function-cat-dim {

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -2345,6 +2345,27 @@ div[class="tooltip-inner"] {
 
 /* end data list*/
 
+
+/* favorites style */
+
+.kbcb-star {
+}
+.kbcb-star-favorite {
+    cursor:pointer;
+    color:orange;
+}
+
+.kbcb-star-nonfavorite {
+    cursor:pointer;
+}
+.kbcb-star-nonfavorite:hover {
+    color:red;
+}
+
+
+
+
+
 /* share panel styles */
 .kb-share-user-permissions-dropdown {
     border-style:none;

--- a/kbase-extension/static/kbase/js/api/Catalog.js
+++ b/kbase-extension/static/kbase/js/api/Catalog.js
@@ -117,6 +117,71 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             [params], 1, _callback, _errorCallback);
     };
  
+     this.add_favorite = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.add_favorite",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
+     this.remove_favorite = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.remove_favorite",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
+     this.list_favorites = function (username, _callback, _errorCallback) {
+        if (typeof username === 'function')
+            throw 'Argument username can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.list_favorites",
+            [username], 1, _callback, _errorCallback);
+    };
+ 
+     this.list_app_favorites = function (item, _callback, _errorCallback) {
+        if (typeof item === 'function')
+            throw 'Argument item can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.list_app_favorites",
+            [item], 1, _callback, _errorCallback);
+    };
+ 
+     this.list_favorite_counts = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.list_favorite_counts",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
      this.get_module_info = function (selection, _callback, _errorCallback) {
         if (typeof selection === 'function')
             throw 'Argument selection can not be a function';
@@ -321,6 +386,32 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
         return json_call_ajax("Catalog.revoke_developer",
             [username], 0, _callback, _errorCallback);
+    };
+ 
+     this.log_exec_stats = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.log_exec_stats",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
+     this.get_exec_aggr_stats = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.get_exec_aggr_stats",
+            [params], 1, _callback, _errorCallback);
     };
   
 

--- a/kbase-extension/static/kbase/js/util/display.js
+++ b/kbase-extension/static/kbase/js/util/display.js
@@ -80,9 +80,64 @@ function($,
         };
     }
 
+
+    /**
+     * @method
+     * getMethodIcon
+     * 
+     * Provides a JQuery object containing an Icon for narrative apps (in the 
+     * legacy style) or methods (soon to be called apps).
+     *
+     * params = {
+     *    isApp: true | false  // set to true to use the default app icon
+     *    url:  string         // url to the icon image, if missing this will provide a default
+     *    size: string         // set the max-width and max-height property for url icons 
+     *                         // (icons are square), default is 50px
+     *    cursor: string       // if set, set the cursor css of the icon, default is 'default'
+     *    setColor: true | false  // this param should probably go away, but if true will set the color of the default icon
+     * }
+     */
+    function getAppIcon(params) {
+
+        var cursor = 'default';
+        if(params.cursor) { cursor = params.cursor; }
+
+        if(params.url) {
+            var size = '50px';
+            if(params.size) { size = params.size; }
+            return $('<img src="'+params.url+'">').css({'max-width':size,'max-height':size, 'cursor':cursor});
+        }
+
+        // no url, so show default
+        var icons = Config.get('icons'); // icon default parameters are set in a config
+
+        var isApp = false;
+        if(params['isApp']) { isApp = params['isApp']; }
+
+        var name = isApp ? "app" : "method";
+        var icon_color = isApp ? icons.colors[9] : icons.colors[5];
+        var icon_class = isApp ? 'app-icon' : 'method-icon';
+
+        var icon = icons.methods[name];
+        var $icon = $('<i>');
+        // background
+        $icon.addClass("fa-stack fa-2x").css({'cursor': cursor});
+        var $i = $('<i>').addClass('fa fa-square fa-stack-2x ' + icon_class);
+        if(params.setColor) { $i.css({color: icon_color}); }
+        $icon.append($i);
+        // add stack of font-awesome icons
+        _.each(icon, function (cls) {
+            $icon.append($('<i>')
+                .addClass("fa fa-inverse fa-stack-1x " + cls));
+        });
+        return $icon;
+    }
+
+
     return {
         lookupUserProfile: lookupUserProfile,
         displayRealName: displayRealName,
-        loadingDiv: loadingDiv
+        loadingDiv: loadingDiv,
+        getAppIcon: getAppIcon
     };
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -36,8 +36,8 @@
             loadingImage: Config.get('loading_gif'),
             methodStoreURL: Config.url('narrative_method_store'),
 
-            appHelpLink: '/#narrativestore/app/',
-            methodHelpLink: '/#narrativestore/method/'
+            appHelpLink: '/#appcatalog/app/l.a/',
+            methodHelpLink: '/#appcatalog/app/'
         },
         IGNORE_VERSION: true,
         defaultInputWidget: 'kbaseNarrativeMethodInput',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -323,10 +323,9 @@
                 .closest('.cell')
                 .trigger('set-title.cell', [appTitle]);             
             
-            var appIcon = '<div class="fa-stack fa-2x"><i  class="fa fa-square fa-stack-2x app-icon"></i><i class="fa fa-inverse fa-stack-1x fa-cubes"></i></div>';
             this.$elem
                 .closest('.cell')
-                .trigger('set-icon.cell', [appIcon]);
+                .trigger('set-icon.cell', [Display.getAppIcon({isApp:true}).html()]);
             
             //require(['kbaseNarrativeCellMenu'], $.proxy(function() {
             //    this.cellMenu = $menuSpan.kbaseNarrativeCellMenu();

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -15,6 +15,7 @@
   require(['jquery',
            'narrativeConfig',
            'util/string',
+           'util/display',
            'util/bootstrapDialog',
            'kbwidget',
            'kbaseAuthenticatedWidget',
@@ -24,6 +25,7 @@
   function($, 
            Config,
            StringUtil,
+           DisplayUtil,
            BootstrapDialog) {
     'use strict';
     $.KBWidget({
@@ -323,9 +325,10 @@
                 .closest('.cell')
                 .trigger('set-title.cell', [appTitle]);             
             
+            var $logo = $('<div>').append(DisplayUtil.getAppIcon({isApp:true}));
             this.$elem
                 .closest('.cell')
-                .trigger('set-icon.cell', [Display.getAppIcon({isApp:true}).html()]);
+                .trigger('set-icon.cell', [$logo.html()]);
             
             //require(['kbaseNarrativeCellMenu'], $.proxy(function() {
             //    this.cellMenu = $menuSpan.kbaseNarrativeCellMenu();

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -39,7 +39,7 @@
             methodStoreURL: Config.url('narrative_method_store'),
 
             appHelpLink: '/#appcatalog/app/l.a/',
-            methodHelpLink: '/#appcatalog/app/'
+            methodHelpLink: '/#appcatalog/app/l.m/' // apps cannot have SDK methods, so always add the legacy module id
         },
         IGNORE_VERSION: true,
         defaultInputWidget: 'kbaseNarrativeMethodInput',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -832,7 +832,8 @@ function($,
                     $dataCol.append($('<span>')
                         .addClass('kb-data-list-narinfo')
                         .append(summary)
-                        .click(
+                        // REMOVE MORE INFO: needs a rethink, because these methods have versions now....
+                        /*.click(
                             function () {
                                 var opened = self.toggleInteractionPanel($interactionPanel, 'info');
                                 if (!opened) {
@@ -845,7 +846,7 @@ function($,
 
                                 // var $infoDiv = self.getNarContent(data.nar_info);
                                 self.setInteractionPanel($interactionPanel, 'Narrative Info', $infoDiv);
-                            })
+                            })*/
                         .append('<br>'));
                 }
                 $dataCol.append($('<span>').addClass('kb-data-list-type').append(this.getTimeStampStr(data.nar_info[3])));

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -35,7 +35,7 @@ function($,
         options: {
             method: null,
             cellId: null,
-            methodHelpLink: '/#/appcatalog/app/',
+            methodHelpLink: '/#appcatalog/app/',
             methodStoreURL: Config.url('narrative_method_store')
         },
         IGNORE_VERSION: true,
@@ -172,6 +172,14 @@ function($,
             var methodId = this.options.cellId + '-method-details-'+StringUtil.uuid();
             var buttonLabel = 'details';
             var methodDesc = this.method.info.tooltip;
+
+            var link = this.options.methodHelpLink;
+            if(this.method.info.module_name) {
+                link = link + this.method.info.id; // TODO: add version here, but we don't have the info stored yet
+            } else {
+                link = link + 'l.m/' + this.method.info.id;
+            }
+
             this.$header = $('<div>').css({'margin-top':'4px'})
                            .addClass('kb-func-desc');
             this.$staticMethodInfo = $('<div>')
@@ -179,7 +187,7 @@ function($,
                               .append($('<h2>')
                                       .attr('id', methodId)
                                       .append(methodDesc +
-                                            ' &nbsp&nbsp<a href="'+ this.options.methodHelpLink + this.method.info.id +
+                                            ' &nbsp&nbsp<a href="'+ link +
                                                 '" target="_blank">more...</a>'
                                       ));
              

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -14,6 +14,7 @@ require(['jquery',
          'narrativeConfig',
          'util/string',
          'util/bootstrapDialog',
+         'util/display',
          'handlebars', 
          'kbwidget', 
          'kbaseAuthenticatedWidget',
@@ -24,7 +25,8 @@ require(['jquery',
 function($, 
          Config,
          StringUtil,
-         BootstrapDialog) {
+         BootstrapDialog,
+         Display) {
     'use strict';
     $.KBWidget({
         name: "kbaseNarrativeMethodCell",
@@ -33,7 +35,8 @@ function($,
         options: {
             method: null,
             cellId: null,
-            methodHelpLink: '/#/appcatalog/app/'
+            methodHelpLink: '/#/appcatalog/app/',
+            methodStoreURL: Config.url('narrative_method_store')
         },
         IGNORE_VERSION: true,
         defaultInputWidget: 'kbaseNarrativeMethodInput',
@@ -231,11 +234,17 @@ function($,
                 .closest('.cell')
                 .trigger('set-title.cell', [self.method.info.name]); 
             
-            var methodIcon = '<div class="fa-stack fa-2x"><i class="fa fa-square fa-stack-2x method-icon"></i><i class="fa fa-inverse fa-stack-1x fa-cube"></i></div>';
-            
+            var $logo = $('<div>');
+            if(this.method.info.icon && this.method.info.icon.url) {
+                var url = this.options.methodStoreURL.slice(0, -3) + this.method.info.icon.url;
+                $logo.append( Display.getAppIcon({url: url}) );
+            } else {
+                $logo.append( Display.getAppIcon({}) );
+            }
+
             this.$elem
                 .closest('.cell')
-                .trigger('set-icon.cell', [methodIcon]);
+                .trigger('set-icon.cell', [$logo.html()]);
 
             require([inputWidgetName], 
               $.proxy(function() {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -33,7 +33,7 @@ function($,
         options: {
             method: null,
             cellId: null,
-            methodHelpLink: '/#/narrativestore/method/'
+            methodHelpLink: '/#/appcatalog/app/'
         },
         IGNORE_VERSION: true,
         defaultInputWidget: 'kbaseNarrativeMethodInput',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -591,6 +591,15 @@ function ($, _, Promise, Config, DisplayUtil) {
                     }
                     //refresh?
                     //self.refreshFromService(self.currentTag);
+                })
+                .tooltip({
+                    title: 'Add or remove from your favorites',
+                    container: 'body',
+                    placement: 'bottom',
+                    delay: {
+                        show: Config.get('tooltip').showDelay,
+                        hide: Config.get('tooltip').hideDelay
+                    }
                 });
             }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -578,7 +578,6 @@ function ($, _, Promise, Config, DisplayUtil) {
                         // remove favorite
                         self.catalog.remove_favorite(params)
                             .then(function() {
-                                console.log('removed favorite!  woot!')
                                 $star.removeClass('kbcb-star-favorite').addClass('kbcb-star-nonfavorite');
                                 method.favorite = null; // important to set this if we don't refresh the panel
                             });
@@ -586,7 +585,6 @@ function ($, _, Promise, Config, DisplayUtil) {
                         // add favorite
                         self.catalog.add_favorite(params)
                             .then(function() {
-                                console.log('added favorite!  woot!')
                                 $star.removeClass('kbcb-star-nonfavorite').addClass('kbcb-star-favorite');
                                 method.favorite =  new Date().getTime(); // important to set this if we don't refresh the panel
                             });
@@ -1011,7 +1009,6 @@ function ($, _, Promise, Config, DisplayUtil) {
                 if(style=='input' || style=='object') {
                     if(spec.info.input_types) {
                         for(var k=0; k<spec.info.input_types.length; k++) {
-                            console.log(spec.info.input_types[k].toLowerCase().indexOf(type));
                             if(spec.info.input_types[k].toLowerCase().indexOf(type) >=0) {
                                 return true;
                             }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -1006,11 +1006,28 @@ function ($, _, Promise, Config, DisplayUtil) {
                 }
                 return false;
             } else {
-
-                // this is a method
-                console.log(spec)
-
-                return true;
+                // this is a method-- things are easy now because this info is returned by the NMS!
+                // if style==object => check both input and output
+                if(style=='input' || style=='object') {
+                    if(spec.info.input_types) {
+                        for(var k=0; k<spec.info.input_types.length; k++) {
+                            console.log(spec.info.input_types[k].toLowerCase().indexOf(type));
+                            if(spec.info.input_types[k].toLowerCase().indexOf(type) >=0) {
+                                return true;
+                            }
+                        }
+                    }
+                } else if (style=='output' || style=='object') {
+                    if(spec.info.output_types) {
+                        for(var k=0; k<spec.info.output_types.length; k++) {
+                            if(spec.info.output_types[k].toLowerCase().indexOf(type) >=0) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                // not found
+                return false;
             }
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -23,7 +23,7 @@ define([
         'kbaseNarrative',
         'catalog-client-api',
         'bootstrap'], 
-function ($, _, Promise, Config, Display) {
+function ($, _, Promise, Config, DisplayUtil) {
     'use strict';
     $.KBWidget({
         name: 'kbaseNarrativeMethodPanel',
@@ -493,13 +493,13 @@ function ($, _, Promise, Config, Display) {
             var $logo = $('<div>');
 
             if(icon=='A') {
-                $logo.append( Display.getAppIcon({ isApp: true , cursor: 'pointer', setColor:true }) );
+                $logo.append( DisplayUtil.getAppIcon({ isApp: true , cursor: 'pointer', setColor:true }) );
             } else {
                 if(method.info.icon && method.info.icon.url) {
                     var url = this.options.methodStoreURL.slice(0, -3) + method.info.icon.url;
-                    $logo.append( Display.getAppIcon({ url: url , cursor: 'pointer' , setColor:true}) );
+                    $logo.append( DisplayUtil.getAppIcon({ url: url , cursor: 'pointer' , setColor:true}) );
                 } else {
-                    $logo.append( Display.getAppIcon({ cursor: 'pointer' , setColor:true}) );
+                    $logo.append( DisplayUtil.getAppIcon({ cursor: 'pointer' , setColor:true}) );
                 }
             }
             // add behavior
@@ -625,14 +625,14 @@ function ($, _, Promise, Config, Display) {
             if (specSet.methods && specSet.methods instanceof Array) {
                 results.methods = {};
                 // we need to fetch some methods, so don't 
-                this.methClient.get_method_spec({ids: specSet.methods, tag:this.currentTag},
-                        function(specs){
+                this.methClient.get_method_spec({ids: specSet.methods, tag:this.currentTag})
+                        .then(function(specs){
                             for(var k=0; k<specs.length; k++) {
                                 results.methods[specs[k].info.id] = specs[k];
                             }
                             callback(results);
-                        },
-                        function(err) {
+                        })
+                        .catch(function(err) {
                             console.error("Error in method panel on 'getFunctionSpecs' when contacting NMS");
                             console.error(err);
                             callback(results); // still return even if we couldn't get the methods

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -11,15 +11,19 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define(['jquery',
+define([
+        'jquery', 
+        'underscore',
+        'bluebird',
         'narrativeConfig',
+        'util/display',
         'kbwidget',
         'kbaseAccordion',
         'kbaseNarrativeControlPanel',
         'kbaseNarrative',
         'catalog-client-api',
         'bootstrap'], 
-function ($, Config) {
+function ($, _, Promise, Config, Display) {
     'use strict';
     $.KBWidget({
         name: 'kbaseNarrativeMethodPanel',
@@ -64,8 +68,6 @@ function ($, Config) {
             var self = this;
             // DOM structure setup here.
             // After this, just need to update the function list
-
-            console.debug(options);
 
             this.currentTag = 'release';
 
@@ -382,7 +384,6 @@ function ($, Config) {
 
             var methodProm = this.methClient.list_methods(filterParams,
                 $.proxy(function(methods) {
-                    console.log(methods);
                     this.methodSpecs = {};
                     this.methodInfo = {};
                     for (var i=0; i<methods.length; i++) {
@@ -490,8 +491,17 @@ function ($, Config) {
         buildMethod: function(icon, method, triggerFn) {
             // add icon (logo)
             var $logo = $('<div>');
-            this.trigger('setMethodIcon.Narrative',
-                         {elt: $logo, is_app: icon == 'A'});
+
+            if(icon=='A') {
+                $logo.append( Display.getAppIcon({ isApp: true , cursor: 'pointer', setColor:true }) );
+            } else {
+                if(method.info.icon && method.info.icon.url) {
+                    var url = this.options.methodStoreURL.slice(0, -3) + method.info.icon.url;
+                    $logo.append( Display.getAppIcon({ url: url , cursor: 'pointer' , setColor:true}) );
+                } else {
+                    $logo.append( Display.getAppIcon({ cursor: 'pointer' , setColor:true}) );
+                }
+            }
             // add behavior
             $logo.click($.proxy(
                 function(e) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -218,11 +218,6 @@ function($,
                     this.setDataIcon(param.elt, param.type);
                 }.bind(this)
             );
-            $(document).on('setMethodIcon.Narrative',
-                function (e, param) {
-                    this.setMethodIcon(param.elt, param.is_app);
-                }.bind(this)
-            );
 
             // Refresh the read-only or View-only mode
             $(document).on('updateReadOnlyMode.Narrative',
@@ -2405,28 +2400,6 @@ function($,
                       .addClass("fa fa-inverse fa-stack-1x " + cls));
                 });
             }
-        },
-
-        /**
-         * Set the visual icon for a method or app.
-         *
-         * @param $logo - Target element
-         * @param is_app - Boolean for app or method
-         */
-        setMethodIcon: function ($logo, is_app) {
-            var name = is_app ? "app" : "method";
-            var ci = is_app ? 9 : 5; // color index
-            var icon = this.meth_icons[name];
-            // background
-            $logo.addClass("fa-stack fa-2x").css({'cursor': 'pointer'})
-              .append($('<i>')
-                .addClass("fa fa-square fa-stack-2x")
-                .css({'color': this.icon_colors[ci]}));
-            // add stack of font-awesome icons
-            _.each(icon, function (cls) {
-                $logo.append($('<i>')
-                  .addClass("fa fa-inverse fa-stack-1x " + cls));
-            });
         },
 
         /**

--- a/test/unit/spec/Util/DisplaySpec.js
+++ b/test/unit/spec/Util/DisplaySpec.js
@@ -1,0 +1,48 @@
+/*global define*/
+/*global describe, it, expect*/
+/*global jasmine*/
+/*global beforeEach, afterEach*/
+/*jslint white: true*/
+
+define(['jquery','util/display'], function($,DisplayUtil) {
+    'use strict';
+    
+    describe('KBase Display Utility function module', function() {
+
+
+        it('getAppIcon() should create a default icons for methods and apps', function() {
+            var $icon = DisplayUtil.getAppIcon({});
+            expect($icon.html()).toContain('method-icon');
+            expect($icon.html()).not.toContain('app-icon');
+
+            var $icon = DisplayUtil.getAppIcon({isApp:true});
+            expect($icon.html()).toContain('app-icon');
+            expect($icon.html()).not.toContain('method-icon');
+        });
+
+        it('getAppIcon() should create a default icons with urls', function() {
+            var $icon = DisplayUtil.getAppIcon({url:'https://kbase.us/someimg.png'});
+            // right now icon is directly an image, but might not always be the case, so
+            // test that we can find the url
+            expect($('<div>').append($icon).html()).toContain('https://kbase.us/someimg.png');
+            expect($('<div>').append($icon).html()).not.toContain('method-icon');
+            expect($('<div>').append($icon).html()).toContain('default');
+            expect($('<div>').append($icon).html()).not.toContain('app-icon');
+        });
+
+        it('getAppIcon() should use the cursor option', function() {
+            var $icon = DisplayUtil.getAppIcon({url:'https://kbase.us/someimg.png', cursor:'pointer'});
+            expect($('<div>').append($icon).html()).toContain('https://kbase.us/someimg.png');
+            expect($('<div>').append($icon).html()).toContain('pointer');
+            expect($('<div>').append($icon).html()).not.toContain('method-icon');
+            expect($('<div>').append($icon).html()).not.toContain('app-icon');
+
+            $icon = DisplayUtil.getAppIcon({cursor:'pointer'});
+            expect($('<div>').append($icon).html()).toContain('pointer');
+            expect($('<div>').append($icon).html()).toContain('method-icon');
+            expect($('<div>').append($icon).html()).not.toContain('app-icon');
+        });
+
+
+    });
+});


### PR DESCRIPTION
This updates the methods panel to add several new features and provide a minor performance improvement:

1) instead of pulling complete specs of methods to filter by type, uses the new NMS brief info object.  So much less data has to be pulled and filtering by type is faster.  Specs are pulled when a method is added or a spec is requested.
2) Custom method icons are now displayed if they are registered with the SDK method or the NMS (also pulled out that code into a util function, with a few new tests, so this isn't copied in multiple places)
3) Links in the method panel and method/app cells are updated to point to the new App Catalog
4) Support for favorites is now in the methods panel.  Your favorites will be sorted to the top of the list, ordered by the date that you added a method to your list of favorites.  Within the panel, you can also directly add/remove favorites by clicking on the star.
