### PR TITLE
Data and Methods side panels now dynamically resize

### DIFF
--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -417,7 +417,7 @@ p#site-title {
 
 .kb-side-panel {
     height: 100%;
-    overflow-y: auto;
+    overflow-y: hidden;
 }
 
 .kb-side-header {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -24,7 +24,9 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
         options: {
             title: 'Control',
             collapsible: true,
-            maxHeight: '400px'
+            maxHeight: '400px',
+            collapseCallback: null,  // called when this panel is minimized/maximized
+            slideTime: 400           // set minimize/maximize animation time
         },
 
         /**
@@ -40,7 +42,7 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
          */
         init: function(options) {
             this._super(options);
-
+            this.slideTime = this.options.slideTime;
             this.render();
             return this;
         },
@@ -75,6 +77,7 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
                                 .attr('role', 'toolbar')
                                 .css({'margin-top' : '-2px'});
 
+            this.isMin = false;
             this.$elem.append($('<div>')
                               .addClass('kb-narr-side-panel')
                                       .append($('<div>')
@@ -87,12 +90,17 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
                                                               if ($(event.currentTarget.firstChild).hasClass('glyphicon-chevron-down')) {
                                                                   $(event.currentTarget.firstChild).removeClass('glyphicon-chevron-down')
                                                                                                    .addClass('glyphicon-chevron-right');
-                                                                  this.$bodyDiv.parent().slideUp(400);
+                                                                  this.$bodyDiv.parent().slideUp(this.slideTime);
+                                                                  this.isMin = true;
                                                               }
                                                               else {
                                                                   $(event.currentTarget.firstChild).removeClass('glyphicon-chevron-right')
                                                                                                    .addClass('glyphicon-chevron-down');
-                                                                  this.$bodyDiv.parent().slideDown(400);
+                                                                  this.$bodyDiv.parent().slideDown(this.slideTime);
+                                                                  this.isMin = false;
+                                                              }
+                                                              if(this.options.collapseCallback) {
+                                                                  this.options.collapseCallback(this.isMin);
                                                               }
                                                           }, this)
                                                       )
@@ -106,6 +114,17 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
                                           'overflow-y' : 'auto'
                                       })
                                       .append(this.$bodyDiv)));
+        },
+
+        // remember the minimization state
+        isMin: null,
+
+        /**
+         * Returns minimization state of the Panel, true if minimized, false otherwise
+         * @public
+         */
+        isMinimized: function() {
+          return isMin;
         },
 
         /**

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -55,7 +55,9 @@ function ($,
 
             max_name_length: 33,
             refresh_interval: 30000,
-            parentControlPanel: null
+            parentControlPanel: null,
+
+            slideTime: 400
         },
         // private variables
         mainListPanelHeight: '340px',
@@ -137,6 +139,12 @@ function ($,
             }
 
             return this;
+        },
+
+        setListHeight: function(height) {
+            if(this.$mainListDiv) {
+                this.$mainListDiv.animate({'height':height},this.options.slideTime);
+            }
         },
 
         /**

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -89,7 +89,8 @@ function($,
                 $dataList.kbaseNarrativeDataList(
                     {
                         ws_name: this.ws_name,
-                        parentControlPanel: this
+                        parentControlPanel: this,
+                        slideTime: this.slideTime
                     }
                 );
 
@@ -163,6 +164,12 @@ function($,
             this.addButton(this.$slideoutBtn);
             
             return this;
+        },
+
+        setListHeight: function(height) {
+            if(this.dataListWidget) {
+                this.dataListWidget.setListHeight(height);
+            }
         },
 
         addButtonToControlPanel: function($btn) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -341,6 +341,12 @@ function ($, _, Promise, Config, DisplayUtil) {
         },
 
 
+        setListHeight: function(height) {
+            if(this.$methodList) {
+                this.$methodList.animate({'height':height}, this.slideTime); // slideTime comes from kbaseNarrativeControlPanel
+            }
+        },
+
         filterList: function() {
             var txt = this.$searchInput.val().trim().toLowerCase();
             if (txt.indexOf("type:") === 0) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -20,7 +20,9 @@ function($, Config) {
             workspaceURL: Config.url('workspace'),
         },
         $dataWidget: null,
+        dataWidgetListHeight: [340, 680], // [height with methods showing, max height]
         $methodsWidget: null,
+        methodsWidgetListHeight: [300, 600], // [height with data showing, max height]
         $narrativesWidget: null,
         $jobsWidget: null,
         $overlay: null,
@@ -34,11 +36,22 @@ function($, Config) {
             var analysisWidgets = this.buildPanelSet([
                 {
                     name : 'kbaseNarrativeDataPanel',
-                    params : {}
+                    params : {
+                        collapseCallback: $.proxy(function(isMinimized) { 
+                                this.handleMinimizedDataPanel(isMinimized);
+                            }
+                            ,this)
+                    }
                 },
                 {
                     name : 'kbaseNarrativeMethodPanel',
-                    params : { autopopulate: false }
+                    params : { 
+                        autopopulate: false , 
+                        collapseCallback: $.proxy(function(isMinimized) { 
+                                this.handleMinimizedMethodPanel(isMinimized);
+                            }
+                            ,this)
+                    }
                 }
             ]);
             this.$dataWidget = analysisWidgets['kbaseNarrativeDataPanel'];
@@ -296,6 +309,36 @@ function($, Config) {
             retObj['panelSet'] = $panelSet;
             return retObj;
         },
+
+
+        /**
+         * Specialized callback controlling heights of panels when data panel is minimized.
+         * Assumes data and method panel are on the same tab.
+         */
+        handleMinimizedDataPanel: function(isMinimized) {
+            if(isMinimized) {
+                // data panel was minimized
+                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1]);
+            } else {
+                // data panel was maximized
+                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0]);
+            }
+        },
+
+        /**
+         * Specialized callback controlling heights of panels when method panel is minimized.
+         * Assumes data and method panel are on the same tab.
+         */
+        handleMinimizedMethodPanel: function(isMinimized) {
+            if(isMinimized) {
+                // data panel was minimized
+                this.$dataWidget.setListHeight(this.dataWidgetListHeight[1]);
+            } else {
+                // data panel was maximized
+                this.$dataWidget.setListHeight(this.dataWidgetListHeight[0]);
+            }
+        },
+
 
         render: function() {
             this.initOverlay();


### PR DESCRIPTION
We should have just done this a while ago!  This turned out to be relatively simple fix.  Added a callback option to the side control panels widget that is triggered when a panel is minimized/maximized.  This is now wired to setting the height of the data and method list, so these lists now dynamically resize to fill up the free space in the side panel.

This isn't the more complicated 'responsive' fix to adjust things everytime the browser resizes or on different screen resolutions, but it's much better than what we have now.

This also tweaks a style so we never get multiple scrollbars appearing in the side panel.
