### PR TITLE
More side panel improvements

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -23,6 +23,7 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
         version: '0.0.1',
         options: {
             title: 'Control',
+            showTitle: true,
             collapsible: true,
             maxHeight: '400px',
             collapseCallback: null,  // called when this panel is minimized/maximized
@@ -77,38 +78,45 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
                                 .attr('role', 'toolbar')
                                 .css({'margin-top' : '-2px'});
 
+            var $titleSpan = $('<span>');
+            if(this.options.showTitle) {
+              $titleSpan
+                .append($('<span>')
+                  .css({'cursor' : 'pointer'})
+                  .click(
+                      $.proxy(function(event) {
+                          event.preventDefault();
+                          if ($(event.currentTarget.firstChild).hasClass('glyphicon-chevron-down')) {
+                              $(event.currentTarget.firstChild).removeClass('glyphicon-chevron-down')
+                                                               .addClass('glyphicon-chevron-right');
+                              this.$bodyDiv.parent().slideUp(this.slideTime);
+                              this.isMin = true;
+                          }
+                          else {
+                              $(event.currentTarget.firstChild).removeClass('glyphicon-chevron-right')
+                                                               .addClass('glyphicon-chevron-down');
+                              this.$bodyDiv.parent().slideDown(this.slideTime);
+                              this.isMin = false;
+                          }
+                          if(this.options.collapseCallback) {
+                              this.options.collapseCallback(this.isMin);
+                          }
+                      }, this)
+                  )
+                  .append($('<span>')
+                          .addClass('glyphicon glyphicon-chevron-down kb-narr-panel-toggle'))
+                  .append(this.options.title))
+            }
+            $titleSpan.append(this.$buttonPanel);
+
+
             this.isMin = false;
             this.$elem.append($('<div>')
-                              .css({'overflow-y':'auto'})
+                              .css({'height':'100%', 'overflow-y':'auto'})
                               .addClass('kb-narr-side-panel')
                                       .append($('<div>')
                                               .addClass('kb-title')
-                                              .append($('<span>')
-                                                      .css({'cursor' : 'pointer'})
-                                                      .click(
-                                                          $.proxy(function(event) {
-                                                              event.preventDefault();
-                                                              if ($(event.currentTarget.firstChild).hasClass('glyphicon-chevron-down')) {
-                                                                  $(event.currentTarget.firstChild).removeClass('glyphicon-chevron-down')
-                                                                                                   .addClass('glyphicon-chevron-right');
-                                                                  this.$bodyDiv.parent().slideUp(this.slideTime);
-                                                                  this.isMin = true;
-                                                              }
-                                                              else {
-                                                                  $(event.currentTarget.firstChild).removeClass('glyphicon-chevron-right')
-                                                                                                   .addClass('glyphicon-chevron-down');
-                                                                  this.$bodyDiv.parent().slideDown(this.slideTime);
-                                                                  this.isMin = false;
-                                                              }
-                                                              if(this.options.collapseCallback) {
-                                                                  this.options.collapseCallback(this.isMin);
-                                                              }
-                                                          }, this)
-                                                      )
-                                                      .append($('<span>')
-                                                              .addClass('glyphicon glyphicon-chevron-down kb-narr-panel-toggle'))
-                                                      .append(this.options.title))
-                                                      .append(this.$buttonPanel))
+                                              .append($titleSpan))
                               .append($('<div>')
                                       .addClass('kb-narr-panel-body')
                                       .css({ 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -79,6 +79,7 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
 
             this.isMin = false;
             this.$elem.append($('<div>')
+                              .css({'overflow-y':'auto'})
                               .addClass('kb-narr-side-panel')
                                       .append($('<div>')
                                               .addClass('kb-title')
@@ -125,6 +126,11 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
          */
         isMinimized: function() {
           return this.isMin;
+        },
+
+        // allows the height of the entire panel to be dynamically set
+        setHeight: function(height) {
+          this.$elem.css({height:height});
         },
 
         /**

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -124,7 +124,7 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
          * @public
          */
         isMinimized: function() {
-          return isMin;
+          return this.isMin;
         },
 
         /**

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -141,9 +141,13 @@ function ($,
             return this;
         },
 
-        setListHeight: function(height) {
+        setListHeight: function(height, animate) {
             if(this.$mainListDiv) {
-                this.$mainListDiv.animate({'height':height},this.options.slideTime);
+                if(animate) {
+                    this.$mainListDiv.animate({'height':height},this.options.slideTime);
+                } else {
+                    this.$mainListDiv.css({'height':height});
+                }
             }
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -166,9 +166,9 @@ function($,
             return this;
         },
 
-        setListHeight: function(height) {
+        setListHeight: function(height, animate) {
             if(this.dataListWidget) {
-                this.dataListWidget.setListHeight(height);
+                this.dataListWidget.setListHeight(height, animate);
             }
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -341,9 +341,14 @@ function ($, _, Promise, Config, DisplayUtil) {
         },
 
 
-        setListHeight: function(height) {
+        setListHeight: function(height, animate) {
             if(this.$methodList) {
-                this.$methodList.animate({'height':height}, this.slideTime); // slideTime comes from kbaseNarrativeControlPanel
+                if(animate) {
+                    this.$methodList.animate({'height':height}, this.slideTime); // slideTime comes from kbaseNarrativeControlPanel
+                }
+                else {
+                    this.$methodList.css({'height':height});
+                }
             }
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -24,8 +24,10 @@ function($, Config) {
         $methodsWidget: null,
         methodsWidgetListHeight: [300, 600], // [height with data showing, max height]
 
-        heightOffset: 220, // in px, space taken up by titles, header bar, etc.  The rest of the real estate is divided
-                           // by half for for the method and data lists
+        heightListOffset: 220,  // in px, space taken up by titles, header bar, etc.  The rest of the real estate is divided
+                                // by half for for the method and data lists
+        heightPanelOffset: 110, // in px, space taken by just the header, the rest is for the full panel size, which is the
+                                // case for the narratives/jobs panels
 
         $narrativesWidget: null,
         $jobsWidget: null,
@@ -60,11 +62,6 @@ function($, Config) {
             ]);
             this.$dataWidget = analysisWidgets['kbaseNarrativeDataPanel'];
             this.$methodsWidget = analysisWidgets['kbaseNarrativeMethodPanel'];
-
-            // handle window size change in left panel, and call it once to set the correct size now
-            $(window).on('resize',$.proxy(function() { this.windowSizeChange(); }, this));
-            this.windowSizeChange();
-
 
             var $analysisPanel = analysisWidgets['panelSet'];
 
@@ -118,12 +115,17 @@ function($, Config) {
                 this.toggleOverlay(panel);
             }, this));
 
+            // handle window size change in left panel, and call it once to set the correct size now
+            $(window).on('resize',$.proxy(function() { this.windowSizeChange(); }, this));
+            this.windowSizeChange();
+
             if (this.autorender) {
                 this.render();
             }
             else {
 
             }
+
 
             return this;
         },
@@ -367,8 +369,8 @@ function($, Config) {
             if(h<300) { // below a height of 300px, don't trim anymore, just let the rest be clipped
                 h = 300;
             }
-            var max = h - this.heightOffset;
-            var min = (h-this.heightOffset)/2;
+            var max = h - this.heightListOffset;
+            var min = (h-this.heightListOffset)/2;
             this.methodsWidgetListHeight[0]=min;
             this.methodsWidgetListHeight[1]=max;
             this.dataWidgetListHeight[0]=min;
@@ -385,6 +387,10 @@ function($, Config) {
             } else {
                 this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0]);
             }
+
+            var fullSize = h - this.heightPanelOffset;
+            this.$narrativesWidget.setHeight(fullSize);
+            this.$jobsWidget.setHeight(fullSize);
         },
 
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -68,7 +68,7 @@ function($, Config) {
             var manageWidgets = this.buildPanelSet([
                 {
                     name : 'kbaseNarrativeManagePanel',
-                    params : { autopopulate: true }
+                    params : { autopopulate: true, showTitle: false }
                 },
             ]);
 
@@ -78,7 +78,7 @@ function($, Config) {
             var jobsWidget = this.buildPanelSet([
                 {
                     name : 'kbaseNarrativeJobsPanel',
-                    params : { autopopulate: true }
+                    params : { autopopulate: true, showTitle: false }
                 }
             ]);
             this.$jobsWidget = jobsWidget['kbaseNarrativeJobsPanel'];


### PR DESCRIPTION
The changes from my PR last night had a side effect of removing scroll bars in the narrative and jobs panel.  I realized that the cleanest way to fix this is to just finally make the heights responsive to the window height, which turned out to be fairly straightforward given the new methods for setting the height of the control panel widgets.  So that finally works now!

I also made a separate minor styling change by removing the titles to the 'Narrative' and 'Jobs' panel.  I think it looks better, but could still use some styling tweaks (for instance, the jobs list seems compressed slightly more now).  We can always revert that or work on styling when we find time later.
