### PR TITLE
A bunch of style changes

### DIFF
--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -175,10 +175,6 @@
                     <div id="kb-notify-area"><div id="notification_area"></div></div>
 
 
-                    <button id="kb-view-only-ctrl" class="btn btn-default navbar-btn kb-nav-btn hidden">
-                        <div class="fa fa-gear"></div>
-                        <div class="kb-nav-btn-txt">controls</div>
-                    </button>
                     <button id="kb-view-only-copy" class="btn btn-default navbar-btn kb-nav-btn hidden">
                         <div class="fa fa-copy"></div>
                         <div class="kb-nav-btn-txt">copy</div>

--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -41,7 +41,8 @@ CSS should go in /kbase-extension/static/kbase/css/kbaseNarrative.css
     height: auto;
     background: none;
     border: none;
-    border-bottom: none;
+    border-left: 1px solid transparent;
+    padding-top: 7px;
 }
 
 div.input_area {
@@ -59,11 +60,9 @@ div.text_cell_input {
 }*/
 
 div.cell {
-    /*padding: 5px 0px 0 0;*/
     margin: 8px 0 8px 0px;
-    padding: 6px 0 6px 4px;
+    padding: 0 0 6px 4px;
     border: 1px solid #CCC;
-    /*border-left: 5px solid  #CCC;*/
     border-radius: 0;
 }
 
@@ -118,6 +117,7 @@ span#notebook_name:hover {
 
 .prompt {
     min-width: 10ex;
+    padding-top: 10px;
 }
 
 

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1135,7 +1135,7 @@ div#notebook_panel {
 
 .kb-narr-panel-body {
     padding: 3px;
-    overflow-y: auto;
+    /*overflow-y: auto;*/
 }
 
 .kb-narr-panel-toggle {

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1651,6 +1651,7 @@ div#notebook_panel {
    margin-top:3px;
    padding-right:0px;
    padding-left:0px;
+   white-space: normal;
 }
 .kb-method-parameter-input {
    vertical-align:middle;

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1347,7 +1347,6 @@ div#notebook_panel {
 }
 
 .kb-toolbar-open {
-    padding-top: 7px;
     border-bottom: 1px solid #CCC;
     border-radius: 0;
 }

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -400,11 +400,13 @@ function($,
         }
         if (this.getWorkspaceName() !== null) {
             this.initSharePanel();
+
+            $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false }).render();
             this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({
                 ws_id: this.getWorkspaceName()
             });
             this.narrController.render().finally(function() {
-                $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false }).render();
+                // $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false }).render();
                 $('#kb-wait-for-ws').remove();
             });
         }
@@ -552,9 +554,17 @@ function($,
         }
     };
 
-    Narrative.prototype.toggleSidePanel = function() {
+    /**
+     * if setHidden === true, then always hide
+     * if setHidden === false (not null or undefined), then always show
+     * if the setHidden variable isn't present, then just toggle
+     */
+    Narrative.prototype.toggleSidePanel = function(setHidden) {
         var delay = 'fast';
-        if ($('#left-column').is(':visible')) {
+        var hidePanel = setHidden;
+        if (hidePanel === null || hidePanel === undefined)
+            hidePanel = $('#left-column').is(':visible') ? true : false;
+        if (hidePanel) {
             $('#left-column').trigger('hideSidePanelOverlay.Narrative');
             $('#left-column').hide('slide', {
                 direction: 'left', 

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeMethodInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeMethodInput.js
@@ -117,10 +117,10 @@ function( $, Config ) {
                                                      .on('click',function() {
                                                         if (self.$advancedOptionsDiv.is(":visible")) {
                                                             self.$advancedOptionsDiv.hide();
-                                                            $(this).find(".kb-method-advanced-options-controller").html("show advanced options");
+                                                            $(this).closest(".kb-method-advanced-options-controller").text("show advanced options");
                                                         } else {
                                                             self.$advancedOptionsDiv.show();
-                                                            $(this).find(".kb-method-advanced-options-controller").html("hide advanced options");
+                                                            $(this).closest(".kb-method-advanced-options-controller").text("hide advanced options");
                                                         }
                                                      } ));
                 $inputParameterContainer.append($advancedOptionsControllerRow);

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
@@ -98,7 +98,7 @@ function($, Config) {
                                 .append(spec.short_hint);
                 if (spec.description && spec.short_hint !== spec.description) {
                     $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
-                                    .tooltip({title:spec.description, html:true}));
+                                    .tooltip({title:spec.description, html:true, container: 'body'}));
                 }
                                 
                 $row.append($nameCol).append($inputCol).append($hintCol);

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
@@ -126,7 +126,7 @@ function($, Config) {
                                 .append(spec.short_hint);
                 if (spec.description && spec.short_hint !== spec.description) {
                     $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
-                                    .tooltip({title:spec.description, html:true}));
+                                    .tooltip({title:spec.description, html:true, container: 'body'}));
                 }
                 $row.append($nameCol).append($inputCol).append($hintCol);
                 

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
@@ -148,7 +148,7 @@ function($, Config) {
             	.append(spec.short_hint);
 	    if (spec.description && spec.short_hint !== spec.description) {
                 $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
-                                .tooltip({title:spec.description, html:true}));
+                                .tooltip({title:spec.description, html:true, container: 'body'}));
             }
             $row.append($nameCol).append($inputCol).append($hintCol);
 

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
@@ -196,7 +196,7 @@ function($, Config) {
                 $hintCol.append(spec.short_hint);
                 if (spec.description && spec.short_hint !== spec.description) {
                     $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
-                                    .tooltip({title:spec.description, html:true}));
+                                    .tooltip({title:spec.description, html:true, container: 'body'}));
                 }
             } else {
                 $removalButton = $('<button>').addClass("kb-default-btn kb-btn-sm")

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextSubdataInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextSubdataInput.js
@@ -416,7 +416,7 @@ function($, Config) {
                 $hintCol.append(spec.short_hint);
                 if (spec.description && spec.short_hint !== spec.description) {
                     $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
-                                    .tooltip({title:spec.description, html:true}));
+                                    .tooltip({title:spec.description, html:true, container: 'body'}));
                 }
             } else {
                 $removalButton = $('<button>').addClass("kb-default-btn kb-btn-sm")

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
@@ -100,7 +100,7 @@ function($, Config) {
                                 .append(spec.short_hint);
 		if (spec.description && spec.short_hint !== spec.description) {
 		    $hintCol.append($('<span>').addClass('fa fa-info kb-method-parameter-info')
-					.tooltip({title:spec.description, html:true}));
+					.tooltip({title:spec.description, html:true, container: 'body'}));
 		}
                 $row.append($nameCol).append($inputCol).append($hintCol);
                 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -115,10 +115,10 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
                               .addClass('kb-narr-side-panel')
                               .append($('<div>')
                                       .addClass('kb-title')
-                                      .append($titleSpan))
+                                      .append($titleSpan)
                               .append($('<div>')
                                       .addClass('kb-narr-panel-body')
-                                      .append(this.$bodyDiv)));
+                                      .append(this.$bodyDiv))));
         },
 
         // remember the minimization state

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -119,9 +119,6 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
                                               .append($titleSpan))
                               .append($('<div>')
                                       .addClass('kb-narr-panel-body')
-                                      .css({ 
-                                          'overflow-y' : 'auto'
-                                      })
                                       .append(this.$bodyDiv)));
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -109,14 +109,13 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
             }
             $titleSpan.append(this.$buttonPanel);
 
-
             this.isMin = false;
             this.$elem.append($('<div>')
                               .css({'height':'100%', 'overflow-y':'auto'})
                               .addClass('kb-narr-side-panel')
-                                      .append($('<div>')
-                                              .addClass('kb-title')
-                                              .append($titleSpan))
+                              .append($('<div>')
+                                      .addClass('kb-title')
+                                      .append($titleSpan))
                               .append($('<div>')
                                       .addClass('kb-narr-panel-body')
                                       .append(this.$bodyDiv)));

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -115,10 +115,10 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
                               .addClass('kb-narr-side-panel')
                               .append($('<div>')
                                       .addClass('kb-title')
-                                      .append($titleSpan)
+                                      .append($titleSpan))
                               .append($('<div>')
                                       .addClass('kb-narr-panel-body')
-                                      .append(this.$bodyDiv))));
+                                      .append(this.$bodyDiv)));
         },
 
         // remember the minimization state

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -70,6 +70,9 @@ function($,
                 }, this)
             );
             
+            // doesn't need a title, so just hide it to avoid padding.
+            // yes, it's a hack. mea culpa.
+            this.$elem.find('.kb-title').hide();
             return this;
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -237,10 +237,11 @@ function($,
                 self.$mainPanel.empty();
 
                 var $msgPanel = $("<div>").css({'margin': '10px', 'text-align': 'center'});
+                self.$copyThisNarrBtn = self.makeCopyThisNarrativeBtn($msgPanel);
                 self.$mainPanel.append(
                     $('<div>').css({'margin': '15px', 'text-align': 'center'})
                     .append(self.makeNewNarrativeBtn())
-                    .append(self.makeCopyThisNarrativeBtn($msgPanel))
+                    .append(self.$copyThisNarrBtn)
                     .append($msgPanel));
 
                 self.$narPanel = $('<div>');
@@ -955,8 +956,7 @@ function($,
                 .append(active)
                 .on('click', function (e) {
                     e.stopPropagation();
-                    var $cpyBtn = $(this);
-                    $cpyBtn.prop('disabled', true).empty().append($working);
+                    $(this).prop('disabled', true).empty().append($working);
                     self.copyThisNarrative($alertContainer, active, null);
                 });
             return $btn;
@@ -982,11 +982,24 @@ function($,
                                         Jupyter.narrative.enableKeyboardManager();
                                     }
                                 });
-                            $dialog.append(
-                                $('<div>').append(
-                                $('<div>').append("Enter a name for the new Narrative"))
-                                .append($('<div>').append($newNameInput))
-                                .append($('<button>').addClass('btn btn-info')
+
+
+                            var $cancelBtn = $('<button>')
+                                             .addClass('kb-default-btn')
+                                             .append('Cancel')
+                                             .click(function () {
+                                                $copyNarButton.prop('disabled', false).empty().append(active);
+                                                self.$copyThisNarrBtn.prop('disabled', false).empty().append(active);
+                                                $dialog.empty();
+                                             });
+
+                            var $copyNarButton = $('<button>').addClass('kb-primary-btn')
+
+                            // $dialog.append(
+                            //     $('<div>').append(
+                            //     $('<div>').append("Enter a name for the new Narrative"))
+                            //     .append($('<div>').append($newNameInput))
+                            //     .append($('<button>').addClass('btn btn-info')
                                     .css({'margin-top': '10px'})
                                     .append('Copy')
                                     .click(function () {
@@ -1081,22 +1094,23 @@ function($,
                                                 $dialog.empty();
                                                 $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
                                             });
-                                    }))
-                                .append(active ?
-                                    $('<button>').addClass('kb-data-list-cancel-btn')
-                                    .append('Cancel')
-                                    .click(function () {
-                                        $cpyBtn.prop('disabled', false).empty().append(active);
-                                        $dialog.empty();
-                                    }) : ''));
+                                    });
+                            $dialog.append(
+                                $('<div>').append(
+                                $('<div>').append("Enter a name for the new Narrative"))
+                                .append($('<div>').append($newNameInput))
+                                .append($copyNarButton)
+                                .append(active ? $cancelBtn : ''));
                         },
                         function (error) {
+                            // error with get_object_info_new
                             console.error(error);
                             $dialog.empty();
                             $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
                         });
                 },
                 function (error) {
+                    // error with get_workspace_info
                     console.error(error);
                     $dialog.empty();
                     $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -28,10 +28,11 @@ function($, Config) {
                                 // by half for for the method and data lists
         heightPanelOffset: 110, // in px, space taken by just the header, the rest is for the full panel size, which is the
                                 // case for the narratives/jobs panels
-
         $narrativesWidget: null,
         $jobsWidget: null,
         $overlay: null,
+
+        hideButtonSize: 4, //percent width
 
         /**
          * Does the initial panel layout - tabs and spots for each widget
@@ -136,18 +137,17 @@ function($, Config) {
          * A bit of a hack. Set a specific read-only mode where we don't see the jobs or methods panel,
          * only the data panel and narratives panel.
          * So we need to remove the 'Jobs' header all together, then hide the methods panel,
-         * and (maybe) expand the data panel to fill the screen
+         * and expand the data panel to fill the screen
          */
-        setReadOnlyMode: function(readOnly, minimizeFn) {
+        setReadOnlyMode: function(readOnly) {
             // toggle off the methods and jobs panels
             this.$methodsWidget.$elem.toggle(!readOnly);
             this.$jobsWidget.$elem.toggle(!readOnly);
             this.$dataWidget.$elem.css({'height': (readOnly ? '100%' : '50%')});
 
             // toggle off the jobs header
-            // omg this is a hack, but i'm out of time.
-            this.$tabs.header.find('div:nth-child(3).kb-side-header').toggle(!readOnly);
-            this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? '50%' : '33.333%')});
+            this.$tabs.header.find('div:nth-child(4).kb-side-header').toggle(!readOnly); // hide the jobs header
+            this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? ((100-this.hideButtonSize)/2)+'%' : ((100-this.hideButtonSize)/3)+'%')});
         },
 
         /**
@@ -167,7 +167,7 @@ function($, Config) {
 
             $header.append($('<div>')
                            .addClass('kb-side-toggle')
-                           .css('width', '4%')
+                           .css('width', this.hideButtonSize + '%')
                            .append($('<span>')
                                    .addClass('fa fa-caret-left'))
                            .click(function() {
@@ -177,7 +177,7 @@ function($, Config) {
                 var tab = tabs[i];
                 $header.append($('<div>')
                                .addClass('kb-side-header')
-                               .css('width', (96/tabs.length)+'%')
+                               .css('width', ((100-this.hideButtonSize)/tabs.length)+'%')
                                .append(tab.tabName)
                                .attr('kb-data-id', i));
                 $body.append($('<div>')

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -267,10 +267,6 @@ function($,
                 $(document).trigger('copyThis.Narrative', [$panel, null, $jump]);
                 return '';
             }.bind(this));
-
-            // $('#kb-view-only-ctrl').click(function () {
-            //     this.toggleReadOnlyMode();
-            // }.bind(this));
         },
 
         initDeleteCellModal: function() {
@@ -838,12 +834,6 @@ function($,
         readOnlyMode: function(delay) {
             // Hide side-panel
             Jupyter.narrative.toggleSidePanel(true);
-            // this.trigger('hideSidePanelOverlay.Narrative');
-            // if (!delay)
-            //     delay = 0;
-            // $('#left-column').hide('slide', {direction: 'left', easing: 'swing'}, delay);
-            // // Move content flush left-ish
-            // $('#notebook-container').animate({left: 0}, {easing: 'swing', duration: delay});
 
             // Hide things
             _.map(this.getReadOnlySelectors(), function (id) {$(id).hide()});
@@ -862,7 +852,6 @@ function($,
                 });
                 $('#kb-side-panel').kbaseNarrativeSidePanel('setReadOnlyMode', true);
                 $('#kb-view-only-copy').removeClass('hidden');
-                // $('#kb-view-only-ctrl').removeClass('hidden');
                 $('#kb-view-mode').hide();
 
                 // Disable clicking on name of narrative
@@ -902,7 +891,6 @@ function($,
                 $('#kb-side-panel').kbaseNarrativeSidePanel('setReadOnlyMode', false);
                 $('#kb-view-only-msg').addClass('hidden');
                 $('#kb-view-only-copy').addClass('hidden');
-                // $('#kb-view-only-ctrl').addClass('hidden');
 
                 // re-enable clicking on narrative name
                 $('#name').click(function (e) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -268,9 +268,9 @@ function($,
                 return '';
             }.bind(this));
 
-            $('#kb-view-only-ctrl').click(function () {
-                this.toggleReadOnlyMode(true);
-            }.bind(this));
+            // $('#kb-view-only-ctrl').click(function () {
+            //     this.toggleReadOnlyMode();
+            // }.bind(this));
         },
 
         initDeleteCellModal: function() {
@@ -837,7 +837,7 @@ function($,
          */
         readOnlyMode: function(delay) {
             // Hide side-panel
-            Jupyter.narrative.toggleSidePanel();
+            Jupyter.narrative.toggleSidePanel(true);
             // this.trigger('hideSidePanelOverlay.Narrative');
             // if (!delay)
             //     delay = 0;
@@ -860,9 +860,9 @@ function($,
                     'copy that can be modified, use the ' +
                     '"Copy" button.'
                 });
-
+                $('#kb-side-panel').kbaseNarrativeSidePanel('setReadOnlyMode', true);
                 $('#kb-view-only-copy').removeClass('hidden');
-                $('#kb-view-only-ctrl').removeClass('hidden');
+                // $('#kb-view-only-ctrl').removeClass('hidden');
                 $('#kb-view-mode').hide();
 
                 // Disable clicking on name of narrative
@@ -902,7 +902,7 @@ function($,
                 $('#kb-side-panel').kbaseNarrativeSidePanel('setReadOnlyMode', false);
                 $('#kb-view-only-msg').addClass('hidden');
                 $('#kb-view-only-copy').addClass('hidden');
-                $('#kb-view-only-ctrl').addClass('hidden');
+                // $('#kb-view-only-ctrl').addClass('hidden');
 
                 // re-enable clicking on narrative name
                 $('#name').click(function (e) {
@@ -921,7 +921,7 @@ function($,
             }
             // Restore side-panel
             // Restore margin for content
-            Jupyter.narrative.toggleSidePanel();
+            Jupyter.narrative.toggleSidePanel(false);
             // $('#notebook-container').animate({left: '380'}, {duration: delay, easing: 'swing'});
             // $('#left-column').show('slide', {direction: 'left', easing: 'swing'}, delay);
             // Show hidden things


### PR DESCRIPTION
Made a number of style changes today, and hopefully closed a couple tickets.

* Toggle button now behaves as expected in read only mode (it was still showing jobs before)
* Slightly off-kilter Narratives and Jobs panel (as mentioned in #507 ) should be more on-kilter now
  * removed extraneous padding at top of Narratives panel
  * Jobs should stretch all the way across the panel again
* https://atlassian.kbase.us/browse/KBASE-2034 - the cancel copying narrative button should work again (also adjusted styles on those buttons)
* Fixed cell minimizing/maximizing that caused the title and icons to wobble.
* Parameter tooltips should float in the 'body' element now, so you can see them.
* https://atlassian.kbase.us/browse/NAR-565 (among others, I'm sure, I just can't find them) - overlapping text in parameters should now keep on its own side.