### PR TITLE
Fix problem with method cell states not getting reloaded.

### DIFF
--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -405,7 +405,9 @@ function($,
             this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({
                 ws_id: this.getWorkspaceName()
             });
-            this.narrController.render().finally(function() {
+
+            this.narrController.render()
+            .finally(function() {
                 // $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false }).render();
                 $('#kb-wait-for-ws').remove();
             });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -174,7 +174,7 @@ function($,
                                .append($('<p>')
                                        .addClass('text-success'));
 
-            var methodId = this.options.cellId + '-method-details-'+StringUtil.uuid();
+            var methodId = 'method-details-'+StringUtil.uuid();
             var buttonLabel = 'details';
             var methodDesc = this.method.info.tooltip;
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -1383,9 +1383,9 @@ function($,
          */
         loadAllRecentCellStates: function() {
             var cells = Jupyter.notebook.get_cells();
-            $.each(cells, $.proxy(function(idx, cell) {
+            $.each(cells, function(idx, cell) {
                 this.loadRecentCellState(cell);
-            }, this));
+            }.bind(this));
         },
 
         /**


### PR DESCRIPTION
See issue: https://atlassian.kbase.us/browse/KBASE-3578

The problem was that when loading states, the process looks for what it expects are a unique id selector of `div[id^=kb-cell-X-UUID]` but that was showing up multiple times, at least once in the subtitle that had its structure shuffled around recently. This patch removes the duplicate.