### PR TITLE
Fix problem with output cell tabs having a gigantic margin.

### DIFF
--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -211,6 +211,11 @@ span#notebook_name:hover {
 .text_cell.kb-cell .rendered_html table {
     border: 1px solid #ddd;
 }
+
+.text_cell.kb-cell .rendered_html ul {
+    margin: 0;
+}
+
 .text_cell.opened.rendered.kb-cell .rendered_html {
     padding: 0;
     border: 0;


### PR DESCRIPTION
Bootstrap tabs (that we use all over the place) are rendered as fancy things on top of an html list. This fixes some margin issues with that.