### PR TITLE
Markdown cell behavior

### DIFF
--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -182,31 +182,7 @@ define(['jquery',
                 "header will appear as the cell title." +
                 "-->"
         };
-//        textCell.MarkdownCell.prototype.toJSON = function () {
-//            var data = cell.Cell.prototype.toJSON.apply(this);
-//            data.source = this.get_text();
-//            console.log('to json');
-//            console.log(this.get_text());
-//            console.log(data.source);
-//            if (data.source == this.placeholder) {
-//                data.source = "";
-//            }
-//            return data;
-//        };
-//        textCell.MarkdownCell.prototype.unrender = function () {
-//            var cont = cell.Cell.prototype.unrender.apply(this);
-//            if (cont) {
-//                console.log('unrender');
-//                console.log(this.get_text());
-//                console.log(this.element);
-//                var text_cell = this.element;
-//                //if (this.get_text() === this.placeholder) {
-//                //    this.set_text('');
-//                //}
-//                this.refresh();
-//            }
-//            return cont;
-//        };
+
         var original_unselect = cell.Cell.prototype.unselect;
         cell.Cell.prototype.unselect = function (leave_selected) {
             var wasSelected = original_unselect.apply(this, [leave_selected]);
@@ -403,7 +379,6 @@ define(['jquery',
                 }
             });
 
-
             /*
              * This is the trick to get the markdown to render, and the edit area
              * to disappear, when the user clicks out of the edit area.
@@ -489,23 +464,9 @@ define(['jquery',
                     $(cell.element)
                         .trigger('set-icon.cell', [cell.getCellState('icon', '')]);
 
-                    //$(cell.element)
-                     //   .trigger('set-icon.cell', ['<i class="fa fa-2x fa-paragraph markdown-icon"></i>']);
-                    
-                    // if (cell.getCellState('selected')) {
-                    //     cell.select();
-                    // }
-                    
                     cell.renderToggleState();
                 }
             });
-
-//            this.element.click(function () {
-//                var cont = that.unrender();
-//                if (cont) {
-//                    that.focus_editor();
-//                }
-//            });
         };
 
         // Patch the MarkdownCell renderer to throw an error when failing to render Javascript we need.
@@ -533,17 +494,6 @@ define(['jquery',
                     // Alas, it has no discriminating attributes!
                     cell.toggle();
                 });
-            // Use another hook on double click to toggle the cell open if it 
-            // was closed.
-            // Note that the base Cell bind_events already has a default
-            // double click behavior
-            // $(this.element)
-            //     .on('dblclick', function (e) {
-            //         // if cell state is closed...
-            //         if (cell.getCellState('toggleState', 'unknown') === 'closed') {
-            //             cell.toggle();
-            //         }
-            //     });
         };
 
         /*

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -403,6 +403,8 @@ define(['jquery',
                     cell.setCellState('title', title);
                     var $menu = $(cell.celltoolbar.element).find('.button_container');
                     $menu.trigger('set-title.toolbar', [title || '']);
+                    if (cellType(cell) !== undefined)
+                        $(cell.element).trigger('show-title.cell');
                 });
 
             $cellNode

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -401,14 +401,16 @@ function($,
         if (this.getWorkspaceName() !== null) {
             this.initSharePanel();
 
-            $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false }).render();
+            // init the controller
             this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({
                 ws_id: this.getWorkspaceName()
             });
 
+            // tell the controller to render itself. when that's done, render the
+            // side panels.
             this.narrController.render()
             .finally(function() {
-                // $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false }).render();
+                $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false }).render();
                 $('#kb-wait-for-ws').remove();
             });
         }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -356,36 +356,6 @@
             var $mintarget = $cellPanel;
             this.panel_minimized = false;
             var self = this;
-            // $controlsSpan.click(function() {
-            //     if (self.panel_minimized) {
-            //         $appSubmittedStamp.hide();
-            //         $appSubtitleDiv.show();
-            //         $cellMenu.minimizeSubtext('');
-
-            //         $mintarget.children(".panel-body").slideDown();
-            //         $mintarget.children(".panel-footer").slideDown();
-            //         $minimizeControl.removeClass("glyphicon-chevron-right")
-            //                         .addClass("glyphicon-chevron-down");
-            //         self.panel_minimized = false;
-            //     }
-            //     else {
-            //         if(self.state.runningState.submittedText && !self.isAwaitingInput()) {
-            //             $appSubmittedStamp.html($('<h2>').append("&nbsp;&nbsp;&nbsp;" +self.state.runningState.submittedText));
-            //             $appSubmittedStamp.show();
-            //             $appSubtitleDiv.hide();
-            //         }
-            //         $cellMenu.minimizeSubtext('test');
-            //         $mintarget.children(".panel-footer").slideUp();
-            //         $mintarget.children(".panel-body").slideUp();
-            //         $minimizeControl.removeClass("glyphicon-chevron-down")
-            //                         .addClass("glyphicon-chevron-right");
-            //         self.panel_minimized = true;
-            //     }
-            // });
-
-            // finally, we refresh so that our drop down or other boxes can be populated
-            console.log(this.$elem.closest('.cell').find('.button_container').data());
-            // this.$elem.closest('.cell').find('.button_container').kbaseNarrativeCellMenu('setSubtitle', 'Not yet submitted.');
             this.refresh();
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -29,6 +29,12 @@ function($, Config, TimeFormat) {
                 Jupyter.notebook.events.trigger('select.Cell', this.options.cell);
             }.bind(this));
 
+            this.$elem.dblclick(function(e) {
+                e.stopPropagation();
+                $(this).trigger('toggle.toolbar');
+                console.log('DOUBLE CLICKED TOOLBAR');
+            });
+
             this.$timestamp = $('<span class="kb-func-timestamp">');
 
             var $deleteBtn = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Delete Cell">')

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -467,6 +467,7 @@ function($,
          * @method
          */
         refresh: function(hideLoadingMessage, initStates) {
+            // console.log('JOB PANEL: refresh');
             if (this.jobStates === null || initStates)
                 this.initJobStates();
 
@@ -531,7 +532,9 @@ function($,
                     }
                     // otherwise, it's a method cell, so fetch info that way.
                     else {
+                        // console.log('JOB PANEL: looking up spec info for ' + jobState.source);
                         specInfo = $sourceCell.kbaseNarrativeMethodCell('getSpecAndParameterInfo');
+                        // console.log('JOB PANEL: ', specInfo);
                         if (jobIncomplete) {
                             if (specInfo) {
                                 jobParamList.push("['" + jobId + "', " +
@@ -587,6 +590,8 @@ function($,
                 allow_stdin: false,
                 store_history: false
             };
+
+            // console.log('JOB PANEL: calling kernel about jobs');
 
             if (Jupyter.notebook.kernel.is_connected())
                 Jupyter.notebook.kernel.execute(pollJobsCommand, callbacks, executeOptions);
@@ -649,6 +654,7 @@ function($,
          * We should also expire jobs in a reasonable time, at least from the Narrative.
          */
         populateJobsPanel: function(fetchedJobStatus, jobInfo) {
+            // console.log("JOB PANEL: fetched jobs", fetchedJobStatus, jobInfo);
             if (!this.jobStates || Object.keys(this.jobStates).length === 0) {
                 this.showMessage('No running jobs!');
                 this.setJobCounter(0);
@@ -880,13 +886,17 @@ function($,
                 status = jobState.status.toLowerCase();
             
             // don't do anything if we don't know the source cell. it might have been deleted.
-            if (!source)
+            if (!source) {
+                console.error("Unknown input cell for job id " + jobId + "! Exiting.");
                 return;
+            }
 
             var $cell = $('#' + source);
             // don't do anything if we know what the source should be, but we can't find it.
-            if (!$cell)
+            if (!$cell) {
+                console.error("Unable to find cell with source " + source + " for job id " + jobId + "! Exiting.");
                 return;
+            }
 
             // if it's running and an NJS job, then it's in an app cell
             if (jobState.state.running_step_id && jobType === 'njs') {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -532,7 +532,7 @@ function($,
                 if (!this.$jobProcessTabs) {
                     this.$jobProcessTabs = $('<div>').addClass('panel-body').addClass('kb-cell-output');
                     var targetPanel = this.$elem;
-                    console.log(this.isJobStatusLoadedFromState, status, jobState, jobInfo);
+                    // console.log(this.isJobStatusLoadedFromState, status, jobState, jobInfo);
                     if (this.isJobStatusLoadedFromState && status) {
                         if ($.inArray(status.toLowerCase(), this.completedStatus) >= 0) {
                             // We move job status panel into cell panel rather than outside because when
@@ -627,12 +627,12 @@ function($,
                 var execStartTime = null;
                 var finishTime = null;
                 var posInQueue = null;
-                console.log(state.step_stats);
+                // console.log(state.step_stats);
                 if (state.step_stats) {
                     for (var key in state.step_stats) {
                         if (state.step_stats.hasOwnProperty(key)) {
                             var stats = state.step_stats[key];
-                            console.log(key, stats);
+                            // console.log(key, stats);
                             if (stats['creation_time'])
                                 creationTime = stats['creation_time'];
                             execStartTime = stats['exec_start_time'];

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -105,16 +105,10 @@
                     .addClass('pull-right kb-func-timestamp');
 
                 if (this.options.time) {
-                    console.log('setting time');
                     this.$timestamp.append($('<span>')
                         .append(this.readableTimestamp(this.options.time)));
                     this.$elem.closest('.cell').find('.button_container').trigger('set-timestamp.toolbar', this.options.time);
                 }
-                //if (this.options.showMenu) {
-                //    var $menuSpan = $('<span style="margin-left:5px">');
-                //    this.$timestamp.append($menuSpan);
-                //    $menuSpan.kbaseNarrativeCellMenu();
-                //}
 
                 var $headerLabel = $('<span>')
                     .addClass('label label-info')
@@ -127,19 +121,7 @@
 
                 var $body = $('<div class="kb-cell-output-content">');
 
-
-                // var $body = $('<div>')
-                //     .addClass(baseClass)
-                //     .append($('<div>')
-                //         .addClass('panel ' + panelClass)
-                //         .append($('<div>')
-                //             .addClass('panel-heading')
-                //             .append($label)
-                //             .append($headerInfo))
-                //         .append($('<div>')
-                //             .addClass('panel-body')
-                //             .append($('<div class="kb-cell-output-content">'))));
-                        
+                       
                 try {
                     require([widget],
                         // If we successfully Require the widget code, render it:

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -114,7 +114,6 @@ function($,
                 }.bind(this)
             );
 
-            console.log('WORKSPACE: setting up dataUpdated.Narrative response');
             $(document).on('dataUpdated.Narrative',
                 function(event) {
                     if (Jupyter && Jupyter.notebook) {
@@ -133,7 +132,6 @@ function($,
                     }
                 }.bind(this)
             );
-            console.log('WORKSPACE: done setting up dataUpdated.Narrative response');
 
             $(document).on('narrativeDataQuery.Narrative',
                 function(e, callback) {


### PR DESCRIPTION
Fixes a few things that were brought up:
1. the cell title for markdown cells shouldn't be present while maximized
2. double-clicking the min/max button (and anywhere in the toolbar, really) could unexpectedly put that into edit mode.

These changes block double-clicking on the toolbar from affecting the cell state, and hide the title on markdown cells only while in an expanded state.