### PR TITLE
Typo in link html caused linkouts to the method man pages to fail.

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -190,7 +190,7 @@ function($,
             this.$methodDesc = $('<div>')
                                .attr('id', methodId)
                                .addClass('kb-method-subtitle')
-                               .append(methodDesc + ' &nbsp;&nbsp;<a link="' + link + '" target="_blank">more...</a>');
+                               .append(methodDesc + ' &nbsp;&nbsp;<a href="' + link + '" target="_blank">more...</a>');
 
             this.$header.append(this.$dynamicMethodSummary);
 


### PR DESCRIPTION
This addresses https://atlassian.kbase.us/browse/KBASE-3624
- just a silly typo in the setup for that link. 