### PR TITLE
Fix narrative name change from old version

### DIFF
--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -586,9 +586,10 @@ define(['jquery',
 
         // Patch the Notebook to return the right name
         notebook.Notebook.prototype.get_notebook_name = function () {
-            if (this.metadata.name)
-                return this.metadata.name;
-            return this.notebook_name;
+            if (!this.metadata.name) {
+                this.metadata.name = this.notebook_name;
+            }
+            return this.metadata.name;
         };
 
         // Patch the Notebook to not wedge a file extension on a new Narrative name

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -602,7 +602,7 @@ function($,
                                         var id = new Date().getTime();
                                         var ws_name = self.my_user_id + ":" + id;
 
-                                        Promise.resolve(this.ws.clone_workspace({
+                                        Promise.resolve(self.ws.clone_workspace({
                                             wsi: {id: ws_info[0]},
                                             workspace: ws_name,
                                             meta: newMeta


### PR DESCRIPTION
See https://atlassian.kbase.us/browse/KBASE-3623

Loading an old version narrative (like what's all in production), then saving it, could revert the narrative name to 'Untitled'. This explicitly puts the name where it's supposed to be when loaded, so saving doesn't change anything.

This also fixes a problem when making a copy of a shared narrative from the narrative manager panel.