### PR TITLE
Address issues in genome widget

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,20 @@
 ### OVERVIEW
 The Narrative Interface allows users to craft KBase Narratives using a combination of GUI-based commands, Python and R scripts, and graphical output elements.
 
-This is built on the IPython Notebook (more notes will follow).
+This is built on the Jupyter Notebook v4.1.0 (more notes will follow).
+
+### Version 2.0.2
+__Changes__
+- JIRA KBASE-3556 - fixed links from genome widget to gene landing page, made contigs in genome tab clickable.
+- Added tools for editing FBA models.
 
 ### Version 2.0.1
 __Changes__
 - JIRA KBASE-3623 - fixed problem where updating an old version of the Narrative typed object could cause the Narrative title to be lost
 - JIRA KBASE-3624 - fixed links in method input cell subtitles to manual pages
 - JIRA KBASE-3630 - fixed problem with hierarchical clustering widget missing a button
-- added widget for sequence comparison
-
+- Added widget for sequence comparison
+- Added tools for editing FBA model media sets.
 
 ### Version 2.0.0
 __Changes__
@@ -22,7 +27,6 @@ __Changes__
 - Adjusted Narrative Management tab to be somewhat more performant.
 - Updated Narrative object definition to match the Jupyter notebook object definition more closely.
 - Data panel should no longer hang forever on Narrative startup.
-
 
 ### Version 1.1.0
 __Changes__

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
@@ -144,7 +144,7 @@ function($,
                     } else {
                         gc_content = "Unknown";
                     }
-                    var overviewData = [gnm.id, '<a href="/functional-site/#/dataview/'+self.ws_name+'/'+self.ws_id+'" target="_blank">'+gnm.scientific_name+'</a>',
+                    var overviewData = [gnm.id, '<a href="/#dataview/'+self.ws_name+'/'+self.ws_id+'" target="_blank">'+gnm.scientific_name+'</a>',
                                         gnm.domain, gnm.genetic_code, gnm.source, gnm.source_id, gc_content, tax, gnm.dna_size,
                                         contigCount, gnm.features.length];
 
@@ -308,8 +308,17 @@ function($,
                     var geneFunc = gene['function'];
                     if (!geneFunc)
                         geneFunc = '-';
-                    genesData.push({id: '<a class="'+pref+'gene-click" data-geneid="'+geneId+'">'+geneId+'</a>',
-                            contig: contigName, start: geneStart, dir: geneDir, len: geneLen, type: geneType, func: geneFunc});
+                    genesData.push({
+                        id: '<a href="/#dataview/'+self.ws_name+'/'+self.ws_id+'?sub=Feature&subid='+geneId+'" target="_blank">'+geneId+'</a>',
+                        // id: '<a class="'+pref+'gene-click" data-geneid="'+geneId+'">'+geneId+'</a>',
+                        // contig: contigName,
+                        contig: '<a class="' + pref + 'contig-click" data-contigname="'+contigName+'">' + contigName + '</a>',
+                        start: geneStart,
+                        dir: geneDir,
+                        len: geneLen,
+                        type: geneType,
+                        func: geneFunc
+                    });
                     geneMap[geneId] = gene;
                     var contig = contigMap[contigName];
                     if (contigName != null && !contig) {
@@ -327,24 +336,24 @@ function($,
                     }
                 }
                 var genesSettings = {
-                        "sPaginationType": "full_numbers",
-                        "iDisplayLength": 10,
-                        "aaSorting": [[ 1, "asc" ], [2, "asc"]],
-                        "aoColumns": [
-                                      {sTitle: "Gene ID", mData: "id"},
-                                      {sTitle: "Contig", mData: "contig"},
-                                      {sTitle: "Start", mData: "start"},
-                                      {sTitle: "Strand", mData: "dir"},
-                                      {sTitle: "Length", mData: "len"},
-                                      {sTitle: "Type", mData: "type"},
-                                      {sTitle: "Function", mData: "func"}
-                                      ],
-                                      "aaData": [],
-                                      "oLanguage": {
-                                          "sSearch": "Search gene:",
-                                          "sEmptyTable": "No genes found."
-                                      },
-                                      "fnDrawCallback": geneEvents
+                    "sPaginationType": "full_numbers",
+                    "iDisplayLength": 10,
+                    "aaSorting": [[ 1, "asc" ], [2, "asc"]],
+                    "aoColumns": [
+                                  {sTitle: "Gene ID", mData: "id"},
+                                  {sTitle: "Contig", mData: "contig"},
+                                  {sTitle: "Start", mData: "start"},
+                                  {sTitle: "Strand", mData: "dir"},
+                                  {sTitle: "Length", mData: "len"},
+                                  {sTitle: "Type", mData: "type"},
+                                  {sTitle: "Function", mData: "func"}
+                                  ],
+                                  "aaData": [],
+                                  "oLanguage": {
+                                      "sSearch": "Search gene:",
+                                      "sEmptyTable": "No genes found."
+                                  },
+                                  "fnDrawCallback": function() { geneEvents(); contigEvents(); }
                 };
 
 
@@ -358,6 +367,7 @@ function($,
 
                 var genesTable = $('#'+pref+'genes-table').dataTable(genesSettings);
                 genesTable.fnAddData(genesData);
+                
 
                 ////////////////////////////// Contigs Tab //////////////////////////////
                 var contigTab = $('#'+pref+'contigs');
@@ -440,7 +450,7 @@ function($,
                     $('#'+tabId).append('<table class="table table-striped table-bordered" \
                             style="margin-left: auto; margin-right: auto;" id="'+tabId+'-table"/>');
                     var elemLabels = ['Gene ID', 'Contig name', 'Gene start', 'Strand', 'Gene length', "Gene type", "Function", "Annotations"];
-                    var elemData = ['<a href="/functional-site/#/genes/'+self.ws_name+'/'+self.ws_id+'/'+geneId+'" target="_blank">'+geneId+'</a>',
+                    var elemData = ['<a href="/#dataview/'+self.ws_name+'/'+self.ws_id+'?sub=Feature&subid='+geneId+'" target="_blank">'+geneId+'</a>',
                                     '<a class="'+tabId+'-click2" data-contigname="'+contigName+'">' + contigName + '</a>',
                                     geneStart, geneDir, geneLen, geneType, geneFunc, geneAnn];
                     var elemTable = $('#'+tabId+'-table');

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'mongonbmanager', 'ws_util', 'common', 'kbasewsmanager', 'services']
 
 from semantic_version import Version
-__version__ = Version("2.0.1")
+__version__ = Version("2.0.2")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -148,5 +148,5 @@
         "showDelay": 750
     }, 
     "use_local_widgets": true, 
-    "version": "2.0.1"
+    "version": "2.0.2"
 }


### PR DESCRIPTION
See https://atlassian.kbase.us/browse/KBASE-3556 - complaint was that data on opened gene tabs was redundant with what's in the gene list. Those links will now open the landing page. This also includes a change to make the contig ids in the gene list clickable.