### PR TITLE
Fix delete cell modal problems

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,10 +1,10 @@
-Last updated 2/2/2016, 9:00pm PST
+Last updated 2/17/2016, 9:00pm PST
 
   * ~~Markdown cells render a little different. Previously headers could be made by "###text" on its own line, now a space is needed: "### text" on that line.~~
   * ~~The "view only" mode has a gigantic margin on the left side. [KBASE-3370](https://atlassian.kbase.us/browse/KBASE-3370)~~
-  * All cells sit in a container that makes it easier to see what's selected or not, which brings up issues.
-  * KBase cells (method, app, output, data viewer) appear as boxes in boxes with duplicated minimization. [KBASE-3335](https://atlassian.kbase.us/browse/KBASE-3335)
-  * Markdown cells don't have any placeholder text (Jupyter feature) and their input boxes appear shrunken when inactive.
+  * ~~All cells sit in a container that makes it easier to see what's selected or not, which brings up issues.~~
+  * ~~KBase cells (method, app, output, data viewer) appear as boxes in boxes with duplicated minimization. [KBASE-3335](https://atlassian.kbase.us/browse/KBASE-3335)~~
+  * ~~Markdown cells don't have any placeholder text (Jupyter feature) and their input boxes appear shrunken when inactive.~~
   * ~~The data panel can still, occasionally, spin nonstop at page load. [KBASE-3338](https://atlassian.kbase.us/browse/KBASE-3338)~~
   * ~~The 'About Jupyter' dialog in the Kernel menu is non-functional~~
   * Missing Jupyter menu bar [KBASE-3371](https://atlassian.kbase.us/browse/KBASE-3371)
@@ -26,7 +26,3 @@ Last updated 2/2/2016, 9:00pm PST
   * Method/app cells should be drag/droppable like data cells.
   * Name change doesn't seem to change temporary state (should actually use temporary state instead of "Untitled" name)
   * Extra copy of workspace client - needs to migrate to the right repo.
-
-- Update the viewers widget to behave better when it can't find a viewer
-- Finally sketch out and prototype a new cell layout that moves titles around.
-- Check in with the SDK team on the styling of their method cell addition with the console logging. It's pretty bare-bones.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,8 @@ __Changes__
 - Added tools for editing FBA models.
 - JIRA NAR-838 - delete cell dialog should no longer break when hitting return to trigger it.
 - JIRA NAR-839 - delete cell dialogs should not pollute the DOM (there's only one dialog now, not a new one for each cell).
+- JIRA NAR-589 - change "Copy Narrative" to "Copy This Narrative" for clarity.
+- JIRA NAR-788 - remove light colors from random picker when coloring user names for sharing.
 
 ### Version 2.0.1
 __Changes__

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@ This is built on the Jupyter Notebook v4.1.0 (more notes will follow).
 __Changes__
 - JIRA KBASE-3556 - fixed links from genome widget to gene landing page, made contigs in genome tab clickable.
 - Added tools for editing FBA models.
+- JIRA NAR-838 - delete cell dialog should no longer break when hitting return to trigger it.
+- JIRA NAR-839 - delete cell dialogs should not pollute the DOM (there's only one dialog now, not a new one for each cell).
 
 ### Version 2.0.1
 __Changes__

--- a/kbase-extension/static/kbase/js/util/bootstrapDialog.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapDialog.js
@@ -7,13 +7,14 @@ function ($) {
     /**
      * options:
      * { 
-         title: string,
-     *   body: jquery node
-     *   buttons: array of jquery nodes
-     *   closeButton: boolean, default false
-     *   }
+     *     title: string,
+     *     body: jquery node
+     *     buttons: array of jquery nodes
+     *     closeButton: boolean, default false
+     *     enterToTrigger: boolean, default false
+     * }
      */
-    var BootstrapDialog = function(options) {
+    var BootstrapDialog = function (options) {
         this.$modal = $('<div class="modal fade" tabindex="-1", role="dialog">');
         this.$dialog = $('<div class="modal-dialog">');
         this.$dialogContent = $('<div class="modal-content">');
@@ -24,6 +25,11 @@ function ($) {
         this.$footer = $('<div class="modal-footer">');
 
         this.$buttonList = $('<div>');
+
+        this.enterToTrigger = false;
+        if (options.enterToTrigger) {
+            this.enterToTrigger = options.enterToTrigger;
+        }
 
         this.initialize(options);
     };
@@ -68,6 +74,18 @@ function ($) {
             var $btn = buttonList[i];
             $btn.addClass('btn btn-default btn-sm');
             this.$footer.append($btn);
+        }
+        if (this.enterToTrigger) {
+            this.$modal
+            .off('keypress')
+            .on('keypress', (function(e) {
+                if (e.keyCode === 13) {
+                    e.stopPropagation();
+                    e.preventDefault();
+
+                    this.$footer.find('.btn:last').trigger('click');
+                }
+            }.bind(this)));
         }
     };
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -239,7 +239,7 @@ function($,
                 var $msgPanel = $("<div>").css({'margin': '10px', 'text-align': 'center'});
                 self.$copyThisNarrBtn = self.makeCopyThisNarrativeBtn($msgPanel);
                 self.$mainPanel.append(
-                    $('<div>').css({'margin': '15px', 'text-align': 'center'})
+                    $('<div>').css({'margin': '10px', 'text-align': 'center'})
                     .append(self.makeNewNarrativeBtn())
                     .append(self.$copyThisNarrBtn)
                     .append($msgPanel));
@@ -948,7 +948,7 @@ function($,
         },
         makeCopyThisNarrativeBtn: function ($alertContainer) {
             var self = this;
-            var active = '<span class="fa fa-copy"></span> Copy Narrative';
+            var active = '<span class="fa fa-copy"></span> Copy This Narrative';
 //            var $active = $('<span>').addClass('fa fa-copy').append(" Copy Narrative");
             var $working = $('<span>').append("Copying Narrative...");
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSharePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSharePanel.js
@@ -514,8 +514,8 @@ function($, Config) {
             '#009688', //teal
             '#4CAF50', //green
             '#8BC34A', //lime green
-            '#CDDC39', //lime
-            '#FFEB3B', //yellow
+            // '#CDDC39', //lime
+            // '#FFEB3B', //yellow
             '#FFC107', //amber
             '#FF9800', //orange
             '#FF5722', //deep orange

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -29,7 +29,6 @@ define(['jquery',
         'bootstrap', 
         'kbaseDefaultNarrativeOutput',
         'kbaseDefaultNarrativeInput',
-        'kbasePrompt',
         'kbaseNarrativeAppCell',
         'kbaseNarrativeMethodCell',
         'kbaseNarrativeSidePanel',
@@ -271,43 +270,40 @@ function($,
             this.$deleteCellModalBody = $('<div>');
 
             var buttonList = [
-                {
-                    name : 'Cancel',
-                    type : 'default',
-                    callback : function(e, $prompt) {
+                $('<button>')
+                .addClass('btn btn-default')
+                .attr('data-dismiss', 'modal')
+                .append('Cancel'),
+
+                $('<button>')
+                .addClass('btn btn-danger')
+                .attr('data-dismiss', 'modal')
+                .append('Delete')
+                .click(function(e) {
+                    if (this.cellToDelete !== undefined && this.cellToDelete !== null) {
+                        var cell = Jupyter.notebook.get_cell(this.cellToDelete);
+                        var removeId = $(cell.element).find('[id^=kb-cell-]').attr('id');
+                        this.trigger('cancelJobCell.Narrative', removeId, false);
+                        Jupyter.notebook.delete_cell(this.cellToDelete);
                         this.cellToDelete = null;
-                        $prompt.closePrompt();
                     }
-                },
-                {
-                    name : 'Delete',
-                    type : 'danger',
-                    callback : $.proxy(function(e, $prompt) {
-                        if (this.cellToDelete !== undefined && this.cellToDelete !== null) {
-                            var cell = Jupyter.notebook.get_cell(this.cellToDelete);
-                            var removeId = $(cell.element).find('[id^=kb-cell-]').attr('id');
-                            this.trigger('cancelJobCell.Narrative', removeId, false);
-                            Jupyter.notebook.delete_cell(this.cellToDelete);
-                            this.cellToDelete = null;
-                        }
-                        $prompt.closePrompt();
-                    }, this)
-                }
+                }.bind(this))
             ];
-            this.$deleteCellModal = $('<div>').kbasePrompt({
-                title : 'Delete Cell and Job?',
-                body : this.$deleteCellModalBody,
-                controls : buttonList
+            this.$deleteCellModal = new BootstrapDialog({
+                title: 'Delete Cell and Job?',
+                body: this.$deleteCellModalBody,
+                closeButton: false,
+                buttons: buttonList,
+                enterToTrigger: true
             });
         },
 
         showDeleteCellModal: function(index, cell, message) {
-            this.initDeleteCellModal();
             if (cell && cell.metadata[this.KB_CELL]) {
                 this.cellToDelete = index;
                 if (message)
                     this.$deleteCellModalBody.empty().html(message);
-                this.$deleteCellModal.openPrompt();
+                this.$deleteCellModal.show();
             }
         },
 


### PR DESCRIPTION
See: https://atlassian.kbase.us/browse/NAR-838 and https://atlassian.kbase.us/browse/NAR-839

Fixes problems with the delete cell modal (appears when deleting a cell linked to an existing job).
1. Now uses the BootstrapDialog module (less jquery solution, more pure bootstrap, which lets their code solve problems).
2. Pressing 'enter' to trigger the delete should delete that cell and close the dialog as usual.
3. No longer creates a new dialog for each cell - just a single dialog that sits in the DOM and gets rebound as needed, and shown/hidden as managed by Bootstrap JS code.