### PR TITLE
Allow methods to specify no output widget

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -1995,6 +1995,10 @@ function($,
                 if (!widget) {
                     if (method.widgets && method.widgets.output) {
                         widget = method.widgets.output;
+                        // if the widget is set to 'no-display', then exit without showing anything
+                        if(widget === 'no-display') {
+                            return;
+                        }
                     }
                     else {
                         widget = this.defaultOutputWidget;


### PR DESCRIPTION
Adds a simple check to not show an output widget if the output widget specified is: 'no-display'.

Tested this locally with Megahit, and seems to all work as expected without side effects.