### PR TITLE
renaming a narrative now triggers a save

### DIFF
--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -83,7 +83,6 @@
  * @static
  */
 define(['jquery',
-    'bluebird',
     'base/js/namespace',
     'base/js/security',
     'base/js/utils',
@@ -104,7 +103,6 @@ define(['jquery',
     'kbaseNarrativeCellMenu'
 ],
     function ($,
-        Promise,
         Jupyter,
         security,
         utils,

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -83,6 +83,7 @@
  * @static
  */
 define(['jquery',
+    'bluebird',
     'base/js/namespace',
     'base/js/security',
     'base/js/utils',
@@ -103,6 +104,7 @@ define(['jquery',
     'kbaseNarrativeCellMenu'
 ],
     function ($,
+        Promise,
         Jupyter,
         security,
         utils,
@@ -638,6 +640,7 @@ define(['jquery',
                                     d.modal('hide');
                                     that.notebook.metadata.name = new_name;
                                     that.element.find('span.filename').text(new_name);
+                                    Jupyter.narrative.saveNarrative();
                                 }, function (error) {
                                 d.find('.rename-message').text(error.message || 'Unknown error');
                                 d.find('input[type="text"]').prop('disabled', false).focus().select();

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -559,7 +559,7 @@ define(['jquery',
             var $cellNode = $(this.element);
             var elemsToToggle = [
                 $cellNode.find('.input .input_area'),
-                $cellNode.find('.widget-area'),
+                // $cellNode.find('.widget-area'),
                 $cellNode.find('.output_wrapper')
             ];
             switch (this.getCellState('toggleState', 'unknown')) {

--- a/kbase-extension/static/kbase/config.json
+++ b/kbase-extension/static/kbase/config.json
@@ -148,5 +148,5 @@
         "showDelay": 750
     }, 
     "use_local_widgets": true, 
-    "version": "2.0.2"
+    "version": "2.0.3"
 }


### PR DESCRIPTION
It's expected that renaming a narrative should save the state of it as well. This is especially clear when a user creates a new narrative, edits a cell, hits the save button, and renames it (before, it wasn't saving, so those changes were lost). This fixes that.