### PR TITLE
Fix environment vars on restart

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "select2-bootstrap-css": "^1.4.5",
     "underscore": "~1.8.3",
     "plotly.js": "git://github.com/plotly/plotly.js/#1.5.1",
-    "bluebird": "3.0.6"
+    "bluebird": "3.0.6",
+    "handlebars": "^4.0.5"
   }
 }

--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -149,6 +149,8 @@
                         <li><a id="kb-about-btn">About the Narrative</a></li>
                         <li><a target="_blank" href="https://kbase.us/narrative-guide/">Narrative User Guide</a></li>
                         <li><a target="_blank" href="https://kbase.us/contact-us/">Contact Us</a></li>
+                        <li role="presentation" class="divider"></li>
+                        <li><a id="kb-shutdown-btn">Shutdown and Restart</a></li>
                     </ul>
                 </div>
                 <a href="http://www.kbase.us">

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -120,6 +120,18 @@ define(['jquery',
         marked) {
         'use strict';
 
+        // inject necessary environment vars into the kernel as soon as it's ready.
+        $([Jupyter.events]).on('kernel_ready.Kernel', 
+            function() {
+                Jupyter.notebook.kernel.execute(
+                    'import os;' +
+                    'os.environ["KB_AUTH_TOKEN"]="' + Jupyter.narrative.authToken + '";' +
+                    'os.environ["KB_WORKSPACE_ID"]="' + Jupyter.notebook.metadata.ws_name + '"'
+                );
+            }
+        );
+
+
         // Patch the security mechanisms to allow any JavaScript to run for now.
         // TODO: update this so only the few KBase commands run.
         security.sanitize_html = function (html, allow_css) {

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -9,6 +9,7 @@
 define([
     'jquery', 
     'bluebird',
+    'handlebars',
     'narrativeConfig',
     'kbaseNarrativeSidePanel', 
     'kbaseNarrativeOutputCell', 
@@ -22,10 +23,12 @@ define([
     'notebook/js/notebook',
     'util/display',
     'util/bootstrapDialog',
+    'text!kbase/templates/update_dialog_body.html',
     'jquery-nearest'
 ], 
 function($,
          Promise,
+         Handlebars,
          Config,
          kbaseNarrativeSidePanel,
          kbaseNarrativeOutputCell,
@@ -38,7 +41,8 @@ function($,
          events,
          Notebook,
          DisplayUtil,
-         BootstrapDialog) {
+         BootstrapDialog,
+         UpdateDialogBodyTemplate) {
     'use strict';
 
     /**
@@ -153,8 +157,8 @@ function($,
      * dialog then lets the user shut down their existing Narrative container.
      */
     Narrative.prototype.initUpgradeDialog = function() {
-        var $newVersion = $('<span>')
-                          .append('<b>No new version</b>');  // init to the current version
+        var bodyTemplate = Handlebars.compile(UpdateDialogBodyTemplate);
+
         var $cancelBtn = $('<button type="button" data-dismiss="modal">')
                          .addClass('btn btn-default')
                          .append('Cancel');
@@ -167,24 +171,22 @@ function($,
 
         var upgradeDialog = new BootstrapDialog({
             title: 'New Narrative version available!',
-            body: $('<div>')
-                  .append($('<span>').append('Your current version of the Narrative is <b>' + this.currentVersion + '</b>. Version '))
-                  .append($newVersion)
-                  .append($('<span>').append(' is now available.<br><br>' + 
-                                             'See <a href="' + Config.get('release_notes') + '" target="_blank">here</a> for current release notes.<br>' +
-                                             'Click "Update and Reload" to reload with the latest version!<br><br>' + 
-                                             '<b>Any unsaved data in any open Narrative in any window WILL BE LOST!</b>')),
             buttons: [$cancelBtn, $upgradeBtn]
         });
         $('#kb-update-btn').click(function(event) {
             upgradeDialog.show();
         });
-        this.checkVersion($newVersion);
-
-        // ONLY CHECK AT STARTUP FOR NOW.
-        // setInterval(function() {
-        //     self.checkVersion($newVersion);
-        // }, this.versionCheckTime);
+        this.checkVersion()
+        .then(function(ver) {
+            upgradeDialog.setBody(bodyTemplate({
+                currentVersion: this.currentVersion,
+                newVersion: ver ? ver.version : "No new version",
+                releaseNotesUrl: Config.get('release_notes')
+            }));
+            if (ver && ver.version && this.currentVersion !== ver.version) {
+                $('#kb-update-btn').fadeIn('fast');
+            }
+        }.bind(this));
     };
 
     /**
@@ -194,22 +196,58 @@ function($,
     Narrative.prototype.checkVersion = function($newVersion) {
         // look up new version here.
         var self = this;
-        Promise.resolve($.ajax({
+        return Promise.resolve($.ajax({
             url: Config.url('version_check'),
             async: true,
             dataType: 'text',
             crossDomain: true,
             cache: false
         })).then(function(ver) {
-            ver = $.parseJSON(ver);
-            if (self.currentVersion !== ver.version) {
-                $newVersion.empty().append('<b>' + ver.version + '</b>');
-                $('#kb-update-btn').fadeIn('fast'); 
-            }
+            return Promise.try(function() {
+                ver = $.parseJSON(ver);
+                return ver;
+            })
         }).catch(function(error) {
             console.error('Error while checking for a version update: ' + error.statusText);
             KBError('Narrative.checkVersion', 'Unable to check for a version update!');
         });
+    };
+
+    Narrative.prototype.createShutdownDialogButtons = function () {
+        var $shutdownButton = $('<button>')
+                              .attr({'type':'button', 'data-dismiss':'modal'})
+                              .addClass('btn btn-danger')
+                              .append('Okay. Shut it all down!')
+                              .click(function(e) {
+                                  this.updateVersion();
+                              }.bind(this));
+
+        var $reallyShutdownPanel = $('<div style="margin-top:10px">')
+                                   .append('This will shutdown your Narrative session and close this window.<br><b>Any unsaved data in any open Narrative in any window WILL BE LOST!</b><br>')
+                                   .append($shutdownButton)
+                                   .hide();
+
+        var $firstShutdownBtn = $('<button>')
+                                .attr({'type':'button'})
+                                .addClass('btn btn-danger')
+                                .append('Shutdown')
+                                .click(function(e) {
+                                    $reallyShutdownPanel.slideDown('fast');
+                                });
+
+        var $cancelButton = $('<button type="button" data-dismiss="modal">')
+                            .addClass('btn btn-default')
+                            .append('Dismiss')
+                            .click(function(e) {
+                                $reallyShutdownPanel.hide();
+                            });
+
+        return {
+            cancelButton: $cancelButton, 
+            firstShutdownButton: $firstShutdownBtn,
+            finalShutdownButton: $shutdownButton,
+            shutdownPanel: $reallyShutdownPanel
+        };
     };
 
     Narrative.prototype.initAboutDialog = function() {
@@ -245,62 +283,38 @@ function($,
         })
         $versionDiv.append($verAccordion);
 
-        var $shutdownButton = $('<button>')
-                              .attr({'type':'button', 'data-dismiss':'modal'})
-                              .addClass('btn btn-danger')
-                              .append('Okay. Shut it all down!')
-                              .click($.proxy(function(e) {
-                                  this.updateVersion();
-                              }, this));
-        var $reallyShutdownPanel = $('<div style="margin-top:10px">')
-                                   .append('This will shutdown your Narrative session and close this window.<br><b>Any unsaved data in any open Narrative in any window WILL BE LOST!</b><br>')
-                                   .append($shutdownButton)
-                                   .hide();
-
-        var $firstShutdownBtn = $('<button>')
-                                .attr({'type':'button'})
-                                .addClass('btn btn-danger')
-                                .append('Shutdown')
-                                .click(function(e) {
-                                    $reallyShutdownPanel.slideDown('fast');
-                                });
-
-        var $versionModal = $('<div tabindex=-1 role="dialog" aria-labelledby="kb-version-label" aria-hidden="true">')
-                            .addClass('modal fade')
-                            .append($('<div>')
-                                    .addClass('modal-dialog')
-                                    .append($('<div>')
-                                        .addClass('modal-content')
-                                        .append($('<div>')
-                                                .addClass('modal-header')
-                                                .append($('<h4>')
-                                                        .addClass('modal-title')
-                                                        .attr('id', 'kb-version-label')
-                                                        .append('KBase Narrative Properties')))
-                                        .append($('<div>')
-                                                .addClass('modal-body')
-                                                .append($versionDiv))
-                                        .append($('<div>')
-                                                .addClass('modal-footer')
-                                                .append($('<div>')
-                                                        .append($('<button type="button" data-dismiss="modal">')
-                                                                .addClass('btn btn-default')
-                                                                .append('Dismiss')
-                                                                .click(function(e) {
-                                                                    $reallyShutdownPanel.hide();
-                                                                }))
-                                                        .append($firstShutdownBtn))
-                                                .append($reallyShutdownPanel))));
+        var shutdownButtons = this.createShutdownDialogButtons();
+        var aboutDialog = new BootstrapDialog({
+            title: 'KBase Narrative Properties',
+            body: $versionDiv,
+            buttons: [
+                shutdownButtons.cancelButton,
+                shutdownButtons.firstShutdownButton,
+                shutdownButtons.shutdownPanel
+            ]
+        });
 
         $('#kb-about-btn').click(function(event) {
-            $versionModal.modal('show');
+            aboutDialog.show();
         });
-        $('#notebook').append($versionModal);
     };
 
-    // Narrative.prototype.initShutdownDialog = function() {
+    Narrative.prototype.initShutdownDialog = function() {
+        var shutdownButtons = this.createShutdownDialogButtons();
 
-    // };
+        var shutdownDialog = new BootstrapDialog({
+            title: 'Shutdown and restart narrative?',
+            body: $('<div>').append('Shutdown and restart your Narrative session? Any unsaved changes in any open Narrative in any window WILL BE LOST!'),
+            buttons: [
+                shutdownButtons.cancelButton,
+                shutdownButtons.finalShutdownButton
+            ]
+        });
+
+        $('#kb-shutdown-btn').click(function() {
+            shutdownDialog.show();
+        });
+    };
 
     Narrative.prototype.saveFailed = function(event, data) {
         $('#kb-save-btn').find('div.fa-save').removeClass('fa-spin');
@@ -369,6 +383,7 @@ function($,
         this.registerEvents();
         this.initAboutDialog();
         this.initUpgradeDialog();
+        this.initShutdownDialog();
 
         // var $sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
 

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -396,11 +396,9 @@ function($,
         Jupyter.CellToolbar.activate_preset("KBase");
         Jupyter.CellToolbar.global_show();
 
-        if (Jupyter && Jupyter.notebook && Jupyter.notebook.metadata) {
-            // $.each(Jupyter.notebook.get_cells(), function(idx, cell) {
-            //     cell.celltoolbar.hide();
-            // });
+        this.authToken = $('#signin-button').kbaseLogin('token');
 
+        if (Jupyter && Jupyter.notebook && Jupyter.notebook.metadata) {
             var creatorId = Jupyter.notebook.metadata.creator || 'KBase User';
             DisplayUtil.displayRealName(creatorId, $('#kb-narr-creator'));
 

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -36,6 +36,11 @@ $('#kb-kernel-ref-btn').click(function(e) {
         Jupyter.notebook.kernel.restart();
     }
 });
+$('#kb-kernel-rec-btn').click(function(e) {
+    if (Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
+        Jupyter.notebook.kernel.reconnect();
+    }
+});
 $('#kb-del-btn').click(function(e) {
     if (Jupyter && Jupyter.notebook) {
         Jupyter.notebook.delete_cell();
@@ -43,8 +48,6 @@ $('#kb-del-btn').click(function(e) {
 });
 $('#kb-jira-btn').attr('href', Config.url('submit_jira_ticket') + '%20' + Config.get('version'));
 $('#kb-status-btn').attr('href', Config.url('status_page'));
-
-
 
 $('#kb-add-code-cell').click(function() {
     Jupyter.narrative.insertAndSelectCellBelow('code');

--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -11,14 +11,13 @@ define(['jquery',
         'kbapi',
         'base/js/utils'
 ], function($, 
-            config,
+            Config,
             kbaseLogin, 
             kbapi, 
-            ipythonUtils) {
+            JupyterUtils) {
     "use strict";
 
-
-    var baseUrl = ipythonUtils.get_body_data('baseUrl');
+    var baseUrl = JupyterUtils.get_body_data('baseUrl');
 
     /* set the auth token by calling the kernel execute method on a function in
      * the magics module
@@ -26,7 +25,7 @@ define(['jquery',
     var ipythonLogin = function(token) {
         window.kb = new KBCacheClient(token);
         $.ajax({
-            url: ipythonUtils.url_join_encode(baseUrl, 'login'),
+            url: JupyterUtils.url_join_encode(baseUrl, 'login'),
         }).then(
             function(ret) { 
                 // console.log(ret); 
@@ -40,7 +39,7 @@ define(['jquery',
 
     var ipythonLogout = function() {
         $.ajax({
-            url: ipythonUtils.url_join_encode(baseUrl, 'logout'),
+            url: JupyterUtils.url_join_encode(baseUrl, 'logout'),
         }).then(
             function(ret) { 
                 // console.log(ret); 

--- a/kbase-extension/static/kbase/js/util/bootstrapDialog.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapDialog.js
@@ -72,7 +72,6 @@ function ($) {
         this.$footer.empty();
         for (var i=0; i<buttonList.length; i++) {
             var $btn = buttonList[i];
-            $btn.addClass('btn btn-default btn-sm');
             this.$footer.append($btn);
         }
         if (this.enterToTrigger) {

--- a/kbase-extension/static/kbase/templates/update_dialog_body.html
+++ b/kbase-extension/static/kbase/templates/update_dialog_body.html
@@ -1,0 +1,10 @@
+<div>
+    <div>
+        Your current version of the Narrative is <b>{{currentVersion}}</b>. Version <b>{{newVersion}}</b> is now available.
+    </div>
+    <div>
+        See <a href="{{releaseNotesUrl}}" target="_blank">here</a> for current release notes.<br>
+        Click "Update and Reload" to reload with the latest version!<br><br>
+        <b>Any unsaved data in any open Narrative in any window WILL BE LOST!</b>
+    </div>
+</div>

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -253,7 +253,7 @@ require.config({
 
         'd3'                                    : 'ext_components/d3/d3.min',//  'kbase/js/ui-common/ext/d3/d3.v3.min',
         'colorbrewer'                           : 'kbase/js/ui-common/ext/colorbrewer.min',
-        'handlebars'                            : 'kbase/js/ui-common/ext/handlebars/handlebars-v1.3.0',
+        'handlebars'                            : 'ext_components/handlebars/handlebars', //kbase/js/ui-common/ext/handlebars/handlebars-v1.3.0',
         'kbwidget'                              : 'kbase/js/ui-common/src/kbwidget',
         'kbaseAccordion'                        : 'kbase/js/ui-common/src/widgets/kbaseAccordion',
         'kbaseAuthenticatedWidget'              : 'kbase/js/ui-common/src/widgets/kbaseAuthenticatedWidget',

--- a/scripts/start_docker_narrative.tmpl
+++ b/scripts/start_docker_narrative.tmpl
@@ -6,6 +6,7 @@ export JUPYTER_RUNTIME_DIR=/tmp/jupyter_runtime
 export JUPYTER_DATA_DIR=/tmp/jupyter_data
 export JUPYTER_PATH=$NARRATIVE_DIR/kbase-extension
 export IPYTHONDIR=$NARRATIVE_DIR/kbase-extension/ipython
+export HOME=/tmp
 CFGDIR=$JUPYTER_CONFIG_DIR/static/kbase
 
 cp $NARRATIVE_DIR/src/config.json $JUPYTER_CONFIG_DIR/static/kbase/

--- a/src/biokbase/narrative/authhandlers.py
+++ b/src/biokbase/narrative/authhandlers.py
@@ -85,8 +85,7 @@ class KBaseLoginHandler(LoginHandler):
 
 
     def post(self):
-        # Just do the same as in get
-        return self.get()
+        pass
 
     @classmethod
     def get_user(cls, handler):

--- a/src/biokbase/narrative/authhandlers.py
+++ b/src/biokbase/narrative/authhandlers.py
@@ -85,7 +85,8 @@ class KBaseLoginHandler(LoginHandler):
 
 
     def post(self):
-        pass
+        # Just do the same as in get
+        return self.get()
 
     @classmethod
     def get_user(cls, handler):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -24,7 +24,7 @@ jsonschema
 pexpect
 pickleshare
 simplegeneric
-qgrid
+# qgrid
 bokeh
 markupsafe
 plotly


### PR DESCRIPTION
There are a few environment variables that are expected to be present in each kernel process. 2 cases can cause those to get jumbled.

1. Manual restarting when multiple kernels are running can inherit variables from another running kernel.
2. Restarting the kernel when connecting to a new Docker container (without doing a page refresh) will start with a fresh session.

Since those values are known by the browser, but not by the kernel or (probably) by the Jupyter client, the main fix here is to set those needed variables every time the kernel gets restarted (triggers the 'kernel_ready.Kernel'). This just executes a tiny command to set things up at the right time.