### PR TITLE
Change method panel to use beta and release mode in non-dev-mode.

### DIFF
--- a/kbase-extension/static/kbase/templates/beta_warning_body.html
+++ b/kbase-extension/static/kbase/templates/beta_warning_body.html
@@ -1,0 +1,8 @@
+<div>
+    <div class="alert alert-warning"><b>This Narrative is now using Beta methods.</b></div>
+    Warning: this exposes methods that are currently in beta. These may fail to run, and any Narratives that use methods in this mode may fail to work in the future.
+</div>
+<br>
+<div>
+    <input type="checkbox"> See this warning for the rest of this session?
+</div>


### PR DESCRIPTION
Currently, when not in dev mode (e.g. on production servers), there's no toggle for the versions of SDK modules. This adds a toggle between release and beta. The concept is that SDK methods that are in development (the 'D' state in appdev, and CI) are intended to only be used by the developer. Beta methods are meant to be tested by colleagues and the community, then released ones should be seen by everyone.

This adds the SDK method toggle back to production servers, but only toggles between released and beta modules. It also has a modal warning when entering beta (though that can be suppressed for the session).