### PR TITLE
Fix job runtime being displayed improperly.

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -108,7 +108,7 @@ function($,
                                       .addClass('glyphicon glyphicon-refresh'))
                               .tooltip({
                                     title : 'Refresh job status', 
-                                    container : 'body',                     
+                                    container : 'body',
                                     delay: {
                                         show: Config.get('tooltip').showDelay, 
                                         hide: Config.get('tooltip').hideDelay
@@ -705,6 +705,8 @@ function($,
                 }
                 this.setJobCounter(stillRunning);
             }
+            // hide any showing tooltips, otherwise they just sit there stagnant forever.
+            this.$jobsPanel.find('span[data-toggle="tooltip"]').tooltip('hide');
             this.$jobsPanel.empty().append($jobsList);
         },
 
@@ -859,7 +861,15 @@ function($,
                 $infoTable.append(this.makeInfoRow('Run Time', runTime));
             }
             if (jobState.timestamp) {
-                started = TimeFormat.prettyTimestamp(jobState.timestamp);
+                started = $(TimeFormat.prettyTimestamp(jobState.timestamp));
+                started.tooltip({
+                    container: 'body',
+                    placement: 'right',
+                    delay: {
+                        show: Config.get('tooltip').showDelay, 
+                        hide: Config.get('tooltip').hideDelay
+                    }
+                });
                 $infoTable.append(this.makeInfoRow('Started', started));
             }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -788,14 +788,14 @@ function($,
                 if (jobState.state.complete_time) {
                     completedTime = TimeFormat.prettyTimestamp(jobState.state.complete_time);
                     if (jobState.state.start_time) {
-                        runTime = TimeFormat.calcTimeFromNow(new Date(jobState.state.start_time), new Date(jobState.state.complete_time));
+                        runTime = TimeFormat.calcTimeDifference(new Date(jobState.state.start_time), new Date(jobState.state.complete_time));
                     }
                 }
                 else if (jobState.state.ujs_info) {
                     if (jobState.state.ujs_info[5] !== null) {
                         completedTime = TimeFormat.prettyTimestamp(jobState.state.ujs_info[5]);
                         if (jobState.state.ujs_info[3]) {
-                            runTime = TimeFormat.calcTimeFromNow(new Date(jobState.state.ujs_info[5]), new Date(jobState.state.ujs_info[3]));
+                            runTime = TimeFormat.calcTimeDifference(new Date(jobState.state.ujs_info[5]), new Date(jobState.state.ujs_info[3]));
                         }
                     }
                 }
@@ -858,7 +858,7 @@ function($,
             if (runTime) {
                 $infoTable.append(this.makeInfoRow('Run Time', runTime));
             }
-            else if (jobState.timestamp) {
+            if (jobState.timestamp) {
                 started = TimeFormat.prettyTimestamp(jobState.timestamp);
                 $infoTable.append(this.makeInfoRow('Started', started));
             }


### PR DESCRIPTION
Was using the wrong time format api call to make the time string.
Also always adds the started time (for now). In some cases, the time it was finished doesn't get added to the status.

It should also show the actual time, not just the relative time, as a tooltip on mouseover. Working on that.