### PR TITLE
fixed a datatables warning if no genes or cdses

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
@@ -172,6 +172,7 @@ function($,
                             if (types[v.type] == undefined) {types[v.type] = 0};
                             types[v.type]++;
                         });
+
                         overviewData.pop();
                         overviewData.push(types['locus']);
                         overviewData.push(types['CDS']);
@@ -421,7 +422,9 @@ function($,
                 }
 
                 var genesTable = $('#'+pref+'genes-table').dataTable(genesSettings);
-                genesTable.fnAddData(genesData);
+                if (genesData.length) {
+                    genesTable.fnAddData(genesData);
+                }
 
                 //XXX plants baloney - build up the CDS div, if necessary.
                 if (gnm.domain == 'Plant') {
@@ -442,7 +445,9 @@ function($,
                     };
 
                     var cdsTable = $('#'+pref+'cds-table').dataTable(cdsSettings);
-                    cdsTable.fnAddData(cdsData);
+                    if (cdsData.length) {
+                        cdsTable.fnAddData(cdsData);
+                    }
                 }
                 //XXX done with plants
 


### PR DESCRIPTION
Nothing major - there's a data tables warning that'll pop up if it tries to populate a genome w/o gene or ids data. This won't add in the data if nothing exists.