### PR TITLE
provide redirect to auth page if there is an auth rejection in the lua startup code

### DIFF
--- a/docker/proxy_mgr.lua
+++ b/docker/proxy_mgr.lua
@@ -1051,7 +1051,7 @@ use_proxy = function(self)
     if target == nil then
         session_lock = locklib:new(M.lock_name, lock_opts)
         elapsed, err = session_lock:lock(session_key)
-        if elasped then
+        if elapsed then
             target = session_map:get(session_key)
         end
         -- still missing, assign container to session

--- a/docker/proxy_mgr.lua
+++ b/docker/proxy_mgr.lua
@@ -139,9 +139,6 @@ M.provision_count = 20
 -- The max number of docker containers to have running, including provisioned
 M.container_max = 5000
 
--- Default URL for authentication failure redirect, nil means just error out without redirect
-M.redirect_on_auth_fail = true
-
 M.load_redirect = "/loading.html?n=%s"
 --
 -- Function that runs a netstat and returns a table of foreign IP:PORT


### PR DESCRIPTION
The lua code was simply returning 401 for auth failure, although there had been code in the past to redirect to a "login page" to force the user to authenticate. The new code routes to the current kbase-ui login widget (#login) with the required routing parameter (nextrequest). In addition, the configurability of
the auth endpoint was removed -- simple string substitution is not really adequate for building the url. Well, it could be, but it is just a single case and one cannot really reconfigure the structure of the auth endpoint without knowing how and probably changing the function.

Also, fixed some bugs in the same function (use_proxy) which probably did not manifest themselves in a measurable way, because they were related to locks, which are released automatically after a period of time. Also, removed dead and commented out code, and added comments to help (at least me) follow the logic.