### PR TITLE
Actual solution to missing inputs problem on reload.

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
@@ -208,19 +208,14 @@ function($, Config) {
         setParameterValue: function(value) {
             // todo: handle case where this is a multiple, we need to check if value array matches number of elements,
             // and if not we must do something special   ...
-            if(value === this.checkedValue) {
-                this.$elem.find("#"+this.spec.id).prop('checked', true);
-            } else if (value === this.uncheckedValue) {
-                this.$elem.find("#"+this.spec.id).prop('checked', false);
-            } else if(value === true) {
-                this.$elem.find("#"+this.spec.id).prop('checked', true);
-            } else if(value === false) {
-                this.$elem.find("#"+this.spec.id).prop('checked', false);
-            } else if(value === "checked") {
-                this.$elem.find("#"+this.spec.id).prop('checked', true);
-            } else if(value === "unchecked") {
-                this.$elem.find("#"+this.spec.id).prop('checked', false);
-            }
+            var setChecked = false;
+            if (value === this.checkedValue ||
+                value === String(this.checkedValue) ||
+                value === true ||
+                value === "true" ||
+                value === "checked")
+                setChecked = true;
+            this.$elem.find("#"+this.spec.id).prop('checked', setChecked);
 
             this.isValid();
         },

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterInput.js
@@ -7,8 +7,8 @@
 
 define(['jquery',
         'narrativeConfig',
-        'kbwidget', 
-        'kbaseAuthenticatedWidget'], 
+        'kbwidget',
+        'kbaseAuthenticatedWidget'],
 function($, Config) {
     'use strict';
     $.KBWidget({
@@ -24,37 +24,35 @@ function($, Config) {
 
         $mainPanel:null,
         spec:null,
-        
+
         init: function(options) {
             this._super(options);
 
             this.spec = options.parsedParameterSpec;
-            
+
             this.$mainPanel = $("<div>");
             this.$elem.append(this.$mainPanel);
             this.render();
-            
+
             return this;
         },
-        
+
         render: function() {
             this.$mainPanel.append("A parameter is not being displayed correctly.");
             console.error("Incorrect Parameter Spec:");
             console.error(this.spec);
         },
-        
+
         getState: function() {
             return this.getParameterValue();
         },
 
         loadState: function(state) {
-            if (!state)
-                return;
             this.setParameterValue(state);
         },
-        
+
         refresh: function() {
-        
+
         },
 
         /*
@@ -65,32 +63,32 @@ function($, Config) {
          * red (see kbaseNarrativeMethodInput for default styles).
          */
         isValid: function() {
-           return { isValid: false, errormssgs: ["A parameter is not specified properly."] }; 
+           return { isValid: false, errormssgs: ["A parameter is not specified properly."] };
         },
-        
+
         /*
          * Necessary for Apps to disable editing parameters that are automatically filled
          * from a previous step.  Returns nothing.
          */
         disableParameterEditing: function() {
-            
+
         },
-        
+
         /*
          * Allows those parameters to be renabled, which may be an option for advanced users.
          */
         enableParameterEditing: function() {
-            
+
         },
-        
+
         /*
          * An App (or a narrative that needs to auto populate certain fields) needs to set
          * specific parameter values based on the App spec, so we need a way to do this.
          */
         setParameterValue: function(value) {
-            
+
         },
-        
+
         /*
          * We need to be able to retrieve any parameter value from this method.  Valid parameter
          * values may be strings, numbers, objects, or lists, but must match what is declared
@@ -99,15 +97,15 @@ function($, Config) {
         getParameterValue: function() {
             return "";
         },
-        
+
         /*
          * This function is invoked every time we run app or method. This is the difference between it
-         * and getParameterValue() which could be invoked many times before running (e.g. when widget 
-         * is rendered). 
+         * and getParameterValue() which could be invoked many times before running (e.g. when widget
+         * is rendered).
          */
         prepareValueBeforeRun: function(methodSpec) {
-        	
+
         }
-        
+
     });
 });


### PR DESCRIPTION
Hm. The last one was really just a partial fix - the real problem was any value that was 'falsy' wasn't necessarily being loaded into the parameter widget properly.

It should be up to each individual parameter input widget to properly deal with any value sent to it.