### PR TITLE
Vis cell refactor chaplin

### DIFF
--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -688,7 +688,7 @@ define(['jquery',
         // Kickstart the Narrative loading routine once the notebook is loaded.
         $([Jupyter.events]).on('notebook_loaded.Notebook', function () {
             require(['kbaseNarrative'], function (Narrative) {
-console.log("NEW NARRATIVE HERE", Narrative);
+
                 Jupyter.narrative = new Narrative();
                 Jupyter.narrative.init();
 

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -20,10 +20,19 @@
  * The example below explain the principle, and might not be valid.
  *
  * Instances are created after the loading of this file and might need to be accessed using events:
- *     define([
- *        'base/js/namespace',
- *        'base/js/events'
- *     ], function(Jupyter, events) {
+ *     define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'*        base/js/namespace',
+		'*        base/js/events
+ *'
+	], function(
+		KBWidget,
+		bootstrap,
+		Jupyter,
+		events
+	) {
  *         events.on("app_initialized.NotebookApp", function () {
  *             Jupyter.keyboard_manager....
  *         });
@@ -679,6 +688,7 @@ define(['jquery',
         // Kickstart the Narrative loading routine once the notebook is loaded.
         $([Jupyter.events]).on('notebook_loaded.Notebook', function () {
             require(['kbaseNarrative'], function (Narrative) {
+console.log("NEW NARRATIVE HERE", Narrative);
                 Jupyter.narrative = new Narrative();
                 Jupyter.narrative.init();
 

--- a/kbase-extension/static/kbase/js/api/ModelingAPI.js
+++ b/kbase-extension/static/kbase/js/api/ModelingAPI.js
@@ -11,7 +11,18 @@
  *  - Could make separate api methods for each service
  */
 
-define(['jquery', 'narrativeConfig'], function($, config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		config
+	) {
 
     function ModelingAPI(token) {
         var self = this;

--- a/kbase-extension/static/kbase/js/api/NarrativeManager.js
+++ b/kbase-extension/static/kbase/js/api/NarrativeManager.js
@@ -6,7 +6,16 @@
  *      nms_url: ...
  *
  */
-define(['jquery'], function( $ ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
     return function(options, auth, auth_cb) {
 
         // setup URLs and Clients
@@ -264,7 +273,7 @@ define(['jquery'], function( $ ) {
                 cell_type: 'markdown',
                 source: "<div id='" + cellId + "'></div>" +
                         "\n<script>" +
-                        "$('#" + cellId + "').kbaseNarrativeAppCell({'appSpec' : '" + this._safeJSONStringify(spec) + "', 'cellId' : '" + cellId + "'});" +
+                         "new kbaseNarrativeAppCell($('#" + cellId + "'), {'appSpec' : '" + this._safeJSONStringify(spec) + "', 'cellId' : '" + cellId + "'});" +
                         "</script>",
                 metadata: { }
             };
@@ -282,7 +291,7 @@ define(['jquery'], function( $ ) {
                 cell_type: 'markdown',
                 source: "<div id='" + cellId + "'></div>" +
                         "\n<script>" +
-                        "$('#" + cellId + "').kbaseNarrativeMethodCell({'method' : '" + this._safeJSONStringify(spec) + "'});" +
+                         "new kbaseNarrativeMethodCell($('#" + cellId + "'), {'method' : '" + this._safeJSONStringify(spec) + "'});" +
                         "</script>",
                 metadata: { }
             };

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -6,45 +6,57 @@
  *
  * To set global variables, use: Jupyter.narrative.<name> = value
  */
-define([
-    'jquery',
-    'bluebird',
-    'handlebars',
-    'narrativeConfig',
-    'kbaseNarrativeSidePanel',
-    'kbaseNarrativeOutputCell',
-    'kbaseNarrativeWorkspace',
-    'kbaseNarrativeMethodCell',
-    'narrativeLogin',
-    'kbase-client-api',
-    'kbaseNarrativePrestart',
-    'ipythonCellMenu',
-    'base/js/events',
-    'notebook/js/notebook',
-    'util/display',
-    'util/bootstrapDialog',
-    'text!kbase/templates/update_dialog_body.html',
-    'jquery-nearest'
-],
-function($,
-         Promise,
-         Handlebars,
-         Config,
-         kbaseNarrativeSidePanel,
-         kbaseNarrativeOutputCell,
-         kbaseNarrativeWorkspace,
-         kbaseNarrativeMethodCell,
-         narrativeLogin,
-         kbaseClient,
-         kbaseNarrativePrestart,
-         kbaseCellToolbar,
-         events,
-         Notebook,
-         DisplayUtil,
-         BootstrapDialog,
-         UpdateDialogBodyTemplate) {
+ 
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'bluebird',
+		'handlebars',
+		'narrativeConfig',
+		'kbaseNarrativeSidePanel',
+		'kbaseNarrativeOutputCell',
+		'kbaseNarrativeWorkspace',
+		'kbaseNarrativeMethodCell',
+        'kbaseAccordion',
+        'kbaseLogin',
+        'kbaseNarrativeSharePanel',
+		'narrativeLogin',
+		'kbase-client-api',
+		'kbaseNarrativePrestart',
+		'ipythonCellMenu',
+		'base/js/events',
+		'notebook/js/notebook',
+		'util/display',
+		'util/bootstrapDialog',
+		'text!kbase/templates/update_dialog_body.html',
+		'jquery-nearest'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Promise,
+		Handlebars,
+		Config,
+		kbaseNarrativeSidePanel,
+		kbaseNarrativeOutputCell,
+		kbaseNarrativeWorkspace,
+		kbaseNarrativeMethodCell,
+        kbaseAccordion,
+        kbaseLogin,
+        kbaseNarrativeSharePanel,
+		narrativeLogin,
+		kbaseClient,
+		kbaseNarrativePrestart,
+		kbaseCellToolbar,
+		events,
+		Notebook,
+		DisplayUtil,
+		BootstrapDialog,
+		UpdateDialogBodyTemplate
+	) {
     'use strict';
-
     /**
      * @constructor
      * The base, namespaced Narrative object. This is mainly used at start-up time, and
@@ -125,7 +137,7 @@ function($,
 
     Narrative.prototype.initSharePanel = function() {
         var $sharePanel = $('<div>');
-        var $shareWidget = $sharePanel.kbaseNarrativeSharePanel({
+        var $shareWidget =  new kbaseNarrativeSharePanel($sharePanel, {
             ws_name_or_id: this.getWorkspaceName()
         });
         $('#kb-share-btn').popover({
@@ -157,7 +169,9 @@ function($,
      * dialog then lets the user shut down their existing Narrative container.
      */
     Narrative.prototype.initUpgradeDialog = function() {
+
         var bodyTemplate = Handlebars.compile(UpdateDialogBodyTemplate);
+
 
         var $cancelBtn = $('<button type="button" data-dismiss="modal">')
                          .addClass('btn btn-default')
@@ -275,7 +289,7 @@ function($,
             }
         );
         var $verAccordion = $('<div style="margin-top:15px">');
-        $verAccordion.kbaseAccordion({
+         new kbaseAccordion($verAccordion, {
             elements: [{
                 title: 'KBase Service URLs',
                 body: $versionTable
@@ -385,7 +399,7 @@ function($,
         this.initUpgradeDialog();
         this.initShutdownDialog();
 
-        // var $sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
+        // var $sidePanel =  new kbaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
 
         // NAR-271 - Firefox needs to be told where the top of the page is. :P
         window.scrollTo(0,0);
@@ -396,7 +410,11 @@ function($,
         Jupyter.CellToolbar.activate_preset("KBase");
         Jupyter.CellToolbar.global_show();
 
-        this.authToken = $('#signin-button').kbaseLogin('token');
+
+        var $login = new kbaseLogin($('#signin-button'));
+
+        this.authToken = $login.token();
+
 
         if (Jupyter && Jupyter.notebook && Jupyter.notebook.metadata) {
             var creatorId = Jupyter.notebook.metadata.creator || 'KBase User';
@@ -408,9 +426,9 @@ function($,
         if (this.getWorkspaceName() !== null) {
             this.initSharePanel();
 
-            var $sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
+            var $sidePanel =  new kbaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
             // init the controller
-            this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({
+            this.narrController =  new kbaseNarrativeWorkspace($('#notebook_panel'), {
                 ws_id: this.getWorkspaceName()
             });
             this.narrController.render()
@@ -487,7 +505,7 @@ function($,
                 // TODO: update kbaseNarrativeMethodCell to return a promise to mark when rendering is complete
                 var newCell = Jupyter.notebook.get_selected_cell();
                 var newCellIdx = Jupyter.notebook.get_selected_index();
-                var newWidget = $('#'+$(newCell.get_text())[0].id).kbaseNarrativeMethodCell();
+                var newWidget =  new kbaseNarrativeMethodCell($('#'+$(newCell.get_text())[0].id));
                 var updateStateAndRun = function(state) {
                     if(newWidget.$inputWidget) {
                         // if the $inputWidget is not null, we are good to go, so set the parameters

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -1,11 +1,20 @@
 /*global define*/
 /*jslint white: true*/
 // Bind all page buttons right at startup.
-define(['jquery',
-        'narrativeConfig', 
-        'bootstrap', 
-        'kbaseNarrativeSharePanel', 
-        'bootstrap'], function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeSharePanel'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeSharePanel
+	) {
 'use strict';
 
 $(document).on('workspaceIdQuery.Narrative', function(e, callback) {

--- a/kbase-extension/static/kbase/js/narrativeConfig.js
+++ b/kbase-extension/static/kbase/js/narrativeConfig.js
@@ -11,15 +11,22 @@
  * @module Narrative
  * @static
  */
-define([
-    'jquery',
-    'bluebird',
-    'json!kbase/config/config.json',
-    'json!kbase/config/icons.json'],
-function($,
-         Promise,
-         configSet,
-         iconsSet) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'bluebird',
+		'json!kbase/config/config.json',
+		'json!kbase/config/icons.json'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Promise,
+		configSet,
+		iconsSet
+	) {
     'use strict';
 
     // Get the workspace id from the URL

--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -5,16 +5,24 @@
  * @author Bill Riehl wjriehl@lbl.gov
  */
 
-define(['jquery', 
-        'narrativeConfig',
-        'kbaseLogin', 
-        'kbapi',
-        'base/js/utils'
-], function($, 
-            Config,
-            kbaseLogin, 
-            kbapi, 
-            JupyterUtils) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseLogin',
+		'kbapi',
+		'base/js/utils'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseLogin,
+		kbapi,
+		JupyterUtils
+	) {
     "use strict";
 
     var baseUrl = JupyterUtils.get_body_data('baseUrl');
@@ -56,7 +64,7 @@ define(['jquery',
         /**
          * Initialize the login widget and bind login/logout callbacks
          */
-        var loginWidget = $elem.kbaseLogin({
+        var loginWidget =  new kbaseLogin($elem, {
             /* If the notebook kernel's initialized, tell it to set the token.
              * This really only gets called when the user does a login on the Narrative page.
              * And since the user needs to be logged in already to get to the Narrative (in production),

--- a/kbase-extension/static/kbase/js/util/bootstrapDialog.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapDialog.js
@@ -1,7 +1,15 @@
 /*global define*/
 /*jslint white: true*/
-define(['jquery', 'bootstrap'], 
-function ($) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
     'use strict';
 
     /**

--- a/kbase-extension/static/kbase/js/util/display.js
+++ b/kbase-extension/static/kbase/js/util/display.js
@@ -5,15 +5,24 @@
  *
  * @author Bill Riehl wjriehl@lbl.gov
  */
-define(['jquery',
-        'bluebird',
-        'narrativeConfig',
-        'util/timeFormat',
-        'kbase-client-api'],
-function($,
-         Promise,
-         Config,
-         TimeFormat) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'bluebird',
+		'narrativeConfig',
+		'util/timeFormat',
+		'kbase-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Promise,
+		Config,
+		TimeFormat,
+		kbase_client_api
+	) {
     'use strict';
 
     var profileClient = new UserProfile(Config.url('user_profile'));

--- a/kbase-extension/static/kbase/js/widgets/function_input/create_metagenome_set.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/create_metagenome_set.js
@@ -4,15 +4,25 @@
  * @author Andreas Wilke <wilke@anl.gov>
  * @public
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeInput',
-        'kbStandaloneListSelect'],
-    function($, Config) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeInput',
+		'kbStandaloneListSelect'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeInput,
+		kbStandaloneListSelect
+	) {
+    return KBWidget({
         name: "create_metagenome_set",
-        parent: "kbaseNarrativeInput",
+        parent : kbaseNarrativeInput,
         version: "1.0.0",
         token: null,
         options: {},

--- a/kbase-extension/static/kbase/js/widgets/function_input/devDataViz.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/devDataViz.js
@@ -5,17 +5,28 @@
 * @public
 */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrative',
-        'kbaseNarrativeInput',
-        'kbStandaloneListSelect'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrative',
+		'kbaseNarrativeInput',
+		'kbStandaloneListSelect'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrative,
+		kbaseNarrativeInput,
+		kbStandaloneListSelect
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "devVizSelector",
-        parent: "kbaseNarrativeInput",
+        parent : kbaseNarrativeInput,
         version: "1.0.0",
         options: {
             ws: 3350 ,

--- a/kbase-extension/static/kbase/js/widgets/function_input/editors/kbaseMediaEditor.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/editors/kbaseMediaEditor.js
@@ -15,21 +15,29 @@
  */
 
 
- define([
-    'jquery',
-    'ModelingAPI',
-    'kbwidget',
-    'kbaseAuthenticatedWidget',
-    'kbaseModal'
-],
-function($, ModelingAPI) {
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'ModelingAPI',
+		'kbaseAuthenticatedWidget',
+		'kbaseModal'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		ModelingAPI,
+		kbaseAuthenticatedWidget,
+		kbaseModal
+	) {
 
 
 'use strict';
 
-$.KBWidget({
+return KBWidget({
     name: "kbaseMediaEditor",
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
     options: {},
     init: function(input) {
@@ -230,7 +238,7 @@ $.KBWidget({
             var table = $('<table class="table table-bordered table-striped kb-editor-table'+
                 ' " style="width: 100% !important;">');
 
-            var modal = $('<div>').kbaseModal({
+            var modal =  new kbaseModal($('<div>'), {
                 title: 'Add Compounds',
                 subText: 'Select compounds below, then click "add".',
                 body: table,
@@ -319,7 +327,7 @@ $.KBWidget({
             input.val(name);
             form.find('div').append(input);
 
-            var modal = $('<div>').kbaseModal({
+            var modal =  new kbaseModal($('<div>'), {
                 title: 'Save Media As...',
                 body: form,
                 buttons: [{
@@ -485,7 +493,7 @@ $.KBWidget({
                 if (input.onSave) input.onSave()
             }).fail(function(e) {
                 var error = JSON.stringify(JSON.parse(e.responseText), null,4);
-                $('<div>').kbaseModal({
+                 new kbaseModal($('<div>'), {
                     title: 'Oh no! Something seems to have went wrong',
                     body: '<pre>'+error+'</pre>'
                 }).show();

--- a/kbase-extension/static/kbase/js/widgets/function_input/editors/kbaseModelEditor.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/editors/kbaseModelEditor.js
@@ -11,21 +11,30 @@
  *
  */
 
- define([
-    'jquery',
-    'ModelingAPI',
-    'kbaseEditHistory',
-    'kbwidget',
-    'kbaseAuthenticatedWidget',
-    'kbaseModal',
-],
-function($, ModelingAPI, EditHistory) {
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'ModelingAPI',
+		'kbaseEditHistory',
+		'kbaseAuthenticatedWidget',
+		'kbaseModal'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		ModelingAPI,
+		EditHistory,
+		kbaseAuthenticatedWidget,
+		kbaseModal
+	) {
 
 'use strict';
 
-$.KBWidget({
+return KBWidget({
     name: "kbaseModelEditor",
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
     options: {},
     init: function(input) {
@@ -379,7 +388,7 @@ $.KBWidget({
             var table = $('<table class="table table-bordered table-striped kb-editor-table'+
                 ' " style="width: 100% !important;">');
 
-            var modal = $('<div>').kbaseModal({
+            var modal =  new kbaseModal($('<div>'), {
                 title: 'Add Reactions',
                 subText: 'Select reactions below, then click "add".',
                 body: table,
@@ -471,7 +480,7 @@ $.KBWidget({
             input.val(name);
             form.find('div').append(input);
 
-            var modal = $('<div>').kbaseModal({
+            var modal =  new kbaseModal($('<div>'), {
                 title: 'Save Media As...',
                 body: form,
                 buttons: [{
@@ -636,7 +645,7 @@ $.KBWidget({
                 addReaction: true,
             }).fail(function(e) {
                 var error = JSON.stringify(JSON.parse(e.responseText), null,4);
-                $('<div>').kbaseModal({
+                 new kbaseModal($('<div>'), {
                     title: 'Oh no! Something seems to have went wrong with the reactions you wanted to add'+
                            'Please contact KBase and we would be glad to help.',
                     body: '<pre>'+error+'</pre>'
@@ -652,7 +661,7 @@ $.KBWidget({
                 removeReaction: true,
             }).fail(function(e) {
                 var error = JSON.stringify(JSON.parse(e.responseText), null,4);
-                $('<div>').kbaseModal({
+                 new kbaseModal($('<div>'), {
                     title: 'Oh no! Something seems to have went wrong with the reactions you wanted to remove.'+
                            'Please contact KBase and we would be glad to help.',
                     body: '<pre>'+error+'</pre>'
@@ -668,7 +677,7 @@ $.KBWidget({
                 direction: directions
             }).fail(function(e) {
                 var error = JSON.stringify(JSON.parse(e.responseText), null,4);
-                $('<div>').kbaseModal({
+                 new kbaseModal($('<div>'), {
                     title: 'Oh no! Something seems to have went wrong with the reactions you wanted to edit.'+
                            'Please contact KBase and we would be glad to help.',
                     body: '<pre>'+error+'</pre>'

--- a/kbase-extension/static/kbase/js/widgets/function_input/editors/kbaseModelEditor.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/editors/kbaseModelEditor.js
@@ -124,7 +124,7 @@ return KBWidget({
                 }
 
                 uiTabs[0].active = true;
-                tabs = container.kbTabs({tabs: uiTabs});
+                tabs = container.kbaseTabTableTabs({tabs: uiTabs});
 
                 buildContent(tabList);
                 container.rmLoading();

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseBuildMediaInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseBuildMediaInput.js
@@ -7,15 +7,24 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeInput'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeInput
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseBuildMediaInput", 
-        parent: "kbaseNarrativeInput",
+        parent : kbaseNarrativeInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),
@@ -137,7 +146,7 @@ function($, Config) {
                                   .hide())
                           .append(this.$errorPanel);
 
-            this.$errorPanel.find("#error-accordion").kbaseAccordion({
+             new kbaseAccordion(this.$errorPanel.find("#error-accordion"), {
                     elements: [{ 
                         title: "Error Details", 
                         body: $("<pre>")

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseDefaultNarrativeInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseDefaultNarrativeInput.js
@@ -5,14 +5,23 @@
  * @public
  */
 
-define(['jquery', 
-        'narrativeConfig',
-        'kbwidget', 
-        'kbaseNarrativeInput'],
-function($, Config) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeInput
+	) {
+    return KBWidget({
         name: "kbaseDefaultNarrativeInput",
-        parent: "kbaseNarrativeInput",
+        parent : kbaseNarrativeInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditMedia.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditMedia.js
@@ -10,22 +10,34 @@
 
 /*global define*/
 /*jslint white: true*/
-define(['jquery',
-        'narrativeConfig',
-        'bluebird',
-        'kbwidget',
-        'kbaseMediaEditor',
-        'kbaseNarrativeMethodInput',
-        'kbaseNarrativeInput',
-        'kbaseNarrativeParameterTextInput',
-        'kbase-client-api'],
-function ($,
-          Config,
-          Promise) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'bluebird',
+		'kbaseMediaEditor',
+		'kbaseNarrativeMethodInput',
+		'kbaseNarrativeInput',
+		'kbaseNarrativeParameterTextInput',
+		'kbase-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		Promise,
+		kbaseMediaEditor,
+		kbaseNarrativeMethodInput,
+		kbaseNarrativeInput,
+		kbaseNarrativeParameterTextInput,
+		kbase_client_api
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseEditMedia',
-        parent: 'kbaseNarrativeMethodInput',
+        parent : kbaseNarrativeMethodInput,
 
         mediaChooserWidget: null,
         $mediaDisplayPanel: null,
@@ -61,8 +73,7 @@ function ($,
 
             // Creates the media chooser widget, which is just a 'text' input
             // This was originally designed to deal with the parameter spec object.
-            this.mediaChooserWidget = this.$mediaChooserPanel.kbaseNarrativeParameterTextInput(
-                {
+            this.mediaChooserWidget =  new kbaseNarrativeParameterTextInput(this.$mediaChooserPanel, {
                     loadingImage: Config.get('loading_gif'),
                     parsedParameterSpec: this.options.method.parameters[0],
                     isInSidePanel: false
@@ -90,7 +101,7 @@ function ($,
                 var mediaWidget = $('<div>');
 
                 var self = this;
-                mediaWidget.kbaseMediaEditor({
+                 new kbaseMediaEditor(mediaWidget, {
                     ws: Jupyter.narrative.getWorkspaceName(),
                     obj: mediaName,
                     onSave: function () { self.trigger('updateData.Narrative') }

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditModel.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditModel.js
@@ -8,22 +8,34 @@
 
 /*global define*/
 /*jslint white: true*/
-define(['jquery',
-        'narrativeConfig',
-        'bluebird',
-        'kbwidget',
-        'kbaseModelEditor',
-        'kbaseNarrativeMethodInput',
-        'kbaseNarrativeInput',
-        'kbaseNarrativeParameterTextInput',
-        'kbase-client-api'],
-function ($,
-          Config,
-          Promise) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'bluebird',
+		'kbaseModelEditor',
+		'kbaseNarrativeMethodInput',
+		'kbaseNarrativeInput',
+		'kbaseNarrativeParameterTextInput',
+		'kbase-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		Promise,
+		kbaseModelEditor,
+		kbaseNarrativeMethodInput,
+		kbaseNarrativeInput,
+		kbaseNarrativeParameterTextInput,
+		kbase_client_api
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseEditModel',
-        parent: 'kbaseNarrativeMethodInput',
+        parent : kbaseNarrativeMethodInput,
 
         modelChooserWidget: null,
         $modelDisplayPanel: null,
@@ -56,8 +68,7 @@ function ($,
 
             // Creates the media chooser widget, which is just a 'text' input
             // This was originally designed to deal with the parameter spec object.
-            this.modelChooserWidget = this.$modelChooserPanel.kbaseNarrativeParameterTextInput(
-                {
+            this.modelChooserWidget =  new kbaseNarrativeParameterTextInput(this.$modelChooserPanel, {
                     loadingImage: Config.get('loading_gif'),
                     parsedParameterSpec: this.options.method.parameters[0],
                     isInSidePanel: false
@@ -84,7 +95,7 @@ function ($,
                 var modelWidget = $('<div>');
 
                 var self = this;
-                modelWidget.kbaseModelEditor({
+                 new kbaseModelEditor(modelWidget, {
                     ws: Jupyter.narrative.getWorkspaceName(),
                     obj: modelName,
                     onSave: function () { self.trigger('updateData.Narrative') }

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseGenomeImportInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseGenomeImportInput.js
@@ -6,9 +6,9 @@
  */
 
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "GenomeImportWidget",
-        parent: "kbaseTabbedInput",
+        parent : kbaseTabbedInput,
         version: "1.0.0",
         options: {
         },

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseGrowthCurvesInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseGrowthCurvesInput.js
@@ -2,20 +2,33 @@
  * @author Pavel Novickov <psnovichkov@lbl.gov>
  * @public
  */
-define(['jquery', 
-        'narrativeConfig',
-        'kbaseNarrativeMethodInput', 
-        'kbaseNarrativeParameterDropdownInput',
-        'kbaseNarrativeParameterCheckboxInput',
-        'kbaseNarrativeParameterCustomTextSubdataInput'],
-    function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeMethodInput',
+		'kbaseNarrativeParameterDropdownInput',
+		'kbaseNarrativeParameterCheckboxInput',
+		'kbaseNarrativeParameterCustomTextSubdataInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeMethodInput,
+		kbaseNarrativeParameterDropdownInput,
+		kbaseNarrativeParameterCheckboxInput,
+		kbaseNarrativeParameterCustomTextSubdataInput
+	) {
     
     var workspaceUrl = Config.url('workspace');
     var loadingImage = Config.get('loading_gif');
     
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseGrowthCurvesInput",
-        parent: "kbaseNarrativeMethodInput",
+        parent : kbaseNarrativeMethodInput,
         
         version: "1.0.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseGrowthParams2DPlotInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseGrowthParams2DPlotInput.js
@@ -2,15 +2,25 @@
  * @author Pavel Novickov <psnovichkov@lbl.gov>
  * @public
  */
-define(['jquery', 
-    'kbaseNarrativeParameterCustomTextSubdataInput',
-    'kbaseNarrativeParameterCustomButtonInput',
-    'kbaseNarrativeParameterCustomDropdownGroupInput'
-       ],
-    function( $ ) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseNarrativeParameterCustomTextSubdataInput',
+		'kbaseNarrativeParameterCustomButtonInput',
+		'kbaseNarrativeParameterCustomDropdownGroupInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseNarrativeParameterCustomTextSubdataInput,
+		kbaseNarrativeParameterCustomButtonInput,
+		kbaseNarrativeParameterCustomDropdownGroupInput
+	) {
+    return KBWidget({
         name: "kbaseGrowthParams2DPlotInput",
-        parent: "kbaseNarrativeMethodInput",
+        parent : kbaseNarrativeMethodInput,
         
         version: "1.0.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseGrowthParamsPlotInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseGrowthParamsPlotInput.js
@@ -2,19 +2,30 @@
  * @author Pavel Novickov <psnovichkov@lbl.gov>
  * @public
  */
-define(['jquery', 
-        'narrativeConfig',
-        'kbaseNarrativeParameterCustomTextSubdataInput',
-        'kbaseNarrativeParameterCustomButtonInput',
-        'kbaseNarrativeParameterCustomDropdownGroupInput'
-       ],
-    function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterCustomTextSubdataInput',
+		'kbaseNarrativeParameterCustomButtonInput',
+		'kbaseNarrativeParameterCustomDropdownGroupInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterCustomTextSubdataInput,
+		kbaseNarrativeParameterCustomButtonInput,
+		kbaseNarrativeParameterCustomDropdownGroupInput
+	) {
     
     var workspaceUrl = Config.url('workspace');
     var loadingImage = Config.get('loading_gif');
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseGrowthParamsPlotInput",
-        parent: "kbaseNarrativeMethodInput",
+        parent : kbaseNarrativeMethodInput,
         
         version: "1.0.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseHomologySearch.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseHomologySearch.js
@@ -5,17 +5,26 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeMethodInput',
-        'kbaseNarrativeParameterAjaxTextSubdataInput'
-],
-function ($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeMethodInput',
+		'kbaseNarrativeParameterAjaxTextSubdataInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeMethodInput,
+		kbaseNarrativeParameterAjaxTextSubdataInput
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseHomologySearch",
-        parent: "kbaseNarrativeMethodInput",
+        parent : kbaseNarrativeMethodInput,
 
         constSequenceNA: 'nucleotide',
         constSequenceAA: 'protein',

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseInputTest.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseInputTest.js
@@ -1,20 +1,31 @@
 /*global define*/
 /*jslint white: true*/
-define(['jquery',
-        'narrativeConfig',
-        'bluebird',
-        'kbwidget',
-        'kbaseNarrativeMethodInput',
-        'kbaseNarrativeInput',
-        'kbaseNarrativeParameterTextInput',
-        'kbase-client-api'],
-function ($,
-          Config,
-          Promise) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'bluebird',
+		'kbaseNarrativeMethodInput',
+		'kbaseNarrativeInput',
+		'kbaseNarrativeParameterTextInput',
+		'kbase-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		Promise,
+		kbaseNarrativeMethodInput,
+		kbaseNarrativeInput,
+		kbaseNarrativeParameterTextInput,
+		kbase_client_api
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseInputTest',
-        parent: 'kbaseNarrativeMethodInput',
+        parent : kbaseNarrativeMethodInput,
 
         mediaChooserWidget: null,
         $mediaDisplayPanel: null,
@@ -40,8 +51,7 @@ function ($,
 
             // Creates the media chooser widget, which is just a 'text' input
             // This was originally designed to deal with the parameter spec object.
-            this.mediaChooserWidget = $mediaChooserPanel.kbaseNarrativeParameterTextInput(
-                {
+            this.mediaChooserWidget =  new kbaseNarrativeParameterTextInput($mediaChooserPanel, {
                     loadingImage: Config.get('loading_gif'),
                     parsedParameterSpec: this.options.method.parameters[0],
                     isInSidePanel: false

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeInput.js
@@ -5,15 +5,24 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseAuthenticatedWidget'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseAuthenticatedWidget
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeInput",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeMethodInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeMethodInput.js
@@ -4,21 +4,36 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeInput',
-        'kbaseNarrativeParameterTextInput',
-        'kbaseNarrativeParameterDropdownInput',
-        'kbaseNarrativeParameterCheckboxInput',
-        'kbaseNarrativeParameterTextareaInput',
-        'kbaseNarrativeParameterFileInput',
-        'kbaseNarrativeParameterTextSubdataInput'],
-function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeInput',
+		'kbaseNarrativeParameterTextInput',
+		'kbaseNarrativeParameterDropdownInput',
+		'kbaseNarrativeParameterCheckboxInput',
+		'kbaseNarrativeParameterTextareaInput',
+		'kbaseNarrativeParameterFileInput',
+		'kbaseNarrativeParameterTextSubdataInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeInput,
+		kbaseNarrativeParameterTextInput,
+		kbaseNarrativeParameterDropdownInput,
+		kbaseNarrativeParameterCheckboxInput,
+		kbaseNarrativeParameterTextareaInput,
+		kbaseNarrativeParameterFileInput,
+		kbaseNarrativeParameterTextSubdataInput
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeMethodInput",
-        parent: "kbaseNarrativeInput",
+        parent : kbaseNarrativeInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseNcbiGenomeImportInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseNcbiGenomeImportInput.js
@@ -6,14 +6,23 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeInput'],
-function($, Config) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeInput
+	) {
+    return KBWidget({
         name: "NcbiGenomeImportInput",
-        parent: "kbaseNarrativeInput",
+        parent : kbaseNarrativeInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseSampleProperty2DPlotInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseSampleProperty2DPlotInput.js
@@ -2,16 +2,26 @@
  * @author Pavel Novickov <psnovichkov@lbl.gov>
  * @public
  */
-define(['jquery', 
-        'narrativeConfig',
-        'kbaseNarrativeParameterCustomTextSubdataInput'],
-    function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterCustomTextSubdataInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterCustomTextSubdataInput
+	) {
     
     var workspaceUrl = Config.url('workspace');
     var loadingImage = Config.get('loading_gif');
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseSampleProperty2DPlotInput",
-        parent: "kbaseNarrativeMethodInput",
+        parent : kbaseNarrativeMethodInput,
         
         version: "1.0.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseSamplePropertyHistogramInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseSamplePropertyHistogramInput.js
@@ -2,18 +2,30 @@
  * @author Pavel Novickov <psnovichkov@lbl.gov>
  * @public
  */
-define(['jquery', 
-        'narrativeConfig',
-        'kbaseNarrativeMethodInput', 
-        'kbaseNarrativeParameterCheckboxInput',
-        'kbaseNarrativeParameterCustomTextSubdataInput'],
-    function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeMethodInput',
+		'kbaseNarrativeParameterCheckboxInput',
+		'kbaseNarrativeParameterCustomTextSubdataInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeMethodInput,
+		kbaseNarrativeParameterCheckboxInput,
+		kbaseNarrativeParameterCustomTextSubdataInput
+	) {
     
     var workspaceUrl = Config.url('workspace');
     var loadingImage = Config.get('loading_gif');
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseSamplePropertyHistogramInput",
-        parent: "kbaseNarrativeMethodInput",
+        parent : kbaseNarrativeMethodInput,
         
         version: "1.0.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseTabbedInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseTabbedInput.js
@@ -5,10 +5,23 @@
  * @public
  */
 
-define(['jquery', 'kbwidget', 'kbaseTabs', 'kbaseNarrativeMethodInput'], function( $ ) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseTabs',
+		'kbaseNarrativeMethodInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseTabs,
+		kbaseNarrativeMethodInput
+	) {
+    return KBWidget({
         name: "kbaseTabbedInput",
-        parent: "kbaseNarrativeMethodInput",
+        parent : kbaseNarrativeMethodInput,
         version: "1.0.0",
         options: {
             isInSidePanel: false
@@ -71,7 +84,7 @@ define(['jquery', 'kbwidget', 'kbaseTabs', 'kbaseNarrativeMethodInput'], functio
             	if (self.options.isInSidePanel) {
             		self.buildTabs(self.tabPane);
             	} else {
-            		self.tabPane.kbaseTabs({canDelete : true, tabs : []});
+            		 new kbaseTabs(self.tabPane, {canDelete : true, tabs : []});
             	}
             	self.tabs = {};
             	self.tabParamToSpec = {};

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterAjaxTextSubdataInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterAjaxTextSubdataInput.js
@@ -5,15 +5,24 @@
  * See the example of ajaxConfig https://select2.github.io/examples.html#data-ajax
  *
  */
-define(['jquery', 
-        'narrativeConfig',
-        'kbwidget', 
-        'kbaseNarrativeParameterCustomTextSubdataInput'],
-    function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterCustomTextSubdataInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterCustomTextSubdataInput
+	) {
 
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterAjaxTextSubdataInput",
-        parent: "kbaseNarrativeParameterCustomTextSubdataInput",
+        parent : kbaseNarrativeParameterCustomTextSubdataInput,
         version: "1.0.0",
         options: {
             isInSidePanel: false,

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCheckboxInput.js
@@ -4,15 +4,24 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeParameterInput'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterInput
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterCheckboxInput",
-        parent: "kbaseNarrativeParameterInput",
+        parent : kbaseNarrativeParameterInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCustomButtonInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCustomButtonInput.js
@@ -5,12 +5,22 @@
  * The dataModel should have fetchData method onButtonClick().
  *
  */
-define(['jquery', 'kbwidget', 'select2'],
-    function( $ ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'select2'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		select2
+	) {
     
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterCustomButtonInput",
-        parent: "kbaseNarrativeParameterInput",  
+        parent : kbaseNarrativeParameterInput,  
         version: "1.0.0",
         options: {
             loadingImage: "../images/ajax-loader.gif",

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCustomDropdownGroupInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCustomDropdownGroupInput.js
@@ -5,12 +5,22 @@
  * The dataModel should have getDropdownSpecs method providing an array of spec files.
  *
  */
-define(['jquery', 'kbwidget', 'kbaseNarrativeParameterDropdownInput'],
-    function( $ ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseNarrativeParameterDropdownInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseNarrativeParameterDropdownInput
+	) {
     
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterCustomDropdownGroupInput",
-        parent: "kbaseNarrativeParameterInput",  
+        parent : kbaseNarrativeParameterInput,  
         version: "1.0.0",
         options: {
             loadingImage: "../images/ajax-loader.gif",

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCustomTextSubdataInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterCustomTextSubdataInput.js
@@ -5,18 +5,27 @@
  * The dataModel should have fetchData method accepting doneCallback method as a parameter.
  *
  */
-define(['jquery', 
-        'narrativeConfig',
-        'kbwidget', 
-        'select2'],
-    function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'select2'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		select2
+	) {
     
     var workspaceUrl = Config.url('workspace');
     var loadingImage = Config.get('loading_gif');
     
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterCustomTextSubdataInput",
-        parent: "kbaseNarrativeParameterInput",  
+        parent : kbaseNarrativeParameterInput,  
         version: "1.0.0",
         options: {
             isInSidePanel: false,

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
@@ -5,16 +5,26 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeParameterInput',
-        'select2'], 
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterInput',
+		'select2'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterInput,
+		select2
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterDropdownInput",
-        parent: "kbaseNarrativeParameterInput",
+        parent : kbaseNarrativeParameterInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
@@ -3,15 +3,24 @@
 /**
  * KBase widget to upload file content into shock node.
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeParameterInput'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterInput
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeParameterFileInput',
-        parent: "kbaseNarrativeParameterInput",
+        parent : kbaseNarrativeParameterInput,
         version: '1.0.0',
         options: {
             isInSidePanel: false,

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterInput.js
@@ -5,15 +5,24 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseAuthenticatedWidget'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseAuthenticatedWidget
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterInput",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
@@ -5,16 +5,26 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeParameterInput',
-        'select2'], 
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterInput',
+		'select2'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterInput,
+		select2
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterTextInput",
-        parent: "kbaseNarrativeParameterInput",
+        parent : kbaseNarrativeParameterInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextSubdataInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextSubdataInput.js
@@ -4,17 +4,28 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'handlebars',
-        'kbwidget',
-        'kbaseNarrativeParameterInput',
-        'select2'],
-function($, Config, Handlebars) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'handlebars',
+		'kbaseNarrativeParameterInput',
+		'select2'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		Handlebars,
+		kbaseNarrativeParameterInput,
+		select2
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterTextSubdataInput",
-        parent: "kbaseNarrativeParameterInput",
+        parent : kbaseNarrativeParameterInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),
@@ -270,6 +281,7 @@ function($, Config, Handlebars) {
         processSubdataQueryResult : function(result, path_to_subdata, selection_id, selection_description, includeWsId, text_template) {
             var self = this;
 
+console.log("h7", Handlebars, text_template);
             var hb_template = Handlebars.compile(text_template);
 
             // loop over subdata from every object

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextareaInput.js
@@ -5,15 +5,24 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeParameterInput'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeParameterInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeParameterInput
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeParameterTextareaInput",
-        parent: "kbaseNarrativeParameterInput",
+        parent : kbaseNarrativeParameterInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_input/rastGenomeImportInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/rastGenomeImportInput.js
@@ -4,14 +4,23 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseNarrativeInput'],
-function($, Config) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseNarrativeInput'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseNarrativeInput
+	) {
+    return KBWidget({
         name: "rastGenomeImportInput",
-        parent: "kbaseNarrativeInput",
+        parent : kbaseNarrativeInput,
         version: "1.0.0",
         options: {
             loadingImage: Config.get('loading_gif'),

--- a/kbase-extension/static/kbase/js/widgets/function_output/contigBrowserPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/contigBrowserPanel.js
@@ -1,8 +1,21 @@
-define(['jquery', 'kbwidget', 'd3', 'kbaseContigBrowserButtons'], function($) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'd3',
+		'kbaseContigBrowserButtons'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		d3,
+		kbaseContigBrowserButtons
+	) {
     return function() {
         this.data = {
             name: "ContigBrowserPanel", 
-            parent: "kbaseWidget",
+            
             version: "1.0.0",
             options: {
                 contig: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataBoxplot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataBoxplot.js
@@ -1,8 +1,21 @@
 /**
  * KBase widget to display table of BIOM data
  */
-define(['jquery', 'kbwidget', 'RGBColor', 'kbStandaloneGraph'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'RGBColor',
+		'kbStandaloneGraph'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		RGBColor,
+		kbStandaloneGraph
+	) {
+    return KBWidget({
         name: 'AbundanceDataBoxplot',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataHeatmap.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataHeatmap.js
@@ -1,11 +1,23 @@
 /**
  * KBase widget to display table of BIOM data
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 
-        'kbStandaloneHeatmap'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbStandaloneHeatmap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbStandaloneHeatmap
+	) {
+    return KBWidget({
             name: 'AbundanceDataHeatmap',
-            parent: "kbaseAuthenticatedWidget",
+            parent : kbaseAuthenticatedWidget,
             version: '1.0.0',
             token: null,
             options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataPcoa.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataPcoa.js
@@ -1,12 +1,25 @@
 /**
  * KBase widget to display table of BIOM data
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget',
-        'kbStandalonePlot', 'RGBColor'],
-        function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbStandalonePlot',
+		'RGBColor'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbStandalonePlot,
+		RGBColor
+	) {
+    return KBWidget({
             name: 'AbundanceDataPcoa',
-            parent: "kbaseAuthenticatedWidget",
+            parent : kbaseAuthenticatedWidget,
             version: '1.0.0',
             token: null,
             options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataTable.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataTable.js
@@ -1,11 +1,23 @@
 /**
  * KBase widget to display table of BIOM data
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget',
-        'kbStandaloneTable'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbStandaloneTable'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbStandaloneTable
+	) {
+    return KBWidget({
         name: 'AbundanceDataTable',
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         token: null,
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAbundanceDataView.js
@@ -1,12 +1,27 @@
 /**
  * KBase widget to display table and boxplot of BIOM data
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 'RGBColor', 
-        'kbStandaloneTable', 'kbStandaloneGraph'], 
-        function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'RGBColor',
+		'kbStandaloneTable',
+		'kbStandaloneGraph'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		RGBColor,
+		kbStandaloneTable,
+		kbStandaloneGraph
+	) {
+    return KBWidget({
         name: 'AbundanceDataView',
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         token: null,
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAnnotationSetTable.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAnnotationSetTable.js
@@ -1,11 +1,23 @@
 /**
  * KBase widget to display table and boxplot of BIOM data
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 'kbStandaloneTable'],
-    function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbStandaloneTable'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbStandaloneTable
+	) {
+    return KBWidget({
         name: 'AnnotationSetTable',
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         token: null,
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAssembly.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAssembly.js
@@ -2,11 +2,21 @@
  * Just a simple example widget - makes a div with "Hello world!"
  * in a user-defined color (must be a css color - 'red' or 'yellow' or '#FF0000')
  */
-define(['jquery', 'kbwidget', 'kbasePrompt'], 
-    function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbasePrompt'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbasePrompt
+	) {
+    return KBWidget({
         name: "AssemblyWidget",
-        parent: "kbaseWidget",
+        
         version: "1.0.0",
         options: {
             color: "black",
@@ -496,7 +506,7 @@ define(['jquery', 'kbwidget', 'kbasePrompt'],
 
         import_contigs_to_ws: function(token, fba_url, ws_url, ws_name, shock_id, shock_url, contig_name){
             var contig_name = $('<div class="input-group"> <span class="input-group-addon">ContigSet Name</span> <input type="text" class="form-control cname-input" value="'+ contig_name +'"> </div>');
-            var $importModal = $('<div></div>').kbasePrompt({
+            var $importModal =  new kbasePrompt($('<div></div>'), {
                 title : 'Import Contigs',
                 body : contig_name,
                 modalClass : 'fade', //Not required. jquery animation class to show/hide. Defaults to 'fade'

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseAssemblyView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseAssemblyView.js
@@ -4,10 +4,21 @@
  * @public
  */
 
- define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
-    $.KBWidget({
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget
+	) {
+    return KBWidget({
         name: "kbaseAssemblyView",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         ws_id: null,
         ws_name: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseBlastOutput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseBlastOutput.js
@@ -1,15 +1,28 @@
-define(['jquery',
-    'util/string',
-    'd3',
-    'kbwidget',
-    'kbaseAuthenticatedWidget',
-    'kbaseTabs',
-    'jquery-dataTables',
-    'jquery-dataTables-bootstrap'],
-function ($, StringUtil) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'util/string',
+		'd3',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		StringUtil,
+		d3,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: "kbaseBlastOutput",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         ws_id: null,
         ws_name: null,
@@ -58,7 +71,7 @@ function ($, StringUtil) {
                 data = data[0].data;
                 var tabPane = $('<div id="' + pref + 'tab-content">');
                 container.append(tabPane);
-                tabPane.kbaseTabs({canDelete: true, tabs: []});
+                 new kbaseTabs(tabPane, {canDelete: true, tabs: []});
 
                 var tabData = self.tabData();
                 var tabNames = tabData.names;

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseCategoryView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseCategoryView.js
@@ -2,7 +2,7 @@
  * KBase widget to display an lists within categories.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'CategoryViewWidget',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseCheckObject.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseCheckObject.js
@@ -2,7 +2,7 @@
  * KBase widget to display if workspace object exists.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'CheckObject',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseChromatograms.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseChromatograms.js
@@ -1,17 +1,30 @@
 
 
-define(['jquery', 
-        'plotly',  
-        'kbaseMatrix2DAbstract',
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'
-        ], function($, Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseMatrix2DAbstract',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseMatrix2DAbstract,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseChromatograms',
-        parent: 'kbaseMatrix2DAbstract',
+        parent : kbaseMatrix2DAbstract,
         version: '1.0.0',
 
         render: function(){

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseChromatographyMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseChromatographyMatrix.js
@@ -1,14 +1,24 @@
-define([
-        'jquery', 
-        'kbwidget', 
-        'kbaseMatrix2DAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseMatrix2DAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseMatrix2DAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseChromatographyMatrix',
-        parent: 'kbaseMatrix2DAbstract',
+        parent : kbaseMatrix2DAbstract,
         version: '1.0.0',
          
         render: function(){
@@ -29,7 +39,7 @@ define([
             var $tabPane = $('<div>')
                 .attr( 'id', pref+'tab-content')
                 .appendTo($container);
-            $tabPane.kbaseTabs({canDelete : true, tabs : []});   
+             new kbaseTabs($tabPane, {canDelete : true, tabs : []});   
 
             // Build matrix overview tab
             var $tabOverview = $("<div/>");

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseCollectionView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseCollectionView.js
@@ -1,10 +1,23 @@
 /**
  * KBase widget to display a Metagenome Collection
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 'kbStandaloneTable'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbStandaloneTable'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbStandaloneTable
+	) {
+    return KBWidget({
         name: 'CollectionView',
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         token: null,
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseCompareFBAs.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseCompareFBAs.js
@@ -3,9 +3,9 @@
  * 
  */
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseCompareFBAs",
-        parent: "kbaseWidget",
+        
         version: "1.0.0",
         options: {
             color: "black",

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseContigSetUploadNarrative.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseContigSetUploadNarrative.js
@@ -1,8 +1,8 @@
 (function( $, undefined ) {
 
-$.KBWidget({
+return KBWidget({
     name: "ContigSetUploadWidget",     
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
 	token: null,
 	ws_name: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseContigSetView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseContigSetView.js
@@ -4,15 +4,27 @@
  * @public
  */
 
-define(['jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs', 
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: "kbaseContigSetView",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         ws_id: null,
         ws_name: null,
@@ -61,7 +73,7 @@ define(['jquery',
             		console.log(cs);
             		var tabPane = $('<div id="'+pref+'tab-content">');
             		container.append(tabPane);
-            		tabPane.kbaseTabs({canDelete : true, tabs : []});
+            		 new kbaseTabs(tabPane, {canDelete : true, tabs : []});
             		var tabNames = ['Overview', 'Contigs'];
             		var tabIds = ['overview', 'contigs'];
             		for (var i=0; i<tabIds.length; i++) {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseDataDump.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseDataDump.js
@@ -2,7 +2,7 @@
  * KBase widget to display workspace object JSON.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'DataDump',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseDefaultNarrativeOutput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseDefaultNarrativeOutput.js
@@ -26,8 +26,17 @@
  * @see kbaseAuthenticatedWidget.js
  * @public
  */
-define(['jquery', 'kbwidget'], function( $ ) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
+    return KBWidget({
         /* 
          * (required) Your widget should be named in CamelCase.
          */
@@ -42,7 +51,7 @@ define(['jquery', 'kbwidget'], function( $ ) {
          * this.user_id() = the logged in user id
          * this.authToken() = the current authentication token
          */
-        parent: 'kbaseWidget',
+        
 
         /*
          * (optional) Widgets should be semantically versioned.

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseDisplayText.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseDisplayText.js
@@ -2,7 +2,7 @@
  * KBase widget to display text.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'DisplayTextWidget',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseDomainAnnotation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseDomainAnnotation.js
@@ -4,15 +4,27 @@
  * @public
  */
 
-define(['jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseDomainAnnotation',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.2',
         options: {
             domainAnnotationID: null,
@@ -135,7 +147,7 @@ define(['jquery',
                     container.empty();
                     var tabPane = $('<div id="'+self.pref+'tab-content">');
                     container.append(tabPane);
-                    tabPane.kbaseTabs({canDelete : true, tabs : []});                    
+                     new kbaseTabs(tabPane, {canDelete : true, tabs : []});                    
                     ///////////////////////////////////// Overview table ////////////////////////////////////////////           
                     var tabOverview = $("<div/>");
                     tabPane.kbaseTabs('addTab', {tab: 'Overview', content: tabOverview, canDelete : false, show: true});

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseDownloadFile.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseDownloadFile.js
@@ -2,7 +2,7 @@
  * KBase widget to download content.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'DownloadFileWidget',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionAnalysis.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionAnalysis.js
@@ -10,12 +10,26 @@
  * @public
  */
 
- define(['jquery', 'plotly', 'kbwidget', 'kbaseAuthenticatedWidget', 'KBModeling'],
-function($, Plotly) {
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseAuthenticatedWidget',
+		'KBModeling'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseAuthenticatedWidget,
+		KBModeling
+	) {
 
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseExpressionAnalysis",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {},
         init: function(input) {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionEstimateK.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionEstimateK.js
@@ -4,14 +4,23 @@
  * @public
  */
 
-define(['jquery', 
-		'kbwidget', 
-		'kbaseAuthenticatedWidget', 
-        'kbaseLinechart'
-		], function($) {
-	$.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbaseLinechart'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseLinechart
+	) {
+	return KBWidget({
 		name: 'kbaseExpressionEstimateK',
-		parent: 'kbaseAuthenticatedWidget',
+		parent : kbaseAuthenticatedWidget,
 		version: '1.0.0',
 		options: {
 			estimateKResultID: null,
@@ -169,8 +178,7 @@ define(['jquery',
             
             $lineChartDiv = $("<div style = 'width : 500px; height : 300px'>");
             $containerDiv.append($lineChartDiv);
-            $lineChartDiv.kbaseLinechart(
-                {
+             new kbaseLinechart($lineChartDiv, {
                     scaleAxes       : true,
 
                     xLabel      : 'Values of K',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
@@ -16,8 +16,7 @@ define (
 		'jquery-dataTables',
 		'jquery-dataTables-bootstrap',
 		'kbaseTreechart',
-		'knhx
-//',
+		'knhx',
 		'jquery-dataScroller'
 	], function(
 		KBWidget,
@@ -28,10 +27,9 @@ define (
 		kbaseAuthenticatedWidget,
 		kbaseTabs,
 		jquery_dataTables,
-		bootstrap,
+		jquery_dataTables_bootstrap,
 		kbaseTreechart,
-		knhx
-_,
+		knhx,
 		jquery_dataScroller
 	) {
 	return KBWidget({

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
@@ -4,24 +4,39 @@
  * @public
  */
 
-define(['jquery', 
-        'narrativeConfig',
-        'util/string',
-		'kbwidget', 
-		'kbaseAuthenticatedWidget', 
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'util/string',
+		'kbaseAuthenticatedWidget',
 		'kbaseTabs',
 		'jquery-dataTables',
 		'jquery-dataTables-bootstrap',
 		'kbaseTreechart',
-		'knhx'
-//        ,'jquery-dataScroller'
-		],
-function($,
-         Config,
-         StringUtil) {
-	$.KBWidget({
+		'knhx
+//',
+		'jquery-dataScroller'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		StringUtil,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap,
+		kbaseTreechart,
+		knhx
+_,
+		jquery_dataScroller
+	) {
+	return KBWidget({
 		name: 'kbaseExpressionFeatureClusters',
-		parent: 'kbaseAuthenticatedWidget',
+		parent : kbaseAuthenticatedWidget,
 		version: '1.0.0',
 		options: {
 			clusterSetID: null,
@@ -145,7 +160,7 @@ function($,
 			var tabPane = $('<div id="'+pref+'tab-content">');
 			$container.append(tabPane);
 
-			tabPane.kbaseTabs({canDelete : true, tabs : []});                    
+			 new kbaseTabs(tabPane, {canDelete : true, tabs : []});                    
 			///////////////////////////////////// Overview table ////////////////////////////////////////////           
 			var tabOverview = $("<div/>");
 			tabPane.kbaseTabs('addTab', {tab: 'Overview', content: tabOverview, canDelete : false, show: true});
@@ -249,7 +264,7 @@ function($,
                 tabPane.kbaseTabs('addTab', {tab: 'Dendrogram', content: tabDendro, canDelete : false, show: false});
                 var dendroPanel = $("<div/>");
                 tabDendro.append(dendroPanel);
-                dendroPanel.kbaseTreechart({ 
+                 new kbaseTreechart(dendroPanel, { 
                     lineStyle: 'square',
                     dataset: root
                 });

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionGenesetBaseWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionGenesetBaseWidget.js
@@ -12,17 +12,29 @@
  * @public
  */
 
-define(['jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap',        
-        'kbaseFeatureValues-client-api'
-        ], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap',
+		'kbaseFeatureValues-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap,
+		kbaseFeatureValues_client_api
+	) {
+    return KBWidget({
         name: 'kbaseExpressionGenesetBaseWidget',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: {
             workspaceID: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionHeatmap.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionHeatmap.js
@@ -5,16 +5,27 @@
  * @public
  */
 
- define([
-        'jquery',
-        'd3',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap',      
-        'kbaseExpressionGenesetBaseWidget'
-        ], function($) {
-    $.KBWidget({
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'd3',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap',
+		'kbaseExpressionGenesetBaseWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		d3,
+		jquery_dataTables,
+		bootstrap,
+		kbaseExpressionGenesetBaseWidget
+	) {
+    return KBWidget({
         name: 'kbaseExpressionHeatmap',
-        parent: 'kbaseExpressionGenesetBaseWidget',
+        parent : kbaseExpressionGenesetBaseWidget,
         version: '1.0.0',
 
         colorGenerator: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -4,18 +4,33 @@
  * @public
  */
 
-define(['jquery', 
-		'kbwidget', 
-		'kbaseAuthenticatedWidget', 
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
 		'kbaseTabs',
 		'jquery-dataTables',
 		'jquery-dataTables-bootstrap',
-		'kbaseFeatureValues-client-api'
-//        ,'jquery-dataScroller'
-		], function($) {
-	$.KBWidget({
+		'kbaseFeatureValues-client-api
+//',
+		'jquery-dataScroller'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap,
+		kbaseFeatureValues_client_api
+_,
+		jquery_dataScroller
+	) {
+	return KBWidget({
 		name: 'kbaseExpressionMatrix',
-		parent: 'kbaseAuthenticatedWidget',
+		parent : kbaseAuthenticatedWidget,
 		version: '1.0.2',
 		options: {
 			expressionMatrixID: null,
@@ -104,7 +119,7 @@ define(['jquery',
 			var tabPane = $('<div id="'+pref+'tab-content">');
 			container.append(tabPane);
 
-			tabPane.kbaseTabs({canDelete : true, tabs : []});                    
+			 new kbaseTabs(tabPane, {canDelete : true, tabs : []});                    
 			///////////////////////////////////// Overview table ////////////////////////////////////////////           
 			var tabOverview = $("<div/>");
 			tabPane.kbaseTabs('addTab', {tab: 'Overview', content: tabOverview, canDelete : false, show: true});

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -13,8 +13,7 @@ define (
 		'kbaseTabs',
 		'jquery-dataTables',
 		'jquery-dataTables-bootstrap',
-		'kbaseFeatureValues-client-api
-//',
+		'kbaseFeatureValues-client-api',
 		'jquery-dataScroller'
 	], function(
 		KBWidget,
@@ -23,9 +22,8 @@ define (
 		kbaseAuthenticatedWidget,
 		kbaseTabs,
 		jquery_dataTables,
-		bootstrap,
-		kbaseFeatureValues_client_api
-_,
+		jquery_dataTables_bootstrap,
+		kbaseFeatureValues_client_api,
 		jquery_dataScroller
 	) {
 	return KBWidget({

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
@@ -5,14 +5,23 @@
  * @public
  */
 
- define([
-        'jquery', 
-        'kbaseExpressionGenesetBaseWidget',      
-        'kbaseHeatmap'
-        ], function($) {
-    $.KBWidget({
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseExpressionGenesetBaseWidget',
+		'kbaseHeatmap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseExpressionGenesetBaseWidget,
+		kbaseHeatmap
+	) {
+    return KBWidget({
         name: 'kbaseExpressionPairwiseCorrelation',
-        parent: 'kbaseExpressionGenesetBaseWidget',
+        parent : kbaseExpressionGenesetBaseWidget,
         version: '1.0.0',
 
         maxRange: null,
@@ -92,8 +101,7 @@
             $containerDiv.append("<div style = 'width : 5px; height : 5px'></div>");
 
             // TODO: heatmap values out of range still scale color instead of just the max/min color
-            var hm = $heatmapDiv.kbaseHeatmap(
-                {
+            var hm =  new kbaseHeatmap($heatmapDiv, {
                     dataset : heatmap,
                     colors : ['#FFA500', '#FFFFFF', '#0066AA'],
                     minValue : self.minRange,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionSparkline.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionSparkline.js
@@ -5,14 +5,23 @@
  * @public
  */
 
- define([
-        'jquery', 
-        'kbaseExpressionGenesetBaseWidget',      
-        'kbaseLinechart'
-        ], function($) {
-    $.KBWidget({
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseExpressionGenesetBaseWidget',
+		'kbaseLinechart'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseExpressionGenesetBaseWidget,
+		kbaseLinechart
+	) {
+    return KBWidget({
         name: 'kbaseExpressionSparkline',
-        parent: 'kbaseExpressionGenesetBaseWidget',
+        parent : kbaseExpressionGenesetBaseWidget,
         version: '1.0.0',
 
         // To be overriden to specify additional parameters
@@ -65,8 +74,7 @@
             $containerDiv.append($lineChartDiv);
             $containerDiv.append("<div style = 'width : 5px; height : 5px'></div>");
 
-            $lineChartDiv.kbaseLinechart(
-                {
+             new kbaseLinechart($lineChartDiv, {
                     scaleAxes       : true,
                     hGrid           : true,
                     xLabel          : 'Conditions',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseFbaModelComparison.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseFbaModelComparison.js
@@ -1,11 +1,22 @@
-define(['jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'], function($) {
-$.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		jquery_dataTables,
+		bootstrap
+	) {
+return KBWidget({
     name: "FbaModelComparisonWidget",     
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
 	token: null,
 	ws_name: null,
@@ -371,7 +382,7 @@ $.KBWidget({
 			container.empty();
 			var tabPane = $('<div id="'+self.pref+'tab-content">');
 			container.append(tabPane);
-			tabPane.kbaseTabs({canDelete : true, tabs : []});
+			 new kbaseTabs(tabPane, {canDelete : true, tabs : []});
             //////////////////////////////////////////// Statistics tab /////////////////////////////////////////////
         	var tabStats = $("<div/>");
 			tabPane.kbaseTabs('addTab', {tab: 'Statistics', content: tabStats, canDelete : false, show: true});

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseFbaModelComparisonNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseFbaModelComparisonNew.js
@@ -1,18 +1,28 @@
-define(['jquery',
-        'narrativeConfig',
-        'bluebird',
-        'util/string',
-        'kbwidget', 
-        'kbaseAuthenticatedWidget',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'],
-function($, 
-         Config,
-         Promise,
-         StringUtil) {
-$.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'bluebird',
+		'util/string',
+		'kbaseAuthenticatedWidget',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		Promise,
+		StringUtil,
+		kbaseAuthenticatedWidget,
+		jquery_dataTables,
+		bootstrap
+	) {
+return KBWidget({
     name: "kbaseFbaModelComparisonNew",     
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
     ws_name: null,
     mc_id: null,
@@ -57,7 +67,7 @@ $.KBWidget({
             container.empty();
             var tabPane = $('<div id="'+pref+'tab-content">');
             container.append(tabPane);
-            tabPane.kbaseTabs({canDelete : true, tabs : []});
+             new kbaseTabs(tabPane, {canDelete : true, tabs : []});
             //////////////////////////////////////////// Statistics tab /////////////////////////////////////////////
             var tabStats = $("<div/>");
             tabPane.kbaseTabs('addTab', {tab: 'Statistics', content: tabStats, canDelete : false, show: true});

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseFbaTabsNarrative.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseFbaTabsNarrative.js
@@ -1,9 +1,9 @@
 (function( $, undefined ) {
 
-$.KBWidget({
+return KBWidget({
     name: "kbaseFbaTabsNarrative",
     version: "1.0.0",
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     options: {
     },
     loadingImage: window.kbconfig.loading_gif,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseFeatureSet.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseFeatureSet.js
@@ -5,19 +5,31 @@
  */
 'use strict';
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseAuthenticatedWidget', 
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap',
-        'knhx', 
-        'widgetMaxWidthCorrection'], 
-function($, 
-         Config) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap',
+		'knhx',
+		'widgetMaxWidthCorrection'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseAuthenticatedWidget,
+		jquery_dataTables,
+		bootstrap,
+		knhx,
+		widgetMaxWidthCorrection
+	) {
+    return KBWidget({
         name: 'kbaseFeatureSet',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '0.0.1',
         options: {
             featureset_name: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGapfillStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGapfillStatus.js
@@ -1,6 +1,6 @@
 
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         /* 
          * (required) Your widget should be named in CamelCase.
          */
@@ -15,7 +15,7 @@
          * this.user_id() = the logged in user id
          * this.authToken() = the current authentication token
          */
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
 
         /*
          * (optional) Widgets should be semantically versioned.
@@ -89,7 +89,7 @@
                                                     var errorRegex = /_ERROR_[^]+_ERROR_/gm
                                                     var errormssg = mssg.match(errorRegex);
                                                     errormssg = errormssg.join("\n\n").replace(/_ERROR_/gm,'')
-                                                    self.$elem.kbaseNarrativeError({'error': {
+                                                     new kbaseNarrativeError(self.$elem, {'error': {
                                                                                         'msg' :  errormssg +"\n\n"+mssg,
                                                                                         'method_name' : 'Gapfill an FBA Model',
                                                                                         'type' : 'Error',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
@@ -143,6 +143,7 @@ define (
             var ready = function(gnm, ctg) {
             		container.empty();
             		var tabPane = $('<div id="'+pref+'tab-content">');
+                    var tabObj = new kbaseTabs(tabPane);
             		container.append(tabPane);
             		 new kbaseTabs(tabPane, {canDelete : true, tabs : []});
 
@@ -154,7 +155,7 @@ define (
 
             		for (var i=0; i<tabIds.length; i++) {
             			var tabDiv = $('<div id="'+pref+tabIds[i]+'"> ');
-            			tabPane.kbaseTabs('addTab', {tab: tabNames[i], content: tabDiv, canDelete : false, show: (i == 0)});
+            			tabObj.addTab({tab: tabNames[i], content: tabDiv, canDelete : false, show: (i == 0)});
             		}
 
                     var contigCount = 0;

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotation.js
@@ -4,24 +4,35 @@
  * @public
  */
 
-define(['jquery',
-        'bluebird',
-        'narrativeConfig',
-        'ContigBrowserPanel',
-        'util/String',
-        'kbwidget',
-        'kbaseAuthenticatedWidget',
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'],
-function($,
-         Promise,
-         Config,
-         ContigBrowserPanel,
-         StringUtil) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'bluebird',
+		'narrativeConfig',
+		'ContigBrowserPanel',
+		'util/String',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Promise,
+		Config,
+		ContigBrowserPanel,
+		StringUtil,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: "kbaseGenomeView",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         ws_id: null,
         ws_name: null,
@@ -133,7 +144,7 @@ function($,
             		container.empty();
             		var tabPane = $('<div id="'+pref+'tab-content">');
             		container.append(tabPane);
-            		tabPane.kbaseTabs({canDelete : true, tabs : []});
+            		 new kbaseTabs(tabPane, {canDelete : true, tabs : []});
 
                     var genomeType = self.genomeType(gnm);
 

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeComparison.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeComparison.js
@@ -4,17 +4,25 @@
  * @public
  */
 
-define(['jquery', 
-        'narrativeConfig',
-        'util/string',
-        'kbwidget',
-        'kbaseAuthenticatedWidget'], 
-function($,
-         Config,
-         StringUtil) {
-$.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'util/string',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		StringUtil,
+		kbaseAuthenticatedWidget
+	) {
+return KBWidget({
     name: "GenomeComparisonWidget",
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
 	ws_name: null,
 	ws_id: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeComparisonViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeComparisonViewer.js
@@ -1,12 +1,24 @@
-define(['jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'], function( $ ) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: "kbaseGenomeComparisonViewer",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         id: null,
         ws: null,
@@ -52,7 +64,7 @@ define(['jquery',
             	container.empty();
             	var tabPane = $('<div id="'+self.pref+'tab-content">');
         		container.append(tabPane);
-        		tabPane.kbaseTabs({canDelete : true, tabs : []});
+        		 new kbaseTabs(tabPane, {canDelete : true, tabs : []});
     			///////////////////////////////////// Overview table ////////////////////////////////////////////    		
         		var tabOverview = $("<div/>");
     			tabPane.kbaseTabs('addTab', {tab: 'Overview', content: tabOverview, canDelete : false, show: true});

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeSetBuilder.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeSetBuilder.js
@@ -4,11 +4,23 @@
  * @public
  */
 
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 'kbasePrompt'], 
-    function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbasePrompt'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbasePrompt
+	) {
+    return KBWidget({
         name: "kbaseGenomeSetBuilder",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
         	loadExisting: null,
@@ -309,7 +321,7 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 'kbasePrompt'],
         },
         
         showInfo: function(message) {
-        	$('<div/>').kbasePrompt({title : 'Information', body : message}).openPrompt();
+        	 new kbasePrompt($('<div/>'), {title : 'Information', body : message}).openPrompt();
         }
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeUploadNarrative.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeUploadNarrative.js
@@ -1,8 +1,8 @@
 (function( $, undefined ) {
 
-$.KBWidget({
+return KBWidget({
     name: "GenomeUploadWidget",     
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
 	token: null,
 	ws_name: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeView.js
@@ -8,9 +8,9 @@
  */
 (function( $, undefined ) {
 
-	$.KBWidget({
+	return KBWidget({
         name: "GenomeView", 
-        parent: "kbaseWidget",
+        
 		version: "1.0.0",
         options: {
             data: null

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeView.js
@@ -6,7 +6,8 @@
  * wjriehl@lbl.gov 
  * October 25, 2013
  */
-(function( $, undefined ) {
+define(['kbwidget', 'jquery', 'bootstrap'],
+function(KBWidget, $, bootstrap) {
 
 	return KBWidget({
         name: "GenomeView", 
@@ -50,4 +51,4 @@
 
 	});
 
-})( jQuery );
+})

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthCurves.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthCurves.js
@@ -1,16 +1,27 @@
 
-define([
-        'jquery', 
-        'plotly',
-        'kbwidget', 
-        'kbaseGrowthMatrixAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($,Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseGrowthMatrixAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseGrowthMatrixAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseGrowthCurves',
-        parent: 'kbaseGrowthMatrixAbstract',
+        parent : kbaseGrowthMatrixAbstract,
         version: '1.0.0',
         options: {
             

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthMatrix.js
@@ -1,15 +1,26 @@
- define([
-        'jquery', 
-        'plotly',
-        'kbwidget', 
-        'kbaseGrowthMatrixAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($,Plotly) {
-    $.KBWidget({
+ define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseGrowthMatrixAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseGrowthMatrixAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseGrowthMatrix',
-        parent: 'kbaseGrowthMatrixAbstract',
+        parent : kbaseGrowthMatrixAbstract,
         version: '1.0.0',
          
         render: function(){
@@ -31,7 +42,7 @@
             var $tabPane = $('<div>')
                 .attr( 'id', pref+'tab-content')
                 .appendTo($container);
-            $tabPane.kbaseTabs({canDelete : true, tabs : []});   
+             new kbaseTabs($tabPane, {canDelete : true, tabs : []});   
 
             // Build  matrix overview tab
             var $tabOverview = $("<div/>");

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthMatrixAbstract.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthMatrixAbstract.js
@@ -1,14 +1,24 @@
-define([
-        'jquery', 
-        'kbwidget', 
-        'kbaseMatrix2DAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseMatrix2DAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseMatrix2DAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseGrowthMatrixAbstract',
-        parent: 'kbaseMatrix2DAbstract',
+        parent : kbaseMatrix2DAbstract,
         version: '1.0.0',
         
         TYPE_SAMPLES : 'Samples',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParameters.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParameters.js
@@ -1,16 +1,27 @@
-define([
-        'jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseGrowthParametersAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbaseGrowthParametersAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseGrowthParametersAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseGrowthParameters',
-        parent: 'kbaseAuthenticatedWidget',
-        parent: 'kbaseGrowthParametersAbstract',
+        parent : kbaseAuthenticatedWidget,
+        parent : kbaseGrowthParametersAbstract,
         version: '1.0.0',
          
 
@@ -28,7 +39,7 @@ define([
             var $tabPane = $('<div>')
                 .attr( 'id', pref+'tab-content')
                 .appendTo($container);
-            $tabPane.kbaseTabs({canDelete : true, tabs : []});   
+             new kbaseTabs($tabPane, {canDelete : true, tabs : []});   
 
             // Build matrix overview tab
             var $tabOverview = $("<div/>");

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParametersAbstract.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParametersAbstract.js
@@ -1,14 +1,24 @@
-define([
-        'jquery', 
-        'kbwidget', 
-        'kbaseGrowthMatrixAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseGrowthMatrixAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseGrowthMatrixAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseGrowthParametersAbstract',
-        parent: 'kbaseGrowthMatrixAbstract',
+        parent : kbaseGrowthMatrixAbstract,
         version: '1.0.0',
         options: {
             growthParametersID: null,   

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParams2DPlot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParams2DPlot.js
@@ -1,18 +1,29 @@
  
 
 
-define([
-        'jquery', 
-        'plotly',
-        'kbwidget', 
-        'kbaseGrowthMatrixAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($,Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseGrowthMatrixAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseGrowthMatrixAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseGrowthParams2DPlot',
-        parent: 'kbaseGrowthMatrixAbstract',
+        parent : kbaseGrowthMatrixAbstract,
         version: '1.0.0',
 
         setTestParameters: function(){

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParamsPlot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGrowthParamsPlot.js
@@ -1,15 +1,26 @@
-define([
-        'jquery', 
-        'plotly',
-        'kbwidget', 
-        'kbaseGrowthParametersAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($,Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseGrowthParametersAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseGrowthParametersAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseGrowthParamsPlot',
-        parent: 'kbaseGrowthParametersAbstract',
+        parent : kbaseGrowthParametersAbstract,
         version: '1.0.0',        
         options: {
             growthParam: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseImageView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseImageView.js
@@ -2,7 +2,7 @@
  * KBase widget to display an image.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'ImageViewWidget',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseIntegrateGapfillOutput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseIntegrateGapfillOutput.js
@@ -1,6 +1,6 @@
 
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         
         name: 'kbaseIntegrateGapfillOutput',
 
@@ -13,7 +13,7 @@
          * this.user_id() = the logged in user id
          * this.authToken() = the current authentication token
          */
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: 
             {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseKeggMap.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseKeggMap.js
@@ -7,7 +7,7 @@
  
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'KeggMapWidget',
         version: '1.0.0',
         imagepath: 'static/kbase/images/keggmap.png',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMSA.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMSA.js
@@ -4,10 +4,21 @@
  * @public
  */
 
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget
+	) {
+    return KBWidget({
         name: 'kbaseMSA',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '0.0.1',
         options: {
             msaID: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMatrix2DAbstract.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMatrix2DAbstract.js
@@ -1,21 +1,31 @@
 
 
-define([
-        'jquery',
-        'narrativeConfig',    
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], 
-    function( $, Config ) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
     
     var workspaceURL = Config.url('workspace');
     var loadingImage = Config.get('loading_gif');
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseMatrix2DAbstract',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: {
             workspaceID: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMediaEditorNarrative.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMediaEditorNarrative.js
@@ -1,6 +1,6 @@
 (function( $, undefined ) {
 
-$.KBWidget({
+return KBWidget({
     name: "kbaseMediaEditorNarrative",
     version: "1.0.0",
     options: {
@@ -20,7 +20,7 @@ $.KBWidget({
         var fba = new fbaModelServices(window.kbconfig.urls.fba);
         var kbws = new workspaceService(window.kbconfig.urls.workspace);
 
-//      var panel = self.$elem.kbasePanel({title: 'Media Info', subText: media})
+//      var panel =  new kbasePanel(self.$elem, {title: 'Media Info', subText: media})
 
         var container = $("<div>"); //panel.body();
         self.$elem.append(container);
@@ -320,7 +320,7 @@ $.KBWidget({
 
                 };
                 container.append('<div id="save-to-ws"></div>')
-                var test = $('#save-to-ws').kbaseSimpleWSSelect({defaultWS:ws, auth: token});
+                var test =  new kbaseSimpleWSSelect($('#save-to-ws'), {defaultWS:ws, auth: token});
                 test.show();
 
 

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMediaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMediaViewer.js
@@ -6,9 +6,9 @@
  */
 
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseMediaViewer", 
-        parent: "kbaseWidget",
+        
         version: "1.0.0",
         options: {
             loadingImage: window.kbconfig.loading_gif,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMetagenomeListUploader.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMetagenomeListUploader.js
@@ -1,7 +1,7 @@
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "MetagenomeListUploadWidget",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         ws: null,
         id: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMetagenomeView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMetagenomeView.js
@@ -1,11 +1,29 @@
 /**
  * KBase widget to display a Metagenome
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 'kbaseTabs', 'RGBColor',
-        'kbStandaloneTable', 'kbStandaloneGraph'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'RGBColor',
+		'kbStandaloneTable',
+		'kbStandaloneGraph'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		RGBColor,
+		kbStandaloneTable,
+		kbStandaloneGraph
+	) {
+    return KBWidget({
         name: 'MetagenomeView',
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         token: null,
         options: {
@@ -91,7 +109,7 @@ define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget', 'kbaseTabs', 'RGBColor
                     // set tabs
                     var tabPane = $('<div id="'+pref+'tab-content">');
         		    container.append(tabPane);
-        		    tabPane.kbaseTabs({canDelete : false, tabs : []});
+        		     new kbaseTabs(tabPane, {canDelete : false, tabs : []});
                 
                     // overview tab
                     var oTabDiv = $('<div id="'+pref+'overview">');

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseModelCoreNarrative.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseModelCoreNarrative.js
@@ -1,6 +1,6 @@
 (function( $, undefined ) {
 
-$.KBWidget({
+return KBWidget({
     name: "kbaseModelCore",
     version: "1.0.0",
     options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseModelMetaNarrative.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseModelMetaNarrative.js
@@ -1,8 +1,8 @@
 (function( $, undefined ) {
 
-$.KBWidget({
+return KBWidget({
     name: "kbaseModelMetaNarrative",     
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     version: "1.0.0",
     options: {
     	data: null,			// if it's not null it's the main data to show

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseModelTabsNarrative.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseModelTabsNarrative.js
@@ -1,9 +1,9 @@
 (function( $, undefined ) {
 
-$.KBWidget({
+return KBWidget({
     name: "kbaseModelTabs",    
     version: "1.0.0",  
-    parent: "kbaseAuthenticatedWidget",
+    parent : kbaseAuthenticatedWidget,
     options: {
     },
     

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseNarrativeError.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseNarrativeError.js
@@ -8,8 +8,19 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define(['jquery', 'kbwidget', 'kbaseAccordion'], function( $ ) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAccordion'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAccordion
+	) {
+    return KBWidget({
         /* 
          * (required) Your widget should be named in CamelCase.
          */
@@ -24,7 +35,7 @@ define(['jquery', 'kbwidget', 'kbaseAccordion'], function( $ ) {
          * this.user_id() = the logged in user id
          * this.authToken() = the current authentication token
          */
-        parent: 'kbaseWidget',
+        
 
         /*
          * (optional) Widgets should be semantically versioned.
@@ -124,8 +135,7 @@ define(['jquery', 'kbwidget', 'kbaseAccordion'], function( $ ) {
                       .append($errorTable)
                       .append($stackTraceAccordion);
 
-            $stackTraceAccordion.kbaseAccordion(
-                { 
+             new kbaseAccordion($stackTraceAccordion, { 
                     elements: [
                         {
                             title: 'Detailed Error Message',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
@@ -4,21 +4,33 @@
  * @public
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'util/string',
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs', 
-        'kbasePrompt',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'], 
-function($,
-         Config,
-         StringUtil) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'util/string',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'kbasePrompt',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		StringUtil,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		kbasePrompt,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: "kbasePanGenome",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
         	ws: null,
@@ -86,7 +98,7 @@ function($,
         		container.empty();
         		var tabPane = $('<div id="'+self.pref+'tab-content">');
         		container.append(tabPane);
-        		tabPane.kbaseTabs({canDelete : true, tabs : []});
+        		 new kbaseTabs(tabPane, {canDelete : true, tabs : []});
 
         		var showOverview = true;
         		if (self.options.withExport)
@@ -465,7 +477,7 @@ function($,
         },
         
         showInfo: function(message) {
-        	$('<div/>').kbasePrompt({title : 'Information', body : message}).openPrompt();
+        	 new kbasePrompt($('<div/>'), {title : 'Information', body : message}).openPrompt();
         }
     });
 

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePhenotypeSimulation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePhenotypeSimulation.js
@@ -1,7 +1,7 @@
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "PhenotypeSimulation",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         simulation_id: null,
         ws_name: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePhenotypeUploader.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePhenotypeUploader.js
@@ -1,7 +1,7 @@
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "PhenotypeUploader",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         phenotype_id: null,
         genome_id: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePromConstraint.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePromConstraint.js
@@ -43,7 +43,7 @@
                 // setup tabs
                 var pcTable = $('<table class="table table-bordered table-striped" style="width: 100%;">');
 
-                var tabs = container.kbTabs({tabs: [
+                var tabs = container.kbaseTabTableTabs({tabs: [
                                             {name: 'Overview', active: true},
                                             {name: 'PROM Constraint', content: pcTable}]
                                           })

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePromConstraint.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePromConstraint.js
@@ -3,9 +3,9 @@
  * 
  */
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "kbasePromConstraint",
-        parent: "kbaseWidget",
+        
         version: "1.0.0",
         options: {
             color: "black",

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseRankAbundancePlot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseRankAbundancePlot.js
@@ -1,8 +1,21 @@
 /**
  * KBase widget to display table of BIOM data
  */
-define(['jquery', 'kbwidget', 'RGBColor', 'kbStandaloneGraph'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'RGBColor',
+		'kbStandaloneGraph'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		RGBColor,
+		kbStandaloneGraph
+	) {
+    return KBWidget({
             name: 'RankAbundancePlot',
             version: '1.0.0',
             options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseRegisterRepoState.js
@@ -5,14 +5,23 @@
  * @public
  */
 
-define(['jquery', 
-		'kbwidget', 
-		'kbaseAuthenticatedWidget', 
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
 		'catalog-client-api'
-		], function($) {
-	$.KBWidget({
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		catalog_client_api
+	) {
+	return KBWidget({
 		name: 'kbaseRegisterRepoState',
-		parent: 'kbaseAuthenticatedWidget',
+		parent : kbaseAuthenticatedWidget,
 		version: '1.0.0',
 		options: {
 		    git_url: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -3,16 +3,27 @@
  * @public
  */
 
-define(['jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap',        
-        'kbase-client-api'
-        ], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap',
+		'kbase-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		jquery_dataTables,
+		bootstrap,
+		kbase_client_api
+	) {
+    return KBWidget({
         name: 'kbaseReportView',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: {
             workspace_name: null,
@@ -131,7 +142,7 @@ define(['jquery',
                                     var obj = _.findWhere(self.objectList, {key: key});
                                     var info = self.createInfoObject(obj.info);
                                     // Insert the narrative data cell into the div we just rendered
-                                    //$('#' + cell_id).kbaseNarrativeDataCell({cell: cell, info: info});
+                                     new kbaseNarrativeDataCell(//$('#' + cell_id), {cell: cell, info: info});
                                     self.trigger('createViewerCell.Narrative', {
                                         'nearCellIdx': near_idx,
                                         'widget': 'kbaseNarrativeDataCell',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSEEDFunctions.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSEEDFunctions.js
@@ -7,16 +7,24 @@
  * will adapt this to work with the KBase SEED annotations
  */
 
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'd3'],
-function($,
-         Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'd3'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		d3
+	) {
 
-    $.KBWidget({
+    return KBWidget({
         name: "KBaseSEEDFunctions",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
 
         wsUrl: Config.url('workspace'),

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSampleProperty2DPlot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSampleProperty2DPlot.js
@@ -1,14 +1,26 @@
-define(['jquery', 
-        'plotly',        
-        'kbwidget', 
-        'kbaseSamplePropertyMatrix', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'    
-        ], function($, Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseSamplePropertyMatrix',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseSamplePropertyMatrix,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseSampleProperty2DPlot',
-        parent: 'kbaseSamplePropertyMatrix',
+        parent : kbaseSamplePropertyMatrix,
         version: '1.0.0',
         options: {
             propertySeriesX: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSamplePropertyHistogram.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSamplePropertyHistogram.js
@@ -1,11 +1,20 @@
-define(['jquery', 
-        'plotly',        
-        'kbwidget', 
-        'kbaseSamplePropertyMatrixAbstract',
-        ], function($, Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseSamplePropertyMatrixAbstract'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseSamplePropertyMatrixAbstract
+	) {
+    return KBWidget({
         name: 'kbaseSamplePropertyHistogram',
-        parent: 'kbaseSamplePropertyMatrixAbstract',
+        parent : kbaseSamplePropertyMatrixAbstract,
         version: '1.0.0',
         options: {
             sampleIds: [],

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSamplePropertyMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSamplePropertyMatrix.js
@@ -1,15 +1,26 @@
-define([
-        'jquery', 
-        'plotly',
-        'kbwidget', 
-        'kbaseSamplePropertyMatrixAbstract', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap' 
-        ], function($,Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseSamplePropertyMatrixAbstract',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseSamplePropertyMatrixAbstract,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseSamplePropertyMatrix',        
-        parent: 'kbaseSamplePropertyMatrixAbstract',
+        parent : kbaseSamplePropertyMatrixAbstract,
         version: '1.0.0',
          
         render: function(){
@@ -36,7 +47,7 @@ define([
             var $tabPane = $('<div>')
                 .attr( 'id', pref+'tab-content')
                 .appendTo($container);
-            $tabPane.kbaseTabs({canDelete : true, tabs : []});   
+             new kbaseTabs($tabPane, {canDelete : true, tabs : []});   
 
             // Build matrix overview tab
             var $tabOverview = $("<div/>");

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSamplePropertyMatrixAbstract.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSamplePropertyMatrixAbstract.js
@@ -1,15 +1,28 @@
-define(['jquery', 
-        'plotly',        
-        'kbwidget', 
-        'kbaseMatrix2DAbstract',
-        'kbaseAuthenticatedWidget', 
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'
-        ], function($, Plotly) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'plotly',
+		'kbaseMatrix2DAbstract',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Plotly,
+		kbaseMatrix2DAbstract,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: 'kbaseSamplePropertyMatrixAbstract',
-        parent: 'kbaseMatrix2DAbstract',
+        parent : kbaseMatrix2DAbstract,
         version: '1.0.0',
 
         

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSeqCompView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSeqCompView.js
@@ -3,18 +3,33 @@
  * @public
  */
 
-define(['jquery',
-        'util/string',
-        'narrativeConfig',
-        'd3',
-        'kbwidget',
-        'kbaseAuthenticatedWidget',
-        'kbaseTabs',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap'], function($, StringUtil, Config) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'util/string',
+		'narrativeConfig',
+		'd3',
+		'kbaseAuthenticatedWidget',
+		'kbaseTabs',
+		'jquery-dataTables',
+		'jquery-dataTables-bootstrap'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		StringUtil,
+		Config,
+		d3,
+		kbaseAuthenticatedWidget,
+		kbaseTabs,
+		jquery_dataTables,
+		bootstrap
+	) {
+    return KBWidget({
         name: "kbaseSeqCompView",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         ws_id: null,
         ws_name: null,
@@ -72,7 +87,7 @@ define(['jquery',
             	    console.log(data);
             	    var tabPane = $('<div id="'+pref+'tab-content">');
             	    container.append(tabPane);
-            	    tabPane.kbaseTabs({canDelete : true, tabs : []});
+            	     new kbaseTabs(tabPane, {canDelete : true, tabs : []});
             	    var tabNames = ['Legend', 'DNAdiff Comparisons'];
             	    var tabIds = ['legend', 'comparisons'];
             	    for (var i=0; i<tabIds.length; i++) {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseShockFileUploader.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseShockFileUploader.js
@@ -2,9 +2,9 @@
  * KBase widget to upload file content into shock node.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseShockFileUploader',
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: {
             'url': 'https://kbase.us/services/shock-api/',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSimulationSet.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSimulationSet.js
@@ -44,7 +44,7 @@
             function buildTable(data) {
                 var simu = data[0].data
                 var simuTable = $('<table class="table table-bordered table-striped" style="width: 100%;">');
-                var tabs = container.kbTabs({tabs: [
+                var tabs = container.kbaseTabTableTabs({tabs: [
                     {name: 'Overview', active: true},
                     {name: 'Simulation Results', content: simuTable}]
                 })

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseSimulationSet.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseSimulationSet.js
@@ -1,7 +1,7 @@
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseSimulationSet",
-        parent: "kbaseWidget",
+        
         version: "1.0.0",
         options: {
             color: "black",

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseTree.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseTree.js
@@ -4,19 +4,29 @@
  * @public
  */
 
-define(['jquery', 
-        'narrativeConfig',
-        'util/string',
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'knhx', 
-        'widgetMaxWidthCorrection'], 
-function($,
-         Config,
-         StringUtil) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'util/string',
+		'kbaseAuthenticatedWidget',
+		'knhx',
+		'widgetMaxWidthCorrection'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		StringUtil,
+		kbaseAuthenticatedWidget,
+		knhx,
+		widgetMaxWidthCorrection
+	) {
+    return KBWidget({
         name: 'kbaseTree',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '0.0.1',
         options: {
             treeID: null,

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseUploadFile.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseUploadFile.js
@@ -2,7 +2,7 @@
  * KBase widget to upload content.
  */
 (function($, undefined) {
-    $.KBWidget({
+    return KBWidget({
         name: 'UploadFileWidget',
         version: '1.0.0',
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseValueList.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseValueList.js
@@ -13,7 +13,7 @@
  }
 */
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "ValueListWidget",
         version: "0.1.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseViewLiveRunLog.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseViewLiveRunLog.js
@@ -2,14 +2,23 @@
  * @public
  */
 
-define(['jquery', 
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'njs-wrapper-client-api'
-        ], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget',
+		'njs-wrapper-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget,
+		njs_wrapper_client_api
+	) {
+    return KBWidget({
         name: 'kbaseViewLiveRunLog',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: {
             job_id: null,

--- a/kbase-extension/static/kbase/js/widgets/genomes/kbaseContigBrowserButtons.js
+++ b/kbase-extension/static/kbase/js/widgets/genomes/kbaseContigBrowserButtons.js
@@ -1,10 +1,19 @@
 /**
  * Requires bootstrap 3 for buttons
  */
-define(['jquery', 'kbwidget'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
+    return KBWidget({
         name: "KBaseContigBrowserButtons",
-        parent: "kbaseWidget", 
+         
         version: "1.0.0",
         options: {
             direction: "horizontal", // also "vertical" eventually.

--- a/kbase-extension/static/kbase/js/widgets/genomes/kbasePhenotypeSet.js
+++ b/kbase-extension/static/kbase/js/widgets/genomes/kbasePhenotypeSet.js
@@ -30,7 +30,7 @@
                     // setup tabs
                     var phenoTable = $('<table class="table table-bordered table-striped" style="width: 100%;">');
 
-                    var tabs = container.kbTabs({tabs: [
+                    var tabs = container.kbaseTabTableTabs({tabs: [
                                                 {name: 'Overview', active: true},
                                                 {name: 'Phenotypes', content: phenoTable}]
                                               })

--- a/kbase-extension/static/kbase/js/widgets/genomes/kbasePhenotypeSet.js
+++ b/kbase-extension/static/kbase/js/widgets/genomes/kbasePhenotypeSet.js
@@ -3,9 +3,9 @@
  * 
  */
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: "kbasePhenotypeSet",
-        parent: "kbaseWidget",
+        
         version: "1.0.0",
         options: {
             color: "black",
@@ -111,7 +111,7 @@
                 var prom = kb.fba.get_media({medias: [id], workspaces: [ws]})
                 $.when(prom).done(function(data) {
                     ele.rmLoading();
-                    $(ele).kbaseMediaEditor({ids: [id], 
+                     new kbaseMediaEditor($(ele), {ids: [id], 
                                              workspaces : [ws],
                                              data: data});
                 }).fail(function(e){

--- a/kbase-extension/static/kbase/js/widgets/kbaseAccordion.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseAccordion.js
@@ -28,7 +28,7 @@ Widget to create an accordion control. Easy to use!
 (function( $, undefined ) {
 
 
-    $.KBWidget({
+    return KBWidget({
         name : 'kbaseAccordion',
         version: "1.0.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/kbaseAuthenticatedWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseAuthenticatedWidget.js
@@ -5,7 +5,7 @@
 (function( $, undefined ) {
 
 
-    $.KBWidget({
+    return KBWidget({
 
 		  name: "kbaseAuthenticatedWidget",
 

--- a/kbase-extension/static/kbase/js/widgets/kbaseDeletePrompt.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseDeletePrompt.js
@@ -2,8 +2,7 @@
 
     Simplified prompt for delete confirmations.
 
-    var $deleteModal = $('<div></div>').kbaseDeletePrompt(
-        {
+    var $deleteModal =  new kbaseDeletePrompt($('<div></div>'), {
             name : tab,
             callback :
                 function(e, $prompt) {
@@ -29,10 +28,10 @@
 */
 
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
 
 		  name: "kbaseDeletePrompt",
-		parent: 'kbasePrompt',
+		parent : kbasePrompt,
 
         version: "1.0.0",
         options: {
@@ -43,8 +42,7 @@
 
             this._super(options);
 
-            return $('<div></div>').kbasePrompt(
-                    {
+             new kbasePrompt(return $('<div></div>'), {
                         title : 'Confirm deletion',
                         body : 'Really delete <strong>' + this.options.name + '</strong>?',
                         controls : [

--- a/kbase-extension/static/kbase/js/widgets/kbaseLoginFuncSite.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseLoginFuncSite.js
@@ -1,33 +1,33 @@
 /*
- 
+
  KBase Bootstrap plugin to handle all login/session related stuff.
- 
+
  Set up a container on your HTML page. It can be whatever you'd like. For example.
- 
+
  <div id = 'fizzlefazzle'></div>
- 
+
  You don't need to give it that ID. I just populated it with junk because I don't want to
  encourage people to use something generic like 'login', since there's no need. You don't need
  an ID at all, just some way to select it.
- 
+
  Later, in your jquery initialization, do this:
- 
+
  $(function() {
  ...
- 
+
  $(#"fizzlefaszzle").login();
- 
+
  }
- 
+
  And that, my friends, is Jenga. You're done. Sit back and enjoy the fruits of your labor.
- 
+
  There are a couple of useful things to know about. You can extract the user_id and kbase_sessionid:
- 
+
  $(#"fizzlefazzle").login('session', 'user_id');
  $(#"fizzlefazzle").login('session', 'kbase_sessionid');
- 
+
  When you're setting it up, you have a few options:
- 
+
  $('#fizzlefazzle').login(
  {
  style : (button|slim|micro|hidden) // try 'em all out! button is the default.
@@ -38,26 +38,35 @@
  user_id : a string with which to pre-populate the user_id on the forms.
  }
  );
- 
+
  You can also completely inline it.
- 
+
  var $login_doodad = $('<span></span>').login({style : 'hidden'});
  $login_doodad.login('login', 'username', 'password', function (args) {
  console.log("Tried to log in and got back: "); console.log(args);
  });
- 
+
  */
 
-define([
-    'jquery',
-    'narrativeConfig',
-    'kbase-client-api',
-    'jqueryCookie',
-    'kbwidget',
-    'kbasePrompt',
-    'bootstrap'
-], function ($, Config) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbase-client-api',
+		'jqueryCookie',
+		'kbasePrompt'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbase_client_api,
+		jqueryCookie,
+		kbasePrompt
+	) {
+    return KBWidget({
         name: "kbaseLogin",
         version: "1.0.0",
         options: {
@@ -80,12 +89,12 @@ define([
         /**
          * Decodes a Globus authentication token, transforming the token
          * plain string into a map of field names to values.
-         * 
+         *
          * @function decodeToken
          * @private
-         * 
+         *
          * @param {string} - A globus auth token
-         * 
+         *
          * @returns {GlobusAuthToken} an object representing the decoded
          * token.
          */
@@ -140,9 +149,9 @@ define([
             if (this.ui) {
                 this.$elem.append(this.ui);
             }
-            
-            // Now the drop down has been added, show the correct 
-            
+
+            // Now the drop down has been added, show the correct
+
 
             if (kbaseCookie.user_id) {
                 if (!this.is_token_valid(kbaseCookie.token)) {
@@ -358,8 +367,7 @@ define([
         _createLoginDialog: function () {
             var $elem = this.$elem;
 
-            var $ld = $('<div></div').kbasePrompt(
-                {
+            var $ld =  new kbasePrompt($('<div></div'), {
                     title: 'Login to KBase',
                     controls: [
                         'cancelButton',

--- a/kbase-extension/static/kbase/js/widgets/kbasePrompt.js
+++ b/kbase-extension/static/kbase/js/widgets/kbasePrompt.js
@@ -4,8 +4,7 @@
 
     var tab = 'Some Tab Value';
 
-    var $deleteModal = $('<div></div>').kbasePrompt(
-        {
+    var $deleteModal =  new kbasePrompt($('<div></div>'), {
             title : 'Confirm deletion',
             body : 'Really delete <strong>' + tab + '</strong>?',
             modalClass : 'fade', //Not required. jquery animation class to show/hide. Defaults to 'fade'
@@ -54,7 +53,7 @@
 
 (function( $, undefined ) {
 
-    $.KBWidget({
+    return KBWidget({
 
 		  name: "kbasePrompt",
 

--- a/kbase-extension/static/kbase/js/widgets/kbasePromptNew.js
+++ b/kbase-extension/static/kbase/js/widgets/kbasePromptNew.js
@@ -4,8 +4,7 @@
 
     var tab = 'Some Tab Value';
 
-    var $deleteModal = $('<div></div>').kbasePrompt(
-        {
+    var $deleteModal =  new kbasePrompt($('<div></div>'), {
             title : 'Confirm deletion',
             body : 'Really delete <strong>' + tab + '</strong>?',
             modalClass : 'fade', //Not required. jquery animation class to show/hide. Defaults to 'fade'
@@ -52,8 +51,17 @@
 
 */
 
-define(['jquery', 'kbwidget', 'bootstrap'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
+    return KBWidget({
 
         name: "kbasePrompt",
 

--- a/kbase-extension/static/kbase/js/widgets/kbaseTabs.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseTabs.js
@@ -44,6 +44,7 @@ define (
 		$,
 		kbaseDeletePrompt
 	) { 
+
     return KBWidget({
 
         name: "kbaseTabs",

--- a/kbase-extension/static/kbase/js/widgets/kbaseTabs.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseTabs.js
@@ -2,8 +2,7 @@
 
     Easy widget to serve as a tabbed container.
 
-    var $tabs = $('#tabs').kbaseTabs(
-        {
+    var $tabs =  new kbaseTabs($('#tabs'), {
             tabPosition : 'bottom', //or left or right or top. Defaults to 'top'
             canDelete : true,       //whether or not the tab can be removed. Defaults to false.
             tabs : [
@@ -33,8 +32,19 @@
 
 */
 
-define(['jquery', 'kbwidget', 'kbaseDeletePrompt'], function($) { 
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseDeletePrompt'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseDeletePrompt
+	) { 
+    return KBWidget({
 
         name: "kbaseTabs",
 
@@ -268,8 +278,7 @@ define(['jquery', 'kbwidget', 'kbaseDeletePrompt'], function($) {
         shouldShowTab : function (tab) { return 1; },
 
         deletePrompt : function(tabName) {
-            var $deleteModal = $('<div></div>').kbaseDeletePrompt(
-                {
+            var $deleteModal =  new kbaseDeletePrompt($('<div></div>'), {
                     name     : tabName,
                     callback : this.deleteTabCallback(tabName),
                 }

--- a/kbase-extension/static/kbase/js/widgets/kbaseUpload.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseUpload.js
@@ -11,7 +11,16 @@
  */
 
 // Jquery UI widget style
-define(['jquery', 'kbwidget'], function($) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
     var MissingOptionError = function(argname) {
         var e = new Error("missing option: '" + argname + "'");
         e.name = "MissingOptionError";
@@ -24,9 +33,9 @@ define(['jquery', 'kbwidget'], function($) {
         return e;
     }
 
-	$.KBWidget({
+	return KBWidget({
         name: "kbaseUploadWidget", 
-        parent: 'kbaseWidget',
+        
 		version: "0.0.1",
         isLoggedIn: false,
 		options: { },

--- a/kbase-extension/static/kbase/js/widgets/kbwidget.js
+++ b/kbase-extension/static/kbase/js/widgets/kbwidget.js
@@ -12,9 +12,9 @@
  * And here's an example:
  *
  *     @example
- *     var widget = $.KBWidget({
+ *     var widget = return KBWidget({
  *         name: "MyFancyWidget",
- *         parent: "MommyWidget",
+ *         parent : MommyWidget,
  *         init: function () {}
  *     });
  */
@@ -333,7 +333,7 @@
         return $(tag);
     }
 
-    $.KBWidget = function (def) {
+    return KBWidget = function (def) {
         def = (def || {});
         var name    = def.name;
         var parent  = def.parent;
@@ -581,7 +581,7 @@
         }
     }
 
-    $.KBWidget(
+    return KBWidget(
         {
             name : 'kbaseWidget',
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/app_card.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/app_card.js
@@ -1,7 +1,15 @@
-define([
-    'bluebird',
-    'jquery'
-], function (Promise, $) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'bluebird',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		Promise,
+		$
+	) {
     'use strict';
 
     // favorites callback should accept:

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/kbaseCatalogBrowser.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/kbaseCatalogBrowser.js
@@ -5,22 +5,33 @@
  browser: true,
  white: true
  */
-define([
-    'jquery',
-    'bluebird',
-    'narrativeConfig',
-    'narrative_core/catalog/app_card',
-    'util/display',
-    'catalog-client-api',
-    'kbase-client-api',
-    'kbwidget',
-    'kbaseAuthenticatedWidget', 
-    'bootstrap',
-],
-    function ($, Promise, Config, AppCard, DisplayUtil) {
-        $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'bluebird',
+		'narrativeConfig',
+		'narrative_core/catalog/app_card',
+		'util/display',
+		'catalog-client-api',
+		'kbase-client-api',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Promise,
+		Config,
+		AppCard,
+		DisplayUtil,
+		catalog_client_api,
+		kbase_client_api,
+		kbaseAuthenticatedWidget
+	) {
+        return KBWidget({
             name: "KBaseCatalogBrowser",
-            parent: "kbaseAuthenticatedWidget",  // todo: do we still need th
+            parent : kbaseAuthenticatedWidget,  // todo: do we still need th
             options: {
                 tag: null,
                 ignoreCategories: {}

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
@@ -2,18 +2,27 @@
  * KBase preset wrapper for its cell menu.
  */
 
-define([
-    'jquery',
-    'notebook/js/celltoolbar',
-    'kbaseNarrativeCellMenu'
-], function($, celltoolbar) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'notebook/js/celltoolbar',
+		'kbaseNarrativeCellMenu'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		celltoolbar,
+		kbaseNarrativeCellMenu
+	) {
     "use strict";
 
     var CellToolbar = celltoolbar.CellToolbar;
 
     var $kbMenu = $('<span>');
     var makeKBaseMenu = function(div, cell) {
-        $(div).kbaseNarrativeCellMenu({cell: cell});
+         new kbaseNarrativeCellMenu($(div), {cell: cell});
     };
 
     var register = function(notebook) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseModal.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseModal.js
@@ -11,7 +11,7 @@
  *
  *   Basic Modal:
  *
- *      var modal = $('<div>').kbaseModal({
+ *      var modal =  new kbaseModal($('<div>'), {
  *         title: 'Model Details',
  *         subText: 'some subtext under title'
  *      });
@@ -20,8 +20,17 @@
  *
 */
 
-define(['jquery', 'kbwidget'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
+    return KBWidget({
         name: "kbaseModal",
         version: "1.0.0",
         options: {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -971,6 +971,7 @@
 
                     var widgetName = this.inputStepLookup[stepId].outputWidgetName;
                     var $outputWidget = $('<div>').css({'padding':'5px 0'});
+console.log("MAKE A");
                      new kbaseNarrativeOutputCell($outputWidget, {
                         widget: widgetName,
                         data: output,
@@ -999,6 +1000,7 @@
         setStepError: function(stepId, error) {
             if (this.inputStepLookup) {
                 if(this.inputStepLookup[stepId]) {
+console.log("MAKE B");
                      new kbaseNarrativeOutputCell(this.inputStepLookup[stepId], {
                         widget: this.OUTPUT_ERROR_WIDGET,
                         data: error,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppCell.js
@@ -12,25 +12,25 @@
  */
 
 (function( $, undefined ) {
-  require(['jquery',
+  require(['kbwidget', 'bootstrap', 'jquery',
            'narrativeConfig',
            'util/string',
            'util/display',
            'util/bootstrapDialog',
-           'kbwidget',
            'kbaseAuthenticatedWidget',
            'kbaseAccordion',
            'kbaseNarrativeOutputCell'
            ], 
-  function($, 
+  function(KBWidget, bootstrap,$, 
            Config,
            StringUtil,
            DisplayUtil,
-           BootstrapDialog) {
+           BootstrapDialog,
+            kbaseAuthenticatedWidget, kbaseAccordion, kbaseNarrativeOutputCell) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeAppCell",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
             app: null,
@@ -168,7 +168,7 @@
 
                 $errorPanel.append($details)
                            .append($tracebackPanel);
-                $tracebackPanel.kbaseAccordion({ elements : tracebackAccordion });
+                 new kbaseAccordion($tracebackPanel, { elements : tracebackAccordion });
             }
             this.$elem.empty().append($errorPanel);
             this.$elem.closest('.cell').find('.button_container').kbaseNarrativeCellMenu('setSubtitle', 'Error! Unable to load app information!');
@@ -341,7 +341,7 @@
                 .trigger('set-icon.cell', [$logo.html()]);
             
             //require(['kbaseNarrativeCellMenu'], $.proxy(function() {
-            //    this.cellMenu = $menuSpan.kbaseNarrativeCellMenu();
+            //    this.cellMenu =  new kbaseNarrativeCellMenu($menuSpan);
             //}, this));
 
 
@@ -971,7 +971,7 @@
 
                     var widgetName = this.inputStepLookup[stepId].outputWidgetName;
                     var $outputWidget = $('<div>').css({'padding':'5px 0'});
-                    $outputWidget.kbaseNarrativeOutputCell({
+                     new kbaseNarrativeOutputCell($outputWidget, {
                         widget: widgetName,
                         data: output,
                         type: 'app',
@@ -999,7 +999,7 @@
         setStepError: function(stepId, error) {
             if (this.inputStepLookup) {
                 if(this.inputStepLookup[stepId]) {
-                    this.inputStepLookup[stepId].kbaseNarrativeOutputCell({
+                     new kbaseNarrativeOutputCell(this.inputStepLookup[stepId], {
                         widget: this.OUTPUT_ERROR_WIDGET,
                         data: error,
                         type: 'error',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCell.js
@@ -4,13 +4,22 @@
  * @public
  */
 
-define(['jquery', 'kbwidget'], function( $ ) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery'
+	], function(
+		KBWidget,
+		bootstrap,
+		$
+	) {
+    return KBWidget({
         /* 
          * (required) Your widget should be named in CamelCase.
          */
         name: 'kbaseNarrativeCell',
-        parent: 'kbaseWidget',
+        
         version: '0.0.1',
         options: {
         },

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -1,15 +1,23 @@
 /*global define*/
 /*jslint white: true*/
-define(['jquery', 
-        'narrativeConfig',
-        'util/timeFormat',
-        'kbwidget', 
-        'bootstrap'], 
-function($, Config, TimeFormat) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'util/timeFormat'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		TimeFormat
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeCellMenu',
-        parent: 'kbaseWidget',
+        
         options: {cell: null, kbWidget: null, kbWidgetType: null},
         genId: function () {
             if (!this.lastId) {
@@ -118,7 +126,7 @@ function($, Config, TimeFormat) {
                             // the method initializes an internal method input widget, but in an async way
                             // so we have to wait and check when that is done.  When it is, we can update state
                             var newCell = Jupyter.notebook.get_selected_cell();
-                            var newWidget = $('#' + $(newCell.get_text())[0].id).kbaseNarrativeMethodCell();
+                            var newWidget =  new kbaseNarrativeMethodCell($('#' + $(newCell.get_text())[0].id));
                             var updateState = function (state) {
                                 if (newWidget.$inputWidget) {
                                     // if the $inputWidget is not null, we are good to go, so set the state

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -7,7 +7,7 @@
  * This is a base class widget for any sidebar widgets that want its behavior.
  * Those sidebars should just include a title option. 
  * Usage: 
- * $('#my-element').kbaseNarrativeControlPanel({ 
+  new kbaseNarrativeControlPanel(* $('#my-element'), { 
  *     title : 'My Controls', 
  *     collapsible : true,
  *     buttons: [],
@@ -16,10 +16,21 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define(['jquery', 'kbwidget', 'kbaseAuthenticatedWidget'], function($) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		kbaseAuthenticatedWidget
+	) {
+    return KBWidget({
         name: 'kbaseNarrativeControlPanel', 
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '0.0.1',
         options: {
             title: 'Control',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
@@ -9,22 +9,33 @@
  */
 /*global define*/
 /*jslint white:true,browser:true*/
-define(['jquery',
-    'underscore',
-    'narrativeConfig',
-    'narrativeViewers',
-    'kbwidget',
-    'kbaseNarrativeCell'
-], function ($, _, Config, Viewers) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'underscore',
+		'narrativeConfig',
+		'narrativeViewers',
+		'kbaseNarrativeCell'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		_,
+		Config,
+		Viewers,
+		kbaseNarrativeCell
+	) {
     'use strict';
 
     /**
      * Initialize
      */
 
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeDataCell',
-        parent: 'kbaseNarrativeCell',
+        parent : kbaseNarrativeCell,
         version: '0.0.1',
         options: {
             info: null, // object info

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -4,29 +4,40 @@
 * @author Michael Sneddon <mwsneddon@lbl.gov>
 * @public
 */
-define(['jquery',
-        'underscore',
-        'bluebird',
-        'narrativeConfig',
-        'util/string',
-        'util/display',
-        'util/timeFormat',
-        'kbase-client-api',
-        'jquery-nearest',
-        'kbwidget',
-        'kbaseAuthenticatedWidget',
-        'kbaseNarrativeDownloadPanel'],
-function ($,
-          _,
-          Promise,
-          Config,
-          StringUtil,
-          DisplayUtil,
-          TimeFormat) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'underscore',
+		'bluebird',
+		'narrativeConfig',
+		'util/string',
+		'util/display',
+		'util/timeFormat',
+		'kbase-client-api',
+		'jquery-nearest',
+		'kbaseAuthenticatedWidget',
+		'kbaseNarrativeDownloadPanel'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		_,
+		Promise,
+		Config,
+		StringUtil,
+		DisplayUtil,
+		TimeFormat,
+		kbase_client_api,
+		jquery_nearest,
+		kbaseAuthenticatedWidget,
+		kbaseNarrativeDownloadPanel
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeDataList',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: {
             ws_name: null, // must be the WS name, not the WS Numeric ID
@@ -597,7 +608,7 @@ function ($,
                     var objId = object_info[1];
                     var downloadPanel = $('<div>');
                     $alertContainer.append(downloadPanel);
-                    downloadPanel.kbaseNarrativeDownloadPanel({token: self._attributes.auth.token, type: type, wsId: wsId, objId: objId});
+                     new kbaseNarrativeDownloadPanel(downloadPanel, {token: self._attributes.auth.token, type: type, wsId: wsId, objId: objId});
                 });
 
             var $rename = $('<span>')
@@ -1009,7 +1020,7 @@ function ($,
             var obj = _.findWhere(self.objectList, {key: key});
             var info = self.createInfoObject(obj.info);
             // Insert the narrative data cell into the div we just rendered
-            //$('#' + cell_id).kbaseNarrativeDataCell({cell: cell, info: info});
+            // new kbaseNarrativeDataCell($('#' + cell_id), {cell: cell, info: info});
             self.trigger('createViewerCell.Narrative', {
                 'nearCellIdx': near_idx,
                 'widget': 'kbaseNarrativeDataCell',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -356,8 +356,6 @@ define (
             var maxObjFetch = 100000;
 
             var self = this;
-console.log("CREATES LOGIN BUTTON");
-console.log("CREATEd LOGIN BUTTON", this);
             if (this.$login == undefined) {
                 if (this.loginInit) {
                     return;
@@ -368,7 +366,7 @@ console.log("CREATEd LOGIN BUTTON", this);
             }
             var user = this.$login.session('user_id');
             //var user = $('#signin-button').kbaseLogin('session', 'user_id');
-console.log("USER IS ", user);
+
             if (!user) {
                 console.error("NarrativeDataPanel: user is not defined, parsing token instead...");
                 var tokenParts = this.token.split("|");

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -14,27 +14,42 @@
  * @author Dan Gunter <dkgunter@lbl.gov>
  * @public
  */
-define(['jquery',
-        'underscore',
-        'bluebird',
-        'narrativeConfig',
-        'util/timeFormat',
-        'kbwidget',
-        'kbaseNarrative',
-        'kbaseNarrativeControlPanel',
-        'kbaseNarrativeDataList',
-        'kbaseNarrativeSidePublicTab',
-        'kbaseNarrativeSideImportTab',
-        'kbaseNarrativeExampleDataTab'],
-function($,
-         _,
-         Promise,
-         Config,
-         TimeFormat) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'underscore',
+		'bluebird',
+		'narrativeConfig',
+		'util/timeFormat',
+		'kbaseNarrative',
+		'kbaseNarrativeControlPanel',
+		'kbaseNarrativeDataList',
+		'kbaseNarrativeSidePublicTab',
+		'kbaseNarrativeSideImportTab',
+		'kbaseNarrativeExampleDataTab',
+        'kbaseLogin'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		_,
+		Promise,
+		Config,
+		TimeFormat,
+		kbaseNarrative,
+		kbaseNarrativeControlPanel,
+		kbaseNarrativeDataList,
+		kbaseNarrativeSidePublicTab,
+		kbaseNarrativeSideImportTab,
+		kbaseNarrativeExampleDataTab,
+        kbaseLogin
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeDataPanel",
-        parent: "kbaseNarrativeControlPanel",
+        parent : kbaseNarrativeControlPanel,
         version: "1.0.0",
         wsClient: null,
         table: null,
@@ -83,8 +98,7 @@ function($,
             var $dataList = $('<div>');
             this.body().append($dataList);
             this.dataListWidget = 
-                $dataList.kbaseNarrativeDataList(
-                    {
+                 new kbaseNarrativeDataList($dataList, {
                         ws_name: this.ws_name,
                         parentControlPanel: this,
                         slideTime: this.slideTime
@@ -342,7 +356,19 @@ function($,
             var maxObjFetch = 100000;
 
             var self = this;
-            var user = $("#signin-button").kbaseLogin('session', 'user_id');
+console.log("CREATES LOGIN BUTTON");
+console.log("CREATEd LOGIN BUTTON", this);
+            if (this.$login == undefined) {
+                if (this.loginInit) {
+                    return;
+                }
+                this.loginInit = true;
+                this.$login = new kbaseLogin( $('#signin-button') );
+                this.loginInit = false;
+            }
+            var user = this.$login.session('user_id');
+            //var user = $('#signin-button').kbaseLogin('session', 'user_id');
+console.log("USER IS ", user);
             if (!user) {
                 console.error("NarrativeDataPanel: user is not defined, parsing token instead...");
                 var tokenParts = this.token.split("|");
@@ -526,15 +552,16 @@ function($,
             }
 
             // Setup the panels that are defined by widgets
-            // minePanel.kbaseNarrativeMyDataTab({ws_name: this.ws_name});
-            // sharedPanel.kbaseNarrativeSharedDataTab({ws_name: this.ws_name});
+             //new kbaseNarrativeMyDataTab(minePanel, {ws_name: this.ws_name});
+             //new kbaseNarrativeSharedDataTab(sharedPanel, {ws_name: this.ws_name});
 
-            this.publicTab = publicPanel.kbaseNarrativeSidePublicTab({$importStatus:importStatus, ws_name: this.ws_name});
-            this.importTab = importPanel.kbaseNarrativeSideImportTab({ws_name: this.ws_name});
-            this.exampleTab = examplePanel.kbaseNarrativeExampleDataTab({$importStatus:importStatus, ws_name: this.ws_name});
+            this.publicTab =  new kbaseNarrativeSidePublicTab(publicPanel, {$importStatus:importStatus, ws_name: this.ws_name});
+            this.importTab =  new kbaseNarrativeSideImportTab(importPanel, {ws_name: this.ws_name});
+            this.exampleTab =  new kbaseNarrativeExampleDataTab(examplePanel, {$importStatus:importStatus, ws_name: this.ws_name});
 
             // It is silly to invoke a new object for each widget
-            var auth = {token: $("#signin-button").kbaseLogin('session', 'token')};
+            var auth = {token : this.$login.session('token')};
+            //var auth = {token: $("#signin-button").kbaseLogin('session', 'token')};
             var ws = new Workspace(this.options.workspaceURL, auth);
 
             closeBtn.click(function() {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataTable.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataTable.js
@@ -9,9 +9,9 @@
  * @public
  */
 (function( $, undefined ) {
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeDataTable',
-        parent: 'kbaseWidget',
+        
         version: '1.0.0',
         options: {
             noDataText: "No data found",

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
@@ -5,14 +5,22 @@
  * @author Roman Sutormin <rsutormin@lbl.gov>
  * @public
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget'],
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeDownloadPanel",
-        parent: "kbaseWidget",
+        
         version: "1.0.0",
         options: {
         	token: null,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
@@ -4,19 +4,28 @@
  * @author Michael Sneddon <mwsneddon@lbl.gov>
  * @public
  */
-define(['jquery',
-        'bluebird',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseAuthenticatedWidget',
-        'kbaseNarrative'],
-function($,
-         Promise,
-         Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'bluebird',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget',
+		'kbaseNarrative'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Promise,
+		Config,
+		kbaseAuthenticatedWidget,
+		kbaseNarrative
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeExampleDataTab',
-        parent: 'kbaseAuthenticatedWidget',
+        parent : kbaseAuthenticatedWidget,
         version: '1.0.0',
         options: {
             ws_name: null, // must be the WS name, not the WS Numeric ID

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -1,27 +1,31 @@
 /*global define*/
 /*jslint white: true*/
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbasePrompt',
-        'kbaseNarrativeControlPanel',
-        'bootstrap',
-        'util/bootstrapDialog',
-        'util/timeFormat',
-        'util/string'],
-function($,
-         Config,
-         kbwidget,
-         kbasePrompt,
-         kbaseNarrativeControlPanel,
-         bootstrap,
-         BootstrapDialog,
-         TimeFormat,
-         StringUtil) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbasePrompt',
+		'kbaseNarrativeControlPanel',
+		'util/bootstrapDialog',
+		'util/timeFormat',
+		'util/string'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbasePrompt,
+		kbaseNarrativeControlPanel,
+		BootstrapDialog,
+        TimeFormat,
+        StringUtil
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeJobsPanel',
-        parent: 'kbaseNarrativeControlPanel',
+        parent : kbaseNarrativeControlPanel,
         version: '0.0.1',
         options: {
             loadingImage: Config.get('loading_gif'),
@@ -1151,7 +1155,7 @@ function($,
                                            .append($errorTable);
                 if (jobState.state.traceback) {
                     var $tb = $('<div>');
-                    $tb.kbaseAccordion({
+                     new kbaseAccordion($tb, {
                         elements: [{
                             title: 'Detailed Error Information',
                             body: $('<pre style="max-height:300px; overflow-y: auto">').append(jobState.state.traceback)
@@ -1241,7 +1245,7 @@ function($,
 
                 this.$errorPanel.append($details)
                                 .append($tracebackPanel);
-                $tracebackPanel.kbaseAccordion({ elements : tracebackAccordion });
+                 new kbaseAccordion($tracebackPanel, { elements : tracebackAccordion });
             }
             if (this.refreshTimer)
                 clearTimeout(this.refreshTimer);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -3,24 +3,32 @@
  * @author Michael Sneddon <mwsneddon@lbl.gov>
  * @public
  */
-define(['jquery', 
-        'narrativeConfig',
-        'narrativeManager',
-        'util/display',
-        'bluebird',
-        'narrativeConfig',
-        'kbwidget', 
-        'kbaseNarrativeControlPanel',
-        'api/NewWorkspace'],
-function($, 
-         Config, 
-         NarrativeManager,
-         DisplayUtil,
-         Promise) {
-    'use strict',
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'narrativeManager',
+		'util/display',
+		'bluebird',
+		'kbaseNarrativeControlPanel',
+		'api/NewWorkspace'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		NarrativeManager,
+		DisplayUtil,
+		Promise,
+		kbaseNarrativeControlPanel,
+		api_NewWorkspace
+	) {
+    'use strict';
+    return KBWidget({
         name: "kbaseNarrativeManagePanel",
-        parent: "kbaseNarrativeControlPanel",
+        parent : kbaseNarrativeControlPanel,
         version: "1.0.0",
         wsClient: null,
         table: null,
@@ -895,7 +903,7 @@ function($,
 
                         var $sharingDiv = $('<div>');
                         self.setInteractionPanel($interactionPanel, 'Share Settings', $sharingDiv);
-                        $sharingDiv.kbaseNarrativeSharePanel({
+                         new kbaseNarrativeSharePanel($sharingDiv, {
                             ws_name_or_id: data.ws_info[0],
                             max_list_height: 'none',
                             add_user_input_width: '280px'

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodCell.js
@@ -10,28 +10,28 @@
  */
 
 (function( $, undefined ) {
-require(['jquery',
+require(['kbwidget', 'bootstrap', 'jquery',
          'narrativeConfig',
          'util/string',
          'util/bootstrapDialog',
          'util/display',
          'handlebars', 
-         'kbwidget', 
          'kbaseAuthenticatedWidget',
          'kbaseNarrativeCellMenu',
          'kbaseTabs',
          'kbaseViewLiveRunLog',
          'kbaseReportView'], 
-function($, 
+function(KBWidget, bootstrap, $, 
          Config,
          StringUtil,
          BootstrapDialog,
          Display,
-         Handlebars) {
+         Handlebars,
+        kbaseAuthenticatedWidget, kbaseNarrativeCellMenu, kbaseTabs, kbaseViewLiveRunLog, kbaseReportView) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeMethodCell",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
             method: null,
@@ -543,7 +543,7 @@ function($,
                         }
                     }
                     targetPanel.append(this.$jobProcessTabs);
-                    this.$jobProcessTabs.kbaseTabs({canDelete: false, tabs: []});
+                     new kbaseTabs(this.$jobProcessTabs, {canDelete: false, tabs: []});
                     this.$jobStatusDiv = $('<div>');
                     this.$jobProcessTabs.kbaseTabs('addTab', {tab: 'Status', content: this.$jobStatusDiv, 
                         canDelete: false, show: true});
@@ -573,7 +573,7 @@ function($,
                     this.$jobProcessTabs.kbaseTabs('addTab', {tab: 'Console Log', showContentCallback: 
                         function() {
                             var $jobLogsPanel = $('<div>');
-                            $jobLogsPanel.kbaseViewLiveRunLog({'job_id': jobId, 'show_loading_error': false});
+                             new kbaseViewLiveRunLog($jobLogsPanel, {'job_id': jobId, 'show_loading_error': false});
                             return $jobLogsPanel;
                         }, 
                         canDelete: false, show: false});
@@ -758,7 +758,7 @@ function($,
                     .append($errorTable);
             if (jobState && jobState.state && jobState.state.traceback) {
                 var $tb = $('<div>');
-                $tb.kbaseAccordion({
+                 new kbaseAccordion($tb, {
                     elements: [{
                         title: 'Detailed Error Information',
                         body: $('<pre style="max-height:300px; overflow-y: auto">').append(jobState.state.traceback)
@@ -857,6 +857,7 @@ function($,
             if(self.method.replacement_text && 
               self.submittedText && !self.isAwaitingInput()) {
                 // If replacement text exists, and the method was submitted, use it
+console.log("h3", self.method.replacement_text, Handlebars);
                 var template = Handlebars.compile(self.method.replacement_text);
                 self.$dynamicMethodSummary.append($('<h1>').html(template(self.getParameterMapForReplacementText())));
                 self.$dynamicMethodSummary.append($('<h2>').append(self.submittedText));

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -11,35 +11,46 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define([
-        'jquery', 
-        'underscore',
-        'bluebird',
-        'handlebars',
-        'narrativeConfig',
-        'util/display',
-        'util/bootstrapDialog',
-        'text!kbase/templates/beta_warning_body.html',
-        'kbwidget',
-        'kbaseAccordion',
-        'kbaseNarrativeControlPanel',
-        'narrative_core/catalog/kbaseCatalogBrowser',
-        'kbaseNarrative',
-        'catalog-client-api',
-        'kbase-client-api',
-        'bootstrap'], 
-function ($, 
-          _,
-          Promise,
-          Handlebars,
-          Config,
-          DisplayUtil,
-          BootstrapDialog,
-          BetaWarningTemplate) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'underscore',
+		'bluebird',
+		'handlebars',
+		'narrativeConfig',
+		'util/display',
+		'util/bootstrapDialog',
+		'text!kbase/templates/beta_warning_body.html',
+		'kbaseAccordion',
+		'kbaseNarrativeControlPanel',
+		'narrative_core/catalog/kbaseCatalogBrowser',
+		'kbaseNarrative',
+		'catalog-client-api',
+		'kbase-client-api'
+	], function(
+		KBWidget,
+		bootstrap_g,
+		$,
+		_,
+		Promise,
+		Handlebars,
+		Config,
+		DisplayUtil,
+		BootstrapDialog,
+		BetaWarningTemplate,
+        kbaseAccordion,
+		kbaseNarrativeControlPanel,
+		narrative_core_catalog_kbaseCatalogBrowser,
+		kbaseNarrative,
+		catalog_client_api,
+		kbase_client_api
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: 'kbaseNarrativeMethodPanel',
-        parent: 'kbaseNarrativeControlPanel',
+        parent : kbaseNarrativeControlPanel,
         version: '0.0.1',
         options: {
             loadingImage: Config.get('loading_gif'),
@@ -293,6 +304,7 @@ function ($,
 
             var devMode = Config.get('dev_mode');
             var showBetaWarning = true;
+console.log("h4", BetaWarningTemplate, Handlebars);
             var betaWarningCompiled = Handlebars.compile(BetaWarningTemplate);
 
             this.betaWarningDialog = new BootstrapDialog({
@@ -941,7 +953,7 @@ function ($,
 
                 this.$errorPanel.append($details)
                                 .append($tracebackPanel);
-                $tracebackPanel.kbaseAccordion({ elements : tracebackAccordion });
+                 new kbaseAccordion($tracebackPanel, { elements : tracebackAccordion });
             }
 
             this.$functionPanel.hide();

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -304,7 +304,7 @@ define (
 
             var devMode = Config.get('dev_mode');
             var showBetaWarning = true;
-console.log("h4", BetaWarningTemplate, Handlebars);
+
             var betaWarningCompiled = Handlebars.compile(BetaWarningTemplate);
 
             this.betaWarningDialog = new BootstrapDialog({

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -124,12 +124,8 @@
                 try {
                     require([widget],
                         // If we successfully Require the widget code, render it:
-                        $.proxy(function () {
-                            var widget_mapping = {
-                                'kbaseDefaultNarrativeOutput' : kbaseDefaultNarrativeOutput
-                            };
-
-                            this.$outWidget = new widget_mapping[widget]($body, widgetData);
+                        $.proxy(function (W) {
+                            this.$outWidget = new W($body, widgetData);
                             // this.$outWidget = $body.find('.panel-body > div')[widget](widgetData);
                             this.$elem.append($body);
                         }, this),

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -1,8 +1,7 @@
-(function ($, undefined) {
-    require(['jquery', 'kbwidget'], function ($) {
-        $.KBWidget({
+    define(['jquery', 'kbwidget', 'bootstrap', 'kbaseDefaultNarrativeOutput'], function ($, KBWidget, bootstrap, kbaseDefaultNarrativeOutput) {
+        return KBWidget({
             name: 'kbaseNarrativeOutputCell',
-            parent: 'kbaseWidget',
+            
             version: '1.0.0',
             options: {
                 widget: 'kbaseDefaultNarrativeOutput',
@@ -126,7 +125,11 @@
                     require([widget],
                         // If we successfully Require the widget code, render it:
                         $.proxy(function () {
-                            this.$outWidget = $body[widget](widgetData);
+                            var widget_mapping = {
+                                'kbaseDefaultNarrativeOutput' : kbaseDefaultNarrativeOutput
+                            };
+
+                            this.$outWidget = new widget_mapping[widget]($body, widgetData);
                             // this.$outWidget = $body.find('.panel-body > div')[widget](widgetData);
                             this.$elem.append($body);
                         }, this),
@@ -227,4 +230,3 @@
 
         });
     });
-})(jQuery);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSharePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSharePanel.js
@@ -5,16 +5,26 @@
  * @author Michael Sneddon <mwsneddon@lbl.gov>
  * @public
  */
-define(['jquery',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseAuthenticatedWidget', 
-        'select2'], 
-function($, Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget',
+		'select2'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbaseAuthenticatedWidget,
+		select2
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeSharePanel",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
             ws_url: Config.url('workspace'),

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
@@ -5,24 +5,30 @@
  * @author Roman Sutormin <rsutormin@lbl.gov>
  * @public
  */
-define(['jquery', 
-        'narrativeConfig',
-        'kbwidget', 
-        'kbaseAuthenticatedWidget', 
-        'select2',
-        'json!kbase/config/upload_config.json',
-        'util/string'], 
-function($,
-         Config,
-         kbwidget,
-         kbaseAuthenticatedWidget,
-         select2,
-         transformConfig,
-         StringUtil) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget',
+		'select2',
+		'json!kbase/config/upload_config.json',
+		'util/string'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		kbwidget,
+		kbaseAuthenticatedWidget,
+		select2,
+		transformConfig
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeSideImportTab",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
             ws_name: null

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -1,19 +1,33 @@
 /*global define*/
 /*jslint white: true*/
-define(['jquery', 
-        'narrativeConfig',
-        'jqueryui',
-        'kbwidget', 
-        'kbaseNarrativeDataPanel', 
-        'kbaseNarrativeMethodPanel', 
-        'kbaseNarrativeManagePanel', 
-        'kbaseNarrativeJobsPanel',
-        'kbaseNarrative'],
-function($, Config) {
-    'use strict',
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeConfig',
+		'jqueryui',
+		'kbaseNarrativeDataPanel',
+		'kbaseNarrativeMethodPanel',
+		'kbaseNarrativeManagePanel',
+		'kbaseNarrativeJobsPanel',
+		'kbaseNarrative'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Config,
+		jqueryui,
+		kbaseNarrativeDataPanel,
+		kbaseNarrativeMethodPanel,
+		kbaseNarrativeManagePanel,
+		kbaseNarrativeJobsPanel,
+		kbaseNarrative
+	) {
+    'use strict';
+    return KBWidget({
         name: 'kbaseNarrativeSidePanel',
-        parent: 'kbaseWidget',
+        
         options: {
             loadingImage: Config.get('loading_gif'),
             autorender: true,
@@ -325,7 +339,13 @@ function($, Config) {
                                  .addClass('kb-side-separator')
                                  .css({'height' : height + '%'});
 
-                retObj[widgetInfo.name] = $widgetDiv[widgetInfo.name](widgetInfo.params);
+                var constructor_mapping = {
+                    'kbaseNarrativeDataPanel' : kbaseNarrativeDataPanel,
+                    'kbaseNarrativeMethodPanel' : kbaseNarrativeMethodPanel,
+                    'kbaseNarrativeManagePanel' : kbaseNarrativeManagePanel,
+                    'kbaseNarrativeJobsPanel' : kbaseNarrativeJobsPanel,
+                };
+                retObj[widgetInfo.name] = new constructor_mapping[widgetInfo.name]($widgetDiv, widgetInfo.params);
                 $panelSet.append($widgetDiv);
             }
             retObj['panelSet'] = $panelSet;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePublicTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePublicTab.js
@@ -5,18 +5,26 @@
  * @author Roman Sutormin <rsutormin@lbl.gov>
  * @public
  */
-define(['jquery',
-        'bluebird',
-        'narrativeConfig',
-        'kbwidget',
-        'kbaseAuthenticatedWidget'],
-function($, 
-         Promise, 
-         Config) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'bluebird',
+		'narrativeConfig',
+		'kbaseAuthenticatedWidget'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Promise,
+		Config,
+		kbaseAuthenticatedWidget
+	) {
     'use strict';
-    $.KBWidget({
+    return KBWidget({
         name: "kbaseNarrativeSidePublicTab",
-        parent: "kbaseAuthenticatedWidget",
+        parent : kbaseAuthenticatedWidget,
         version: "1.0.0",
         options: {
             $importStatus:$('<div>'),

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -37,7 +37,8 @@ define (
 		'kbaseNarrativeMethodCell',
 		'kbaseNarrativeSidePanel',
 		'kbaseNarrativeDataPanel',
-        'kbaseNarrativeOutputCell'
+        'kbaseNarrativeOutputCell',
+        'kbaseTabs'
 	], function(
 		KBWidget,
 		bootstrap,
@@ -54,7 +55,8 @@ define (
 		kbaseNarrativeMethodCell,
 		kbaseNarrativeSidePanel,
 		kbaseNarrativeDataPanel,
-        kbaseNarrativeOutputCell
+        kbaseNarrativeOutputCell,
+        kbaseTabs
 	) {
 
     return KBWidget({
@@ -350,7 +352,7 @@ define (
             // Yeah, I know it's ugly, but that's how it goes.
             var cellContent = "<div id='" + cellId + "'></div>" +
                               "\n<script>" +
-                               "new kbaseNarrativeMethodCell($('#" + cellId + "'), {'method' : '" + StringUtil.safeJSONStringify(method) + "', 'cellId' : '" + cellId + "'});" +
+                               "$('#" + cellId + "').kbaseNarrativeMethodCell({'method' : '" + StringUtil.safeJSONStringify(method) + "', 'cellId' : '" + cellId + "'});" +
                               "</script>";
 
             cell.set_text(cellContent);
@@ -1347,8 +1349,10 @@ define (
                 if (target && widget) {
                     try {
                         var widget_mapping = {
-                            'kbaseNarrativeOutputCell' : kbaseNarrativeOutputCell
+                            'kbaseNarrativeOutputCell' : kbaseNarrativeOutputCell,
+                            'kbaseTabs' : kbaseTabs
                         };
+
                         var $widget = new widget_mapping[widget] ( $(cell.element).find(target) ) ;
                         if ($widget.prototype.loadState) {
                             $widget.loadState(state.state);
@@ -1951,7 +1955,7 @@ define (
 
             var cellText = '<div id="' + outCellId + '"></div>\n' +
                        '<script>' +
-                       'new kbaseNarrativeOutputCell($("#' + outCellId + '"), ' + outputData + ');' +
+                       '$("#' + outCellId + '").kbaseNarrativeOutputCell(' + outputData + ');' +
                        '</script>';
             cell.set_text(cellText);
             cell.rendered = false; // force a render

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -56,7 +56,7 @@ define (
 		kbaseNarrativeDataPanel,
         kbaseNarrativeOutputCell
 	) {
-console.log("KNOC : ", kbaseNarrativeOutputCell);
+
     return KBWidget({
         name: 'kbaseNarrativeWorkspace',
 
@@ -1267,7 +1267,7 @@ console.log("KNOC : ", kbaseNarrativeOutputCell);
             }
             else if (this.isOutputCell(cell)) {
                 // do output widget stuff.
-console.log("OUTPUT WIDGET STUFF");
+
                 widget = 'kbaseNarrativeOutputCell';
             }
             else if (this.isAppCell(cell)) {
@@ -1301,7 +1301,7 @@ console.log("OUTPUT WIDGET STUFF");
          * @private
          */
         loadRecentCellState: function(cell) {
-console.log("LRCS");
+
             var state = this.getRecentState(cell);
             if (state) {
                 var target = 'div[id^=kb-cell-]';

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -20,30 +20,46 @@
  * @public
  */
 
-define(['jquery',
-        'underscore',
-        'bluebird',
-        'narrativeConfig',
-        'util/bootstrapDialog',
-        'util/string',
-        'jquery-nearest',
-        'kbwidget',
-        'bootstrap',
-        'kbaseDefaultNarrativeOutput',
-        'kbaseDefaultNarrativeInput',
-        'kbaseNarrativeAppCell',
-        'kbaseNarrativeMethodCell',
-        'kbaseNarrativeSidePanel',
-        'kbaseNarrativeDataPanel'],
-function($,
-         _,
-         Promise,
-         Config,
-         BootstrapDialog,
-         StringUtil) {
-    $.KBWidget({
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'underscore',
+		'bluebird',
+		'narrativeConfig',
+		'util/bootstrapDialog',
+		'util/string',
+		'jquery-nearest',
+		'kbaseDefaultNarrativeOutput',
+		'kbaseDefaultNarrativeInput',
+		'kbaseNarrativeAppCell',
+		'kbaseNarrativeMethodCell',
+		'kbaseNarrativeSidePanel',
+		'kbaseNarrativeDataPanel',
+        'kbaseNarrativeOutputCell'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		_,
+		Promise,
+		Config,
+		BootstrapDialog,
+		StringUtil,
+        jqueryN,
+		kbaseDefaultNarrativeOutput,
+		kbaseDefaultNarrativeInput,
+		kbaseNarrativeAppCell,
+		kbaseNarrativeMethodCell,
+		kbaseNarrativeSidePanel,
+		kbaseNarrativeDataPanel,
+        kbaseNarrativeOutputCell
+	) {
+console.log("KNOC : ", kbaseNarrativeOutputCell);
+    return KBWidget({
         name: 'kbaseNarrativeWorkspace',
-        parent: 'kbaseWidget',
+
         version: '1.0.0',
         options: {
             loadingImage: Config.get('loading_gif'),
@@ -334,7 +350,7 @@ function($,
             // Yeah, I know it's ugly, but that's how it goes.
             var cellContent = "<div id='" + cellId + "'></div>" +
                               "\n<script>" +
-                              "$('#" + cellId + "').kbaseNarrativeMethodCell({'method' : '" + StringUtil.safeJSONStringify(method) + "', 'cellId' : '" + cellId + "'});" +
+                               "new kbaseNarrativeMethodCell($('#" + cellId + "'), {'method' : '" + StringUtil.safeJSONStringify(method) + "', 'cellId' : '" + cellId + "'});" +
                               "</script>";
 
             cell.set_text(cellContent);
@@ -441,7 +457,7 @@ function($,
             // Yeah, I know it's ugly, but that's how it goes.
             var cellContent = "<div id='" + cellId + "'></div>" +
                               "\n<script>" +
-                              "$('#" + cellId + "').kbaseNarrativeAppCell({'appSpec' : '" + StringUtil.safeJSONStringify(appSpec) + "', 'cellId' : '" + cellId + "'});" +
+                               "new kbaseNarrativeAppCell($('#" + cellId + "'), {'appSpec' : '" + StringUtil.safeJSONStringify(appSpec) + "', 'cellId' : '" + cellId + "'});" +
                               "</script>";
             cell.set_text(cellContent);
             cell.rendered = false;
@@ -1251,6 +1267,7 @@ function($,
             }
             else if (this.isOutputCell(cell)) {
                 // do output widget stuff.
+console.log("OUTPUT WIDGET STUFF");
                 widget = 'kbaseNarrativeOutputCell';
             }
             else if (this.isAppCell(cell)) {
@@ -1284,6 +1301,7 @@ function($,
          * @private
          */
         loadRecentCellState: function(cell) {
+console.log("LRCS");
             var state = this.getRecentState(cell);
             if (state) {
                 var target = 'div[id^=kb-cell-]';
@@ -1328,8 +1346,12 @@ function($,
                 // it might not be either! if we don't have both a target and widget, don't do anything!
                 if (target && widget) {
                     try {
-                        if ($(cell.element).find(target)[widget](['prototype'])['loadState']) {
-                            $(cell.element).find(target)[widget]('loadState', state.state);
+                        var widget_mapping = {
+                            'kbaseNarrativeOutputCell' : kbaseNarrativeOutputCell
+                        };
+                        var $widget = new widget_mapping[widget] ( $(cell.element).find(target) ) ;
+                        if ($widget.prototype.loadState) {
+                            $widget.loadState(state.state);
                             // later, do something with the timestamp.
                         }
                     } catch(err) {
@@ -1929,7 +1951,7 @@ function($,
 
             var cellText = '<div id="' + outCellId + '"></div>\n' +
                        '<script>' +
-                       '$("#' + outCellId + '").kbaseNarrativeOutputCell(' + outputData + ');' +
+                       'new kbaseNarrativeOutputCell($("#' + outCellId + '"), ' + outputData + ');' +
                        '</script>';
             cell.set_text(cellText);
             cell.rendered = false; // force a render
@@ -2032,7 +2054,7 @@ function($,
 
             cellText = '<div id="' + outCellId + '"></div>\n' +
                        '<script>' +
-                       '$("#' + outCellId + '").kbaseNarrativeOutputCell(' + outputData + ');' +
+                       'new kbaseNarrativeOutputCell($("#' + outCellId + '")' + outputData + ');' +
                        '</script>';
             outputCell.set_text(cellText);
             outputCell.rendered = false; // force a render

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
@@ -1,12 +1,24 @@
 /*global define*/
 /*jslint white: true*/
 
-define(['jquery',
-        'underscore',
-        'narrativeConfig',
-        'bluebird',
-        'kbase-client-api'],
-function($, _, Config, Promise, Clients) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'underscore',
+		'narrativeConfig',
+		'bluebird',
+		'kbase-client-api'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		_,
+		Config,
+		Promise,
+		Clients
+	) {
     'use strict';
 
     /**

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
@@ -147,7 +147,6 @@ define (
         }
 
         return loadViewerInfo().then(function(viewerInfo) {
-            console.log(viewerInfo);
             
             var o = dataCell.obj_info;
             var methodId = viewerInfo.viewers[o.bare_type];
@@ -187,14 +186,15 @@ define (
             // XXX: Temporary until all widgets are loaded with Require.
             // First, try to load it from global space.
             var $elem = $('<div>');
+
             try {
                 w = $elem[outputWidget](output);
             }
             // If that fails, try to load with require. 
             // If THAT fails, fail with an error (though the error should be improved)
             catch (err) {
-                require([outputWidget], function () {
-                    w = $elem[outputWidget](output);
+                require([outputWidget], function (W) {
+                    w = new W($elem, output);
                     return w;
                 }, function () {
                     console.error("error making widget: " + outputWidget);

--- a/src/biokbase-doc/kbaseExampleWidget.js
+++ b/src/biokbase-doc/kbaseExampleWidget.js
@@ -10,9 +10,9 @@
  * @author Bill Riehl <wjriehl@lbl.gov>
  */
 (function($, undefined) {
-	$.KBWidget({
+	return KBWidget({
 		name: "kbaseExampleWidget",
-		parent: "kbaseWidget",
+		
 		options: {
 			output: "Some output placeholder",
 		},

--- a/test/unit/spec/Util/BootstrapDialogSpec.js
+++ b/test/unit/spec/Util/BootstrapDialogSpec.js
@@ -4,7 +4,18 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['jquery', 'util/bootstrapDialog'], function($, Dialog) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'util/bootstrapDialog'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		bootstrap
+	) {
     var $simpleBody = $('<div>').append('This is a body text');
     var simpleTitle = 'Title';
     var simpleButtons = [

--- a/test/unit/spec/Util/DisplaySpec.js
+++ b/test/unit/spec/Util/DisplaySpec.js
@@ -4,7 +4,18 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['jquery','util/display'], function($,DisplayUtil) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'util/display'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		DisplayUtil
+	) {
     'use strict';
     
     describe('KBase Display Utility function module', function() {

--- a/test/unit/spec/Util/StringSpec.js
+++ b/test/unit/spec/Util/StringSpec.js
@@ -4,7 +4,16 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['util/string'], function(StringUtil) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'util/string'
+	], function(
+		KBWidget,
+		bootstrap,
+		StringUtil
+	) {
     'use strict';
     
     describe('KBase String Utility function module', function() {

--- a/test/unit/spec/Util/TimeFormatSpec.js
+++ b/test/unit/spec/Util/TimeFormatSpec.js
@@ -4,7 +4,18 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['jquery', 'util/timeFormat'], function($, TF) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'util/timeFormat'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		TF
+	) {
     'use strict';
     var testISOTime = '2015-12-09T21:58:22.202Z';
     var testISOTime2 = '2016-01-06T00:48:43.196Z';

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -4,7 +4,18 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['jquery', 'kbwidget', 'narrativeLogin'], function($, KBWidget, Narrative) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeLogin'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		KBWidget
+	) {
     describe('Test the kbaseNarrative module', function() {
         it('Should do things', function() {
 

--- a/test/unit/spec/narrativeConfigSpec.js
+++ b/test/unit/spec/narrativeConfigSpec.js
@@ -4,7 +4,18 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['narrativeConfig', 'bluebird'], function(Config, Promise) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'narrativeConfig',
+		'bluebird'
+	], function(
+		KBWidget,
+		bootstrap,
+		Config,
+		Promise
+	) {
     'use strict';
     describe('Tests for narrativeConfig', function() {
         it('loaded the config module', function() {

--- a/test/unit/spec/narrativeLoginSpec.js
+++ b/test/unit/spec/narrativeLoginSpec.js
@@ -1,4 +1,15 @@
-define(['jquery', 'narrativeLogin'], function($, Login) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'jquery',
+		'narrativeLogin'
+	], function(
+		KBWidget,
+		bootstrap,
+		$,
+		Login
+	) {
     describe('Test the kbaseNarrative module', function() {
         it('Should do things', function() {
             expect(Login.init).not.toBe(null);

--- a/test/unit/spec/narrativeViewersSpec.js
+++ b/test/unit/spec/narrativeViewersSpec.js
@@ -4,7 +4,16 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['narrativeViewers'], function(Viewers) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'narrativeViewers'
+	], function(
+		KBWidget,
+		bootstrap,
+		Viewers
+	) {
     'use strict';
     describe('Test the NarrativeViewers module', function() {
         it('should load viewer info as a promise', function(done) {

--- a/test/unit/specTemplate.js
+++ b/test/unit/specTemplate.js
@@ -4,7 +4,16 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define(['a_module'], function(Module) {
+define (
+	[
+		'kbwidget',
+		'bootstrap',
+		'a_module'
+	], function(
+		KBWidget,
+		bootstrap,
+		Module
+	) {
     'use strict';
     describe('Test the module', function() {
         it('Should do things', function() {


### PR DESCRIPTION
I am become death, destroyer of worlds.

Only 170 files changed. No big deal.

Also points to new revised-widgets and ui-common submodules (revised-widgets+chaplin and chaplin, respectively), which also contain the mods for refactoring.

In my testing, it seems to mostly work most of the time for most things. input widgets may not be properly loading their state, and things which rely upon the non-AMD modeling widgets probably don't work well at all - I did work towards refactoring them, but haven't gotten 'em operational.

To do your own migrating of your own widgets - use the make-not-a-plugin.pl script in the root of ui-common#chaplin. It'll mostly handle most cases most of the time.