### PR TITLE
integrate input cell refactor

### DIFF
--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -173,8 +173,13 @@ span#notebook_name:hover {
     background-color: #FFF;
 }
 */
+
 .notebook_app .celltoolbar > .button_container {
-    width: 100%;
+    flex: 0 auto;
+}
+
+.notebook_app .celltoolbar > .button_container:nth-child(1) {
+    flex: auto;
 }
 
 .notebook_app .prompt {

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -156,9 +156,14 @@ define(['jquery',
         cellToolbar.CellToolbar.prototype.renderToggleState = function () {
             var toggleState = this.cell.getCellState('toggleState', 'unknown');
             // Test to see if the kbaseNarrativeCellMenu is attached to this toolbar.
-            var elemData = $(this.inner_element).find('.button_container').data();
-            if (elemData && elemData['kbaseNarrativeCellMenu'])
-               $(this.inner_element).find('.button_container').kbaseNarrativeCellMenu('toggleState', toggleState);
+            // 
+            //var elemData = $(this.inner_element).find('.button_container').data();
+            //if (elemData && elemData['kbaseNarrativeCellMenu'])
+            //   $(this.inner_element).find('.button_container').kbaseNarrativeCellMenu('toggleState', toggleState);
+            //   
+            // TODO: rewire the rendering of togglestate to just go through the
+            // natural cell toolbar refresh which occurs when the cell metadata
+            // is updated (cell.metadata = {what:'ever'};).
         };
 
         // disable hiding of the toolbar

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -607,7 +607,7 @@ define(['jquery',
             cells.forEach(function (cell) {
                 fun(cell);
             });
-        }
+        };
 
 
         // Patch the Notebook to return the right name

--- a/kbase-extension/static/kbase/js/widgetApi/messageManager.js
+++ b/kbase-extension/static/kbase/js/widgetApi/messageManager.js
@@ -1,0 +1,113 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+], function () {
+    'use strict';
+
+    function Messages(config) {
+        var awaitingResponse = {},
+            listeners = {},
+            lastId = 0,
+            root = config.root,
+            name = config.name;
+
+        function genId() {
+            lastId += 1;
+            return 'msg_' + String(lastId);
+        }
+        
+        var partners = {};
+        function addPartner(config) {
+            partners[config.name] = config;
+        }
+
+        function listenForMessage(listener) {
+            if (!listeners[listener.name]) {
+                listeners[listener.name] = [];
+            }
+            listeners[listener.name].push(listener);
+        }
+
+        function receiveMessage(event) {
+            var origin = event.origin || event.originalEvent.origin,
+                message = event.data,
+                listener, response;
+            
+            if (message.id && awaitingResponse[message.id]) {
+                try {
+                    response = awaitingResponse[message.id];
+                    delete awaitingResponse[message.id];
+                    response.handler(message, event);
+                    return;
+                } catch (ex) {
+                    console.error('Error handling response for message ', message, ex);
+                }
+            }
+
+            if (listeners[message.name]) {
+                listeners[message.name].forEach(function (listener) {
+                    try {
+                        listener.handler(message, event);
+                        return;
+                    } catch (ex) {
+                        console.error('Error handling listener for message ', message, ex);
+                    }
+                });
+            }
+
+        }
+        
+        function getPartner(name) {
+            var partner = partners[name];
+            if (!partner) {
+                throw new Error('Partner ' + name + ' not registered');
+            }
+            return partner;                
+        }
+
+        function sendMessage(partnerName, message) {
+            var partner = getPartner(partnerName);
+            message.from = name;
+            partner.window.postMessage(message, partner.host);
+        }
+
+        function sendRequest(partnerName, message, handler) {
+            var id = genId();
+            message.id = id;
+            awaitingResponse[id] = {
+                started: new Date(),
+                handler: handler
+            };
+            sendMessage(partnerName, message);
+        }
+        
+        function request(partnerName, message) {
+            return new Promise(function (resolve, reject) {
+                sendRequest(partnerName, message, function (response) {
+                    resolve(response);
+                });
+            });
+        }
+        
+        function setName(newName) {
+            if (name !== undefined) {
+                throw new Error('Name is already set');
+            }
+            name = newName;
+        }
+        
+        root.addEventListener('message', receiveMessage, false);
+
+
+        return {
+            addPartner: addPartner,
+            request: request,
+            send: sendMessage,
+            // sendMessages: sendMessages,
+            listen: listenForMessage,
+            setName: setName
+        };
+    }
+
+    return Messages;
+});

--- a/kbase-extension/static/kbase/js/widgetApi/narrativeDataWidget.js
+++ b/kbase-extension/static/kbase/js/widgetApi/narrativeDataWidget.js
@@ -45,7 +45,7 @@ define([
                         req = runtimeManager.getModuleLoader('0.1.1', require, '/narrative/widgetApi/kbase/js/widgetApi');
 
                     req([
-                        'kb_widget/widgetManager',
+                        'kb_widget_service/widgetManager',
                         // 'yaml!./config.yml',
                         'kb_common/props',
                         'kb_common/session',

--- a/kbase-extension/static/kbase/js/widgetApi/narrativeDataWidgetIFrame.js
+++ b/kbase-extension/static/kbase/js/widgetApi/narrativeDataWidgetIFrame.js
@@ -1,0 +1,328 @@
+/*global define,require*/
+/*jslint white:true,browser:true */
+/*
+ * Narrative Data Widget
+ * 
+ * Embodies a KBase data widget which can be safely displayed in a Narrative.
+ * Handles
+ * - fetching widget
+ * - building runtime env
+ * - insert widget
+ * - load widget
+ * - listen for widget events
+ * - provide widget event implementation within the narrative.
+ */
+define([
+    'bluebird',
+    'runtimeManager',
+    'messageManager',
+    'narrativeConfig',
+    // Use our locally defined widget service for protyping the iframe stuff, then merge that in
+    'widgetService2'
+], function (Promise, RuntimeManager, MessageManager, NarrativeConfig, WidgetService) {
+    'use strict';
+    function factory(config) {
+        var widgetTitle = config.title,
+            widgetParentNode = config.parent,
+            authRequired = config.authRequired,
+            narrativeConfig = NarrativeConfig.getConfig(),
+            messageManager = MessageManager({
+                root: window,
+                name: 'parent'
+            });
+
+        function showErrorMessage(message) {
+            widgetParentNode.innerHTML = '<div style="margin: 1em; padding: 1em; border: 2px red solid;"><h1>Error in ' + widgetTitle + '</h1><p>' + message + '</p></div>';
+        }
+
+        function runWidget(objectRefs, options) {
+            return new Promise(function (resolve, reject) {
+                try {
+                    var runtimeManager = RuntimeManager.make({
+                        cdnUrl: narrativeConfig.services.cdn.url
+                    }),
+                        // This runtime object is provided for the boot up of the widget invocation
+                        // machinery, NOT running the widget.
+                        // Note -- need to use the global require in order to generate additional require objects
+                        // via require.config()
+                        req = runtimeManager.getModuleLoader('0.1.1', require, '/narrative/widgetApi/kbase/js/widgetApi');
+
+                    req([
+                        //'kb_widget_service/widgetManager',
+                        // 'yaml!./config.yml',
+                        'kb_common/props',
+                        'kb_common/session',
+                        'kb_common/html',
+                        'uuid'
+                    ],
+                        function (Props, Session, Html, Uuid) {
+                            // just a little synchronous auth token business for now
+                            function getAuthToken() {
+                                var session = Session.make({cookieName: 'kbase_session'});
+                                return session.getAuthToken();
+                            }
+                            function makeWidgetHostAdapter(objectRefs, options) {
+                                var configProps = Props.make({data: NarrativeConfig.getConfig()});
+                                return function (bus) {
+                                    bus.subscribe('ready', function () {
+                                        bus.publish('start', {
+                                            objectRefs: objectRefs,
+                                            options: options
+                                        });
+                                    });
+
+                                    bus.subscribe('config', function (data) {
+                                        return {
+                                            value: configProps.getItem(data.property, data.defaultValue)
+                                        };
+                                    });
+
+                                    bus.subscribe('authToken', function () {
+                                        var token = getAuthToken();
+                                        return {
+                                            value: token
+                                        };
+                                    });
+
+                                    bus.subscribe('error', function (data) {
+                                        showErrorMessage(data.message);
+
+                                    });
+                                };
+                            }
+                            var waitingPartners = {};
+                            function findWaiting(frameWindow) {
+                                var keys = Object.keys(waitingPartners), i;
+                                for (i = 0; i < keys.length; i += 1) {
+                                    var key = keys[i], partner = waitingPartners[key];
+                                    if (frameWindow === partner.window) {
+                                        return partner;
+                                    }
+                                }
+                            }
+                            
+                            function urlToHost(urlString) {
+                                var url = new URL(urlString);
+                                return url.protocol + '//' + url.host;
+                            }
+                            
+                            function renderIFrameWidget(node, url, host) {
+                                var div = Html.tag('div'),
+                                    iframe = Html.tag('iframe'),
+                                    iframeId = (new Uuid(4)).format(),
+                                    iframeNodeId = 'frame_' + iframeId,
+                                    iframeHost = urlToHost(url);
+                                
+                               
+                                node.innerHTML = div({class: 'row'}, [
+                                    div({class: 'col-md-12'}, [
+                                        Html.makePanel({
+                                            title: 'iFrame Remote Loading Example ' + iframeId,
+                                            content: iframe({
+                                                dataFrame: iframeNodeId,
+                                                dataParams: encodeURIComponent(JSON.stringify({
+                                                    parentHost: host,
+                                                    frameId: 'frame_' + iframeId,
+                                                    objectRef: '4079/2/1'
+                                                })),
+                                                style: {width: '100%', height: 'auto', border: '0px green dotted'},
+                                                src: url})
+                                        })
+                                    ])
+                                ]);
+                                // Note that this listener needs to be effective before the iframe loads.
+                                // This is not a problem since although the iframe will be present in the DOM 
+                                // at this point in the code, the content will not have loaded yet.
+                                waitingPartners[iframeId] = {
+                                    name: iframeId,
+                                    window: node.querySelector('[data-frame="'+iframeNodeId+'"]').contentWindow,
+                                    host: iframeHost
+                                };
+                            }
+                            messageManager.listen({
+                                name: 'ready',
+                                handler: function (message, event) {
+
+                                    // Now we only add the parter after the initial handshake.
+
+                                    // Do we have the partner?
+                                    var source = event.source,
+                                        waitingPartner = findWaiting(source);
+
+                                    if (!waitingPartner) {
+                                        console.error('Not a waiting parter ', source, waitingPartners);
+                                        throw new Error('Not a waiting parter');
+                                    }
+
+                                    // frameId = source.frameElement.getAttribute('data-frame'),
+                                    delete waitingPartners[waitingPartner.name];
+
+                                    messageManager.addPartner({
+                                        name: waitingPartner.name,
+                                        window: source,
+                                        host: waitingPartner.host
+                                    });
+
+                                    console.log('Sending to ' + waitingPartner.name);
+                                    messageManager.send(waitingPartner.name, {
+                                        name: 'start',
+                                        config: {
+                                            frameId: waitingPartner.name,                            
+                                            host: 'http://localhost:8888'
+                                        },
+                                        params: {
+                                            objectRef: '4079/2/1'
+                                        }
+                                    });
+                                }
+                            });
+                            
+                            messageManager.listen({
+                                name: 'authStatus',
+                                handler: function (message) {
+                                    messageManager.send(message.from, {
+                                        name: 'authStatus',
+                                        id: message.id,
+                                        auth: {
+                                            token: getAuthToken()
+                                        }
+                                    });
+                                }
+                            });
+
+                            messageManager.listen({
+                                name: 'config',
+                                handler: function (message) {
+                                    var configProps = Props.make({data: NarrativeConfig.getConfig()});
+                                    messageManager.send(message.from, {
+                                        name: 'config',
+                                        id: message.id,
+                                        value: configProps.getItem(message.property, message.defaultValue)
+                                    });
+                                }
+                            });
+
+                            messageManager.listen({
+                                name: 'rendered',
+                                handler: function (message, event) {
+                                    // adjust height of source window...
+                                    console.log('rendering ...' + message.from);
+                                    var height = message.height; // event.source.contentWindow.height;
+                                    var iframe = document.querySelector('[data-frame="frame_' + message.from + '"]');
+                                    iframe.style.height = height + 'px';
+                                }
+                            });
+                            
+                            /*
+                             * Loading...
+                             */
+                            widgetParentNode.innerHTML = Html.loading('Loading widget');
+
+                            /*
+                             * Enforce preconditions
+                             * This is handy for anything we can handle before we
+                             * even get to the widget.
+                             */
+                            if (authRequired && !getAuthToken()) {
+                                // All errors need to be thrown via reject with a real error object.
+                                reject(new Error('This widget requires authorization'));
+                                return;
+                            }
+
+                            /*
+                             * This function creates a function which, given a pubsub bus object, creates
+                             * the necessary hooks for implementing the interface.
+                             */
+                            
+                            // use raw widget service for now.
+                            var widgetService = WidgetService.make({
+                                url: 'http://widget.kbase.us/wsvc'
+                            });
+                            var widget = widgetService.getWidget(config.package, config.version, config.widget);
+                            if (!widget) {
+                                throw new Error('Cannot find widget: ' + config.package + ', ' + config.version + ', ' + config.widget);
+                            }
+                            
+//                            var widgetManager = WidgetManager.make({
+//                                widgetServiceUrl: config.services.widget.url,
+//                                cdnUrl: config.services.cdn.url
+//                            });
+//                            var widgetDiv = widgetManager.addWidget({
+//                                package: packageName,
+//                                version: packageVersion,
+//                                widget: widgetName,
+//                                panel: true,
+//                                title: widgetTitle
+//                            });
+
+                            // The "widget" is provided as simple markup (string) with an id set and mapped 
+                            // internally to the right widget invocation stuff.
+                            renderIFrameWidget(widgetParentNode, widget.widget.url, 'http://localhost:8888');
+                            
+                            messageManager.listen({
+                                name: 'ready',
+                                handler: function (message, event) {
+
+                                    // Now we only add the parter after the initial handshake.
+
+                                    // Do we have the partner?
+                                    var source = event.source,
+                                        waitingPartner = findWaiting(source);
+
+                                    if (!waitingPartner) {
+                                        console.error('Not a waiting parter ', source, waitingPartners);
+                                        throw new Error('Not a waiting parter');
+                                    }
+
+                                    // frameId = source.frameElement.getAttribute('data-frame'),
+                                    delete waitingPartners[waitingPartner.name];
+
+                                    messageManager.addPartner({
+                                        name: waitingPartner.name,
+                                        window: source,
+                                        host: waitingPartner.host
+                                    });
+
+                                    console.log('Sending to ' + waitingPartner.name);
+                                    messageManager.send(waitingPartner.name, {
+                                        name: 'start',
+                                        config: {
+                                            frameId: waitingPartner.name,                            
+                                            host: 'http://localhost:8080'
+                                        },
+                                        params: {
+                                            objectRef: '4079/2/1'
+                                        }
+                                    });
+                                }
+                            });
+
+                            // After the widget wrapper is placed into the dom, we can launch the widget.
+//                            widgetManager.loadWidgets(makeWidgetHostAdapter(objectRefs, options))
+//                                .then(function () {
+//                                    resolve();
+//                                })
+//                                .catch(function (err) {
+//                                    console.error('load widgets error', err);
+//                                    reject(err);
+//                                });
+                        });
+                } catch (ex) {
+                    reject(ex);
+                }
+            });
+        }
+
+
+        return {
+            runWidget: runWidget,
+            showErrorMessage: showErrorMessage
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/kbase-extension/static/kbase/js/widgetApi/runtimeManager.js
+++ b/kbase-extension/static/kbase/js/widgetApi/runtimeManager.js
@@ -16,35 +16,34 @@ define([
                         underscore: 'underscore/1.8.3/underscore',
                         bootstrap: 'bootstrap/3.3.6/js/bootstrap',
                         bootstrap_css: 'bootstrap/3.3.6/css/bootstrap',
-                        d3: 'd3js/3.5.16/d3',
+                        d3: 'd3/3.5.16/d3',
                         datatables: 'datatables/1.10.10/js/jquery.dataTables',
                         datatables_css: 'datatables/1.10.10/css/jquery.dataTables',
-                        datatables_bootstrap: 'bootstrap.datatables/0.4.0/js/datatables-bootstrap3',
-                        datatables_bootstrap_css: 'bootstrap.datatables/0.4.0/css/datatables-bootstrap3',
+                        datatables_bootstrap: 'datatables-bootstrap3-plugin/0.4.0/js/datatables-bootstrap3',
+                        datatables_bootstrap_css: 'datatables-bootstrap3-plugin/0.4.0/css/datatables-bootstrap3',
                         'font-awesome': 'font-awesome/4.3.0/font-awesome',
-                        handlebars: 'handlebarsjs/4.0.5/handlebars',
+                        handlebars: 'handlebars/4.0.5/handlebars',
                         'js-yaml': 'js-yaml/3.3.1/js-yaml',
                         knockout: 'knockout/3.4.0/knockout',
                         numeral: 'numeral/1.5.0/numeral',
                         nunjucks: 'nunjucks/2.4.1/nunjucks',
                         plotly: 'plotly/1.5.0/plotly',
-                        uuid: 'pure-uuid/1.1.1/uuid',
+                        uuid: 'pure-uuid/1.3.0/uuid',
                         
                         
                         // require plugins
                         css: 'require-css/0.1.8/css',
-                        text: 'requirejs.text/2.0.14/text',
+                        text: 'requirejs-text/2.0.14/text',
                         yaml: 'require-yaml/0.1.2/yaml',
                             
                         // kbase
-                        // kbase
-                        'kb_service': 'kb_service/1.2.4',
-                        'kb_common': 'kb_common/1.5.3',
-                        'kb_widget': 'kb_widget/0.1.0'
+                        'kb_service': 'kbase-service-clients-js/1.4.0',
+                        'kb_common': 'kbase-common-js/1.5.3',
+                        'kb_widget_service': 'kbase-widget-service/0.1.0'
                     },
                     shim: {
                         bootstrap: {
-                            deps: ['css!bootstrap_css']
+                            deps: ['css!bootstrap_css', 'jquery']
                         },
                         datatables: {
                             deps: ['css!datatables_css']
@@ -64,30 +63,30 @@ define([
                         underscore: 'underscore/1.8.3/underscore',
                         bootstrap: 'bootstrap/3.3.6/js/bootstrap',
                         bootstrap_css: 'bootstrap/3.3.6/css/bootstrap',
-                        d3: 'd3js/3.5.16/d3',
+                        d3: 'd3/3.5.16/d3',
                         datatables: 'datatables/1.10.10/js/jquery.dataTables',
                         datatables_css: 'datatables/1.10.10/css/jquery.dataTables',
-                        datatables_bootstrap: 'bootstrap.datatables/0.4.0/js/datatables-bootstrap3',
-                        datatables_bootstrap_css: 'bootstrap.datatables/0.4.0/css/datatables-bootstrap3',
+                        datatables_bootstrap: 'datatables-bootstrap3-plugin/0.4.0/js/datatables-bootstrap3',
+                        datatables_bootstrap_css: 'datatables-bootstrap3-plugin/0.4.0/css/datatables-bootstrap3',
                         'font-awesome': 'font-awesome/4.3.0/font-awesome',
-                        handlebars: 'handlebarsjs/4.0.5/handlebars',
+                        handlebars: 'handlebars/4.0.5/handlebars',
                         'js-yaml': 'js-yaml/3.3.1/js-yaml',
                         knockout: 'knockout/3.4.0/knockout',
                         numeral: 'numeral/1.5.0/numeral',
                         nunjucks: 'nunjucks/2.4.1/nunjucks',
                         plotly: 'plotly/1.5.0/plotly',
-                        uuid: 'pure-uuid/1.1.1/uuid',
-                        
+                        uuid: 'pure-uuid/1.3.0/uuid',
                         
                         // require plugins
                         css: 'require-css/0.1.8/css',
-                        text: 'requirejs.text/2.0.14/text',
+                        text: 'requirejs-text/2.0.14/text',
                         yaml: 'require-yaml/0.1.2/yaml',
                             
                         // kbase
-                        'kb_service': 'kb_service/1.2.4',
-                        'kb_common': 'kb_common/1.5.3',
-                        'kb_widget': 'kb_widget/0.1.0'
+                        // kbase
+                        'kb_service': 'kbase-service-clients-js/1.4.0',
+                        'kb_common': 'kbase-common-js/1.5.4',
+                        'kb_widget_service': 'kbase-widget-service/0.1.0'
                     },
                     shim: {
                         bootstrap: {
@@ -129,7 +128,7 @@ define([
             var runtime = getRuntime(version);
             return baseRequire.config({
                 context: 'runtime_' + runtime.version,
-                baseUrl: baseUrl, 
+                baseUrl: baseUrl,
                 paths: runtime.amd.paths,
                 shim: runtime.amd.shim
             });

--- a/kbase-extension/static/kbase/js/widgetApi/widgetService2.js
+++ b/kbase-extension/static/kbase/js/widgetApi/widgetService2.js
@@ -1,0 +1,199 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    
+], function () {
+    'use strict';
+    
+    function factory(config) {
+         var url = config.url,
+            cdnUrl = config.cdn;
+        // NB: For prototyping we supply this widget db in code.
+        // This is modeling a service which provides widget lookup.
+        var widgetPackages = [
+            {
+                name: 'widgets',
+                versions: [
+                    {
+                        version: '0.1.0',
+                        config: {
+                            runtime: {
+                                version: '0.1.1'
+                            }
+                        },
+                        widgets: [
+                            {
+                                widgetName: 'test',
+                                fileName: 'testWidget.js',
+                                amdName: 'testWidget',
+                                // inputs are named properties, with optional type and required flag
+                                input: {
+                                    objectRef: {
+                                        required: true,
+                                        type: '??'
+                                    }
+                                }
+                            },
+                            {
+                                widgetName: 'pairedEndLibrary',
+                                fileName: 'pairedEndLibrary.js',
+                                amdName: 'pairedEndLibrary',
+                                input: {
+                                    objects: {
+                                        objectRef: {
+                                            required: true
+                                        }
+                                    },
+                                    options: {}
+                                }
+                            },
+                            {
+                                widgetName: 'contigSet',
+                                fileName: 'contigSet.js',
+                                amdName: 'contigSet',
+                                input: {
+                                    objects: {
+                                        objectRef: {
+                                            required: true
+                                        }
+                                    },
+                                    options: {}
+                                }
+                            },
+                            {
+                                widgetName: 'genomeComparison',
+                                fileName: 'genomeCompairson.js',
+                                amdName: 'genomeComparison',
+                                input: {
+                                    objects: {
+                                        objectRef: {
+                                            required: true
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                widgetName: 'objectOverview',
+                                // TODO: this needs to be dynamically allocated
+                                // when a widget container is launched, or perhaps
+                                // mapped into the widget service server with a specific root.
+                                // Yeah, that would probably work.
+                                url: 'http://localhost:9001/index.html',
+                                input: {
+                                    objects: {
+                                        objectRef: {
+                                            required: true
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                widgetName: 'pairedEndLibrary',
+                                // TODO: this needs to be dynamically allocated
+                                // when a widget container is launched, or perhaps
+                                // mapped into the widget service server with a specific root.
+                                // Yeah, that would probably work.
+                                url: 'http://localhost:9002/index.html',
+                                input: {
+                                    objects: {
+                                        objectRef: {
+                                            required: true
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ];
+        
+        var widgetDb = {};
+        widgetPackages.forEach(function (widgetPackage) {
+            widgetDb[widgetPackage.name] = {};
+            widgetPackage.versions.forEach(function(version) {
+                widgetDb[widgetPackage.name][version.version] = {
+                    config: version.config,
+                    widgets: {}
+                };
+                version.widgets.forEach(function (widget) {
+                    widgetDb[widgetPackage.name][version.version].widgets[widget.widgetName] = widget;
+                });
+            });
+        });
+
+        function findPackage(packageName, version) {
+            var widgetPackage = widgetDb[packageName];
+            if (!widgetPackage) {
+                throw new Error('Cannot locate package ' + packageName);
+            }
+            var versionedPackage = widgetPackage[version];
+            if (!versionedPackage) {
+                throw new Error('Cannot locate version ' + version + ' for package ' + packageName);
+            }
+
+            return versionedPackage;
+        }
+
+        /*
+         * Get a specific widget
+         */
+        function getWidget(packageName, version, widgetName) {
+            var versionedPackage = findPackage(packageName, version),
+                widget = versionedPackage.widgets[widgetName];
+            
+            if (!widget) {
+                throw new Error('Cannot locate widget ' + widgetName + ' in package ' + packageName + ' version ' + version);
+            }
+
+            return {
+                widget: widget,
+                packageName: packageName,
+                packageVersion: version
+            };
+        }
+        
+        /*
+         * Find a widget with certain constraints.
+         * Currently finds the most recent widget
+         */
+        function findWidget(findWidgetName) {
+            var i, j, k, widgetPackage, version, widget;
+            for (i = 0; i < widgetPackages.length; i += 1) {
+                widgetPackage = widgetPackages[i];
+                for (j = 0; j < widgetPackage.versions.length; j += 1) {
+                    version = widgetPackage.versions[j];
+                    for (k = 0; k < version.widgets.length; k += 1) {
+                        widget = version.widgets[k];
+                        if (widget.widgetName === findWidgetName) {
+                            return {
+                                packageName: widgetPackage.name,
+                                packageVersion: version.version,
+                                widget: widget
+                            };
+                        }
+                    }
+                }
+                
+            }
+        }
+
+        function getBaseUrl(widgetDef) {
+            return [url, widgetDef.packageName, widgetDef.packageVersion].join('/');
+        }
+
+        return Object.freeze({
+            getBaseUrl: getBaseUrl,
+            getWidget: getWidget,
+            findWidget: findWidget,
+            version: '0.1.0',
+            about: 'This is the Widget Service Factory'
+        });
+    }
+    
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
@@ -1,36 +1,141 @@
 /**
  * KBase preset wrapper for its cell menu.
  */
-
-define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
-		'notebook/js/celltoolbar',
-		'kbaseNarrativeCellMenu'
-	], function(
-		KBWidget,
-		bootstrap,
-		$,
-		celltoolbar,
-		kbaseNarrativeCellMenu
-	) {
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'jquery',
+    'notebook/js/celltoolbar',
+    'base/js/namespace',
+    'kb_common/html',
+    'kbaseNarrativeCellMenu'
+], function ($, celltoolbar, Jupyter, html, KBaseNarrativeCellMenu) {
     "use strict";
 
-    var CellToolbar = celltoolbar.CellToolbar;
+    /*
+     * Dealing with metadata
+     */
+    function createMeta(cell, initial) {
+        var meta = cell.metadata;
+        meta.kbase = initial;
+        cell.metadata = meta;
+    }
+    function getMeta(cell, group, name) {
+        if (!cell.metadata.kbase[group]) {
+            return;
+        }
+        return cell.metadata.kbase[group][name];
+    }
+    function setMeta(cell, group, name, value) {
+        /*
+         * This funny business is because the trigger on setting the metadata 
+         * property (via setter and getter in core Cell object) is only invoked 
+         * when the metadata preoperty is actually set -- doesn't count if 
+         * properties of it are.
+         */
+        var temp = cell.metadata;
+        if (!temp.kbase[group]) {
+            temp.kbase[group] = {};
+        }
+        temp.kbase[group][name] = value;
+        cell.metadata = temp;
+    }
 
-    var $kbMenu = $('<span>');
-    var makeKBaseMenu = function(div, cell) {
-         new kbaseNarrativeCellMenu($(div), {cell: cell});
+    function doEditNotebookMetadata() {
+        Jupyter.notebook.edit_metadata({
+            notebook: Jupyter.notebook,
+            keyboard_manager: Jupyter.notebook.keyboard_manager
+        });
+    }
+    function editNotebookMetadata(toolbarDiv, cell) {
+        if (!cell.metadata.kbase) {
+            return;
+        }
+        if (cell.metadata.kbase.type !== 'method') {
+            return;
+        }
+        var button = html.tag('button'),
+            editButton = button({
+                type: 'button',
+                class: 'btn btn-default btn-xs',
+                dataElement: 'kbase-edit-notebook-metadata'}, [
+                'Edit Notebook Metadata'
+            ]);
+        toolbarDiv.append(editButton);
+        toolbarDiv.find('[data-element="kbase-edit-notebook-metadata"]').on('click', function () {
+            doEditNotebookMetadata(cell);
+        });
+    }
+
+    function initCodeInputArea(cell) {
+        var codeInputArea = cell.input.find('.input_area');
+        if (!cell.kbase.inputAreaDisplayStyle) {
+            cell.kbase.inputAreaDisplayStyle = codeInputArea.css('display');
+        }
+        setMeta(cell, 'user-settings', 'showCodeInputArea', false);
+    }
+
+    function showCodeInputArea(cell) {
+        var codeInputArea = cell.input.find('.input_area');
+        if (getMeta(cell, 'user-settings', 'showCodeInputArea')) {
+            codeInputArea.css('display', cell.kbase.inputAreaDisplayStyle);
+        } else {
+            codeInputArea.css('display', 'none');
+        }
+    }
+
+    function toggleCodeInputArea(cell) {
+        /*
+         * the code input area's style is stached for future restoration.
+         */
+        if (getMeta(cell, 'user-settings', 'showCodeInputArea')) {
+            setMeta(cell, 'user-settings', 'showCodeInputArea', false);
+        } else {
+            setMeta(cell, 'user-settings', 'showCodeInputArea', true);
+        }
+        showCodeInputArea(cell);
+        return getMeta(cell, 'user-settings', 'showCodeInputArea');
+    }
+
+    function makeKBaseMenu(div, cell) {
+        new KBaseNarrativeCellMenu(div, {cell: cell});
+    }
+    function toggleInput(toolbarDiv, cell) {
+        if (!cell.metadata.kbase) {
+            return;
+        }
+        if (cell.metadata.kbase.type !== 'method') {
+            return;
+        }
+        var button = html.tag('button'),
+            inputAreaShowing = getMeta(cell, 'user-settings', 'showCodeInputArea'),
+            label = inputAreaShowing ? 'Hide code' : 'Show code',
+            toggleButton = button({
+                type: 'button',
+                class: 'btn btn-default btn-xs',
+                dataElement: 'kbase-method-cell-hideshow'}, [
+                label
+            ]);
+        toolbarDiv.append(toggleButton);
+        toolbarDiv.find('[data-element="kbase-method-cell-hideshow"]').on('click', function (e) {
+            toggleCodeInputArea(cell);
+        });
+    }
+
+    function status(toolbarDiv, cell) {
+        var status = getMeta(cell, 'attributes', 'status'),
+            content = span({style: {fontWeight: 'bold'}}, status);
+        toolbarDiv.append(span({style: {padding: '4px'}}, content));
+    }
+
+    var register = function (notebook) {
+        celltoolbar.CellToolbar.register_callback('kbase-toggle-input', toggleInput);
+        celltoolbar.CellToolbar.register_callback('kbase-edit-notebook-metadata', editNotebookMetadata);
+        celltoolbar.CellToolbar.register_callback('kbase.menu', makeKBaseMenu);
+        celltoolbar.CellToolbar.register_callback('kbase-status', status);
+
+        // default.rawedit for the metadata editor
+        celltoolbar.CellToolbar.register_preset('KBase', ['kbase.menu', 'default.rawedit', 'kbase-toggle-input', 'kbase-edit-notebook-metadata', 'kbase-status']);
     };
-
-    var register = function(notebook) {
-        CellToolbar.register_callback('kbase.menu', makeKBaseMenu);
-        var kbasePreset = [];
-        kbasePreset.push('kbase.menu');
-
-        CellToolbar.register_preset('KBase', kbasePreset);
-    };
-    return {'register': register};
+    return {register: register};
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -1,19 +1,12 @@
 /*global define*/
 /*jslint white: true*/
-define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
-		'narrativeConfig',
-		'util/timeFormat'
-	], function(
-		KBWidget,
-		bootstrap,
-		$,
-		Config,
-		TimeFormat
-	) {
+define(['jquery',
+    'narrativeConfig',
+    'util/timeFormat',
+    'base/js/namespace',
+    'kbwidget',
+    'bootstrap'],
+    function ($, Config, TimeFormat, Jupyter) {
     'use strict';
     return KBWidget({
         name: 'kbaseNarrativeCellMenu',
@@ -35,6 +28,15 @@ define (
 
             this.$timestamp = $('<span class="kb-func-timestamp">');
 
+                var devMode = true;
+
+                var $editMetadataButton = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Edit Cell Metadata (dev mode!!)">')
+                    .append($('<span class="fa fa-file-o" style="font-size:14pt;">'))
+                    .click(function () {
+                        alert('editing metadata....');
+                    }
+                    .bind(this));
+
             var $deleteBtn = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Delete Cell">')
                 .append($('<span class="fa fa-trash-o" style="font-size:14pt;">'))
                 .click(function () {
@@ -47,11 +49,10 @@ define (
             this.$collapseBtn = $('<button type="button" class="btn btn-default btn-xs" role="button" data-button="toggle" style="width:20px"><span class="fa fa-chevron-down"></button>')
                 .on('click', function () {
                     this.$elem.trigger('toggle.toolbar');
-                }.bind(this));
-
-            var cell = this.options.cell;
-
-
+                        e.preventDefault();
+                        e.stopPropagation();
+                    }
+                    .bind(this));
 
             this.$menu = $('<ul>')
                 .addClass('dropdown-menu dropdown-menu-right');
@@ -251,7 +252,7 @@ define (
                     default: 
                         self.$jobStateIcon.html('?: ' + data.status); 
                 }
-            })
+                });
             
             this.$elem.on('job-state.toolbar', function (e, data) {
                 switch (data.status) {
@@ -343,6 +344,7 @@ define (
                             .append(this.$jobStateIcon)
                             .append($deleteBtn)
                             .append($dropdownMenu)
+                                .append($editMetadataButton)
                         )
                     )
                 )
@@ -411,8 +413,10 @@ define (
 
             return this;
         },
-
-        toggleState: function(state) {
+            toggleState: function (state) {
+                if (!this.$collapseBtn) {
+                    return;
+                }
             var $icon = this.$collapseBtn.find('span.fa');
 
             switch (state) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeCellMenu.js
@@ -1,16 +1,16 @@
 /*global define*/
 /*jslint white: true*/
-define(['jquery',
+define([
+    'jquery',
     'narrativeConfig',
     'util/timeFormat',
     'base/js/namespace',
     'kbwidget',
-    'bootstrap'],
-    function ($, Config, TimeFormat, Jupyter) {
+    'bootstrap'
+], function ($, Config, TimeFormat, Jupyter, KBWidget) {
     'use strict';
     return KBWidget({
         name: 'kbaseNarrativeCellMenu',
-        
         options: {cell: null, kbWidget: null, kbWidgetType: null},
         genId: function () {
             if (!this.lastId) {
@@ -28,14 +28,14 @@ define(['jquery',
 
             this.$timestamp = $('<span class="kb-func-timestamp">');
 
-                var devMode = true;
+            var devMode = true;
 
-                var $editMetadataButton = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Edit Cell Metadata (dev mode!!)">')
-                    .append($('<span class="fa fa-file-o" style="font-size:14pt;">'))
-                    .click(function () {
-                        alert('editing metadata....');
-                    }
-                    .bind(this));
+            var $editMetadataButton = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Edit Cell Metadata (dev mode!!)">')
+                .append($('<span class="fa fa-file-o" style="font-size:14pt;">'))
+                .click(function () {
+                    alert('editing metadata....');
+                }
+                .bind(this));
 
             var $deleteBtn = $('<button type="button" class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="left" Title="Delete Cell">')
                 .append($('<span class="fa fa-trash-o" style="font-size:14pt;">'))
@@ -47,16 +47,16 @@ define(['jquery',
                 .append($('<span class="fa fa-cog" style="font-size:14pt">'));
 
             this.$collapseBtn = $('<button type="button" class="btn btn-default btn-xs" role="button" data-button="toggle" style="width:20px"><span class="fa fa-chevron-down"></button>')
-                .on('click', function () {
+                .on('click', function (e) {
                     this.$elem.trigger('toggle.toolbar');
-                        e.preventDefault();
-                        e.stopPropagation();
-                    }
-                    .bind(this));
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+                .bind(this));
 
             this.$menu = $('<ul>')
                 .addClass('dropdown-menu dropdown-menu-right');
-            
+
             if (Config.get('dev_mode')) {
                 this.addMenuItem({
                     icon: 'fa fa-code',
@@ -127,7 +127,7 @@ define(['jquery',
                             // the method initializes an internal method input widget, but in an async way
                             // so we have to wait and check when that is done.  When it is, we can update state
                             var newCell = Jupyter.notebook.get_selected_cell();
-                            var newWidget =  new kbaseNarrativeMethodCell($('#' + $(newCell.get_text())[0].id));
+                            var newWidget = new kbaseNarrativeMethodCell($('#' + $(newCell.get_text())[0].id));
                             var updateState = function (state) {
                                 if (newWidget.$inputWidget) {
                                     // if the $inputWidget is not null, we are good to go, so set the state
@@ -147,19 +147,18 @@ define(['jquery',
                 this.addMenuItem({
                     icon: 'fa fa-terminal',
                     text: 'Toggle Cell Type',
-                    action: function() {
+                    action: function () {
                         if (this.options.cell.cell_type === "markdown") {
                             Jupyter.notebook.to_code();
-                        }
-                        else {
+                        } else {
                             Jupyter.notebook.to_markdown();
                         }
-                    }.bind(this),
+                    }.bind(this)
                 });
             }
 
             var self = this;
-            
+
             // Job State Icon
             this.$jobStateIcon = $('<span>');
 
@@ -173,11 +172,11 @@ define(['jquery',
             this.$elem.on('start-running', function () {
                 self.$runningIcon.show();
             });
-            
+
             this.$elem.on('stop-running', function () {
                 self.$runningIcon.hide();
             });
-            
+
             this.$elem.on('runningIndicator.toolbar', function (e, data) {
 //                if (data.enabled) {
 //                    self.$runningIcon.show();
@@ -193,12 +192,12 @@ define(['jquery',
 //                    }));
 //                }
             });
-            
+
             this.$elem.on('show-title.toolbar', function () {
                 this.$elem.find('div.title').css('display', 'inline-block');
             }.bind(this));
 
-            this.$elem.on('hide-title.toolbar', function() {
+            this.$elem.on('hide-title.toolbar', function () {
                 this.$elem.find('div.title').css('display', 'none');
             }.bind(this));
 
@@ -206,7 +205,7 @@ define(['jquery',
                 Jupyter.notebook.events.trigger('select.Cell', this.options.cell);
             }.bind(this));
 
-            this.$elem.dblclick(function(e) {
+            this.$elem.dblclick(function (e) {
                 e.stopPropagation();
                 $(this).trigger('toggle.toolbar');
             });
@@ -226,57 +225,57 @@ define(['jquery',
             function makeIcon(icon) {
                 var spinClass = icon.spin ? 'fa-spin' : '',
                     label = icon.label ? icon.label + ' ' : '',
-                    iconHtml = '<span>'+label+'<i class="fa fa-' + icon.class + " " + spinClass +'" style="color: '+ (icon.color || '#000') +'"></i></span>';
+                    iconHtml = '<span>' + label + '<i class="fa fa-' + icon.class + " " + spinClass + '" style="color: ' + (icon.color || '#000') + '"></i></span>';
                 return iconHtml;
             }
-            
+
             this.$elem.on('run-state.toolbar', function (e, data) {
                 switch (data.status) {
                     case 'submitted':
                         self.$jobStateIcon.html(makeIcon({
-                            class: 'asterisk', 
-                            color: 'orange', 
+                            class: 'asterisk',
+                            color: 'orange',
                             spin: true,
                             label: 'Queued'
                         }));
                         break;
-                    case 'running': 
+                    case 'running':
                         self.$jobStateIcon.html(makeIcon({class: 'circle-o-notch', color: 'blue', spin: true, label: 'Running'}));
                         break;
                     case 'complete':
                         self.$jobStateIcon.html(makeIcon({class: 'check', color: 'green', label: 'Finished'}));
                         break;
-                    case 'error': 
+                    case 'error':
                         self.$jobStateIcon.html('ERROR');
                         break;
-                    default: 
-                        self.$jobStateIcon.html('?: ' + data.status); 
+                    default:
+                        self.$jobStateIcon.html('?: ' + data.status);
                 }
-                });
-            
+            });
+
             this.$elem.on('job-state.toolbar', function (e, data) {
                 switch (data.status) {
                     case 'queued':
                         self.$jobStateIcon.html(makeIcon({
-                            class: 'asterisk', 
-                            color: 'orange', 
+                            class: 'asterisk',
+                            color: 'orange',
                             spin: true,
                             label: 'Queued'
                         }));
                         break;
                     case 'in-progress':
-                    case 'running': 
+                    case 'running':
                         self.$jobStateIcon.html(makeIcon({class: 'circle-o-notch', color: 'blue', spin: true, label: 'Running'}));
                         break;
-                    case 'error': 
+                    case 'error':
                         self.$jobStateIcon.html('ERROR');
                         break;
                     case 'complete':
                     case 'completed':
                         self.$jobStateIcon.html(makeIcon({class: 'check', color: 'green', label: 'Finished'}));
                         break;
-                    default: 
-                        self.$jobStateIcon.html('?: ' + data.status); 
+                    default:
+                        self.$jobStateIcon.html('?: ' + data.status);
                 }
             });
 
@@ -330,12 +329,12 @@ define(['jquery',
                     .append($('<div class="col-sm-8">')
                         .append($('<div class="buttons pull-left">')
                             .append(this.$collapseBtn)
-                        )
+                            )
                         .append($('<div class="title" style="display:inline-block">')
                             .append('<div data-element="title" class="title"></div>') // title here
                             .append(this.$subtitle)
+                            )
                         )
-                    )
                     .append($('<div class="col-sm-4">')
                         .append($('<div class="buttons pull-right">')
                             .append(this.$timestamp)
@@ -344,13 +343,13 @@ define(['jquery',
                             .append(this.$jobStateIcon)
                             .append($deleteBtn)
                             .append($dropdownMenu)
-                                .append($editMetadataButton)
+                            .append($editMetadataButton)
+                            )
                         )
                     )
-                )
-            );
+                );
             $deleteBtn.tooltip();
-            
+
             /*
              * A workaround to provide the default state to buttons, et al.
              * jupyter should call select/unselect on each cell as they are added,
@@ -358,13 +357,13 @@ define(['jquery',
              * but no unselect event upon which to trigger actions.
              * Actually, there should be a 'can unselect' as well, since a cell
              * might no be happy with being left in an unfinished state.
-            */
+             */
             $dropdownMenu.find('.btn').addClass('disabled');
             $deleteBtn.addClass('disabled');
 
             // Set up title.
-            var $titleNode = this.$elem.find('[data-element="title"]');            
-            this.$elem.on('set-title.toolbar', function (e, title) { 
+            var $titleNode = this.$elem.find('[data-element="title"]');
+            this.$elem.on('set-title.toolbar', function (e, title) {
                 e.stopPropagation();
 //                if (typeof title === 'object') {
 //                    if (title.suffix) {
@@ -375,25 +374,25 @@ define(['jquery',
 //                }
                 $titleNode.html(title);
             });
-            
+
             /* And an icon -- hack to go into the input prompt for now...
              *
              * Get the cell node from the cell passed in, rather than use our
              * node and find it.
              * $cell =  = $(options.cell.element);
-            */
-           
+             */
+
             this.$elem.on('set-icon.toolbar', function (e, icon) {
-                var $cell = $(self.options.cell.element), 
+                var $cell = $(self.options.cell.element),
                     $iconNode = $cell.find('.prompt');
                 e.stopPropagation();
                 var wrapped = '<div style="text-align: center;">' + icon + '</div>';
                 $iconNode.html(wrapped);
             });
-            
+
             var $cell = (options && options.cell && $(options.cell.element)) || self.$elem.closest('.cell'),
                 icon = $cell.data('icon');
-            
+
             if (icon) {
                 this.$elem.trigger('set-icon.toolbar', [icon]);
             }
@@ -404,19 +403,19 @@ define(['jquery',
             if (title) {
                 this.$elem.trigger('set-title.toolbar', [title]);
             }
-            
+
             // Rendering done, now add events.
-            
+
             // Events done, not call actions.
             // this.options.cell.celltoobar.renderToggleState();
 
 
             return this;
         },
-            toggleState: function (state) {
-                if (!this.$collapseBtn) {
-                    return;
-                }
+        toggleState: function (state) {
+            if (!this.$collapseBtn) {
+                return;
+            }
             var $icon = this.$collapseBtn.find('span.fa');
 
             switch (state) {
@@ -428,7 +427,7 @@ define(['jquery',
                         var type = this.options.cell.metadata['kb-cell']['type'];
                         var $kbCell = $(this.options.cell.element).find('[id^=kb-cell]');
                         if ($kbCell) {
-                            switch(type) {
+                            switch (type) {
                                 case 'kb_app':
                                     this.$subtitle.html($kbCell.kbaseNarrativeAppCell('getSubtitle'));
                                     break;
@@ -441,7 +440,7 @@ define(['jquery',
                                 case 'function_input':
                                     // doing this more declarative causes some funky rendering issues.
                                     // we need some better message passing, I think.
-                                    $kbCell.trigger('get_cell_subtitle.Narrative', function(text) {
+                                    $kbCell.trigger('get_cell_subtitle.Narrative', function (text) {
                                         this.$subtitle.html(text);
                                     }.bind(this));
                                     break;
@@ -460,12 +459,10 @@ define(['jquery',
                     break;
             }
         },
-
         setSubtitle: function (value) {
             if (this.$subtitle)
                 this.$subtitle.html(value);
         },
-
         addMenuItem: function (item) {
             var label = '';
             if (item.icon) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -14,9 +14,7 @@
 define (
 	[
 		'kbwidget',
-		'bootstrap',
 		'jquery',
-		'underscore',
 		'bluebird',
 		'handlebars',
 		'narrativeConfig',
@@ -25,27 +23,27 @@ define (
 		'text!kbase/templates/beta_warning_body.html',
 		'kbaseAccordion',
 		'kbaseNarrativeControlPanel',
+                'base/js/namespace',
+                'kb_service/client/narrativeMethodStore',
+                
 		'narrative_core/catalog/kbaseCatalogBrowser',
 		'kbaseNarrative',
 		'catalog-client-api',
-		'kbase-client-api'
+		'kbase-client-api',
+		'bootstrap'
 	], function(
 		KBWidget,
-		bootstrap_g,
 		$,
-		_,
 		Promise,
 		Handlebars,
 		Config,
 		DisplayUtil,
 		BootstrapDialog,
 		BetaWarningTemplate,
-        kbaseAccordion,
+                kbaseAccordion,
 		kbaseNarrativeControlPanel,
-		narrative_core_catalog_kbaseCatalogBrowser,
-		kbaseNarrative,
-		catalog_client_api,
-		kbase_client_api
+                Jupyter,
+                NarrativeMethodStore
 	) {
     'use strict';
     return KBWidget({
@@ -125,7 +123,7 @@ define (
                                 );
 
             this.$searchInput.on('keyup', function (e) {
-                if (e.keyCode == 27) {
+                if (e.keyCode === 27) {
                     this.$searchDiv.toggle({effect: 'blind', duration: 'fast'});
                 }
             }.bind(this));
@@ -276,8 +274,8 @@ define (
                             })
                            .click(function(e) {
                                 var versionTag = 'release';
-                                if(this.versionState=='B') { versionTag='beta'; }
-                                else if(this.versionState=='D') { versionTag='dev'; }
+                                if(this.versionState === 'B') { versionTag='beta'; }
+                                else if(this.versionState === 'D') { versionTag='dev'; }
                                 this.refreshFromService(versionTag);
 
                                 if(this.appCatalog) {
@@ -541,7 +539,7 @@ define (
                                     for(var k=0; k<favs.length; k++) {
                                         var fav = favs[k];
                                         var lookup = fav.id;
-                                        if(fav.module_name_lc != 'nms.legacy') {
+                                        if(fav.module_name_lc !== 'nms.legacy') {
                                             lookup = fav.module_name_lc + '/' + lookup
                                         }
                                         if(self.methodSpecs[lookup]) {
@@ -573,7 +571,7 @@ define (
                 if(!method['spec']) {
                     self.methClient.get_method_spec({ids:[method.info.id],tag:self.currentTag})
                         .then(function(spec){
-                            // todo: cache this sped into the methods list
+                            // todo: cache this spec into the methods list
                             self.trigger('methodClicked.Narrative', [spec[0], self.currentTag]);
                         });
                 } else {
@@ -655,7 +653,7 @@ define (
             // add icon (logo)
             var $logo = $('<div>');
 
-            if(icon=='A') {
+            if(icon === 'A') {
                 $logo.append( DisplayUtil.getAppIcon({ isApp: true , cursor: 'pointer', setColor:true }) );
             } else {
                 if(method.info.icon && method.info.icon.url) {
@@ -674,9 +672,9 @@ define (
                 }, this));
 
             var $star = $('<i>');
-            if(icon=='M') {
+            if(icon === 'M') {
                 if(method.favorite) {
-                    $star.addClass('fa fa-star kbcb-star-favorite').append('&nbsp;')
+                    $star.addClass('fa fa-star kbcb-star-favorite').append('&nbsp;');
                 } else {
                     $star.addClass('fa fa-star kbcb-star-nonfavorite').append('&nbsp;');
                 }
@@ -685,7 +683,7 @@ define (
                     var params = {};
                     if(method.info.module_name) {
                         params['module_name'] = method.info.module_name;
-                        params['id'] = method.info.id.split('/')[1]
+                        params['id'] = method.info.id.split('/')[1];
                     } else {
                         params['id'] = method.info.id;
                     }
@@ -1007,14 +1005,14 @@ define (
                                             var $opened = $(this).closest('.panel').find('.in');
                                             var $target = $(this).next();
 
-                                            if ($opened != undefined) {
+                                            if ($opened !== undefined) {
                                                 $opened.collapse('hide');
                                                 var $i = $opened.parent().first().find('i');
                                                 $i.removeClass('fa fa-chevron-down');
                                                 $i.addClass('fa fa-chevron-right');
                                             }
 
-                                            if ($target.get(0) != $opened.get(0)) {
+                                            if ($target.get(0) !== $opened.get(0)) {
                                                 $target.collapse('show');
                                                 var $i = $(this).parent().find('i');
                                                 $i.removeClass('fa fa-chevron-right');
@@ -1116,7 +1114,7 @@ define (
                         }
                     }
                 }
-            }
+            };
             if (spec.steps) {
                 // ignoring apps right now
                 for (var i=0; i<spec.steps.length; i++) {
@@ -1131,7 +1129,7 @@ define (
             } else {
                 // this is a method-- things are easy now because this info is returned by the NMS!
                 // if style==object => check both input and output
-                if(style=='input' || style=='object') {
+                if(style === 'input' || style === 'object') {
                     if(spec.info.input_types) {
                         for(var k=0; k<spec.info.input_types.length; k++) {
                             if(spec.info.input_types[k].toLowerCase().indexOf(type) >=0) {
@@ -1139,7 +1137,7 @@ define (
                             }
                         }
                     }
-                } else if (style=='output' || style=='object') {
+                } else if (style === 'output' || style === 'object') {
                     if(spec.info.output_types) {
                         for(var k=0; k<spec.info.output_types.length; k++) {
                             if(spec.info.output_types[k].toLowerCase().indexOf(type) >=0) {
@@ -1186,7 +1184,7 @@ define (
                 for (var id in set) {
                     // have to make sure module names are in LC, annoying, I know!
                     var idTokens = id.split('/');
-                    if(idTokens.length==2) { // has a module name
+                    if(idTokens.length === 2) { // has a module name
                         id = idTokens[0].toLowerCase() + '/' + idTokens[1];
                     }
                     if (!filterFn(fnInput, set[id])) {
@@ -1234,6 +1232,6 @@ define (
         // Temporary pass-through for Jim's gallery widget
         toggleOverlay: function() {
             this.trigger('toggleSidePanelOverlay.Narrative');
-        },
+        }
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -320,26 +320,48 @@ define (
         },
 
         buildMethodCodeCell: function(spec, tag) {
-            var cell = Jupyter.narrative.insertAndSelectCellBelow('code');
+            // TODO: should probably throw an error here
+            // should not even get here!
             var methodName = "Unknown method";
-            if (spec && spec.behavior && spec.behavior.kb_service_method) {
-                methodName = spec.behavior.kb_service_method;
+            // if (spec && spec.behavior && spec.behavior.kb_service_method) {
+            if (!spec || !spec.info) {
+                console.error('ERROR build method code cell: ', spec, tag);
+                alert('Sorry, could not find this method');
+                return;
             }
-            var moduleName = "Unknown module";
-            if (spec && spec.behavior && spec.behavior.kb_service_name) {
-                moduleName = spec.behavior.kb_service_name;
-            }
+            // methodName = spec.behavior.kb_service_method;
+            // var moduleName = "Unknown module";
+            //if (spec && spec.behavior && spec.behavior.kb_service_name) {
+            //    // moduleName = spec.behavior.kb_service_name;
+            //    moduleName = spec.info.module_name;
+            // }
+            // TODO: probably should record the git commit hash and/or the version
+            // 
             var cellMetadata = {
-                'kbase': {
-                    'type': 'method',
-                    'method': {
-                        'version': tag,
-                        'name': methodName,
-                        'module': moduleName
+                kbase: {
+                    type: 'method',
+                    method: {
+                        tag: tag,
+                        name: spec.info.id,
+                        module: spec.info.module_name,
+                        gitCommitHash: spec.info.git_commit_hash,
+                        version: spec.info.ver
                     }
                 }
             };
+            // This will also trigger the create.Cell event, which is not very 
+            // useful for us really since we haven't been able to set the
+            // metadata yet. Don't worry, I checked, the Jupyter api does not
+            // provide a way to set the cell metadata as it is being created.
+            var cell = Jupyter.narrative.insertAndSelectCellBelow('code');
+            
             cell.metadata = cellMetadata;
+            
+            // Now we need to invent a way of triggering the cell to set itself up.
+            $([Jupyter.events]).trigger('updated.Cell', {
+                cell: cell
+            });
+
         },
 
 

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -46,7 +46,24 @@ require.config({
          * New Test Runtime and Widget Framework
          */
         runtimeManager : 'kbase/js/widgetApi/runtimeManager',
+        messageManager : 'kbase/js/widgetApi/messageManager',
         narrativeDataWidget: 'kbase/js/widgetApi/narrativeDataWidget',
+        narrativeDataWidgetIFrame: 'kbase/js/widgetApi/narrativeDataWidgetIFrame',
+        widgetService2: 'kbase/js/widgetApi/widgetService2',
+        
+        /*
+         * From CDN
+         */
+        kb_common: 'http://cdn.kbase.us/cdn/kbase-common-js/1.5.4/',
+        kb_service: 'http://cdn.kbase.us/cdn/kbase-service-clients-js/1.4.0/',
+        uuid: 'http://cdn.kbase.us/cdn/pure-uuid/1.3.0/uuid',
+        //bluebird: 'http://cdn.kbase.us/cdn/bluebird/3.3.4/bluebird',
+        //underscore: 'http://cdn.kbase.us/cdn/underscore/1.8.3/underscore',
+        text:  'http://cdn.kbase.us/cdn/requirejs-text/2.0.14/text',
+        css: 'http://cdn.kbase.us/cdn/require-css/0.1.8/css',
+        'font-awesome': 'http://cdn.kbase.us/cdn/font-awesome/4.3.0/css/font-awesome',
+        
+        
 
         /***
          * CORE NARRATIVE WIDGETS

--- a/nbextensions/install.sh
+++ b/nbextensions/install.sh
@@ -1,0 +1,15 @@
+dir=$(pwd)
+narrdir=$(cd ../..;pwd)
+
+export NARRATIVE_DIR=$narrdir
+export JUPYTER_CONFIG_DIR=$narrdir/kbase-extension
+export JUPYTER_RUNTIME_DIR=/tmp/jupyter_runtime
+export JUPYTER_DATA_DIR=/tmp/jupyter_data
+export JUPYTER_PATH=$narrdir/kbase-extension
+export IPYTHONDIR=$narrdir/kbase-extension/ipython
+
+echo 'Root dir'
+echo ${dir}
+
+jupyter nbextension install ${dir}/methodCell --symlink --sys-prefix
+jupyter nbextension enable methodCell/main --sys-prefix

--- a/nbextensions/methodCell/events.js
+++ b/nbextensions/methodCell/events.js
@@ -1,0 +1,77 @@
+/*global define,console*/
+/*jslint white:true,browser:true*/
+define([
+    'kb_common/html'
+], function (html) {
+    'use strict';
+
+    function factory(config) {
+        var events = [];
+        function addEvent(event) {
+            var selector, id;
+            if (event.id) {
+                id = event.id;
+                selector = '#' + event.id;
+            } else if (event.selector) {
+                id = html.genId();
+                selector = event.selector;
+            } else {
+                id = html.genId();
+                selector = '#' + id;
+            }
+            events.push({
+                type: event.type,
+                selector: selector,
+                handler: function (e) {
+                    event.handler(e);
+                }
+            });
+            return id;
+        }
+        function addEvents(newEvents) {
+            var selector, id;
+            if (newEvents.id) {
+                id = newEvents.id;
+                selector = '#' + newEvents.id;
+            } else if (newEvents.selector) {
+                id = html.genId();
+                selector = newEvents.selector;
+            } else {
+                id = html.genId();
+                selector = '#' + id;
+            }
+            newEvents.events.forEach(function (event) {
+                events.push({
+                    type: event.type,
+                    selector: selector,
+                    handler: function (e) {
+                        event.handler(e);
+                    }
+                });
+            });
+            return id;
+        }
+        function attachEvents(root) {
+            events.forEach(function (event) {
+                var node = root.querySelector(event.selector);
+                if (!node) {
+                    console.error('could not find node for ' + event.selector);
+                    throw new Error('could not find node for ' + event.selector);
+                }
+                node.addEventListener(event.type, event.handler);
+            });
+            events = [];
+        }
+        return {
+            addEvent: addEvent,
+            addEvents: addEvents,
+            attachEvents: attachEvents
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/html.js
+++ b/nbextensions/methodCell/html.js
@@ -1,0 +1,733 @@
+/*global
+ define
+ */
+/*jslint
+ browser: true,
+ white: true
+ */
+define([
+    'underscore'
+], function (underscore) {
+    'use strict';
+    return (function () {
+        
+        // fake uuid for now
+        var uuidState = 0;
+        function uuid() {
+            uuidState += 1;
+            return 'fake_uuid_' + (new Date()).getTime() + '_' + uuidState();
+        }
+
+        function jsonToHTML(node) {
+            var nodeType = typeof node,
+                out;
+            if (nodeType === 'string') {
+                return node;
+            }
+            if (nodeType === 'boolean') {
+                if (node) {
+                    return 'true';
+                }
+                return 'false';
+            }
+            if (nodeType === 'number') {
+                return String(node);
+            }
+            if (nodeType === 'object' && node.push) {
+                out = '';
+                node.forEach(function (item) {
+                    out += jsonToHTML(item);
+                });
+                return out;
+            }
+            if (nodeType === 'object') {
+                out = '';
+                out += '<' + nodeType.tag;
+                if (node.attributes) {
+                    node.attributes.keys().forEach(function (key) {
+                        out += key + '="' + node.attributes[key] + '"';
+                    });
+                }
+                out += '>';
+                if (node.children) {
+                    out += jsonToHTML(node.children);
+                }
+                out += '</' + node.tag + '>';
+                return out;
+            }
+        }
+
+        var tags = {};
+        /**
+         * Given a simple object of keys and values, create a string which 
+         * encodes them into a form suitable for the value of a style attribute.
+         * Style attribute values are themselves attributes, but due to the limitation
+         * of html attributes, they are embedded in a string:
+         * The format is
+         * key: value;
+         * Note that values are not quoted, and the separator between fields is
+         * a semicolon
+         * Note that we expect the value to be embedded withing an html attribute
+         * which is quoted with double-qoutes; but we don't do any escaping here.
+         * @param {type} attribs
+         * @returns {String}
+         */
+        function camelToHyphen(s) {
+            return s.replace(/[A-Z]/g, function (m) {
+                return '-' + m.toLowerCase();
+            });
+        }
+        function makeStyleAttribs(attribs) {
+            if (attribs) {
+                return Object.keys(attribs)
+                    .map(function (rawKey) {
+                        var value = attribs[rawKey],
+                            key = camelToHyphen(rawKey);
+
+                        if (typeof value === 'string') {
+                            return key + ': ' + value;
+                        }
+                        // just ignore invalid attributes for now
+                        // TODO: what is the proper thing to do?
+                        return '';
+                    })
+                    .filter(function (field) {
+                        return field ? true : false;
+                    })
+                    .join('; ');
+            }
+            return '';
+        }
+
+        /**
+         * The attributes for knockout's data-bind is slightly different than
+         * for style. The syntax is that of a simple javascript object.
+         * property: value, property: "value", property: 123
+         * So, we simply escape double-quotes on the value, so that unquoted values
+         * will remain as raw names/symbols/numbers, and quoted strings will retain
+         * the quotes.
+         * TODO: it would be smarter to detect if it was a quoted string
+         * 
+         * @param {type} attribs
+         * @returns {String}
+         */
+        function makeDataBindAttribs(attribs) {
+            if (attribs) {
+                return Object.keys(attribs)
+                    .map(function (key) {
+                        var value = attribs[key];
+                        if (typeof value === 'string') {
+                            //var escapedValue = value.replace(/\"/g, '\\"');
+                            return key + ':' + value;
+                        }
+                        if (typeof value === 'object') {
+                            return key + ': {' + makeDataBindAttribs(value) + '}';
+                        }
+                        // just ignore invalid attributes for now
+                        // TODO: what is the proper thing to do?
+                        return '';
+                    })
+                    .filter(function (field) {
+                        return field ? true : false;
+                    })
+                    .join(',');
+            }
+            return '';
+        }
+
+        /**
+         * Given a simple object of keys and values, create a string which 
+         * encodes a set of html tag attributes.
+         * String values escape the "
+         * Boolean values either insert the attribute name or not
+         * Object values are interpreted as "embedded attributes" (see above)
+         * @param {type} attribs
+         * @returns {String}
+         */
+        function makeTagAttribs(attribs) {
+            var quoteChar = '"', escapedValue;
+            if (attribs) {
+                return Object.keys(attribs)
+                    .map(function (key) {
+                        var value = attribs[key],
+                            attribName = camelToHyphen(key);
+                        // The value may itself be an object, which becomes a special string.
+                        // This applies for "style" and "data-bind", each of which have a 
+                        // structured string value.
+                        // Another special case is an array, useful for space-separated
+                        // attributes, esp. "class".
+                        if (typeof value === 'object') {
+                            if (value === null) {
+                                // null works just like false.
+                                value = false;
+                            } else if (value instanceof Array) {
+                                value = value.join(' ');
+                            } else {
+                                switch (attribName) {
+                                    case 'style':
+                                        value = makeStyleAttribs(value);
+                                        break;
+                                    case 'data-bind':
+                                        // reverse the quote char, since data-bind attributes 
+                                        // can contain double-quote, which can't itself
+                                        // be quoted.
+                                        quoteChar = "'";
+                                        value = makeDataBindAttribs(value);
+                                        break;
+                                    default:
+                                        value = false;
+                                }
+                            }
+                        }
+                        if (typeof value === 'string') {
+                            escapedValue = value.replace(new RegExp('\\' + quoteChar, 'g'), '\\' + quoteChar);
+                            return attribName + '=' + quoteChar + escapedValue + quoteChar;
+                        }
+                        if (typeof value === 'boolean') {
+                            if (value) {
+                                return attribName;
+                            }
+                            return false;
+                        }
+                        if (typeof value === 'number') {
+                            return attribName + '=' + quoteChar + String(value) + quoteChar;
+                        }
+                        return false;
+                    })
+                    .filter(function (field) {
+                        return field ? true : false;
+                    })
+                    .join(' ');
+            }
+            return '';
+        }
+        function renderContent(children) {
+            if (children) {
+                if (underscore.isString(children)) {
+                    return children;
+                }
+                if (underscore.isNumber(children)) {
+                    return String(children);
+                }
+                if (underscore.isArray(children)) {
+                    return children.map(function (item) {
+                        return renderContent(item);
+                    }).join('');
+                }
+            } else {
+                return '';
+            }
+        }
+        function merge(obj1, obj2) {
+            function isObject(x) {
+                if (typeof x === 'object' &&
+                    x !== null &&
+                    !(x instanceof Array)) {
+                    return true;
+                }
+                return false;
+            }
+            function merger(a, b) {
+                Object.keys(b).forEach(function (key) {
+                    if (isObject(a) && isObject(b)) {
+                        a[key] = merger(a[key], b[key]);
+                    }
+                    a[key] = b[key];
+                });
+                return a;
+            }
+            return merger(obj1, obj2);
+        }
+        function tag(tagName, options) {
+            options = options || {};
+            var tagAttribs;
+            if (tags[tagName] && !options.ignoreCache) {
+                return tags[tagName];
+            }
+            var tagFun = function (attribs, children) {
+                var node = '<' + tagName;
+                if (underscore.isArray(attribs)) {
+                    // skip attribs, just go to children.
+                    children = attribs;
+                    attribs = null;
+                } else if (underscore.isString(attribs)) {
+                    // skip attribs, just go to children.
+                    children = attribs;
+                    attribs = null;
+                } else if (underscore.isNull(attribs) || underscore.isUndefined(attribs)) {
+                    if (!children) {
+                        children = '';
+                    }
+                } else if (underscore.isObject(attribs)) {
+                    if (options.attribs) {
+                        attribs = merge(merge({}, options.attribs), attribs);
+                    }
+                } else if (underscore.isNumber(attribs)) {
+                    children = String(attribs);
+                    attribs = null;
+                } else if (underscore.isBoolean(attribs)) {
+                    if (attribs) {
+                        children = 'true';
+                    } else {
+                        children = 'false';
+                    }
+                    attribs = null;
+                } else {
+                    throw 'Cannot make tag ' + tagName + ' from a ' + (typeof attribs);
+                }
+                attribs = attribs || options.attribs;
+                if (attribs) {
+                    tagAttribs = makeTagAttribs(attribs);
+                    if (tagAttribs && tagAttribs.length > 0) {
+                        node += ' ' + tagAttribs;
+                    }
+                }
+
+                node += '>';
+                if (options.close !== false) {
+                    node += renderContent(children);
+                    node += '</' + tagName + '>';
+                }
+                return node;
+            };
+            if (!options.ignoreCache) {
+                tags[tagName] = tagFun;
+            }
+            return tagFun;
+        }
+        function genId() {
+            return 'kb_html_' + uuid();
+        }
+        function makeTable(arg) {
+            var table = tag('table'),
+                thead = tag('thead'),
+                tbody = tag('tbody'),
+                tr = tag('tr'),
+                th = tag('th'),
+                td = tag('td'), id, attribs;
+            arg = arg || {};
+            if (arg.id) {
+                id = arg.id;
+            } else {
+                id = genId();
+                arg.generated = {id: id};
+            }
+            attribs = {id: id};
+            if (arg.class) {
+                attribs.class = arg.class;
+            } else if (arg.classes) {
+                attribs.class = arg.classes.join(' ');
+            }
+            return table(attribs, [
+                thead(tr(arg.columns.map(function (x) {
+                    return th(x);
+                }))),
+                tbody(arg.rows.map(function (row) {
+                    return tr(row.map(function (x) {
+                        return td(x);
+                    }));
+                }))
+            ]);
+        }
+
+        function bsPanel(title, content) {
+            var div = tag('div'),
+                span = tag('span');
+
+            return div({class: 'panel panel-default'}, [
+                div({class: 'panel-heading'}, [
+                    span({class: 'panel-title'}, title)
+                ]),
+                div({class: 'panel-body'}, [
+                    content
+                ])
+            ]);
+        }
+
+        function makePanel(arg) {
+            var div = tag('div'),
+                span = tag('span'),
+                klass = arg.class || 'default';
+
+            return div({class: 'panel panel-' + klass}, [
+                div({class: 'panel-heading'}, [
+                    span({class: 'panel-title'}, arg.title)
+                ]),
+                div({class: 'panel-body'}, [
+                    arg.content
+                ])
+            ]);
+        }
+
+        function loading(msg) {
+            var span = tag('span'),
+                i = tag('i'),
+                prompt;
+            if (msg) {
+                prompt = msg + '... &nbsp &nbsp';
+            }
+            return span([
+                prompt,
+                i({class: 'fa fa-spinner fa-pulse fa-2x fa-fw margin-bottom'})
+            ]);
+        }
+
+        /*
+         * 
+         */
+        function makeTableRotated(arg) {
+            function columnLabel(column) {
+                var key;
+                if (typeof column === 'string') {
+                    key = column;
+                } else {
+                    if (column.label) {
+                        return column.label;
+                    }
+                    key = column.key;
+                }
+                return key
+                    .replace(/(id|Id)/g, 'ID')
+                    .split(/_/g).map(function (word) {
+                    return word.charAt(0).toUpperCase() + word.slice(1);
+                })
+                    .join(' ');
+            }
+            function formatValue(rawValue, column) {
+                if (typeof column === 'string') {
+                    return rawValue;
+                }
+                if (column.format) {
+                    return column.format(rawValue);
+                }
+                if (column.type) {
+                    switch (column.type) {
+                        case 'bool':
+                            // yuck, use truthiness
+                            if (rawValue) {
+                                return 'True';
+                            }
+                            return 'False';
+                        default:
+                            return rawValue;
+                    }
+                }
+                return rawValue;
+            }
+
+            var table = tag('table'),
+                tr = tag('tr'),
+                th = tag('th'),
+                td = tag('td'),
+                id = genId(),
+                attribs = {id: id};
+            if (arg.class) {
+                attribs.class = arg.class;
+            } else if (arg.classes) {
+                attribs.class = arg.classes.join(' ');
+            }
+
+            return table(attribs,
+                arg.columns.map(function (column, index) {
+                    return tr([
+                        th(columnLabel(column)),
+                        arg.rows.map(function (row) {
+                            return td(formatValue(row[index], column));
+                        })
+                    ]);
+                }));
+        }
+
+        function makeRotatedTable(data, columns) {
+            function columnLabel(column) {
+                var key;
+                if (column.label) {
+                    return column.label;
+                }
+                if (typeof column === 'string') {
+                    key = column;
+                } else {
+                    key = column.key;
+                }
+                return key
+                    .replace(/(id|Id)/g, 'ID')
+                    .split(/_/g).map(function (word) {
+                    return word.charAt(0).toUpperCase() + word.slice(1);
+                })
+                    .join(' ');
+            }
+            function columnValue(row, column) {
+                var rawValue = row[column.key];
+                if (column.format) {
+                    return column.format(rawValue);
+                }
+                if (column.type) {
+                    switch (column.type) {
+                        case 'bool':
+                            // yuck, use truthiness
+                            if (rawValue) {
+                                return 'True';
+                            }
+                            return 'False';
+                        default:
+                            return rawValue;
+                    }
+                }
+                return rawValue;
+            }
+
+            var table = tag('table'),
+                tr = tag('tr'),
+                th = tag('th'),
+                td = tag('td');
+            return table({class: 'table table-stiped table-bordered'},
+                columns.map(function (column) {
+                    return tr([
+                        th(columnLabel(column)), data.map(function (row) {
+                            return td(columnValue(row, column));
+                        })
+                    ]);
+                }));
+        }
+
+        function properCase(string) {
+            return string.charAt(0).toUpperCase() + string.slice(1);
+        }
+
+        function makeObjTable(data, options) {
+            var tableData = (data instanceof Array && data) || [data],
+                columns = (options && options.columns) || Object.keys(tableData[0]).map(function (key) {
+                return {
+                    key: key,
+                    label: properCase(key)
+                };
+            }),
+                classes = (options && options.classes) || ['table-striped', 'table-bordered'],
+                table = tag('table'),
+                tr = tag('tr'),
+                th = tag('th'),
+                td = tag('td');
+
+            function columnValue(row, column) {
+                var rawValue = row[column.key];
+                if (column.format) {
+                    return column.format(rawValue);
+                }
+                if (column.type) {
+                    switch (column.type) {
+                        case 'bool':
+                            // yuck, use truthiness
+                            if (rawValue) {
+                                return 'True';
+                            }
+                            return 'False';
+                        default:
+                            return rawValue;
+                    }
+                }
+                return rawValue;
+            }
+            if (options && options.rotated) {
+                return table({class: 'table ' + classes.join(' ')},
+                    columns.map(function (column) {
+                        return tr([
+                            th(column.label),
+                            tableData.map(function (row) {
+                                return td({dataElement: column.key}, columnValue(row, column));
+                            })
+                        ]);
+                    }));
+            }
+            return table({class: 'table ' + classes.join(' ')},
+                [tr(columns.map(function (column) {
+                        return th(column.label);
+                    }))].concat(tableData.map(function (row) {
+                return tr(columns.map(function (column) {
+                    return td({dataElement: column.key}, columnValue(row, column));
+                }));
+            })));
+        }
+
+        function makeObjectTable(data, options) {
+            function columnLabel(column) {
+                var key;
+                if (column.label) {
+                    return column.label;
+                }
+                if (typeof column === 'string') {
+                    key = column;
+                } else {
+                    key = column.key;
+                }
+                return key
+                    .replace(/(id|Id)/g, 'ID')
+                    .split(/_/g).map(function (word) {
+                    return word.charAt(0).toUpperCase() + word.slice(1);
+                })
+                    .join(' ');
+            }
+            function columnValue(row, column) {
+                var rawValue = row[column.key];
+                if (column.format) {
+                    return column.format(rawValue);
+                }
+                if (column.type) {
+                    switch (column.type) {
+                        case 'bool':
+                            // yuck, use truthiness
+                            if (rawValue) {
+                                return 'True';
+                            }
+                            return 'False';
+                        default:
+                            return rawValue;
+                    }
+                }
+                return rawValue;
+            }
+            var columns, classes;
+            if (!options) {
+                options = {};
+            } else if (options.columns) {
+                columns = options.columns;
+            } else {
+                columns = options;
+                options = {};
+            }
+            if (!columns) {
+                columns = Object.keys(data).map(function (columnName) {
+                    return {
+                        key: columnName
+                    };
+                });
+            } else {
+                columns = columns.map(function (column) {
+                    if (typeof column === 'string') {
+                        return {
+                            key: column
+                        };
+                    }
+                    return column;
+                });
+            }
+            if (options.classes) {
+                classes = options.classes;
+            } else {
+                classes = ['table-striped', 'table-bordered'];
+            }
+
+            var table = tag('table'),
+                tr = tag('tr'),
+                th = tag('th'),
+                td = tag('td'),
+                result = table({class: 'table ' + classes.join(' ')},
+                    columns.map(function (column) {
+                        return tr([
+                            th(columnLabel(column)),
+                            td(columnValue(data, column))
+                        ]);
+                    }));
+            return result;
+        }
+
+        function flatten(html) {
+            if (underscore.isString(html)) {
+                return html;
+            }
+            if (underscore.isArray(html)) {
+                return html.map(function (h) {
+                    return flatten(h);
+                }).join('');
+            }
+            throw new Error('Not a valid html representation -- must be string or list');
+        }
+
+        function makeList(arg) {
+            if (underscore.isArray(arg.items)) {
+                var ul = tag('ul'),
+                    li = tag('li');
+                return ul(arg.items.map(function (item) {
+                    return li(item);
+                }));
+            }
+            return 'Sorry, cannot make a list from that';
+        }
+
+        /**
+         * Make a bootsrap tabset:
+         * arg.tabs.id
+         * arg.tabs.label
+         * arg.tabs.name
+         * arg.tabs.content
+         * 
+         * @param {type} arg
+         * @returns {unresolved}
+         */
+        function makeTabs(arg) {
+            var ul = tag('ul'),
+                li = tag('li'),
+                a = tag('a'),
+                div = tag('div'),
+                tabsId = arg.id,
+                tabsAttribs = {};
+
+            if (tabsId) {
+                tabsAttribs.id = tabsId;
+            }
+            arg.tabs.forEach(function (tab) {
+                tab.id = genId();
+            });
+            return div(tabsAttribs, [
+                ul({class: 'nav nav-tabs', role: 'tablist'},
+                    arg.tabs.map(function (tab, index) {
+                        var attribs = {
+                            role: 'presentation'
+                        };
+                        if (index === 0) {
+                            attribs.class = 'active';
+                        }
+                        return li(attribs, a({
+                            href: '#' + tab.id,
+                            'aria-controls': 'home',
+                            role: 'tab',
+                            'data-toggle': 'tab'
+                        }, tab.label));
+                    })),
+                div({class: 'tab-content'},
+                    arg.tabs.map(function (tab, index) {
+                        var attribs = {
+                            role: 'tabpanel',
+                            class: 'tab-pane',
+                            id: tab.id
+                        };
+                        if (tab.name) {
+                            attribs['data-name'] = tab.name;
+                        }
+                        if (index === 0) {
+                            attribs.class += ' active';
+                        }
+                        return div(attribs, tab.content);
+                    })
+                    )
+            ]);
+        }
+
+        return {
+            html: jsonToHTML,
+            tag: tag,
+            makeTable: makeTable,
+            makeTableRotated: makeTableRotated,
+            makeRotatedTable: makeRotatedTable,
+            makeObjectTable: makeObjectTable,
+            makeObjTable: makeObjTable,
+            genId: genId,
+            bsPanel: bsPanel,
+            panel: bsPanel,
+            makePanel: makePanel,
+            loading: loading,
+            flatten: flatten,
+            makeList: makeList,
+            makeTabs: makeTabs
+        };
+    }());
+});

--- a/nbextensions/methodCell/main.js
+++ b/nbextensions/methodCell/main.js
@@ -1,0 +1,618 @@
+/*global define,console*/
+/*jslint white:true,browser:true*/
+/*
+ * KBase Method Cell Extension
+ * 
+ * Supports kbase method cells and the kbase cell toolbar.
+ * 
+ * Note that, out of our control, this operates under the "module as singleton" model.
+ * In this model, the execution of the module the first time per session is the same
+ * as creating a global management object.
+ * 
+ * Thus we do things like createa a message bus
+ * 
+ * @param {type} $
+ * @param {type} Jupyter
+ * @param {type} html
+ * 
+ */
+define([
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    'bluebird',
+    './widgets/codeCellInputWidget',
+    './widgets/FieldWidget',
+    './runtime',
+    './microBus',
+    'kb_service/utils',
+    'kb_service/client/workspace',
+    'css!./styles/method-widget.css',
+    'bootstrap'
+], function ($, Jupyter, html, Promise, CodeCellInputWidget, FieldWidget, Runtime, Bus, serviceUtils, Workspace) {
+    'use strict';
+    var t = html.tag,
+        div = t('div'), button = t('button'), span = t('span'), form = t('form'),
+        mainBus, methodCells = {},
+        workspaceInfo,
+        env,
+        runtime = Runtime.make();
+
+//    function getAuthToken() {
+//        if (env === 'narrative') {
+//            return Jupyter.narrative.authToken;
+//        }
+//        throw new Error('No authorization implemented for this environment: ' + env);
+//    }
+
+    function addCell(cell) {
+        methodCells[cell.cell_id] = {
+            cell: cell
+        };
+    }
+
+    function showNotifications(cell) {
+        // Update comment if any
+        if (!cell.metadata.kbase.notifications) {
+            return;
+        }
+
+        var notificationsNode = cell.kbase.$node.find('[data-element="body"] [data-element="notifications"]'),
+            content;
+
+        cell.metadata.kbase.notifications.forEach(function (notification) {
+            content = div({class: 'alert alert-' + notification.type, dataDismiss: 'alert'}, [
+                notification.message,
+                button({type: 'button', class: 'close', dataDismiss: 'alert', ariaLabel: 'Close'}, [
+                    span({ariaHidden: 'true'}, '&times;')
+                ])
+            ]);
+            notificationsNode.append(content);
+        });
+    }
+
+    function addNotification(cell, type, message) {
+        if (!cell.metadata.kbase.notifications) {
+            cell.metadata.kbase.notifications = [];
+        }
+        cell.metadata.kbase.notifications.push({
+            type: type,
+            message: message
+        });
+        showNotifications(cell);
+    }
+
+    function findElement(cell, path) {
+        var selector = path.map(function (segment) {
+            return '[data-element="' + segment + '"]';
+        }).join(' '),
+            node = cell.kbase.$node.find(selector);
+
+        return node;
+    }
+
+    function showStatus(cell) {
+        var status = getMeta(cell, 'attributes', 'status') || 'n/a',
+            node = findElement(cell, ['prompt', 'status']);
+        node.text(status);
+    }
+
+    function setStatus(cell, status) {
+        setMeta(cell, 'attributes', 'status', status);
+    }
+
+    function getStatus(cell) {
+        return getMeta(cell, 'attributes', 'status');
+    }
+
+
+    function makeInputField(cell, parameterSpec, value) {
+        var bus = Bus.make(),
+            inputWidget = getInputWidgetFactory(parameterSpec);
+
+        // Listen for changed values coming from any cell. Since invocation of
+        // this function implies that we know the cell, the parameter, and
+        // the input widget, this is the place to tie it all together.
+        bus.listen({
+            test: function (message) {
+                return (message.type === 'changed');
+            },
+            handle: function (message) {
+                setMeta(cell, 'params', parameterSpec.id, message.newValue);
+            }
+        });
+
+        return FieldWidget.make({
+            inputControl: inputWidget,
+            showHint: true,
+            useRowHighight: true,
+            initialValue: value,
+            spec: parameterSpec,
+            bus: bus
+        });
+    }
+
+    function getParamValue(cell, paramName) {
+        if (!cell.metadata.kbase.params) {
+            return;
+        }
+        return cell.metadata.kbase.params[paramName];
+    }
+
+    /*
+     * Python interop
+     */
+
+    function pythonString(string, singleQuote) {
+        if (singleQuote) {
+            return "'" + string + "'";
+        }
+        return '"' + string + '"';
+    }
+
+    function updatePython(cell) {
+        var params = JSON.stringify({
+            params: cell.metadata.kbase.params,
+            method: cell.metadata.kbase.method,
+            cell: {
+                id: cell.cell_id
+            }
+        }),
+            pythonCode = [
+                'import json',
+                'from_javascript = ' + pythonString(params, true),
+                'incoming_data = json.loads(from_javascript)',
+                'run_method(incoming_data)'
+            ],
+            pythonCodeString = pythonCode.join('\n');
+        cell.set_text(pythonCodeString);
+        cell.execute();
+        setStatus(cell, 'running');
+    }
+
+
+    /*
+     * Dealing with metadata
+     */
+    function createMeta(cell, initial) {
+        var meta = cell.metadata;
+        meta.kbase = initial;
+        cell.metadata = meta;
+    }
+    function getMeta(cell, group, name) {
+        if (!cell.metadata.kbase[group]) {
+            return;
+        }
+        return cell.metadata.kbase[group][name];
+    }
+    function setMeta(cell, group, name, value) {
+        /*
+         * This funny business is because the trigger on setting the metadata 
+         * property (via setter and getter in core Cell object) is only invoked 
+         * when the metadata preoperty is actually set -- doesn't count if 
+         * properties of it are.
+         */
+        var temp = cell.metadata;
+        if (!temp.kbase[group]) {
+            temp.kbase[group] = {};
+        }
+        temp.kbase[group][name] = value;
+        cell.metadata = temp;
+    }
+
+    function extendCell(cell) {
+        var prototype = Object.getPrototypeOf(cell);
+        prototype.createMeta = function(initial) {
+            var meta = this.metadata;
+            meta.kbase = initial;
+            this.metadata = meta;
+        };
+        prototype.getMeta = function (group, name) {
+            if (!this.metadata.kbase) {
+                return;
+            }
+            if (!this.metadata.kbase[group]) {
+                return;
+            }
+            return this.metadata.kbase[group][name];
+        };
+        prototype.setMeta = function(group, name, value) {
+            /*
+             * This funny business is because the trigger on setting the metadata 
+             * property (via setter and getter in core Cell object) is only invoked 
+             * when the metadata preoperty is actually set -- doesn't count if 
+             * properties of it are.
+             */
+            var temp = this.metadata;
+            if (!temp.kbase) {
+                temp.kbase = {};
+            }
+            if (!temp.kbase[group]) {
+                temp.kbase[group] = {};
+            }
+            temp.kbase[group][name] = value;
+            this.metadata = temp;
+        };
+    }
+    
+    // TOOLBAR
+    
+    function doEditNotebookMetadata() {
+        Jupyter.notebook.edit_metadata({
+                notebook: Jupyter.notebook,
+                keyboard_manager: Jupyter.notebook.keyboard_manager
+        });
+    }
+    function editNotebookMetadata(toolbarDiv, cell) {
+        if (!cell.metadata.kbase) {
+            return;
+        }
+        if (cell.metadata.kbase.type !== 'method') {
+            return;
+        }
+        var button = html.tag('button'),
+            editButton = button({
+                type: 'button',
+                class: 'btn btn-default btn-xs',
+                dataElement: 'kbase-edit-notebook-metadata'}, [
+                'Edit Notebook Metadata'
+            ]);
+        $(toolbarDiv).append(editButton);
+        $(toolbarDiv).find('[data-element="kbase-edit-notebook-metadata"]').on('click', function () {
+            doEditNotebookMetadata(cell);
+        });
+    }
+
+    function initCodeInputArea(cell) {
+        var codeInputArea = cell.input.find('.input_area');
+        if (!cell.kbase.inputAreaDisplayStyle) {
+            cell.kbase.inputAreaDisplayStyle = codeInputArea.css('display');
+        }
+        setMeta(cell, 'user-settings', 'showCodeInputArea', false);
+    }
+
+    function showCodeInputArea(cell) {
+        var codeInputArea = cell.input.find('.input_area');
+        if (getMeta(cell, 'user-settings', 'showCodeInputArea')) {
+            codeInputArea.css('display', cell.kbase.inputAreaDisplayStyle);
+        } else {
+            codeInputArea.css('display', 'none');
+        }
+    }
+
+    function toggleCodeInputArea(cell) {
+        var codeInputArea = cell.input.find('.input_area');
+        /*
+         * the code input area's style is stached for future restoration.
+         */
+        if (getMeta(cell, 'user-settings', 'showCodeInputArea')) {
+            setMeta(cell, 'user-settings', 'showCodeInputArea', false);
+        } else {
+            setMeta(cell, 'user-settings', 'showCodeInputArea', true);
+        }
+        showCodeInputArea(cell);
+        return getMeta(cell, 'user-settings', 'showCodeInputArea');
+    }
+
+    function addJob(cell, job_id) {
+        var jobRec = {
+            jobId: job_id,
+            added: (new Date()).toUTCString(),
+            lastUpdated: (new Date()).toUTCString()
+        },
+        jobs;
+        if (!getMeta(cell, 'attributes', 'jobs')) {
+            jobs = [];
+        } else {
+            jobs = getMeta(cell, 'attributes', 'jobs');
+        }
+        jobs.push(jobRec);
+        console.log('jobs', jobs);
+        setMeta(cell, 'attributes', 'jobs', jobs);
+    }
+
+    /*
+     * Sub tasks of cell setup
+     */
+
+    function setupToolbar() {
+        /*
+         * Cell Toolbar
+         */
+        function toggleInput(toolbarDiv, cell) {
+            if (!cell.metadata.kbase) {
+                return;
+            }
+            if (cell.metadata.kbase.type !== 'method') {
+                return;
+            }
+            var inputAreaShowing = getMeta(cell, 'user-settings', 'showCodeInputArea'),
+                label = inputAreaShowing ? 'Hide code' : 'Show code',
+                toggleButton = button({
+                    type: 'button',
+                    class: 'btn btn-default btn-xs',
+                    dataElement: 'kbase-method-cell-hideshow'}, [
+                    label
+                ]);
+            $(toolbarDiv).append(toggleButton);
+            $(toolbarDiv).find('[data-element="kbase-method-cell-hideshow"]').on('click', function (e) {
+                toggleCodeInputArea(cell);
+            });
+        }
+        function credit(toolbarDiv, cell) {
+            $(toolbarDiv).append(span({style: {padding: '4px'}}, 'KBase Toolbar'));
+        }
+        function status(toolbarDiv, cell) {
+            var status = getMeta(cell, 'attributes', 'status'),
+                content = span({style: {fontWeight: 'bold'}}, status);
+            $(toolbarDiv).append(span({style: {padding: '4px'}}, content));
+        }
+        function info(toolbarDiv, cell) {
+            var id = cell.cell_id,
+                content = span({style: {fontStyle: 'italic'}}, id);
+            $(toolbarDiv).append(span({style: {padding: '4px'}}, content));
+        }
+        Jupyter.CellToolbar.register_callback('kbase-toggle-input', toggleInput);
+        Jupyter.CellToolbar.register_callback('kbase-credit', credit);
+        Jupyter.CellToolbar.register_callback('kbase-status', status);
+        Jupyter.CellToolbar.register_callback('kbase-info', info);
+        Jupyter.CellToolbar.register_callback('kbase-edit-notebook-metadata', editNotebookMetadata);
+
+        // Jupyter.CellToolbar.register_preset('KBase', ['kbase-edit-notebook-metadata', 'kbase-toggle-input', 'default.rawedit', 'kbase-credit', 'kbase-status', 'kbase-info']);
+    }
+
+    // This is copied out of jupyter code.
+    function activateToolbar() {
+        var toolbarName = 'KBase';
+        Jupyter.CellToolbar.global_show();
+        Jupyter.CellToolbar.activate_preset(toolbarName, Jupyter.events);
+        Jupyter.notebook.metadata.celltoolbar = toolbarName;
+    }
+
+    function updateRunStatus(cell, data) {
+        switch (data.status) {
+            case 'error':
+                setMeta(cell, 'attributes', 'status', 'job:' + data.status);
+                addNotification(cell, 'danger', data.message);
+                break;
+            case 'job_started':
+                addJob(cell, data.job_id);
+                setMeta(cell, 'attributes', 'status', 'job_started');
+                // TODO: tell the job manager? or perhaps it already knows.
+                break;
+        }
+    }
+    
+    function makeMethodId(module, name) {
+        return [module, name].filter(function (element) {
+            return element ? true : false;
+        }).join('/');
+    }
+
+    function setupCell(cell) {
+        return Promise.try(function () {
+            // Only handle kbase cells.
+            if (cell.cell_type !== 'code') {
+                console.log('not a code cell!');
+                return;
+            }
+            if (!cell.metadata.kbase) {
+                console.log('not a kbase code cell');
+                return;
+            }
+            if (cell.metadata.kbase.type !== 'method') {
+                console.log('not a kbase method cell, ignoring');
+                return;
+            }
+
+            extendCell(cell);
+
+            addCell(cell);
+
+            // The kbase property is only used for managing runtime state of the cell
+            // for kbase. Anything to be persistent should be on the metadata.
+            cell.kbase = {
+            };
+
+            // Cell metadata is always accessed directly on the metadata object of the cell.
+            if (!cell.metadata.kbase) {
+                createMeta({
+                    attributes: {
+                        status: 'new',
+                        created: (new Date()).toUTCString()
+                    }
+                });
+            }
+
+            /*
+             * Code input area sync.
+             * Defaults to hidden, but we need to reflect the state of the 
+             * metadata settings.
+             */
+            initCodeInputArea(cell);
+
+            showCodeInputArea(cell);
+
+
+            // Update metadata.
+            setMeta(cell, 'attributes', 'lastLoaded', (new Date()).toUTCString());
+
+            var cellBus = Bus.make(),
+                methodId = makeMethodId(getMeta(cell, 'method', 'module'), getMeta(cell, 'method', 'name')),
+                version = getMeta(cell, 'method', 'version'),
+                inputWidget = CodeCellInputWidget.make({
+                    bus: cellBus,
+                    cell: cell,
+                    runtime: runtime,
+                    // nmsUrl: 'https://ci.kbase.us/services/narrative_method_store/rpc',
+                    // workspaceUrl: 'https://ci.kbase.us/services/ws',
+                    workspaceInfo: workspaceInfo
+                }),
+                kbaseNode = document.createElement('div');
+
+            // Create (above) and place the main container for the input cell.
+            cell.input.after($(kbaseNode));
+            cell.kbase.node = kbaseNode;
+            cell.kbase.$node = $(kbaseNode);
+            
+            // set up events.
+            
+            cellBus.on('submitted', function (message) {
+                updatePython(cell);
+            });
+            cellBus.on('status', function (message) {
+                setStatus(cell, message.status);
+            });
+
+            /*
+             * This looks simple, but follow code cell input widget, field widget, 
+             * and ultimately the input widget called for by the paramater
+             * spec for details...
+             */
+            /*
+             * Insert the kbase widget dom node
+             * Essentially this is a "row" of the cell. The code cell, in its natural
+             * state, has an input and output area, named "input" and "output_wrapper"
+             * The practice established by the ipywidget extension is that an extension
+             * may place another element in the code cell. There doesn't seem to be 
+             * any documentation for standards -- ipywidgets just places theirs after
+             * the input. We just do the same, although there should be a protocol 
+             * for ordering, compatability. Perhaps if we set the code cell subtype,
+             * we can assume that no-other type of extension operates on this cell
+             * (TODO: see if there is something already in place, I don't think so.)
+             * 
+             */
+            return inputWidget.attach(kbaseNode)
+                .then(function () {
+                    return inputWidget.start();
+                })
+                .then(function () {
+                    return inputWidget.run({
+                        methodId: methodId,
+                        methodVersion: version,
+                        authToken: runtime.authToken()
+                    });
+                })
+                .then(function () {
+                    showNotifications(cell);
+
+                    /*
+                     * Cell events
+                     * runstatus - events from the method running manager
+                     * NB need to listen on the main bus, because the cell (so far) 
+                     * talks through the module instance, which itself has a 
+                     * global instance of the mainbus
+                     */
+                    mainBus.listen({
+                        test: function (message) {
+                            return (message.type === 'runstatus');
+                        },
+                        handle: function (message) {
+                             updateRunStatus(cell, message);
+                            // console.log('RUNSTATUS', message);
+                        }
+                    });
+//                    mainBus.listen({
+//                        test: function (message) {
+//                            return (message.id === 'submitted');
+//                        },
+//                        handle: function (message) {
+//                            // Very simple, since the cell will already have
+//                            // been updated by any input cell changes.
+//                            updatePython(cell);
+//                        }
+//                    });
+                });
+        });
+    }
+
+    function setupNotebook() {
+        return Promise.all(Jupyter.notebook.get_cells().map(function (cell) {
+            return setupCell(cell);
+        }));
+    }
+    
+    function getWorkspaceRef() {
+        // TODO: all kbase notebook metadata should be on a kbase top level property;
+         var workspaceName = Jupyter.notebook.metadata.ws_name, // Jupyter.notebook.metadata.kbase.ws_name,
+             workspaceId;
+         
+         if (workspaceName) {
+             return {workspace: workspaceName};
+         }
+        
+        workspaceId = Jupyter.notebook.metadata.ws_id; // Jupyter.notebook.metadata.kbase.ws_id;
+        if (workspaceId) {
+            return {id: workspaceId};
+        }
+        
+        throw new Error('workspace name or id is missing from this narrative');
+    }
+
+    function setupWorkspace(workspaceUrl) {
+        // TODO where to get config from generally?
+        var workspaceRef = getWorkspaceRef(),
+            workspace = new Workspace(workspaceUrl, {
+                token: runtime.authToken()
+            });
+
+        return workspace.get_workspace_info(workspaceRef);
+
+    }
+
+    /*
+     * Called directly by Jupyter during the notebook startup process. 
+     * Called after the notebook is loaded and the dom structure is created.
+     * The job of this call is to mutate the notebook and cells to suite 
+     * oneself, set up any services or other things needed for operation of
+     * the notebook or cells.
+     * The work is carried out asynchronously through an orphan promise.
+     */
+    function load_ipython_extension() {
+        console.log('Loading KBase Method Cell Extension...');
+        
+        // Set the notebook environment. 
+        // For instance, we don't want to override the toolbar in the Narrative, but we need to supply our on in a plain notebook.
+        env = 'narrative';
+        
+        // Set up our toolbar extensions.
+        setupToolbar();
+
+        // And make a toolbar preset composed of the extensions, and activate it for this notebook.
+        if (env !== 'narrative') {
+            activateToolbar();
+        }
+
+        // TODO: get the kbase specific info out of the notebook, specifically
+        // the workspace name, ...
+
+        setupWorkspace(runtime.config('services.workspace.url'))
+            .then(function (wsInfo) {
+                workspaceInfo = serviceUtils.workspaceInfoToObject(wsInfo);
+                return workspaceInfo;
+            })
+            .then(function () {
+                return setupNotebook();
+            })
+            .catch(function (err) {
+                console.error('ERROR', err);
+            });
+
+    }
+
+    // MAIN
+    // module state instantiation
+
+    function init() {
+        mainBus = Bus.make();
+    }
+    init();
+
+    return {
+        // This is the sole ipython/jupyter api call
+        load_ipython_extension: load_ipython_extension,
+        // These are kbase api calls
+        send: mainBus.send,
+        listen: mainBus.listen
+    };
+});

--- a/nbextensions/methodCell/main.js
+++ b/nbextensions/methodCell/main.js
@@ -342,8 +342,8 @@ define([
         function credit(toolbarDiv, cell) {
             $(toolbarDiv).append(span({style: {padding: '4px'}}, 'KBase Toolbar'));
         }
-        function status(toolbarDiv, cell) {
-            var status = getMeta(cell, 'attributes', 'status'),
+        function status(toolbarDiv, cell) {            
+            var status = cell.getMeta('attributes', 'status'),
                 content = span({style: {fontWeight: 'bold'}}, status);
             $(toolbarDiv).append(span({style: {padding: '4px'}}, content));
         }
@@ -439,7 +439,7 @@ define([
 
             var cellBus = Bus.make(),
                 methodId = makeMethodId(getMeta(cell, 'method', 'module'), getMeta(cell, 'method', 'name')),
-                version = getMeta(cell, 'method', 'version'),
+                methodTag = getMeta(cell, 'method', 'tag'),
                 inputWidget = CodeCellInputWidget.make({
                     bus: cellBus,
                     cell: cell,
@@ -489,7 +489,7 @@ define([
                 .then(function () {
                     return inputWidget.run({
                         methodId: methodId,
-                        methodVersion: version,
+                        methodTag: methodTag,
                         authToken: runtime.authToken()
                     });
                 })
@@ -594,10 +594,23 @@ define([
             .then(function () {
                 return setupNotebook();
             })
+            .then(function () {
+                // set up event hooks
+                $([Jupyter.events]).on('updated.Cell', function (event, data) {
+                    setupCell(data.cell)
+                        .then(function () {
+                            console.log('Cell created?');
+                        })
+                        .catch(function (err) {
+                            console.error('ERROR creating cell', err);
+                        });
+                });
+                // also delete.Cell, edit_mode.Cell, select.Cell, command_mocd.Cell, output_appended.OutputArea ...
+                // preset_activated.CellToolbar, preset_added.CellToolbar
+            })
             .catch(function (err) {
-                console.error('ERROR', err);
+                console.error('ERROR setting up nodebook', err);
             });
-
     }
 
     // MAIN

--- a/nbextensions/methodCell/microBus.js
+++ b/nbextensions/methodCell/microBus.js
@@ -1,0 +1,120 @@
+/*global define */
+/*jslint white:true,global:true*/
+/*
+ * MiniBus
+ * A lightweight message bus implementation.
+ * The metaphor of the bus, is that of the hardware bus ... a set of devices
+ * connected over a communication channel (wires) which can send and receive
+ * data over the channel.
+ * As with hardware buses, this requires that each thing on the bus -- components -- 
+ * need to have the smarts to deal with the bus. However, in our case those 
+ * requirements are very minimal.
+ * 
+ * bus - the object which manages the communication and to which components may send and receive messages
+ * message - a piece of data sent from one component to another, a plain javascript object
+ * envelope - an internal container for the message which acts both as a wrapper and
+ *            place to retain message state.
+ * timeout - each message may provide a timeout
+ * 
+ * api
+ * send - a component places a message onto the bus
+ * listen - a component requests that messages meeting a certain pattern invoke a function it provides
+ *
+ */
+define([
+], function () {
+    'use strict';
+    function factory(config) {
+        var listeners = [],
+            queue = [],
+            interval = 0,
+            timer;
+        function testListener(message, tester) {
+            try {
+                return tester(message);
+            } catch (ex) {
+                console.error('microBus test failure', ex);
+                return false;
+            }
+        }
+        function letListenerHandle(message, handle) {
+            try {
+                handle(message);
+            } catch (ex) {
+                console.error('microBus handle failure', ex);
+            }
+        }
+        function processPending() {
+            var processing = queue;
+            queue = [];
+            processing.forEach(function (item) {
+                listeners.forEach(function (listener) {
+                    if (testListener(item.message, listener.test)) {
+                        letListenerHandle(item.message, listener.handle);
+                    }
+                });
+            });
+        }
+        /*
+         * 
+         * running the bus queue is as
+         */
+        function run() {
+            if (timer) {
+                return;
+            }
+            timer = window.setTimeout(function () {
+                timer = null;
+                try {
+                    processPending();
+                } catch (ex) {
+                    console.error('microBus processing error', ex);
+                }
+            }, interval);
+        }
+        /*
+         * Listening registers a function which when true given a message,
+         * invokes the receiving function.
+         * 
+         */
+        function listen(spec) {
+            listeners.push({
+                test: spec.test,
+                handle: spec.handle
+            });
+        }
+        function on(type, handler) {
+            listeners.push({
+                test: function (message) {
+                    return (type === message.type);
+                },
+                handle: handler
+            });
+        }
+
+        /*
+         * sending places a message into the queue (bus)
+         */
+        function send(message, options) {
+            queue.push({
+                message: message,
+                envelope: {
+                    created: new Date()
+                }
+            });
+            run();
+        }
+
+        return {
+            listen: listen,
+            send: send,
+            on: on
+        };
+    }
+    
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/miniBus.js
+++ b/nbextensions/methodCell/miniBus.js
@@ -1,0 +1,80 @@
+/*global define */
+/*jslint white:true,global:true*/
+/*
+ * MiniBus
+ * A lightweight message bus implementation.
+ * Specialized for cells. 
+ *
+ */
+define([
+], function () {
+    'use strict';
+    function factory(config) {
+        var listener = {
+            cells: {}
+        },
+        pending = [],
+            interval = 0,
+            timer;
+        function addListener(cell, message, handler) {
+            if (!listener.cells[cell.cell_id]) {
+                listener.cells[cell.cell_id] = {};
+            }
+            var listeners = listener.cells[cell.cell_id];
+            listeners[message] = handler;
+        }
+        function processPending() {
+            console.log('processing pending', pending.length);
+            var processing = pending;
+            pending = [];
+            processing.forEach(function (item) {
+                if (!listener.cells[item.cellId]) {
+                    return;
+                }
+                if (!listener.cells[item.cellId][item.message]) {
+                    return;
+                }
+                var fun = listener.cells[item.cellId][item.message];
+
+                try {
+                    fun(item.data);
+                } catch (ex) {
+                    console.error('ERROR (1)', ex);
+                }
+            });
+        }
+        function run() {
+            if (timer) {
+                return;
+            }
+            timer = window.setTimeout(function () {
+                try {
+                    processPending();
+                } catch (ex) {
+                    console.error('ERROR (2)', ex);
+                } finally {
+                    timer = null;
+                }
+            }, interval);
+        }
+        function send(cellId, message, data) {
+            pending.push({
+                cellId: cellId,
+                message: message,
+                data: data
+            });
+            run();
+        }
+
+        return {
+            listen: addListener,
+            send: send
+        };
+    }
+    
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/parameterSpec.js
+++ b/nbextensions/methodCell/parameterSpec.js
@@ -1,0 +1,103 @@
+/*global define*/
+/*jstlint white:true,browser:true*/
+
+define([
+], function () {
+    'use strict';
+
+    function factory(config) {
+        var spec = config.parameterSpec,
+            multiple = spec.allow_multiple ? true : false,
+            _required = spec.optional ? false : true,
+            isOutputName = spec.text_options && spec.text_options.is_output_name;
+        
+        function name() {
+            return spec.id;
+        }
+
+        function label() {
+            return spec.ui_name;
+        }
+
+        function hint() {
+            return spec.short_hint;
+        }
+
+        function description() {
+            return spec.description;
+        }
+
+        function info() {
+            return 'info disabled for now';
+//            return table({class: 'table table-striped'}, [
+//                tr([
+//                    th('Types'),
+//                    tr(td(table({class: 'table'}, spec.text_options.valid_ws_types.map(function (type) {
+//                        return tr(td(type));
+//                    }))))
+//                ])
+//            ]);
+        }
+
+        function multipleItems() {
+            return multiple;
+        }
+
+        function fieldType() {
+            return spec.field_type;
+        }
+
+        function type() {
+            return spec.type;
+        }
+
+        function dataType() {
+            if (!spec.text_options) {
+                return 'unspecified';
+            }
+            var validateAs = spec.text_options.validate_as;
+            type;
+            if (validateAs) {
+                return validateAs;
+            }
+
+            // Some parameter specs have valid_ws_types as an empty set, which 
+            // does not mean what it could, it means that it is not an option.
+            if (spec.text_options.valid_ws_types && spec.text_options.valid_ws_types.length > 0) {
+                return 'workspaceObjectReference';
+            }
+
+            return 'unspecified';
+        }
+
+        function uiClass() {
+            return spec.ui_class;
+        }
+
+        function required() {
+            return _required;
+        }
+
+        return {
+            id: spec.id,
+            spec: spec,
+            name: name,
+            label: label,
+            hint: hint,
+            description: description,
+            info: info,
+            multipleItems: multipleItems,
+            fieldType: fieldType,
+            type: type,
+            dataType: dataType,
+            uiClass: uiClass,
+            required: required
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/runtime.js
+++ b/nbextensions/methodCell/runtime.js
@@ -1,0 +1,47 @@
+/*global define */
+/*jslint white:true,browser:true*/
+define([
+    'base/js/namespace',
+    'narrativeConfig'
+], function (Jupyter, Config) {
+    'use strict';
+
+    function factory(config) {
+
+        function authToken() {
+            return Jupyter.narrative.authToken;
+        }
+
+        function getConfig(key, defaultValue) {
+            var path = key.split('.'),
+                root = path[0],
+                rest = path.slice(1),
+                configRoot = Config.get(root);
+            if (!configRoot) {
+                return defaultValue;
+            }
+            rest.forEach(function (pathElement) {
+                configRoot = configRoot[pathElement];
+                if (!configRoot) {
+                    return;
+                }
+            });
+            if (!configRoot) {
+                return defaultValue;
+            }
+            return configRoot;
+        }
+
+
+        return {
+            authToken: authToken,
+            config: getConfig
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/styles/method-widget.css
+++ b/nbextensions/methodCell/styles/method-widget.css
@@ -1,0 +1,143 @@
+/** new method parameter styling **/
+.kb-method-parameter-panel {
+   border-left: 3px solid #fff;
+}
+.kb-method-parameter-panel-hover {
+   border-left: 3px solid #428bca;
+}
+.kb-method-parameter-row {
+   margin:0px;
+   padding:5px;
+   border-radius:5px;
+}
+/* for some reason, the css :hover doesn't work right on this div, so we use jquery to toggle this class */
+.kb-method-parameter-row-hover {
+   background:#F9F9F9;
+}
+
+.kb-method-parameter-row-error {
+   background: #f2dede;
+}
+.kb-method-parameter-error-message {
+   padding:5px;
+   text-align:center;
+   font-family: 'OxygenBold', sans-serif;
+   font-weight: bold;
+   font-size: 9pt;
+   color:#F44336;
+}
+
+
+/* not sure how to get text in these divs to valign middle... */
+.kb-method-parameter-name {
+   font-family: 'OxygenBold', sans-serif;
+   color:#777;
+   text-align:right;
+   vertical-align:middle;
+   margin-top:3px;
+   padding-right: 4px;
+   padding-left:0px;
+   white-space: normal;
+}
+.kb-method-parameter-input {
+   vertical-align:middle;
+   white-space: nowrap;
+   xpadding-left:10px;
+}
+.kb-method-parameter-input input {
+   font-weight: bold;
+}
+
+.kb-method-parameter-input select.form-control {
+    margin: 0;
+}
+
+/*
+This set of styles is a to accomodate the required/satisfied icon which appears
+between the select input control and the help text to the right of it. The
+problem is that within the columns used for layout the select is set to 100% width
+and yet the icon is placed right next to it. The result is that the icon is shoved
+to the right of the select control and into the next column, overlapping the
+help text. The old method handling this was to scoot the help text far enough over
+to accomodate the the icon intruding into its space. This technique makes space
+in the column in which the icon lives, and does this by shrinking the select
+control with padding, and then scooting the icon back into its column.
+*/
+.kb-method-parameter-input > div {
+    /* allow space for the required (red arrow), satisfied (green checkbox) icon */
+    padding-right: 20px;
+}
+.kb-method-parameter-input .kb-method-parameter-accepted-glyph,
+.kb-method-parameter-input .kb-method-parameter-required-glyph {
+    /* This scoots the icon inside */
+    xmargin-left: -15px;
+    font-size: 15px;
+}
+.kb-method-parameter-hint {
+    padding-left: 7px;
+}
+
+.kb-parameter-data-selection {
+   font-weight: bold;
+}
+
+.kb-method-parameter-hint {
+   color: #777;
+   text-align:left;
+   margin-top:3px;
+}
+
+.kb-method-parameter-required-glyph {
+   color: #F44336;
+   margin-left:7px;
+}
+.kb-method-parameter-accepted-glyph {
+   color: #4BB856;
+   margin-left:7px;
+}
+
+.kb-method-parameter-info {
+   color: #777;
+   margin-left:7px;
+}
+
+.kb-parameter-data-row-remove {
+   color: #777;
+}
+.kb-parameter-data-row-add {
+   color: #777;
+}
+
+
+.kb-method-advanced-options-controller-inactive {
+   font-family: 'OxygenBold', sans-serif;
+   font-style: italic;
+   font-size: 10pt;
+   line-height: 14px;
+   color: #777;
+   text-align: center;
+}
+.kb-method-advanced-options-controller {
+   font-family: 'OxygenBold', sans-serif;
+   cursor:pointer;
+   font-style: italic;
+   font-size: 10pt;
+   line-height: 14px;
+   color: #0088cc;
+   text-align: center;
+}
+.kb-method-advanced-options-controller:hover {
+    color: #2a6496;
+}
+
+.kb-method-footer {
+    width: 100%;
+    overflow: none;
+    background-color: #F5F5F5;
+    padding: 10px;
+}
+
+.kb-method-subtitle {
+    background-color: #F5F5F5;
+    padding: 3px 5px;
+}

--- a/nbextensions/methodCell/styles/method-widget.css
+++ b/nbextensions/methodCell/styles/method-widget.css
@@ -1,51 +1,59 @@
+/* Wrapper class 
+  All classes below may be wrapped in this class to avoid polluting
+  the Narrative styles.
+*/
+.kb-method-cell {
+
+}
+
 /** new method parameter styling **/
 .kb-method-parameter-panel {
-   border-left: 3px solid #fff;
+    border-left: 3px solid #fff;
 }
 .kb-method-parameter-panel-hover {
-   border-left: 3px solid #428bca;
+    border-left: 3px solid #428bca;
 }
 .kb-method-parameter-row {
-   margin:0px;
-   padding:5px;
-   border-radius:5px;
+    margin:0px;
+    padding:5px;
+    border-radius:5px;
 }
 /* for some reason, the css :hover doesn't work right on this div, so we use jquery to toggle this class */
 .kb-method-parameter-row-hover {
-   background:#F9F9F9;
+    background:#F9F9F9;
 }
 
 .kb-method-parameter-row-error {
-   background: #f2dede;
+    background: #f2dede;
 }
 .kb-method-parameter-error-message {
-   padding:5px;
-   text-align:center;
-   font-family: 'OxygenBold', sans-serif;
-   font-weight: bold;
-   font-size: 9pt;
-   color:#F44336;
+    padding:5px;
+    text-align:center;
+    font-family: 'OxygenBold', sans-serif;
+    font-weight: bold;
+    font-size: 9pt;
+    color:#F44336;
 }
 
 
 /* not sure how to get text in these divs to valign middle... */
 .kb-method-parameter-name {
-   font-family: 'OxygenBold', sans-serif;
-   color:#777;
-   text-align:right;
-   vertical-align:middle;
-   margin-top:3px;
-   padding-right: 4px;
-   padding-left:0px;
-   white-space: normal;
+    font-family: 'OxygenBold', sans-serif;
+    color:#777;
+    text-align:right;
+    vertical-align:middle;
+    margin-top:3px;
+    padding-right: 4px;
+    padding-left:0px;
+    white-space: normal;
 }
 .kb-method-parameter-input {
-   vertical-align:middle;
-   white-space: nowrap;
-   xpadding-left:10px;
+    vertical-align:middle;
+    white-space: nowrap;
+    xpadding-left:10px;
 }
 .kb-method-parameter-input input {
-   font-weight: bold;
+    font-weight: bold;
 }
 
 .kb-method-parameter-input select.form-control {
@@ -78,53 +86,53 @@ control with padding, and then scooting the icon back into its column.
 }
 
 .kb-parameter-data-selection {
-   font-weight: bold;
+    font-weight: bold;
 }
 
 .kb-method-parameter-hint {
-   color: #777;
-   text-align:left;
-   margin-top:3px;
+    color: #777;
+    text-align:left;
+    margin-top:3px;
 }
 
 .kb-method-parameter-required-glyph {
-   color: #F44336;
-   margin-left:7px;
+    color: #F44336;
+    margin-left:7px;
 }
 .kb-method-parameter-accepted-glyph {
-   color: #4BB856;
-   margin-left:7px;
+    color: #4BB856;
+    margin-left:7px;
 }
 
 .kb-method-parameter-info {
-   color: #777;
-   margin-left:7px;
+    color: #777;
+    margin-left:7px;
 }
 
 .kb-parameter-data-row-remove {
-   color: #777;
+    color: #777;
 }
 .kb-parameter-data-row-add {
-   color: #777;
+    color: #777;
 }
 
 
 .kb-method-advanced-options-controller-inactive {
-   font-family: 'OxygenBold', sans-serif;
-   font-style: italic;
-   font-size: 10pt;
-   line-height: 14px;
-   color: #777;
-   text-align: center;
+    font-family: 'OxygenBold', sans-serif;
+    font-style: italic;
+    font-size: 10pt;
+    line-height: 14px;
+    color: #777;
+    text-align: center;
 }
 .kb-method-advanced-options-controller {
-   font-family: 'OxygenBold', sans-serif;
-   cursor:pointer;
-   font-style: italic;
-   font-size: 10pt;
-   line-height: 14px;
-   color: #0088cc;
-   text-align: center;
+    font-family: 'OxygenBold', sans-serif;
+    cursor:pointer;
+    font-style: italic;
+    font-size: 10pt;
+    line-height: 14px;
+    color: #0088cc;
+    text-align: center;
 }
 .kb-method-advanced-options-controller:hover {
     color: #2a6496;
@@ -140,4 +148,30 @@ control with padding, and then scooting the icon back into its column.
 .kb-method-subtitle {
     background-color: #F5F5F5;
     padding: 3px 5px;
+}
+
+
+.kb-method-cell .panel-title > [data-toggle="collapse"]::before {
+    display: inline-block;
+    margin-left: 0px;
+    margin-right: 4px;
+    font-family: "FontAwesome";
+    font-style: normal;
+    font-weight: normal;
+    font-size: 90%;
+    width: 12px;
+    color: silver;
+    line-height: 1;
+    vertical-align: baseline;
+    content: "\f078 ";
+}
+.kb-method-cell .panel-title > [data-toggle="collapse"].collapsed::before {
+    margin-left: 2px; margin-right: 2px;
+    content: "\f054 ";
+}
+
+/* tweaks to elemnts that should be dimmed when the cell is not selected */
+
+.unselected .kb-method-cell {
+    opacity: 0.5;
 }

--- a/nbextensions/methodCell/validation.js
+++ b/nbextensions/methodCell/validation.js
@@ -1,0 +1,261 @@
+/*global define, minLength*/
+/*jslint white:true,browser:true*/
+define([
+], function () {
+    'use strict';
+
+    function Validators() {
+
+        function toInteger(value) {
+            var numericValue = Number(value);
+            if (isNaN(numericValue)) {
+                return false;
+            }
+            if (numericValue === Math.floor(numericValue)) {
+                return numericValue;
+            }
+            return false;
+        }
+
+        function toFloat(value) {
+            var floatValue = parseFloat(value);
+            if (isNaN(floatValue)) {
+                return false;
+            }
+            return floatValue;
+        }
+        
+        function validateSet(value, options) {
+            var errorMessage, diagnosis;
+            // values are raw, no parsing.
+            
+            // the only meaningful value for an empty value is 'undefined'.
+            if (value === undefined) {
+                if (options.required) {
+                    diagnosis = 'required-missing';
+                    errorMessage = 'value is required';
+                } else {
+                    diagnosis = 'optional-empty';                   
+                }
+            } else {
+                if (!options.values.some(function(setValue) {
+                    return (setValue === value);
+                })) {
+                    diagnosis = 'invalid',
+                    errorMessage = 'Value not in the set';
+                } else {
+                    diagnosis = 'valid';
+                }
+            }
+            
+            return {
+                isValid: errorMessage ? false : true,
+                errorMessage: errorMessage,
+                diagnosis: diagnosis,
+                value: value,
+                parsedValue: value
+            };
+        }
+
+
+        function validateWorkspaceObjectRef(value, options) {
+            var parsedValue,
+                errorMessage, diagnosis;
+
+            if (typeof value !== 'string') {
+                diagnosis = 'invalid';
+                errorMessage = 'value must be a string in workspace object name format';
+            } else {
+                parsedValue = value.trim();
+                if (!parsedValue) {
+                    if (options.required) {
+                        diagnosis = 'required-missing';
+                        errorMessage = 'value is required';
+                    } else {
+                        diagnosis = 'optional-empty';
+                    }
+                } else if (!/^\d+\/\d+\/\d+/.test(value)) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'Invalid object reference format (#/#/#)';
+                } else {
+                    diagnosis = 'valid';
+                }
+            }
+            return {
+                isValid: errorMessage ? false : true,
+                errorMessage: errorMessage,
+                diagnosis: diagnosis,
+                value: value,
+                parsedValue: parsedValue
+            };
+        }
+
+        function validateWorkspaceObjectName(value, options) {
+            var parsedValue,
+                errorMessage, diagnosis;
+
+            if (typeof value !== 'string') {
+                diagnosis = 'invalid';
+                errorMessage = 'value must be a string in workspace object name format';
+            } else {
+                parsedValue = value.trim();
+                if (!parsedValue) {
+                    if (options.required) {
+                        diagnosis = 'required-missing';
+                        errorMessage = 'value is required';
+                    } else {
+                        diagnosis = 'optional-empty';
+                    }
+                } else if (/\s/.test(parsedValue)) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'spaces are not allowed in data object names';
+                } else if (/^\d+$/.test(parsedValue)) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'data object names cannot be a number';
+                } else if (!/^[A-Za-z0-9|\.|\||_\-]*$/.test(parsedValue)) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'object names can only include the symbols _ - . |';
+                } else {
+                    diagnosis = 'valid';
+                }
+            }
+            return {
+                isValid: errorMessage ? false : true,
+                errorMessage: errorMessage,
+                diagnosis: diagnosis,
+                value: value,
+                parsedValue: parsedValue
+            };
+        }
+
+        function validateInteger(value, options) {
+            var plainValue = value.trim(),
+                parsedValue,
+                errorMessage, diagnosis,
+                min = options.min_int,
+                max = options.max_int;
+
+            if (!plainValue) {
+                if (options.required) {
+                    diagnosis = 'required-missing';
+                    errorMessage = 'value is required';
+                } else {
+                    diagnosis = 'optional-empty';
+                }
+            } else {
+                parsedValue = toInteger(plainValue);
+                if (parsedValue === false) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'value must be an integer';
+                } else if (max && max < parsedValue) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'the maximum value for this parameter is ' + max;
+                } else if (min && min > parsedValue) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'the minimum value for this parameter is ' + min;
+                } else {
+                    diagnosis = 'valid';
+                }
+            }
+
+            return {
+                isValid: errorMessage ? false : true,
+                errorMessage: errorMessage,
+                diagnosis: diagnosis,
+                value: value,
+                plainValue: plainValue,
+                parsedValue: parsedValue
+            };
+        }
+
+        function validateFloat(value, options) {
+            var plainValue = value.trim(),
+                parsedValue,
+                errorMessage, diagnosis,
+                min = options.min_float,
+                max = options.max_float;
+            
+             if (!plainValue) {
+                if (options.required) {
+                    diagnosis = 'required-missing';
+                    errorMessage = 'value is required';
+                } else {
+                    diagnosis = 'optional-empty';
+                }
+            } else {
+                parsedValue = parseFloat(plainValue);
+                if (isNaN(parsedValue)) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'value must be numeric';
+                } else if (!isFinite(parsedValue)) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'value must be a finite float';
+                } else if (max && max < parsedValue) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'the maximum value for this parameter is ' + max;
+                } else if (min && min > parsedValue) {
+                    diagnosis = 'invalid';
+                    errorMessage = 'the minimum value for this parameter is ' + min;
+                } else {
+                    diagnosis = 'valid';
+                }
+            }
+            return {
+                isValid: errorMessage ? false : true,
+                errorMessage: errorMessage,
+                diagnosis: diagnosis,
+                value: value,
+                plainValue: plainValue,
+                parsedValue: parsedValue
+            };
+        }
+
+        function validateText(value, options) {
+            var parsedValue = value.trim(),
+                errorMessage, diagnosis,
+                minLength = options.min_length,
+                maxLength = options.max_length,
+                regexp = options.regexp_constraint ? new RegExp(regexp) : false;
+
+            if (!parsedValue) {
+                if (options.required) {
+                    diagnosis = 'required-missing';
+                    errorMessage = 'value is required';
+                } else {
+                    diagnosis = 'optional-empty';
+                }
+            } else if (parsedValue.length < minLength) {
+                diagnosis = 'invalid';
+                errorMessage = 'the minimum length for this parameter is ' + minLength;
+            } else if (parsedValue.length > maxLength) {
+                diagnosis = 'invalid';
+                errorMessage = 'the maximum length for this parameter is ' + maxLength;
+            } else if (regexp && !regexp.test(parsedValue)) {
+                diagnosis = 'invalid';
+                errorMessage = 'The text value did not match the regular expression constraint ' + options.regexp_constraint;
+            } else {
+                diagnosis = 'valid';
+            }
+
+            return {
+                isValid: errorMessage ? false : true,
+                errorMessage: errorMessage,
+                diagnosis: diagnosis,
+                value: value,
+                parsedValue: parsedValue
+            };
+        }
+
+        return {
+            validateWorkspaceObjectName: validateWorkspaceObjectName,
+            validateWorkspaceObjectRef: validateWorkspaceObjectRef,
+            validateInteger: validateInteger,
+            validateFloat: validateFloat,
+            validateText: validateText,
+            validateSet: validateSet
+        };
+    }
+
+
+    return Validators();
+});

--- a/nbextensions/methodCell/widgets/codeCellInputWidget.js
+++ b/nbextensions/methodCell/widgets/codeCellInputWidget.js
@@ -1,0 +1,415 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+
+define([
+    'bluebird',
+    '../parameterSpec',
+    './fieldWidget',
+    '../runtime',
+    '../microBus',
+    '../events',
+    'kb_common/html',
+    './input/singleTextInput',
+    './input/multiTextInput',
+    './input/singleSelectInput',
+    './input/singleIntInput',
+    './input/multiIntInput',
+    './input/objectInput',
+    './input/newObjectInput',
+    './undefinedWidget',
+    './input/singleCheckbox',
+    './input/singleFloatInput',
+    'kb_service/client/narrativeMethodStore',
+    './inputWrapperWidget'
+], function (Promise, ParameterSpec, FieldWidget, Runtime, Bus, Events, html, SingleTextInputWidget, MultiTextInputWidget, SingleSelectInputWidget, SingleIntInputWidget, MultiIntInputWidget, ObjectInputWidget, NewObjectInputWidget, UndefinedInputWidget, SingleCheckboxInputWidget, SingleFloatInputWidget, NarrativeMethodStore, RowWidget) {
+    'use strict';
+
+    var t = html.tag,
+        div = t('div'), span = t('span'), form = t('form'), button = t('button');
+
+    function factory(config) {
+        var container, places,
+            workspaceInfo = config.workspaceInfo,
+            cell = config.cell,
+            parentBus = config.bus,
+            inputWidgetBus = Bus.make(),
+            runtime = Runtime.make();
+
+        // DATA API
+        function fetchData(methodId, methodVersion) {
+            var methodRef = {
+                ids: [methodId],
+                tag: methodVersion
+            },
+            nms = new NarrativeMethodStore(runtime.config('services.narrative_method_store.url'), {
+                token: runtime.authToken()
+            });
+            
+            return nms.get_method_spec(methodRef)
+                .then(function (data) {
+                    if (!data[0]) {
+                        throw new Error('Method not found');
+                    }
+                    // Get an input field widget per parameter
+                    return data[0].parameters.map(function (parameterSpec) {
+                        return ParameterSpec.make({parameterSpec: parameterSpec});
+                    });
+                });
+        }
+
+        // RENDER API
+
+        function renderLayout() {
+            var events = Events.make(),
+                content = div({class: 'kbase-extension', style: {display: 'flex', alignItems: 'stretch'}}, [
+                div({class: 'prompt', dataElement: 'prompt', style: {display: 'flex', alignItems: 'stretch', width: '14ex', flexDirection: 'column'}}, [
+                    div({dataElement: 'status'})
+                ]),
+                div({class: 'body', dataElement: 'body', style: {display: 'flex', alignItems: 'stretch', flexDirection: 'column', flex: '1'}}, [
+                    div({dataElement: 'notifications', style: {display: 'block', width: '100%'}}),
+                    div({dataElement: 'widget', style: {display: 'block', width: '100%'}}, [
+                        form({dataElement: 'input-widget-form'}, div({class: 'container-fluid'}, [
+                            // Insert fields into here.
+                            div({class: 'panel panel-default'}, [
+                                div({class: 'panel-heading'}, [
+                                    div({class: 'panel-tite'}, 'Toolbar')
+                                ]),
+                                div({class: 'panel-body'}, [
+                                    button({type: 'button', class: 'btn btn-default', id: events.addEvent({
+                                        type: 'click',
+                                        handler: function (e) {
+                                            inputWidgetBus.send({id: 'reset'});
+                                        }
+                                    })}, 'Reset to Defaults')
+                                ])
+                            ]),
+                            div({class: 'panel panel-default'}, [
+                                div({class: 'panel-heading'}, [
+                                    div({class: 'panel-tite'}, 'Regular Parameters')
+                                ]),
+                                div({class: 'panel-body'}, [
+                                    div({dataElement: 'input-widget-regular-fields', class: 'container-fluid'})
+                                ])
+                            ]),
+                            div({class: 'panel panel-default'}, [
+                                div({class: 'panel-heading'}, [
+                                    div({class: 'panel-tite'}, 'Advanced Parameters')
+                                ]),
+                                div({class: 'panel-body'}, [
+                                    div({dataElement: 'input-widget-advanced-fields', class: 'container-fluid'})
+                                ])
+                            ]),
+                            // Submit row.
+                            div({dataElement: 'input-widget-controls', class: 'container-fluid'}, [
+                                div({class: 'row'}, [
+                                    div({class: 'col-md-3'}),
+                                    div({class: 'col-md-9'}, button({type: 'submit'}, 'Run'))
+                                ])
+                            ])
+                        ]))
+                    ])
+                ])
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        function getParamValue(cell, paramName) {
+            if (!cell.metadata.kbase.params) {
+                return;
+            }
+            return cell.metadata.kbase.params[paramName];
+        }
+        /*
+         * 
+         * Evaluates the parameter spec to determine which input widget needs to be
+         * invoked, but doesn't know what the widget does.
+         * Provides the communication bus for each input to route info to the widget
+         * and out of it.
+         * 
+         *  In terms of widgets it looks like this:
+         *  
+         *  InputCellWidget
+         *    inputWidgets
+         *      FieldWidget
+         *        textInputWidget
+         *      FieldWidget
+         *        objectInputWidget
+         *      FieldWidget
+         *        newObjectInputWidget
+         *      FieldWidget
+         *        integerInputWidget
+         *      FieldWidget
+         *        floatInputWidget
+         */
+
+        /*
+         * The input control widget is selected based on these parameters:
+         * - data type - (text, int, float, workspaceObject (ref, name)
+         * - input method - input, select
+         */
+        function getInputWidgetFactory(parameterSpec) {
+            var dataType = parameterSpec.dataType(),
+                spec = parameterSpec.spec,
+                fieldType = spec.field_type;
+
+            // NOTE:
+            // field_type is text or dropdown, but does not always correspond to the 
+            // type of control to build. E.g. selecting a workspace object is actually
+            // a dropdown even though the field_type is 'text'.
+
+            switch (dataType) {
+                case 'string':
+                case 'text':
+                    if (parameterSpec.multipleItems()) {
+                        return UndefinedInputWidget;
+                    }
+                    switch (fieldType) {
+                        case 'text':
+                            return SingleTextInputWidget;
+                            break;
+                        case 'dropdown':
+                            return SingleSelectInputWidget;
+                            break;
+                        default:
+                            return UndefinedInputWidget;
+                    }
+                case 'int':
+                    if (parameterSpec.multipleItems()) {
+                        return MultiIntInputWidget;
+                    }
+                    return SingleIntInputWidget;
+                case 'float':
+                    if (parameterSpec.multipleItems()) {
+                        return UndefinedInputWidget;
+                    }
+                    return SingleFloatInputWidget;
+                case 'workspaceObjectReference':
+                    switch (parameterSpec.uiClass()) {
+                        case 'input':
+                            return ObjectInputWidget;
+                        case 'output':
+                            return NewObjectInputWidget;
+                        case 'parameter':
+                            return ObjectInputWidget;
+                        default:
+                            return UndefinedInputWidget;
+                    }
+                case 'unspecified':
+                    // a bunch of field types are untyped:
+                    switch (fieldType) {
+                        case 'text':
+                            if (parameterSpec.multipleItems()) {
+                                return MultiTextInputWidget;
+                            }
+                            return SingleTextInputWidget;
+                        case 'checkbox':
+                            return SingleCheckboxInputWidget;
+                        case 'textarea':
+                            return UndefinedInputWidget;
+                        case 'custom_button':
+                            return UndefinedInputWidget;
+                        case 'textsubdata':
+                            if (parameterSpec.multipleItems()) {
+                                return UndefinedInputWidget;
+                            }
+                            return UndefinedInputWidget;
+                        case 'file':
+                            return UndefinedInputWidget;
+                        case 'custom_textsubdata':
+                            if (parameterSpec.multipleItems()) {
+                                return UndefinedInputWidget;
+                            }
+                            return UndefinedInputWidget;
+                        case 'custom_widget':
+                            return UndefinedInputWidget;
+                        case 'tab':
+                            return UndefinedInputWidget;
+                        default:
+                            return UndefinedInputWidget;
+                    }
+                default:
+                    return UndefinedInputWidget;
+                    // return makeUnknownInput;
+            }
+        }
+
+        function makeFieldWidget(cell, parameterSpec, value) {
+            var bus = Bus.make(),
+                inputWidget = getInputWidgetFactory(parameterSpec);
+            
+            inputBusses.push(bus);
+
+            // Listen for changed values coming from any cell. Since invocation of
+            // this function implies that we know the cell, the parameter, and
+            // the input widget, this is the place to tie it all together.
+            bus.listen({
+                test: function (message) {
+                    return (message.type === 'changed');
+                },
+                handle: function (message) {
+                    cell.setMeta('params', parameterSpec.id, message.newValue);
+                    // TODO this properly
+                    parentBus.send({
+                        type: 'status',
+                        status: 'editing'
+                    });
+                }
+            });
+            
+            // Listen for sync request from widget. 
+            // We'll send the widget the current state of the param stored
+            // in the metadata, aka, our data store.
+            bus.listen({
+                test: function (message) {
+                    return (message.type === 'sync');
+                },
+                handle: function (message) {
+                    var value = getParamValue(cell, parameterSpec.id);
+                    bus.send({
+                        type: 'update',
+                        value: value
+                    });
+                }
+            });
+
+            return FieldWidget.make({
+                inputControlFactory: inputWidget,
+                showHint: true,
+                useRowHighight: true,
+                initialValue: value,
+                parameterSpec: parameterSpec,
+                bus: bus,
+                workspaceId: workspaceInfo.id,
+                runtime: runtime
+            });
+        }
+
+        function createNode(markup) {
+            var node = document.createElement('div');
+            node.innerHTML = markup;
+            return node.firstChild;
+        }
+
+        // LIFECYCYLE API
+
+        function init(config) {
+            return Promise.try(function () {
+                return null;
+            });
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                container = node;
+                var layout = renderLayout();
+                container.innerHTML = layout.content;
+                layout.events.attachEvents(container);
+                places = {
+                    status: container.querySelector('[data-element="status"]'),
+                    notifications: container.querySelector('[data-element="notifications"]'),
+                    regularFields: container.querySelector('[data-element="input-widget-regular-fields"]'),
+                    advancedFields: container.querySelector('[data-element="input-widget-advanced-fields"]'),
+                    widget: container.querySelector('[data-element="widget"]')
+                };
+                return null;
+            });
+        }
+
+        var inputBusses = [];
+        function start() {
+            return Promise.try(function () {
+                inputWidgetBus.listen({
+                    test: function (message) {
+                        return (message.id === 'reset');
+                    },
+                    handle: function (message) {
+                        inputBusses.forEach(function (bus) {
+                            bus.send({
+                                type: 'reset-to-defaults'
+                            });
+                        });
+                    }
+                });
+                return null;
+            });
+        }
+
+        function run(params) {
+            var widgets = [];
+            return fetchData(params.methodId, params.methodVersion)
+                .then(function (parameterSpecs) {
+                    var regularParams = parameterSpecs.filter(function (spec) {
+                        return (spec.spec.advanced !== 1);
+                    }),
+                        advancedParams = parameterSpecs.filter(function (spec) {
+                            return (spec.spec.advanced === 1);
+                        });
+
+                    return [regularParams, advancedParams];
+
+                })
+                .spread(function (regularParams, advancedParams) {
+                    // First create the row layout 
+                    return Promise.all(regularParams.map(function (spec) {
+                        var fieldWidget = makeFieldWidget(cell, spec, cell.getMeta('params', spec.name())),
+                            rowWidget = RowWidget.make({widget: fieldWidget, spec: spec}),
+                            rowNode = document.createElement('div');
+                        places.regularFields.appendChild(rowNode);
+                        widgets.push(rowWidget);
+                        rowWidget.attach(rowNode);
+                    }))
+                        .then(function () {
+                            return Promise.all(advancedParams.map(function (spec) {
+                                var fieldWidget = makeFieldWidget(cell, spec, cell.getMeta('params', spec.name())),
+                                    rowWidget = RowWidget.make({widget: fieldWidget, spec: spec}),
+                                    rowNode = document.createElement('div');
+                                places.advancedFields.appendChild(rowNode);
+                                widgets.push(rowWidget);
+                                rowWidget.attach(rowNode);
+                            }));
+                        });
+                })
+                .then(function () {
+                    return widgets.map(function (widget) {
+                        return widget.start();
+                    });
+                })
+                .then(function () {
+                    return widgets.map(function (widget) {
+                        return widget.run(params);
+                    });
+                })
+                .then(function () {
+                    cell.kbase.$node.find('[data-element="input-widget-form"]').on('submit', function (e) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        parentBus.send({
+                            type: 'submitted'
+                        });
+                    });
+//                    cell.kbase.$node.find('[data-element="input-widget-form"]').on('submit', function (e) {
+//                        e.preventDefault();
+//                        parentBus.send({
+//                            id: 'submitted'
+//                        });
+//                    });
+                });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/codeCellInputWidget.js
+++ b/nbextensions/methodCell/widgets/codeCellInputWidget.js
@@ -44,7 +44,7 @@ define([
             nms = new NarrativeMethodStore(runtime.config('services.narrative_method_store.url'), {
                 token: runtime.authToken()
             });
-            
+
             return nms.get_method_spec(methodRef)
                 .then(function (data) {
                     if (!data[0]) {
@@ -62,54 +62,70 @@ define([
         function renderLayout() {
             var events = Events.make(),
                 content = div({class: 'kbase-extension', style: {display: 'flex', alignItems: 'stretch'}}, [
-                div({class: 'prompt', dataElement: 'prompt', style: {display: 'flex', alignItems: 'stretch', width: '14ex', flexDirection: 'column'}}, [
-                    div({dataElement: 'status'})
-                ]),
-                div({class: 'body', dataElement: 'body', style: {display: 'flex', alignItems: 'stretch', flexDirection: 'column', flex: '1'}}, [
-                    div({dataElement: 'notifications', style: {display: 'block', width: '100%'}}),
-                    div({dataElement: 'widget', style: {display: 'block', width: '100%'}}, [
-                        form({dataElement: 'input-widget-form'}, div({class: 'container-fluid'}, [
-                            // Insert fields into here.
-                            div({class: 'panel panel-default'}, [
-                                div({class: 'panel-heading'}, [
-                                    div({class: 'panel-tite'}, 'Toolbar')
+                    div({class: 'prompt', dataElement: 'prompt', style: {display: 'flex', alignItems: 'stretch', width: '14ex', flexDirection: 'column'}}, [
+                        div({dataElement: 'status'})
+                    ]),
+                    div({class: 'body', dataElement: 'body', style: {display: 'flex', alignItems: 'stretch', flexDirection: 'column', flex: '1'}}, [
+                        div({dataElement: 'notifications', style: {display: 'block', width: '100%'}}),
+                        div({dataElement: 'widget', style: {display: 'block', width: '100%'}}, [
+                            form({dataElement: 'input-widget-form'}, div({class: 'container-fluid'}, [
+                                // Insert fields into here.
+                                div({class: 'panel panel-default'}, [
+                                    div({class: 'panel-heading'}, [
+                                        div({class: 'panel-tite'}, 'Toolbar')
+                                    ]),
+                                    div({class: 'panel-body'}, [
+                                        button({type: 'button', class: 'btn btn-default', id: events.addEvent({
+                                                type: 'click',
+                                                handler: function (e) {
+                                                    inputWidgetBus.send({id: 'reset'});
+                                                }
+                                            })}, 'Reset to Defaults')
+                                    ])
                                 ]),
-                                div({class: 'panel-body'}, [
-                                    button({type: 'button', class: 'btn btn-default', id: events.addEvent({
-                                        type: 'click',
-                                        handler: function (e) {
-                                            inputWidgetBus.send({id: 'reset'});
-                                        }
-                                    })}, 'Reset to Defaults')
-                                ])
-                            ]),
-                            div({class: 'panel panel-default'}, [
-                                div({class: 'panel-heading'}, [
-                                    div({class: 'panel-tite'}, 'Regular Parameters')
+                                div({class: 'panel panel-default'}, [
+                                    div({class: 'panel-heading'}, [
+                                        div({class: 'panel-tite'}, 'Inputs')
+                                    ]),
+                                    div({class: 'panel-body'}, [
+                                        div({dataElement: 'input-widget-input-fields', class: 'container-fluid'})
+                                    ])
                                 ]),
-                                div({class: 'panel-body'}, [
-                                    div({dataElement: 'input-widget-regular-fields', class: 'container-fluid'})
-                                ])
-                            ]),
-                            div({class: 'panel panel-default'}, [
-                                div({class: 'panel-heading'}, [
-                                    div({class: 'panel-tite'}, 'Advanced Parameters')
+                                div({class: 'panel panel-default'}, [
+                                    div({class: 'panel-heading'}, [
+                                        div({class: 'panel-tite'}, 'Outputs')
+                                    ]),
+                                    div({class: 'panel-body'}, [
+                                        div({dataElement: 'input-widget-output-fields', class: 'container-fluid'})
+                                    ])
                                 ]),
-                                div({class: 'panel-body'}, [
-                                    div({dataElement: 'input-widget-advanced-fields', class: 'container-fluid'})
+                                div({class: 'panel panel-default'}, [
+                                    div({class: 'panel-heading'}, [
+                                        div({class: 'panel-tite'}, 'Parameters')
+                                    ]),
+                                    div({class: 'panel-body'}, [
+                                        div({dataElement: 'input-widget-parameter-fields', class: 'container-fluid'})
+                                    ])
+                                ]),
+                                div({class: 'panel panel-default'}, [
+                                    div({class: 'panel-heading'}, [
+                                        div({class: 'panel-tite'}, 'Advanced Parameters')
+                                    ]),
+                                    div({class: 'panel-body'}, [
+                                        div({dataElement: 'input-widget-advanced-parameter-fields', class: 'container-fluid'})
+                                    ])
+                                ]),
+                                // Submit row.
+                                div({dataElement: 'input-widget-controls', class: 'container-fluid'}, [
+                                    div({class: 'row'}, [
+                                        div({class: 'col-md-3'}),
+                                        div({class: 'col-md-9'}, button({type: 'submit'}, 'Run'))
+                                    ])
                                 ])
-                            ]),
-                            // Submit row.
-                            div({dataElement: 'input-widget-controls', class: 'container-fluid'}, [
-                                div({class: 'row'}, [
-                                    div({class: 'col-md-3'}),
-                                    div({class: 'col-md-9'}, button({type: 'submit'}, 'Run'))
-                                ])
-                            ])
-                        ]))
+                            ]))
+                        ])
                     ])
-                ])
-            ]);
+                ]);
             return {
                 content: content,
                 events: events
@@ -239,7 +255,7 @@ define([
         function makeFieldWidget(cell, parameterSpec, value) {
             var bus = Bus.make(),
                 inputWidget = getInputWidgetFactory(parameterSpec);
-            
+
             inputBusses.push(bus);
 
             // Listen for changed values coming from any cell. Since invocation of
@@ -258,7 +274,7 @@ define([
                     });
                 }
             });
-            
+
             // Listen for sync request from widget. 
             // We'll send the widget the current state of the param stored
             // in the metadata, aka, our data store.
@@ -310,8 +326,10 @@ define([
                 places = {
                     status: container.querySelector('[data-element="status"]'),
                     notifications: container.querySelector('[data-element="notifications"]'),
-                    regularFields: container.querySelector('[data-element="input-widget-regular-fields"]'),
-                    advancedFields: container.querySelector('[data-element="input-widget-advanced-fields"]'),
+                    inputFields: container.querySelector('[data-element="input-widget-input-fields"]'),
+                    outputFields: container.querySelector('[data-element="input-widget-output-fields"]'),
+                    parameterFields: container.querySelector('[data-element="input-widget-parameter-fields"]'),
+                    advancedParameterFields: container.querySelector('[data-element="input-widget-advanced-parameter-fields"]'),
                     widget: container.querySelector('[data-element="widget"]')
                 };
                 return null;
@@ -341,75 +359,102 @@ define([
             var widgets = [];
             return fetchData(params.methodId, params.methodVersion)
                 .then(function (parameterSpecs) {
-                    var regularParams = parameterSpecs.filter(function (spec) {
-                        return (spec.spec.advanced !== 1);
+                    var inputParams = parameterSpecs.filter(function (spec) {
+                        return (spec.spec.ui_class === 'input');
                     }),
-                        advancedParams = parameterSpecs.filter(function (spec) {
-                            return (spec.spec.advanced === 1);
+                        outputParams = parameterSpecs.filter(function (spec) {
+                            return (spec.spec.ui_class === 'output');
+                        }),
+                        parameterParams = parameterSpecs.filter(function (spec) {
+                            return (spec.spec.advanced !== 1 && spec.spec.ui_class === 'parameter');
+                        }),
+                        advancedParameterParams = parameterSpecs.filter(function (spec) {
+                            return (spec.spec.advanced === 1 && spec.spec.ui_class === 'parameter');
                         });
 
-                    return [regularParams, advancedParams];
+                    return [inputParams, outputParams, parameterParams, advancedParameterParams];
 
                 })
-                .spread(function (regularParams, advancedParams) {
+                .spread(function (inputParams, outputParams, parameterParams, advancedParameterParams) {
                     // First create the row layout 
-                    return Promise.all(regularParams.map(function (spec) {
+                    return Promise.all(inputParams.map(function (spec) {
                         var fieldWidget = makeFieldWidget(cell, spec, cell.getMeta('params', spec.name())),
                             rowWidget = RowWidget.make({widget: fieldWidget, spec: spec}),
                             rowNode = document.createElement('div');
-                        places.regularFields.appendChild(rowNode);
+                        places.inputFields.appendChild(rowNode);
                         widgets.push(rowWidget);
                         rowWidget.attach(rowNode);
                     }))
                         .then(function () {
-                            return Promise.all(advancedParams.map(function (spec) {
+                            return Promise.all(outputParams.map(function (spec) {
                                 var fieldWidget = makeFieldWidget(cell, spec, cell.getMeta('params', spec.name())),
                                     rowWidget = RowWidget.make({widget: fieldWidget, spec: spec}),
                                     rowNode = document.createElement('div');
-                                places.advancedFields.appendChild(rowNode);
+                                places.outputFields.appendChild(rowNode);
                                 widgets.push(rowWidget);
                                 rowWidget.attach(rowNode);
                             }));
+                        })
+                        .then(function () {
+                            return Promise.all(parameterParams.map(function (spec) {
+                                var fieldWidget = makeFieldWidget(cell, spec, cell.getMeta('params', spec.name())),
+                                    rowWidget = RowWidget.make({widget: fieldWidget, spec: spec}),
+                                    rowNode = document.createElement('div');
+                                places.parameterFields.appendChild(rowNode);
+                                widgets.push(rowWidget);
+                                rowWidget.attach(rowNode);
+                            }));
+                        })
+                        .then(function () {
+                            return Promise.all(advancedParameterParams.map(function (spec) {
+                                var fieldWidget = makeFieldWidget(cell, spec, cell.getMeta('params', spec.name())),
+                                    rowWidget = RowWidget.make({widget: fieldWidget, spec: spec}),
+                                    rowNode = document.createElement('div');
+                                places.advancedParameterFields.appendChild(rowNode);
+                                widgets.push(rowWidget);
+                                rowWidget.attach(rowNode);
+                            }));
+                            });
+                    })
+                    .then(function () {
+                        return widgets.map(function (widget) {
+                            return widget.start();
                         });
-                })
-                .then(function () {
-                    return widgets.map(function (widget) {
-                        return widget.start();
-                    });
-                })
-                .then(function () {
-                    return widgets.map(function (widget) {
-                        return widget.run(params);
-                    });
-                })
-                .then(function () {
-                    cell.kbase.$node.find('[data-element="input-widget-form"]').on('submit', function (e) {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        parentBus.send({
-                            type: 'submitted'
+                    })
+                    .then(function () {
+                        return widgets.map(function (widget) {
+                            return widget.run(params);
                         });
-                    });
+                    })
+                    .then(function () {
+                        cell.kbase.$node.find('[data-element="input-widget-form"]').on('submit', function (e) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            parentBus.send({
+                                type: 'submitted'
+                            });
+                        });
 //                    cell.kbase.$node.find('[data-element="input-widget-form"]').on('submit', function (e) {
 //                        e.preventDefault();
 //                        parentBus.send({
 //                            id: 'submitted'
 //                        });
 //                    });
-                });
-        }
+                    });
+                }
 
-        return {
-            init: init,
-            attach: attach,
-            start: start,
-            run: run
-        };
-    }
+                return {
+                    init: init,
+                    attach: attach,
+                    start: start,
+                    run: run
+                };
+            }
 
-    return {
-        make: function (config) {
+            return {
+            make: function (config) {
             return factory(config);
         }
-    };
+    }
+    ;
 });

--- a/nbextensions/methodCell/widgets/fieldWidget.js
+++ b/nbextensions/methodCell/widgets/fieldWidget.js
@@ -1,0 +1,344 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+/*
+ * The Field Widget has two main jobs:
+ * - render an input within within a layout
+ * - provide reaction to input widget events to give user feedback 
+ * 
+ * The first goal is accomplished through the usual widget machineral - attach, start, run, stop. 
+ * The second through a simple message bus in which the input widget emits from a set
+ * of events which reflect the state of the input after user interaction.
+ */
+define([
+    'bluebird',
+    'jquery',
+    'kb_common/html',
+    '../events'
+], function (Promise, $, html, Events) {
+    'use strict';
+    var t = html.tag,
+        div = t('div'), span = t('span'), label = t('label'), button = t('button'),
+        table = t('table'), tr = t('tr'), th = t('th'), td = t('td'),
+        classSets = {
+            standard: {
+                nameColClass: 'col-md-2',
+                inputColClass: 'col-md-5',
+                hintColClass: 'col-md-5'
+            },
+            sidePanel: {
+                nameColClass: 'col-md-12',
+                inputColClass: 'col-md-12',
+                hintColClass: 'col-md-12'
+            }
+        };
+
+
+    function factory(config) {
+        var places, container,
+            inputControlFactory = config.inputControlFactory,
+            inputControl = inputControlFactory.make({
+                bus: config.bus,
+                initialValue: config.initialValue,
+                parameterSpec: config.parameterSpec,
+                workspaceInfo: config.workspaceInfo,
+                workspaceId: config.workspaceId
+            }),
+            options = {},
+            fieldId = html.genId(),
+            bus = config.bus,
+            spec = config.parameterSpec;
+
+        // options.isOutputName = spec.text_options && spec.text_options.is_output_name;
+        options.enabled = true;
+        options.classes = classSets.standard;
+
+
+        function setError(errorMessage) {
+            // places.$feedback.removeClass();
+            places.$field.addClass('kb-method-parameter-row-error');
+            places.$errorPanel.addClass('kb-method-parameter-row-error');
+            places.$error
+                .html(errorMessage);
+            places.$errorPanel
+                .show();
+        }
+
+        function clearError() {
+            places.$field.removeClass('kb-method-parameter-row-error');
+            places.$error
+                .html('');
+            places.$errorPanel
+                .hide();
+        }
+
+        function hideError() {
+            places.$field.removeClass('kb-method-parameter-row-error');
+            places.$errorPanel.hide();
+            places.$feedback.removeClass();
+        }
+
+        function feedbackNone() {
+            places.$feedback
+                .removeClass()
+                .hide();
+        }
+
+        function feedbackOk() {
+            places.$feedback
+                .removeClass()
+                // .addClass('kb-method-parameter-accepted-glyph fa fa-check')
+                .prop('title', 'input is ok')
+                .show();
+        }
+
+        function feedbackRequired(row) {
+            places.$feedback
+                .removeClass()
+                .addClass('kb-method-parameter-required-glyph fa fa-arrow-left')
+                .prop('title', 'required field')
+                .show();
+        }
+        
+         function feedbackError(row) {
+            places.$feedback
+                .removeClass()
+                .addClass('kb-method-parameter-required-glyph fa fa-ban')
+                .show();
+        }
+        
+        function parameterInfoContent(spec) {
+            return div([
+                div({style: {fontWeight: 'bold'}}, spec.label()),
+                div({style: {fontStyle: 'italic'}}, spec.name()),
+                div({style: {fontSize: '80%'}}, spec.description())
+            ]);
+        }
+        function parameterInfoTypeRules(spec) {
+            switch (spec.dataType()) {
+                case 'float': 
+                    return [
+                        tr([th('Min'), td(spec.spec.text_options.min_float)]),
+                        tr([th('Max'), td(spec.spec.text_options.max_float)])
+                    ];
+            }
+        }
+        function parameterInfoRules(spec) {
+            return table({class: 'table table-striped'}, [
+                tr([th('Required'), td(spec.required() ? 'yes' : 'no')]),
+                tr([th('Type'), td(spec.dataType())]),
+                tr([th('Multiple values?'), td(spec.multipleItems() ? 'yes' : 'no')]),
+                (function () {
+                    if (!spec.spec.default_values) {
+                        return;
+                    }
+                    if (spec.spec.default_values.length === 0) {
+                        return;
+                    }
+                    if (spec.multipleItems()) {
+                        tr([th('Default value'), td(spec.spec.default_values[0])]);
+                    }
+                    return tr([th('Default value'), td(spec.spec.default_values.join('<br>'))]);
+                }())
+            ].concat(parameterInfoTypeRules(spec)));
+        }
+
+        function render(events) {
+            var placeholder = '',
+                fieldContainer,
+                feedbackTip, nameCol, inputCol, hintCol;
+
+            // PLACHOLDER (todo: put it somewhere!)
+            if (spec.text_options && spec.text_options.placeholder) {
+                placeholder = spec.text_options.placeholder.replace(/(\r\n|\n|\r)/gm, '');
+            }
+
+            // FEEDBACK
+            if (spec.required()) {
+                feedbackTip = span({
+                    class: 'kb-method-parameter-required-glyph fa fa-arrow-left',
+                    title: 'required field',
+                    dataElement: 'feedback'
+                });
+            }
+
+            // INPUT (control with feedback)
+            // Note -- here is where we 
+            inputCol = div({class: [options.classes.inputColClass, 'kb-method-parameter-input'].join(' ')}, [
+                div({style: {width: '100%', display: 'inline-block'}}, [
+                    div({dataElement: 'input-control'})
+                ]),
+                div({style: {display: 'inline-block'}}, [
+                    feedbackTip
+                ])
+            ]);
+
+            // FIELD NAME
+//            nameCol = div({class: options.classes.nameColClass}, 
+//                class: [options.classes.nameColClass, 'kb-method-parameter-name'].join(' ')
+//            }, spec.label());
+
+            // HINT (help)
+            var infoTipText;
+            if (spec.description() && spec.hint() !== spec.description()) {
+                infoTipText = spec.description();
+            } else {
+                infoTipText = spec.hint() || spec.description();
+            }
+            
+            var infoId = html.genId();
+
+            var content = div({class: 'form-horizontal', style: {marginTop: '8px'}, id: fieldId}, [
+                div({class: 'form-group', dataElement: 'field-panel'},[
+                    label({class: 'col-md-3 control-label kb-method-parameter-name'}, [
+                        spec.label()
+                    ]),
+                    div({class: 'col-md-4'}, div({class: 'kb-method-parameter-input'}, [
+                        div({class: 'input-group', style: {width: '100%'}}, [
+                            div({dataElement: 'input-control'}),
+                            div({class: 'input-group-addon', style: {width: '50px', padding: '0'}}, [
+                                div({dataElement: 'feedback'})
+                            ]),
+                            div({class: 'input-group-addon', style: {width: '30px', padding: '0'}}, [
+                                div({dataElement: 'info'}, button({
+                                    class: 'btn btn-link btn-xs',
+                                    type: 'button',
+                                    id: events.addEvent({
+                                        type: 'click',
+                                        handler: function (e) {
+                                           var info = document.getElementById(infoId);
+                                           if (info.style.display === 'block') {
+                                               info.style.display = 'none';
+                                           } else {
+                                               info.style.display = 'block';
+                                           }
+                                        }
+                                    })
+                                },
+                                    span({class: 'fa fa-info-circle'})
+                                ))
+                            ])
+                        ])
+                    ])),
+                    div({class: 'col-md-5'},  div({id: infoId, style: {display: 'none'}}, html.makeTabs({
+                            tabs: [
+                            {
+                                label: 'Description',
+                                name: 'description',
+                                content: infoTipText
+                            },
+                            {
+                                label: 'About',
+                                name: 'about',
+                                content: parameterInfoContent(spec)
+                            },
+                             {
+                                label: 'Rules',
+                                name: 'rules',
+                                content: parameterInfoRules(spec)
+                            }
+                        ]})))
+                    
+                ]),
+                div({class: 'form-group', dataElement: 'error-panel', style: {display: 'none'}}, [                    
+                    div({class:'col-md-2'}),
+                    div({class: 'col-md-5'},  div({
+                        class: ['kb-method-parameter-error-message'].join(' '),
+                        dataElement: 'error-message'
+                    })),
+                    div({class: 'col-md-5'})
+                ])
+            ]);
+            
+            return content;
+        }
+
+        // LIFECYCLE
+
+//        function init() {
+//            // A bit more friendly and normalized properties of the parameter spec.
+//            // options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+//            // options.classes g= classSets[options.environment];
+//            options.multiple = spec.multiple();
+//            options.required = spec.required();
+//            // options.isOutputName = spec.text_options && spec.text_options.is_output_name;
+//            options.enabled = true;
+//            // return inputControl.init();
+//        }
+
+        function attach(node) {
+            var events = Events.make(),
+                $container;
+            container = node;
+            container.innerHTML = render(events);
+            events.attachEvents(container);
+
+            // create the "places" shortcuts.
+            $container = $(container);
+            places = {
+                $field: $container.find('#' + fieldId),
+                $fieldPanel: $container.find('[data-element="field-panel"]'),
+                $input: $container.find('[data-element="input"]'),
+                $error: $container.find('[data-element="error-message"]'),
+                $errorPanel: $container.find('[data-element="error-panel"]'),
+                $feedback: $container.find('[data-element="feedback"]'),
+                $removalButton: $container.find('[data-element="removal-button"]')
+            };
+            return inputControl.attach($container.find('[data-element="input-control"]').get(0));
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.listen({
+                    test: function (message) {
+                        return (message.type === 'validation');
+                    },
+                    handle: function (message) {
+                        switch (message.diagnosis) {
+                            case 'valid':
+                                feedbackOk();
+                                clearError();
+                                break;
+                            case 'required-missing':
+                                feedbackRequired();
+                                // setError(message.errorMessage, spec.label());
+                                clearError();
+                                break;
+                            case 'invalid':
+                                feedbackError();
+                                setError(message.errorMessage, spec.label());
+                                break;
+                            case 'optional-empty':
+                                feedbackNone();
+                                clearError();
+                                break;
+                        }
+                    }
+                });
+                if (inputControl.start) {
+                    return inputControl.start();
+                }
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                if (inputControl.run) {
+                    return inputControl.run(params);
+                }
+            });
+        }
+
+        return {
+            // init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/intInput.js
+++ b/nbextensions/methodCell/widgets/input/intInput.js
@@ -1,0 +1,532 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'jquery',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function ($, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            rows = [],
+            parent,
+            container,
+            $container,
+            places = {
+                addRowController: null,
+                rows: null
+            };
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+        function getParameterValues() {
+            return rows.map(function (row) {
+                return row.$input.val();
+            });
+        }
+
+        function validate() {
+            if (!options.enabled) {
+                return {
+                    isValid: true,
+                    errorMessages: []
+                };
+            }
+
+            var values = getParameterValues(),
+                someErrorDetected = false,
+                errorMessages = [];
+
+            values.forEach(function (rawValue, index) {
+                var errorMessage,
+                    value  = rawValue.trim(),
+                    row = rows[index],
+                    fieldType,
+                    validationResult;
+                    
+                // Validate if we need to.
+                if (options.required && index === 0 && !value) {
+                    errorMessage = 'required field ' + spec.ui_name + ' missing';
+                } else if (!options.required && value === '') {
+                    // just skip it, it is ok.
+                } else {
+                    if (spec.text_options) {
+                        if (spec.text_options.validate_as) {
+                            fieldType = spec.text_options.validate_as.toLowerCase();
+                            switch (fieldType) {
+                                case 'int':
+                                    validationResult = Validation.validateInteger(value, spec.text_options);
+                                    if (!validationResult.isValid) {
+                                        errorMessage = validationResult.errorMessage;
+                                    } else {
+                                        // Events may be configured by the widget host.
+                                        // TODO: this should be an event and not a callback.
+                                        if (config.events.change) {
+                                            try {
+                                                config.events.change(validationResult.parsedValue);
+                                            } catch (ex) {
+                                                console.error('ERROR', ex);
+                                            }
+                                        }
+                                    }
+                                    break;
+                                case 'float':
+                                    validationResult = Validation.validateFloat(value, spec.text_options);
+                                    if (!validationResult.isValid) {
+                                        errorMessage = validationResult.errorMessage;
+                                    }
+                                    break;
+                            }
+                        } else if (spec.text_options.valid_ws_types) {
+                            // Entry of workspace object names.
+                            // TODO any reason this can't be typed like int and float?         
+                            validationResult = Validation.validateWorkspaceObjectName(value);
+                            if (!validationResult.isValid) {
+                                errorMessage = validationResult.errorMessage;
+                            }
+                        }
+                    }
+                }
+
+                // todo -- special handling for multiple values.
+                if (errorMessage) {
+                    setRowError(row, errorMessage, spec.ui_name);
+                    if (options.required) {
+                        if (value === '') {
+                            rowFeedbackRequired(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    } else {
+                        rowFeedbackNone(row);
+                    }
+                    errorMessages.push(errorMessage + 'in field ' + spec.ui_name);
+                    someErrorDetected = true;
+                } else {
+                    clearRowError(row);
+                    if (options.required) {
+                        rowFeedbackOk(row);
+                    } else {
+                        if (value === '') {
+                            rowFeedbackNone(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    }
+                }
+            });
+
+            return {
+                isValid: !someErrorDetected,
+                errorMessages: errorMessages
+            };
+        }
+
+        function removeRow(rowId) {
+            rows = rows.map(function (row) {
+                if (row.id === rowId) {
+                    row.$row.remove();
+                    return false;
+                }
+                return row;
+            }).filter(function (row) {
+                return row;
+            });
+        }
+
+
+
+        function addRow(defaultValue, showHint, useRowHighlight) {
+            var placeholder = '',
+                rowId = html.genId(),
+                inputControl, feedbackTip, parameterRow, id,
+                nameCol, inputCol, removalButton, hintCol,
+                events = Events.make();
+            if (spec.text_options && spec.text_options.placeholder) {
+                placeholder = spec.text_options.placeholder.replace(/(\r\n|\n|\r)/gm, '');
+            }
+            defaultValue = defaultValue || '';
+
+            inputControl = input({
+                id: events.addEvent({type: 'change', handler: validate}),
+                placeholder: placeholder,
+                value: defaultValue,
+                type: 'text',
+                dataElement: 'input',
+                style: {width: '100%'},
+                class: 'form-control'
+            });
+
+
+            // this is a column adjacent to the form controls which provides status flags (error, data required, data complete and ok)
+            // TODO: this and other elements should be set up without any styles,
+            // and then the initial evaluation of the parameters vis-a-vis the ui will
+            // set the correct styles...
+            if (options.required && showHint) {
+                feedbackTip = span({
+                    class: 'kb-method-parameter-required-glyph fa fa-arrow-left',
+                    title: 'required field',
+                    dataElement: 'feedback'
+                });
+            } else {
+                feedbackTip = span({dataElement: 'feedback'});
+            }
+
+
+            // paremeter name display
+            var style = {};
+            if (options.environment === 'sidePanel') {
+                style = {
+                    textAlign: 'left', paddingLeft: '10px'
+                };
+            }
+            nameCol = div({
+                class: [options.classes.nameColClass, 'kb-method-parameter-name'].join(' '),
+                style: style
+            }, [(function () {
+                    if (showHint) {
+                        return spec.ui_name;
+                    }
+                })]);
+
+            // Input column display
+            inputCol = div({class: [options.classes.inputColClass, 'kb-method-parameter-input'].join(' ')}, [
+                div({style: {widgth: '100%', display: 'inline-block'}}, [
+                    inputControl
+                ]),
+                div({style: {display: 'inline-block'}}, [
+                    feedbackTip
+                ])
+            ]);
+
+            if (showHint) {
+                var infoTip;
+                if (spec.description && spec.short_hint !== spec.description) {
+                    infoTip = span({
+                        class: 'fa fa-info kb-method-parameter-info',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'auto',
+                        container: 'body',
+                        html: 'true',
+                        title: spec.description
+                    });
+                }
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    spec.short_hint, infoTip
+                ]);
+            } else {
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    button({class: 'kb-default-btn kb-btn-sm', id: events.addEvent({type: 'click', handler: function () {
+                                removeRow(rowId);
+                            }})}, [
+                        span({class: 'kb-parameter-data-row-remove fa fa-remove'}, [
+                            'remove ' + spec.ui_name
+                        ])
+                    ])
+                ]);
+            }
+
+
+            // put it all together.
+
+            // The row itself.
+            parameterRow = div({class: 'row kb-method-parameter-row', dataElement: 'row'}, [
+                nameCol, inputCol, hintCol
+            ]);
+            if (options.useRowHighlight) {
+                events.addEvent({type: 'mouseeneter', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+                events.addEvent({type: 'mouseleave', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+            }
+
+            // Error display
+            var errorRow = div({class: 'row', dataElement: 'error-panel'}, [
+                div({class: options.classes.nameColClass}),
+                div({
+                    class: ['kb-method-parameter-error-message', options.classes.inputColClass].join(' '),
+                    style: {display: 'none'},
+                    dataElement: 'error-message'
+                })
+            ]);
+
+            var row = div({
+                dataElement: 'field',
+                id: rowId
+            }, [parameterRow, errorRow]);
+
+            // Finally, into the DOM!
+            $container.find('[data-element="rows-container"]').append(row);
+
+            events.attachEvents($container.get(0));
+
+            // Now we keep a handy copy of nodes around.
+            // In truth, we could implement this as an api and avoid this junk, which also 
+            // embeds a lot of jquery/dom nonsense.
+            var $field = $container.find('#' + rowId);
+
+            // The row exists to provide mount points for the various ui
+            // elements for this control.
+            rows.push({
+                rowId: rowId,
+                $row: $field.find('[data-element="row"]'),
+                $input: $field.find('[data-element="input"]'),
+                $error: $field.find('[data-element="error-message"]'),
+                $feedback: $field.find('[data-element="feedback"]'),
+                $field: $field,
+                $all: $field,
+                $removalButton: $field.find('[data-element="removal-button"]')
+            });
+
+        }
+
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function render() {
+            var defaultValue = '',
+                defaultValues;
+
+            if (!options.multiple) {
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    // TODO!!!
+                    // the condition for using the first defaultvalue in the defaultValues 
+                    // array is suspect ... 
+                    // this says we use the default value if it is not an empty string or set as undefined
+                    // (because it can't really be undefined or we would not be here)
+                    // so this basically collapses to if it is an empty string use an empty string, otherwise
+                    // use the default value.
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+                addRow(defaultValue, true, true);
+            } else {
+
+                // TODO: the main panel hover bit...
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+
+                // TODO what is the funny bit with using the default value first?
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValues.forEach(function (defaultValue) {
+                        var betterDefaultValue = (defaultValue !== '' && defaultValue !== undefined) ? defaultValue : '';
+                        addRow(betterDefaultValue, false, false);
+                    });
+                }
+
+                // TODO: addTheAddRowController();
+
+            }
+        }
+
+        function layout() {
+            var events = Events.make(),
+                content;
+            if (options.multiple) {
+                content = div({
+                    class: 'kb-method-parameter-row',
+                    dataElement: 'main-panel',
+                    id: events.addEvents({events: [
+                            {
+                                type: 'mouseeneter',
+                                handler: function (e) {
+                                    e.target.classList.add('kb-method-parameter-row-hover');
+                                }
+                            },
+                            {
+                                type: 'mouseleave',
+                                handler: function (e) {
+                                    e.target.classList.remove('kb-method-parameter-row-hover');
+                                }
+                            }
+                        ]})}, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            } else {
+                content = div({
+                    dataElement: 'main-panel'
+                }, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            }
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        // CLIENT API
+
+        function name() {
+            return spec.id;
+        }
+
+        function label() {
+            return spec.ui_name;
+        }
+
+        function hint() {
+            return spec.short_hint;
+        }
+
+        function description() {
+            return spec.description;
+        }
+        
+        function info() {
+            return '';
+        }
+
+        function multipleItems() {
+            return options.multiple;
+        }
+
+        function fieldType() {
+            return spec.field_type;
+        }
+
+        function type() {
+            return spec.type;
+        }
+
+        function dataType() {
+            if (!spec.text_options) {
+                return 'text';
+            }
+            var validateAs = spec.text_options.validate_as;
+            type;
+            if (validateAs) {
+                return validateAs;
+            }
+
+            if (spec.text_options.valid_ws_types) {
+                return 'workspaceObjectReference';
+            }
+
+            return 'unknown';
+        }
+
+        function uiClass() {
+            return spec.ui_class;
+        }
+
+        function required() {
+            return options.required;
+        }
+
+        function control() {
+            return 'control here';
+        }
+
+        // DATA API
+
+        /*
+         * If multiple values are supported, we always return an array
+         * If not, always return an atomic value
+         * // TODO: this data should always be scrubbed!
+         */
+        function value() {
+            console.log('INPUT', rows[0].$input);
+            if (options.multiple) {
+                return rows.map(function (row) {
+                    return row.$input.val();
+                });
+            }
+            return rows[0].$input.val();
+        }
+
+
+        // LIFECYCLE API
+
+        var domId = html.genId();
+        var widgetRootNode;
+        function id() {
+            return domId;
+        }
+
+        function init() {
+            // Normalize the parameter specification settings.
+            // TODO: much of this is just silly, we should be able to use the spec 
+            //   directly in most places.
+            options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+            options.classes = classSets[options.environment];
+            options.multiple = spec.allow_multiple ? true : false;
+            options.required = spec.optional ? false : true;
+            options.isOutputName = spec.text_options && spec.text_options.is_output_name;
+            options.enabled = true;
+            console.log('HMM', spec);
+        }
+
+        function attach(node) {
+            parent = node;
+
+            widgetRootNode = parent.querySelector('#' + domId);
+            if (!widgetRootNode) {
+                throw new Error('The domId for this widget does not exist in the parent context');
+            }
+
+            // container = node.append(document.createElement('div'));
+            $container = $(widgetRootNode);
+            var theLayout = layout();
+            widgetRootNode.innerHTML = theLayout.content;
+            theLayout.events.attachEvents(widgetRootNode);
+        }
+
+        function start(params) {
+            // return render();
+            render(params);
+        }
+
+        return {
+            id: id,
+            init: init,
+            attach: attach,
+            start: start,
+            name: name,
+            label: label,
+            hint: hint,
+            description: description,
+            info: description,
+            multipleItems: multipleItems,
+            fieldType: fieldType,
+            type: type,
+            dataType: dataType,
+            uiClass: uiClass,
+            required: required,
+            control: control,
+            value: value
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/multiIntInput.js
+++ b/nbextensions/methodCell/widgets/input/multiIntInput.js
@@ -1,0 +1,319 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), button = t('button');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus,
+            model = [];
+
+        // Validate configuration.
+        // Nothing to do...
+
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        function normalizeModel() {
+            var newModel = model.filter(function (item) {
+                return item ? true : false;
+            });
+            model = newModel;
+        }
+        function syncModel(value) {
+            model = [];
+            config.initialValue.forEach(function (item) {
+                model.push(item);
+            });
+            normalizeModel();
+        }
+
+        if (config.initialValue) {
+            syncModel(config.initialValue);
+        }
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function copyProps(from, props) {
+            var newObj = {};
+            props.forEach(function (prop) {
+                newObj[prop] = from[prop];
+            });
+            return newObj;
+        }
+
+        function validate(rawValue) {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var validationOptions = copyProps(spec.spec.text_options, ['min_int', 'max_int']);
+
+                validationOptions.required = spec.required();
+                return Validation.validateInteger(rawValue, validationOptions);
+            });
+        }
+
+        function updateValue() {
+
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, index, events, bus) {
+            // CONTROL
+            var preButton, postButton,
+                control = input({
+                    id: events.addEvents({
+                        events: [
+                            {
+                                type: 'change',
+                                handler: function (e) {
+                                    var control = e.target,
+                                        value = control.value,
+                                        index = control.getAttribute('data-index');
+                                    validate(value)
+                                        .then(function (result) {
+                                            if (result.isValid) {
+                                                if (index === 'add') {
+                                                    model.push(result.parsedValue);
+                                                } else {
+                                                    index = parseInt(index);
+                                                    model[index] = result.parsedValue;
+                                                }
+                                                normalizeModel();
+
+                                                bus.send({
+                                                    type: 'changed',
+                                                    newValue: model
+                                                });
+                                            }
+                                            bus.send({
+                                                type: 'validation',
+                                                errorMessage: result.errorMessage,
+                                                diagnosis: result.diagnosis
+                                            });
+                                        });
+                                }
+                            },
+                            {
+                                type: 'focus',
+                                handler: function (e) {
+                                    Jupyter.keyboard_manager.disable();
+                                }
+                            },
+                            {
+                                type: 'blur',
+                                handler: function (e) {
+                                    Jupyter.keyboard_manager.enable();
+                                }
+                            }
+                        ]}),
+                    type: 'text',
+                    class: 'form-control',
+                    dataElement: 'input',
+                    dataIndex: String(index),
+                    value: currentValue
+                });
+            if (index === 'add') {
+                preButton = div({class: 'input-group-addon', style: {width: '10ex'}}, 'Add');
+                postButton = div({class: 'input-group-addon'}, button({
+                    class: 'btn btn-primary btn-xs',
+                    type: 'button',
+                    style: {width: '4ex'},
+                    id: events.addEvent({type: 'click', handler: function (e) {
+                            // alert('add me');
+                        }})
+                }, '+'));
+            } else {
+                preButton = div({class: 'input-group-addon', style: {width: '10ex'}}, index + '.');
+                postButton = div({class: 'input-group-addon'}, button({
+                    class: 'btn btn-danger btn-xs',
+                    type: 'button',
+                    style: {width: '4ex'},
+                    dataIndex: String(index),
+                    id: events.addEvent({type: 'click', handler: function (e) {
+                            var index = e.target.getAttribute('data-index');
+                            var control = container.querySelector('input[data-index="' + index + '"]');
+                            control.value = '';
+                            control.dispatchEvent(new Event('change'));
+
+                            // alert('delete me ' + control.value);
+                        }})
+                }, 'x'));
+            }
+            return div({class: 'input-group'}, [
+                preButton,
+                control,
+                postButton
+            ]);
+        }
+
+        function render(input) {
+            var events = Events.make(),
+                items = model.map(function (value, index) {
+                    return makeInputControl(value, index, events, bus);
+                });
+
+            items = items.concat(makeInputControl('', 'add', events, bus));
+
+            var content = items.join('\n');
+
+            $container.find('[data-element="input-container"]').html(content);
+            events.attachEvents(container);
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+        function autoValidate() {
+            return Promise.all(model.map(function (value, index) {
+                // could get from DOM, but the model is the same.
+                var rawValue = container.querySelector('[data-index="' + index + '"]').value;
+                // console.log('VALIDATE', value);
+                return validate(rawValue);
+            }))
+                .then(function (results) {
+                    // a bit of a hack -- we need to handle the 
+                    // validation here, and update the individual rows
+                    // for now -- just create one mega message.
+                    var errorMessages = [],
+                        validation;
+                    results.forEach(function (result, index) {
+                        if (result.errorMessage) {
+                            errorMessages.push(result.errorMessage + ' in item ' + index);
+                        }
+                    });
+                    if (errorMessages.length) {
+                        validation = {
+                            type: 'validation',
+                            diagnosis: 'invalid',
+                            errorMessage: errorMessages.join('<br/>')
+                        };
+                    } else {
+                        validation = {
+                            type: 'validation',
+                            diagnosis: 'valid'
+                        };
+                    }
+                    bus.send(validation);
+                });
+        }
+
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.listen({
+                    test: function (message) {
+                        return (message.type === 'changed');
+                    },
+                    handle: function (message) {
+                        render();
+                    }
+                });
+            });
+        }
+
+        function run(input) {
+            return Promise.try(function () {
+                if (input.value) {
+                    syncModel(input.value);
+                }
+                return render(input);
+            })
+                .then(function () {
+                    return autoValidate();
+                });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/multiTextInput.js
+++ b/nbextensions/methodCell/widgets/input/multiTextInput.js
@@ -1,0 +1,357 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), button = t('button');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            container,
+            $container,
+            bus = config.bus,
+            model = {
+                value: []
+            };
+
+        // Validate configuration.
+        // Nothing to do...
+
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        function normalizeModel() {
+            var newModel = model.value.filter(function (item) {
+                return item ? true : false;
+            });
+            model.value = newModel;
+        }
+
+        function setModelValue(value, index) {
+            return Promise.try(function () {
+                if (index !== undefined) {
+                    if (value) {
+                        model.value[index] = value;
+                    } else {
+                        delete model.value[index];
+                    }
+                } else {
+                    if (value) {
+                        model.value = value.map(function (item) {
+                            return item;
+                        });
+                    } else {
+                        unsetModelValue();
+                    }
+                }
+                normalizeModel();
+            })
+                .then(function () {
+                    render();
+                });
+        }
+
+        function addModelValue(value) {
+            return Promise.try(function () {
+                model.value.push(value);
+            })
+                .then(function () {
+                    render();
+                });
+
+        }
+
+        function unsetModelValue() {
+            return Promise.try(function () {
+                model.value = [];
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function resetModelValue() {
+            if (spec.spec.default_values && spec.spec.default_values.length > 0) {
+                setModelValue(spec.spec.default_values);
+            } else {
+                unsetModelValue();
+            }
+        }
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function copyProps(from, props) {
+            var newObj = {};
+            props.forEach(function (prop) {
+                newObj[prop] = from[prop];
+            });
+            return newObj;
+        }
+
+        function validate(rawValue) {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var validationOptions = copyProps(spec.spec.text_options, ['regexp_constraint', 'min_length', 'max_length']);
+
+                validationOptions.required = spec.required();
+                return Validation.validateText(rawValue, validationOptions);
+            });
+        }
+
+        function updateValue() {
+
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, index, events, bus) {
+            // CONTROL
+            var preButton, postButton,
+                control = input({
+                    id: events.addEvents({
+                        events: [
+                            {
+                                type: 'change',
+                                handler: function (e) {
+                                    var control = e.target,
+                                        value = control.value,
+                                        index = control.getAttribute('data-index');
+                                    validate(value)
+                                        .then(function (result) {
+                                            if (result.isValid) {
+                                                if (index === 'add') {
+                                                    addModelValue(result.parsedValue);
+                                                } else {
+                                                    index = parseInt(index, 10);
+                                                    setModelValue(result.parsedValue, index);
+                                                }
+                                                normalizeModel();
+
+                                                bus.send({
+                                                    type: 'changed',
+                                                    newValue: model.value
+                                                });
+                                            }
+                                            bus.send({
+                                                type: 'validation',
+                                                errorMessage: result.errorMessage,
+                                                diagnosis: result.diagnosis
+                                            });
+                                            return null;
+                                        })
+                                        .catch(function (err) {
+                                            console.error(err);
+                                        });
+                                }
+                            },
+                            {
+                                type: 'focus',
+                                handler: function (e) {
+                                    Jupyter.keyboard_manager.disable();
+                                }
+                            },
+                            {
+                                type: 'blur',
+                                handler: function (e) {
+                                    Jupyter.keyboard_manager.enable();
+                                }
+                            }
+                        ]}),
+                    type: 'text',
+                    class: 'form-control',
+                    dataElement: 'input',
+                    dataIndex: String(index),
+                    value: currentValue
+                });
+            if (index === 'add') {
+                preButton = div({class: 'input-group-addon', style: {width: '5ex', padding: '0'}}, '');
+                postButton = div({class: 'input-group-addon', style: {padding: '0'}}, button({
+                    class: 'btn btn-primary btn-link btn-xs',
+                    type: 'button',
+                    style: {width: '4ex'},
+                    id: events.addEvent({type: 'click', handler: function (e) {
+                            // alert('add me');
+                        }})
+                }, '+'));
+            } else {
+                preButton = div({class: 'input-group-addon', style: {width: '5ex', padding: '0'}}, String(index + 1) + '.');
+                postButton = div({class: 'input-group-addon', style: {padding: '0'}}, button({
+                    class: 'btn btn-danger btn-link btn-xs',
+                    type: 'button',
+                    style: {width: '4ex'},
+                    dataIndex: String(index),
+                    id: events.addEvent({type: 'click', handler: function (e) {
+                            var index = e.target.getAttribute('data-index'),
+                                control = container.querySelector('input[data-index="' + index + '"]');
+                            control.value = '';
+                            control.dispatchEvent(new Event('change'));
+                        }})
+                }, 'x'));
+            }
+            return div({class: 'input-group'}, [
+                preButton,
+                control,
+                postButton
+            ]);
+        }
+
+        function render(input) {
+            var events = Events.make(),
+                items = model.value.map(function (value, index) {
+                    return makeInputControl(value, index, events, bus);
+                });
+
+            items = items.concat(makeInputControl('', 'add', events, bus));
+
+            var content = items.join('\n');
+
+            $container.find('[data-element="input-container"]').html(content);
+            events.attachEvents(container);
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+        function autoValidate() {
+            return Promise.all(model.value.map(function (value, index) {
+                // could get from DOM, but the model is the same.
+                var rawValue = container.querySelector('[data-index="' + index + '"]').value;
+                // console.log('VALIDATE', value);
+                return validate(rawValue);
+            }))
+                .then(function (results) {
+                    // a bit of a hack -- we need to handle the 
+                    // validation here, and update the individual rows
+                    // for now -- just create one mega message.
+                    var errorMessages = [],
+                        validation;
+                    results.forEach(function (result, index) {
+                        if (result.errorMessage) {
+                            errorMessages.push(result.errorMessage + ' in item ' + index);
+                        }
+                    });
+                    if (errorMessages.length) {
+                        validation = {
+                            type: 'validation',
+                            diagnosis: 'invalid',
+                            errorMessage: errorMessages.join('<br/>')
+                        };
+                    } else {
+                        validation = {
+                            type: 'validation',
+                            diagnosis: 'valid'
+                        };
+                    }
+                    bus.send(validation);
+                });
+        }
+
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.on('reset-to-defaults', function (message) {
+                    resetModelValue();
+                });
+                bus.on('update', function (message) {
+                    setModelValue(message.value);
+                });
+                bus.on('refresh', function () {
+
+                });
+                bus.send({type: 'sync'});
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                // nothing to do now... we are ... reactive.
+            });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/newObjectInput.js
+++ b/nbextensions/methodCell/widgets/input/newObjectInput.js
@@ -1,0 +1,270 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus,
+            model = {
+                value: undefined
+            };
+
+        // Validate configuration.
+        // Nothing to do...
+
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        function setModelValue(value) {
+            return Promise.try(function () {
+                if (model.value !== value) {
+                    model.value = value;
+                    return true;
+                }
+                return false;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function unsetModelValue() {
+            return Promise.try(function () {
+                model.value = undefined;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function resetModelValue() {
+            if (spec.spec.default_values && spec.spec.default_values.length > 0) {
+                setModelValue(spec.spec.default_values[0]);
+            } else {
+                unsetModelValue();
+            }
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function copyProps(from, props) {
+            var newObj = {};
+            props.forEach(function (prop) {
+                newObj[prop] = from[prop];
+            });
+            return newObj;
+        }
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    validationOptions = {},
+                    validationResult;
+
+                validationOptions.required = spec.required();
+                validationResult = Validation.validateWorkspaceObjectName(rawValue, validationOptions);
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, events, bus) {
+            // CONTROL
+            return input({
+                id: events.addEvents({
+                    events: [
+                        {
+                            type: 'change',
+                            handler: function (e) {
+                                validate()
+                                    .then(function (result) {
+                                        if (result.isValid) {
+                                            bus.send({
+                                                type: 'changed',
+                                                newValue: result.value
+                                            });
+                                        } else if (result.diagnosis === 'required-missing') {
+                                            bus.send({
+                                                type: 'changed',
+                                                newValue: result.value
+                                            });
+                                        }
+                                        bus.send({
+                                            type: 'validation',
+                                            errorMessage: result.errorMessage,
+                                            diagnosis: result.diagnosis
+                                        });
+                                    });
+                            }
+                        },
+                        {
+                            type: 'focus',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.disable();
+                            }
+                        },
+                        {
+                            type: 'blur',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.enable();
+                            }
+                        }
+                    ]}),
+                class: 'form-control',
+                dataElement: 'input',
+                value: currentValue
+            });
+        }
+
+        function render() {
+            Promise.try(function () {
+                var events = Events.make(),
+                    inputControl = makeInputControl(model.value, events, bus);
+
+                $container.find('[data-element="input-container"]').html(inputControl);
+                events.attachEvents(container);
+            })
+                .then(function () {
+                    return autoValidate();
+                });
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        function autoValidate() {
+            return validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.on('reset-to-defaults', function (message) {
+                    resetModelValue();
+                });
+                bus.on('update', function (message) {
+                    setModelValue(message.value);
+                });
+                bus.on('refresh', function () {
+
+                });
+                bus.send({type: 'sync'});
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                // nothing to do now... we are ... reactive.
+            });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/objectInput.js
+++ b/nbextensions/methodCell/widgets/input/objectInput.js
@@ -1,0 +1,302 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'jquery',
+    'bluebird',
+    'kb_common/html',
+    'kb_service/client/workspace',
+    'kb_service/utils',
+    '../../validation',
+    '../../events',
+    '../../runtime',
+    'bootstrap',
+    'css!font-awesome'
+], function ($, Promise, html, Workspace, serviceUtils, Validation, Events, Runtime) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'),
+        select = t('select'), option = t('option');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            workspaceId = config.workspaceId,
+            bus = config.bus,
+            runCount = 0,
+            model = {
+                availableValues: undefined,
+                value: undefined
+            },
+            runtime = Runtime.make();
+
+        // Validate configuration.
+        if (!workspaceId) {
+            throw new Error('Workspace id required for the object widget');
+        }
+        //if (!workspaceUrl) {
+        //    throw new Error('Workspace url is required for the object widget');
+        //}
+
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+        function makeInputControl(events, bus) {
+            // There is an input control, and a dropdown,
+            // TODO select2 after we get a handle on this...
+            var selectOptions;
+            if (model.availableValues) {
+                selectOptions = model.availableValues.map(function (objectInfo) {
+                    var selected = false;
+                    if (objectInfo.ref === model.value) {
+                        selected = true;
+                    }
+                    return option({
+                        value: objectInfo.ref,
+                        selected: selected
+                    }, objectInfo.name);
+                });
+            }
+
+            // CONTROL
+            return select({
+                id: events.addEvent({type: 'change', handler: function (e) {
+                        validate()
+                            .then(function (result) {
+                                if (result.isValid) {
+                                    bus.send({
+                                        type: 'changed',
+                                        newValue: result.value
+                                    });
+                                } else if (result.diagnosis === 'required-missing') {
+                                    bus.send({
+                                        type: 'changed',
+                                        newValue: result.value
+                                    });
+                                }
+                                bus.send({
+                                    type: 'validation',
+                                    errorMessage: result.errorMessage,
+                                    diagnosis: result.diagnosis
+                                });
+                            });
+                    }}),
+                class: 'form-control',
+                dataElement: 'input'
+            }, [option({value: ''}, '')].concat(selectOptions));
+        }
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        function setModelValue(value) {
+            return Promise.try(function () {
+                if (model.value !== value) {
+                    model.value = value;
+                    return true;
+                }
+                return false;
+            })
+                .then(function (changed) {
+                    return render();
+                });
+        }
+
+        function unsetModelValue() {
+            return Promise.try(function () {
+                model.value = undefined;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function resetModelValue() {
+            if (spec.spec.default_values && spec.spec.default_values.length > 0) {
+                setModelValue(spec.spec.default_values[0]);
+            } else {
+                unsetModelValue();
+            }
+        }
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    validationOptions = {},
+                    validationResult;
+                validationOptions.required = spec.required();
+
+                validationResult = Validation.validateWorkspaceObjectRef(rawValue, validationOptions);
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+        function getObjectsByType(type) {
+            var workspace = new Workspace(runtime.config('services.workspace.url'), {
+                token: runtime.authToken()
+            });
+            return workspace.list_objects({
+                type: type,
+                ids: [workspaceId]
+            })
+                .then(function (data) {
+                    return data.map(function (objectInfo) {
+                        return serviceUtils.objectInfoToObject(objectInfo);
+                    });
+                });
+        }
+
+        function fetchData() {
+            var types = spec.spec.text_options.valid_ws_types;
+            return Promise.all(types.map(function (type) {
+                return getObjectsByType(type);
+            }))
+                .then(function (objectSets) {
+                    return Array.prototype.concat.apply([], objectSets);
+                })
+                .then(function (objects) {
+                    objects.sort(function (a, b) {
+                        if (a.name < b.name) {
+                            return -1;
+                        }
+                        if (a.name === b.name) {
+                            return 0;
+                        }
+                        return 1;
+                    });
+                    return objects;
+                });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function render() {
+            return Promise.try(function () {
+                var events = Events.make(),
+                    inputControl = makeInputControl(events, bus),
+                    content = div({class: 'input-group', style: {width: '100%'}}, inputControl);
+
+                $container.find('[data-element="input-container"]').html(content);
+                events.attachEvents(container);
+            })
+                .then(function () {
+                    return autoValidate();
+                });
+        }
+
+        /*
+         * In the layout we set up an environment in which one or more parameter
+         * rows may be inserted.
+         * For the objectInput, there is only ever one control.
+         */
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        function autoValidate() {
+            return validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.on('reset-to-defaults', function (message) {
+                    resetModelValue();
+                });
+                bus.on('update', function (message) {
+                    setModelValue(message.value);
+                });
+                bus.send({type: 'sync'});
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                return fetchData(params);
+            })
+                .then(function (data) {
+                    model.availableValues = data;
+                    render();
+                });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/objectInput_1.js
+++ b/nbextensions/methodCell/widgets/input/objectInput_1.js
@@ -1,0 +1,642 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'jquery',
+    'bluebird',
+    'kb_common/html',
+    'kb_service/client/workspace',
+    'kb_service/utils',
+    './validation',
+    './events',
+    'bootstrap',
+    'css!font-awesome'
+], function ($, Promise, html, Workspace, serviceUtils, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var classSets = {
+        standard: {
+            nameColClass: 'col-md-2',
+            inputColClass: 'col-md-5',
+            hintColClass: 'col-md-5'
+        },
+        sidePanel: {
+            nameColClass: 'col-md-12',
+            inputColClass: 'col-md-12',
+            hintColClass: 'col-md-12'
+        }
+    },
+    t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button'),
+        select = t('select'), option = t('option'),
+        table = t('table'), tr = t('tr'), th = t('th'), td = t('td');
+
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            rows = [],
+            parent,
+            container,
+            $container,
+            places = {
+                addRowController: null,
+                rows: null
+            },
+            workspaceId = config.workspaceId,
+            workspaceUrl = config.workspaceUrl,
+            authToken = config.authToken || null,
+            commBus = config.commBus;
+        
+        // Validate configuration.
+        if (!workspaceId) {
+            throw new Error('Workspace id required for the object widget');
+        }
+        if (!workspaceUrl) {
+            throw new Error('Workspace url is required for the object widget');
+        }
+        
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+        function getInputValues() {
+            return rows.map(function (row) {
+                return row.$input.val();
+            });
+        }
+
+        function setRowError(row, errorMessage, uiName) {
+            row.$row.addClass('kb-method-parameter-row-error');
+            row.$error
+                .html(errorMessage)
+                .show();
+            row.$feedback.removeClass();
+        }
+
+        function clearRowError(row) {
+            row.$row.removeClass('kb-method-parameter-row-error');
+            row.$error
+                .html('')
+                .hide();
+        }
+
+        function hideError(row, value) {
+            if (!row) {
+                return;
+            }
+            row.$row.removeClass('kb-method-parameter-row-error');
+            row.$error.hide();
+            row.$feedback.removeClass();
+        }
+
+        function rowFeedbackNone(row) {
+            row.$feedback
+                .removeClass()
+                .hide();
+        }
+
+
+        function rowFeedbackOk(row) {
+            row.$feedback
+                .removeClass()
+                .addClass('kb-method-parameter-accepted-glyph fa fa-check')
+                .prop('title', 'required field')
+                .show();
+        }
+
+
+        function rowFeedbackRequired(row) {
+            row.$feedback
+                .removeClass()
+                .addClass('kb-method-parameter-required-glyph fa fa-arrow-left')
+                .prop('title', 'required field')
+                .show();
+        }
+
+        function validate() {
+            if (!options.enabled) {
+                return {
+                    isValid: true,
+                    errorMessages: []
+                };
+            }
+
+            var values = getInputValues(),
+                someErrorDetected = false,
+                errorMessages = [];
+
+            values.forEach(function (rawValue, index) {
+                var errorMessage,
+                    value  = rawValue.trim(),
+                    row = rows[index],
+                    fieldType,
+                    validationResult;
+                    
+                // Validate if we need to.
+                if (options.required && index === 0 && !value) {
+                    errorMessage = 'required field ' + spec.ui_name + ' missing';
+                } else if (!options.required && value === '') {
+                    // just skip it, it is ok.
+                } else {
+                    // Truth be told, we cannot even get here unless this condition
+                    // is met.
+                    if (spec.text_options && spec.text_options.valid_ws_types) {
+                        // Entry of workspace object names.
+                        // TODO any reason this can't be typed like int and float?         
+                        validationResult = Validation.validateObjectRef(value);
+                        if (!validationResult.isValid) {
+                            errorMessage = validationResult.errorMessage;
+                        }
+                    }
+                }
+
+                // todo -- special handling for multiple values.
+                if (errorMessage) {
+                    setRowError(row, errorMessage, spec.ui_name);
+                    if (options.required) {
+                        if (value === '') {
+                            rowFeedbackRequired(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    } else {
+                        rowFeedbackNone(row);
+                    }
+                    errorMessages.push(errorMessage + 'in field ' + spec.ui_name);
+                    someErrorDetected = true;
+                } else {
+                    clearRowError(row);
+                    if (options.required) {
+                        rowFeedbackOk(row);
+                    } else {
+                        if (value === '') {
+                            rowFeedbackNone(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    }
+                }
+            });
+
+            return {
+                isValid: !someErrorDetected,
+                errorMessages: errorMessages,
+                value: validationResult.parsedValue
+            };
+        }
+
+        function removeRow(rowId) {
+            rows = rows.map(function (row) {
+                if (row.id === rowId) {
+                    row.$row.remove();
+                    return false;
+                }
+                return row;
+            }).filter(function (row) {
+                return row;
+            });
+        }
+        
+        function getObjectsByType(type) {
+            var workspace = new Workspace(workspaceUrl, {
+                token: authToken
+            });
+            return workspace.list_objects({
+                type: type,
+                ids: [workspaceId]
+            })
+                .then(function (data) {
+                    return data.map(function (objectInfo) {
+                        return serviceUtils.objectInfoToObject(objectInfo);
+                    });
+                });
+                
+        }
+        
+        function fetchData() {
+            var types = spec.text_options.valid_ws_types;
+            return Promise.all(types.map(function (type) {
+                return getObjectsByType(type);
+            }))
+                .then(function (objectSets) {
+                    return Array.prototype.concat.apply([], objectSets);
+                })
+                .then(function (objects) {
+                    objects.sort(function (a, b) {
+                        if (a.name < b.name) {
+                            return -1;
+                        } else if (a.name === b.name) {
+                            return 0;
+                        }
+                        else return 1;
+                    });
+                    return objects
+                });
+        }
+
+        function addRow(defaultValue, data, showHint, useRowHighlight) {
+            var placeholder = '',
+                rowId = html.genId(),
+                fieldControl, inputControl, selectControl,
+                feedbackTip, parameterRow, id,
+                nameCol, inputCol, removalButton, hintCol,
+                events = Events.make();
+            if (spec.text_options && spec.text_options.placeholder) {
+                placeholder = spec.text_options.placeholder.replace(/(\r\n|\n|\r)/gm, '');
+            }
+            defaultValue = defaultValue || '';
+            
+            
+            // There is an input control, and a dropdown,
+            // TODO select2 after we get a handle on this...
+            var selectOptions = data.map(function (objectInfo) {
+                return option({
+                    value: objectInfo.ref
+                }, objectInfo.name);
+            });
+            
+            
+            selectControl = select({
+                id: events.addEvent({type: 'change', handler: function (e) {
+                    var result = validate();
+                    if (result.isValid) {
+                        commBus.send('changed', {
+                           value: result.value
+                        });
+                    }
+                }}),
+                class: 'form-control',
+                dataElement: 'input'
+            }, [option({value: ''}, '')].concat(selectOptions));
+            fieldControl = selectControl;
+
+
+            // this is a column adjacent to the form controls which provides status flags (error, data required, data complete and ok)
+            // TODO: this and other elements should be set up without any styles,
+            // and then the initial evaluation of the parameters vis-a-vis the ui will
+            // set the correct styles...
+            if (options.required && showHint) {
+                feedbackTip = span({
+                    class: 'kb-method-parameter-required-glyph fa fa-arrow-left',
+                    title: 'required field',
+                    dataElement: 'feedback'
+                });
+            } else {
+                feedbackTip = span({dataElement: 'feedback'});
+            }
+
+
+            // paremeter name display
+            var style = {};
+            if (options.environment === 'sidePanel') {
+                style = {
+                    textAlign: 'left', paddingLeft: '10px'
+                };
+            }
+            nameCol = div({
+                class: [options.classes.nameColClass, 'kb-method-parameter-name'].join(' '),
+                style: style
+            }, [(function () {
+                    if (showHint) {
+                        return spec.ui_name;
+                    }
+                })]);
+
+            // Input column display
+            inputCol = div({class: [options.classes.inputColClass, 'kb-method-parameter-input'].join(' ')}, [
+                div({style: {widgth: '100%', display: 'inline-block'}}, [
+                    fieldControl
+                ]),
+                div({style: {display: 'inline-block'}}, [
+                    feedbackTip
+                ])
+            ]);
+
+            if (showHint) {
+                var infoTip;
+                if (spec.description && spec.short_hint !== spec.description) {
+                    infoTip = span({
+                        class: 'fa fa-info kb-method-parameter-info',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'auto',
+                        container: 'body',
+                        html: 'true',
+                        title: spec.description
+                    });
+                }
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    spec.short_hint, infoTip
+                ]);
+            } else {
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    button({class: 'kb-default-btn kb-btn-sm', id: events.addEvent({type: 'click', handler: function () {
+                                removeRow(rowId);
+                            }})}, [
+                        span({class: 'kb-parameter-data-row-remove fa fa-remove'}, [
+                            'remove ' + spec.ui_name
+                        ])
+                    ])
+                ]);
+            }
+
+
+            // put it all together.
+
+            // The row itself.
+            parameterRow = div({class: 'row kb-method-parameter-row', dataElement: 'row'}, [
+                nameCol, inputCol, hintCol
+            ]);
+            if (options.useRowHighlight) {
+                events.addEvent({type: 'mouseeneter', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+                events.addEvent({type: 'mouseleave', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+            }
+
+            // Error display
+            var errorRow = div({class: 'row', dataElement: 'error-panel'}, [
+                div({class: options.classes.nameColClass}),
+                div({
+                    class: ['kb-method-parameter-error-message', options.classes.inputColClass].join(' '),
+                    style: {display: 'none'},
+                    dataElement: 'error-message'
+                })
+            ]);
+
+            var row = div({
+                dataElement: 'field',
+                id: rowId
+            }, [parameterRow, errorRow]);
+
+            // Finally, into the DOM!
+            $container.find('[data-element="rows-container"]').append(row);
+
+            events.attachEvents($container.get(0));
+
+            // Now we keep a handy copy of nodes around.
+            // In truth, we could implement this as an api and avoid this junk, which also 
+            // embeds a lot of jquery/dom nonsense.
+            var $field = $container.find('#' + rowId);
+
+            // The row exists to provide mount points for the various ui
+            // elements for this control.
+            rows.push({
+                rowId: rowId,
+                $row: $field.find('[data-element="row"]'),
+                $input: $field.find('[data-element="input"]'),
+                $error: $field.find('[data-element="error-message"]'),
+                $feedback: $field.find('[data-element="feedback"]'),
+                $field: $field,
+                $all: $field,
+                $removalButton: $field.find('[data-element="removal-button"]')
+            });
+
+        }
+
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function render(params, data) {
+            var defaultValue = '',
+                defaultValues;
+
+            if (!options.multiple) {
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    // TODO!!!
+                    // the condition for using the first defaultvalue in the defaultValues 
+                    // array is suspect ... 
+                    // this says we use the default value if it is not an empty string or set as undefined
+                    // (because it can't really be undefined or we would not be here)
+                    // so this basically collapses to if it is an empty string use an empty string, otherwise
+                    // use the default value.
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+                addRow(defaultValue, data, true, true);
+            } else {
+
+                // TODO: the main panel hover bit...
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+
+                // TODO what is the funny bit with using the default value first?
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValues.forEach(function (defaultValue) {
+                        var betterDefaultValue = (defaultValue !== '' && defaultValue !== undefined) ? defaultValue : '';
+                        addRow(betterDefaultValue, data, false, false);
+                    });
+                }
+
+                // TODO: addTheAddRowController();
+
+            }
+        }
+
+        function layout() {
+            var events = Events.make(),
+                content;
+            if (options.multiple) {
+                content = div({
+                    class: 'kb-method-parameter-row',
+                    dataElement: 'main-panel',
+                    id: events.addEvents({events: [
+                            {
+                                type: 'mouseeneter',
+                                handler: function (e) {
+                                    e.target.classList.add('kb-method-parameter-row-hover');
+                                }
+                            },
+                            {
+                                type: 'mouseleave',
+                                handler: function (e) {
+                                    e.target.classList.remove('kb-method-parameter-row-hover');
+                                }
+                            }
+                        ]})}, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            } else {
+                content = div({
+                    dataElement: 'main-panel'
+                }, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            }
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        // CLIENT API
+
+        function name() {
+            return spec.id;
+        }
+
+        function label() {
+            return spec.ui_name;
+        }
+
+        function hint() {
+            return spec.short_hint;
+        }
+
+        function description() {
+            return spec.description;
+        }
+        
+        function info() {
+            return table({class: 'table table-striped'}, [
+                tr([
+                    th('Types'),
+                    tr(td(table({class: 'table'}, spec.text_options.valid_ws_types.map(function (type) {
+                        return tr(td(type));
+                    }))))
+                ])
+            ]);
+        }
+
+        function multipleItems() {
+            return options.multiple;
+        }
+
+        function fieldType() {
+            return spec.field_type;
+        }
+
+        function type() {
+            return spec.type;
+        }
+
+        function dataType() {
+            if (!spec.text_options) {
+                return 'text';
+            }
+            var validateAs = spec.text_options.validate_as;
+            type;
+            if (validateAs) {
+                return validateAs;
+            }
+
+            if (spec.text_options.valid_ws_types) {
+                return 'workspaceObjectReference';
+            }
+
+            return 'unknown';
+        }
+
+        function uiClass() {
+            return spec.ui_class;
+        }
+
+        function required() {
+            return options.required;
+        }
+
+        function control() {
+            return 'control here';
+        }
+
+        // DATA API
+
+        /*
+         * If multiple values are supported, we always return an array
+         * If not, always return an atomic value
+         * // TODO: this data should always be scrubbed!
+         */
+        function value() {
+            if (options.multiple) {
+                return rows.map(function (row) {
+                    return row.$input.val();
+                });
+            }
+            return rows[0].$input.val();
+        }
+
+
+        // LIFECYCLE API
+
+        var domId = html.genId();
+        var widgetRootNode;
+        function id() {
+            return domId;
+        }
+
+        function init() {
+            // Normalize the parameter specification settings.
+            // TODO: much of this is just silly, we should be able to use the spec 
+            //   directly in most places.
+            options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+            options.classes = classSets[options.environment];
+            options.multiple = spec.allow_multiple ? true : false;
+            options.required = spec.optional ? false : true;
+            options.isOutputName = spec.text_options && spec.text_options.is_output_name;
+            options.enabled = true;
+        }
+
+        function attach(node) {
+            parent = node;
+
+            widgetRootNode = parent.querySelector('#' + domId);
+            if (!widgetRootNode) {
+                throw new Error('The domId for this widget does not exist in the parent context');
+            }
+
+            // container = node.append(document.createElement('div'));
+            $container = $(widgetRootNode);
+            var theLayout = layout();
+            widgetRootNode.innerHTML = theLayout.content;
+            theLayout.events.attachEvents(widgetRootNode);
+        }
+
+        function start(params) {
+            // return render();
+            fetchData(params)
+                .then(function (data) {
+                    render(params, data);
+                });
+        }
+
+        return {
+            id: id,
+            init: init,
+            attach: attach,
+            start: start,
+            name: name,
+            label: label,
+            hint: hint,
+            description: description,
+            info: info,
+            multipleItems: multipleItems,
+            fieldType: fieldType,
+            type: type,
+            dataType: dataType,
+            uiClass: uiClass,
+            required: required,
+            control: control,
+            value: value
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/objectInput_2.js
+++ b/nbextensions/methodCell/widgets/input/objectInput_2.js
@@ -1,0 +1,267 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'jquery',
+    'bluebird',
+    'kb_common/html',
+    'kb_service/client/workspace',
+    'kb_service/utils',
+    '../validation',
+    '../events',
+    'bootstrap',
+    'css!font-awesome'
+], function ($, Promise, html, Workspace, serviceUtils, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'),
+        select = t('select'), option = t('option');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            workspaceId = config.workspaceId,
+            workspaceUrl = config.workspaceUrl,
+            bus = config.bus;
+
+        // Validate configuration.
+        if (!workspaceId) {
+            throw new Error('Workspace id required for the object widget');
+        }
+        if (!workspaceUrl) {
+            throw new Error('Workspace url is required for the object widget');
+        }
+
+        function makeInputControl(data, events, bus) {
+            // There is an input control, and a dropdown,
+            // TODO select2 after we get a handle on this...
+            var selectOptions = data.map(function (objectInfo) {
+                return option({
+                    value: objectInfo.ref
+                }, objectInfo.name);
+            });
+
+            // CONTROL
+            return select({
+                id: events.addEvent({type: 'change', handler: function (e) {
+                        var result = validate();
+                        if (result.isValid) {
+                            bus.send({
+                                type: 'changed',
+                                newValue: result.value
+                            });
+                        }
+                        bus.send({
+                            type: 'validation',
+                            errorMessage: result.errorMessage,
+                            diagnosis: result.diagnosis
+                        });
+                    }}),
+                class: 'form-control',
+                dataElement: 'input'
+            }, [option({value: ''}, '')].concat(selectOptions));
+        }
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        function validate() {
+            if (!options.enabled) {
+                return {
+                    isValid: true,
+                    validated: false,
+                    diagnosis: 'disabled'
+                };
+            }
+
+            var rawValue = getInputValue(),
+                someErrorDetected = false,
+                errorMessage,
+                value = rawValue.trim(),
+                validationResult,
+                diagnosis;
+
+            // Validate if we need to.
+            if (options.required && !value) {
+                errorMessage = 'required field ' + spec.label() + ' missing';
+                diagnosis = 'required-missing';
+            } else if (!options.required && value === '') {
+                // just skip it, it is ok.
+                diagnosis = 'optional-empty';
+            } else {
+                // Truth be told, we cannot even get here unless this condition
+                // is met.
+                validationResult = Validation.validateObjectRef(value);
+                if (!validationResult.isValid) {
+                    errorMessage = validationResult.errorMessage;
+                    diagnosis = 'invalid';
+                }
+            }
+
+            return {
+                isValid: !someErrorDetected,
+                validated: true,
+                diagnosis: diagnosis || 'valid',
+                errorMessage: errorMessage,
+                value: validationResult.parsedValue
+            };
+        }
+
+        function getObjectsByType(type, authToken) {
+            var workspace = new Workspace(workspaceUrl, {
+                token: authToken
+            });
+            return workspace.list_objects({
+                type: type,
+                ids: [workspaceId]
+            })
+                .then(function (data) {
+                    return data.map(function (objectInfo) {
+                        return serviceUtils.objectInfoToObject(objectInfo);
+                    });
+                });
+        }
+
+        function fetchData(input) {
+            var types = spec.spec.text_options.valid_ws_types;
+            return Promise.all(types.map(function (type) {
+                return getObjectsByType(type, input.authToken);
+            }))
+                .then(function (objectSets) {
+                    return Array.prototype.concat.apply([], objectSets);
+                })
+                .then(function (objects) {
+                    objects.sort(function (a, b) {
+                        if (a.name < b.name) {
+                            return -1;
+                        }
+                        if (a.name === b.name) {
+                            return 0;
+                        }
+                        return 1;
+                    });
+                    return objects;
+                });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function render(params, data) {
+            var events = Events.make();
+            var inputControl = makeInputControl(data, events, bus);
+            
+            $container.find('[data-element="input-container"]').html(inputControl);
+                
+        }
+
+        /*
+         * In the layout we set up an environment in which one or more parameter
+         * rows may be inserted.
+         * For the objectInput, there is only ever one control.
+         */
+        function layout(events) {
+            var content;
+            if (options.multiple) {
+                content = div({
+                    class: 'kb-method-parameter-row',
+                    dataElement: 'main-panel',
+                    id: events.addEvents({events: [
+                            {
+                                type: 'mouseeneter',
+                                handler: function (e) {
+                                    e.target.classList.add('kb-method-parameter-row-hover');
+                                }
+                            },
+                            {
+                                type: 'mouseleave',
+                                handler: function (e) {
+                                    e.target.classList.remove('kb-method-parameter-row-hover');
+                                }
+                            }
+                        ]})}, [
+                    div({dataElement: 'input-container'})
+                ]);
+            } else {
+                content = div({
+                    dataElement: 'main-panel'
+                }, [
+                    div({dataElement: 'input-container'})
+                ]);
+            }
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        // LIFECYCLE API
+
+        function init() {
+            // Normalize the parameter specification settings.
+            // TODO: much of this is just silly, we should be able to use the spec 
+            //   directly in most places.
+            options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+            // options.classes = classSets[options.environment];
+            options.multiple = spec.multipleItems();
+            options.required = spec.required();
+            // options.isOutputName = spec.text_options && spec.text_options.is_output_name;
+            options.enabled = true;
+        }
+
+        function attach(node) {
+            return Promise.try(function () {                
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+        
+        function start() {
+            return Promise.try(function () {                
+            });
+        }
+
+        function run(params) {
+            // return render();
+            return fetchData(params)
+                .then(function (data) {
+                    return render(params, data);
+                });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/singleBooleanInput.js
+++ b/nbextensions/methodCell/widgets/input/singleBooleanInput.js
@@ -1,0 +1,271 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button'), select = t('select'), option = t('option');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus,
+            valueChecked = spec.spec.checkbox_options.checked_value,
+            valueUnchecked = spec.spec.checkbox_options.unchecked_value;
+
+        // Validate configuration.
+        // Nothing to do...
+        
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            var checkbox = container.querySelector('[data-element="input-container"] [data-element="input"]');
+            if (checkbox.checked) {
+                return valueChecked;
+            }
+            return valueUnchecked;
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+        
+        function copyProps(from, props) {
+            var newObj = {};
+            props.forEach(function (prop) {
+                newObj[prop] = from[prop];
+            });
+            return newObj;
+        }
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    // TODO should actually create the set of checkbox values and
+                    // make this a validation option, although not specified as 
+                    // such in the spec.
+                    validationOptions = {
+                        required: spec.required(),
+                        values: [valueChecked, valueUnchecked]
+                    },
+                    validationResult;
+
+                console.log('VALIDATING', rawValue);
+                // validationResult = Validation.validateInteger(rawValue, validationOptions);
+                validationResult = Validation.validateSet(rawValue, validationOptions);
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function xmakeInputControl(currentValue, events, bus) {
+            // CONTROL
+            var initialControlValue;
+            if (currentValue) {
+                initialControlValue = String(currentValue);
+            }
+            return input({
+                id: events.addEvents({
+                    events: [
+                        {
+                            type: 'change',
+                            handler: function (e) {
+                                validate()
+                                    .then(function (result) {
+                                        if (result.isValid) {
+                                            bus.send({
+                                                type: 'changed',
+                                                newValue: result.value
+                                            });
+                                        }
+                                        bus.send({
+                                            type: 'validation',
+                                            errorMessage: result.errorMessage,
+                                            diagnosis: result.diagnosis
+                                        });
+                                    });
+                            }
+                        },
+                        {
+                            type: 'focus',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.disable();
+                            }
+                        },
+                        {
+                            type: 'blur',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.enable();
+                            }
+                        }
+                    ]}),
+                type: 'checkbox',
+                class: 'form-control',
+                dataElement: 'input',
+                value: initialControlValue
+            });
+        }
+        
+        function makeInputControl(currentValue, data, events, bus) {
+            var selectOptions = [
+                option({
+                    value: 'yes',
+                    selected: (currentValue === 'yes' ? true : false)
+                }, 'Yes'),
+                option({
+                    value: 'no',
+                    selected: (currentValue === 'no' ? true : false)
+                }, 'No')
+            ];
+
+            // CONTROL
+            return select({
+                id: events.addEvent({type: 'change', handler: function (e) {
+                        validate()
+                            .then(function (result) {
+                                if (result.isValid) {
+                                    bus.send({
+                                        type: 'changed',
+                                        newValue: result.value
+                                    });
+                                }
+                                bus.send({
+                                    type: 'validation',
+                                    errorMessage: result.errorMessage,
+                                    diagnosis: result.diagnosis
+                                });
+                            });
+                    }}),
+                class: 'form-control',
+                dataElement: 'input'
+            }, [option({value: ''}, '')].concat(selectOptions));
+        }
+
+        function render(params) {
+            var events = Events.make(),
+                inputControl = makeInputControl(params.value || config.initialValue, events, bus);
+
+            $container.find('[data-element="input-container"]').html(inputControl);
+            events.attachEvents(container);
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+        function autoValidate() {
+            return validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                return render(params);
+            })
+            .then(function () {
+                return autoValidate();
+            });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/singleCheckbox.js
+++ b/nbextensions/methodCell/widgets/input/singleCheckbox.js
@@ -1,0 +1,318 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), label = t('label');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            container,
+            $container,
+            bus = config.bus,
+            valueChecked = spec.spec.checkbox_options.checked_value,
+            valueUnchecked = spec.spec.checkbox_options.unchecked_value,
+            model = {
+                updates: 0,
+                value: undefined
+            };
+
+        // Validate configuration.
+        // Nothing to do...
+
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            var checkbox = container.querySelector('[data-element="input-container"] [data-element="input"]');
+            if (checkbox.checked) {
+                return valueChecked;
+            }
+            return valueUnchecked;
+        }
+
+        /*
+         * 
+         * Sets the value in the model and then refreshes the widget.
+         * 
+         */
+        function setModelValue(value) {
+            return Promise.try(function () {
+                if (model.value !== value) {
+                    model.value = value;
+                    return true;
+                }
+                return false;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function unsetModelValue() {
+            return Promise.try(function () {
+                model.value = undefined;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function meansChecked(value) {
+            if (!value) {
+                return false;
+            }
+            switch (value.trim()) {
+                case '1':
+                case 'true':
+                    return true;
+                case '0':
+                case 'false':
+                case '':
+                    return false;
+            }
+        }
+
+        function resetModelValue() {
+            if (spec.spec.default_values && spec.spec.default_values.length > 0) {
+                if (meansChecked(spec.spec.default_values[0])) {
+                    setModelValue(valueChecked);
+                } else {
+                    setModelValue(valueUnchecked);
+                }
+            } else {
+                unsetModelValue();
+            }
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function copyProps(from, props) {
+            var newObj = {};
+            props.forEach(function (prop) {
+                newObj[prop] = from[prop];
+            });
+            return newObj;
+        }
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    // TODO should actually create the set of checkbox values and
+                    // make this a validation option, although not specified as 
+                    // such in the spec.
+                    validationOptions = {
+                        required: spec.required(),
+                        values: [valueChecked, valueUnchecked]
+                    },
+                validationResult;
+
+                validationResult = Validation.validateSet(rawValue, validationOptions);
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, events, bus) {
+            // CONTROL
+            var checked = false,
+                booleanString = 'no';
+            if (model.value === valueChecked) {
+                checked = true;
+                booleanString = 'yes';
+            }
+            return label({class: 'checkbox-inline'}, [
+                input({
+                    id: events.addEvents({
+                        events: [
+                            {
+                                type: 'change',
+                                handler: function (e) {
+                                    validate()
+                                        .then(function (result) {
+                                            if (result.isValid) {
+                                                bus.send({
+                                                    type: 'changed',
+                                                    newValue: result.value
+                                                });
+                                                setModelValue(result.value);
+                                            }
+                                            bus.send({
+                                                type: 'validation',
+                                                errorMessage: result.errorMessage,
+                                                diagnosis: result.diagnosis
+                                            });
+                                        });
+                                }
+                            },
+                            {
+                                type: 'focus',
+                                handler: function (e) {
+                                    Jupyter.keyboard_manager.disable();
+                                }
+                            },
+                            {
+                                type: 'blur',
+                                handler: function (e) {
+                                    Jupyter.keyboard_manager.enable();
+                                }
+                            }
+                        ]}),
+                    type: 'checkbox',
+                    dataElement: 'input',
+                    checked: checked,
+                    value: valueChecked
+                }),
+                booleanString]);
+        }
+        function autoValidate() {
+            return validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+        function render() {
+            Promise.try(function () {
+                var events = Events.make(),
+                    inputControl = makeInputControl(model.value, events, bus);
+
+                $container.find('[data-element="input-container"]').html(inputControl);
+                events.attachEvents(container);
+            })
+                .then(function () {
+                    return autoValidate();
+                });
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.listen({
+                    test: function (message) {
+                        return (message.type === 'reset-to-defaults');
+                    },
+                    handle: function () {
+                        resetModelValue();
+                    }
+                });
+
+                // shorthand for a test of the message type.
+                bus.on('update', function (message) {
+                    setModelValue(message.value);
+                });
+
+                bus.send({type: 'sync'});
+                return null;
+                // return resetModelValue();
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                return setModelValue(params.value);
+            });
+            //.then(function () {
+            //    return autoValidate();
+            //});
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/singleFloatInput.js
+++ b/nbextensions/methodCell/widgets/input/singleFloatInput.js
@@ -1,0 +1,272 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus,
+            model = {
+                value: undefined
+            };
+
+        // Validate configuration.
+        // Nothing to do...
+
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        function setModelValue(value) {
+            return Promise.try(function () {
+                if (model.value !== value) {
+                    model.value = value;
+                    return true;
+                }
+                return false;
+            })
+                .then(function (changed) {
+                    return render();
+                });
+        }
+
+        function unsetModelValue() {
+            return Promise.try(function () {
+                model.value = undefined;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function resetModelValue() {
+            if (spec.spec.default_values && spec.spec.default_values.length > 0) {
+                setModelValue(spec.spec.default_values[0]);
+            } else {
+                unsetModelValue();
+            }
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function copyProps(from, props) {
+            var newObj = {};
+            props.forEach(function (prop) {
+                newObj[prop] = from[prop];
+            });
+            return newObj;
+        }
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    validationOptions = copyProps(spec.spec.text_options, ['min_float', 'max_float']),
+                    validationResult;
+
+                validationOptions.required = spec.required();
+                validationResult = Validation.validateFloat(rawValue, validationOptions);
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, events, bus) {
+            // CONTROL
+            var initialControlValue;
+            if (currentValue) {
+                initialControlValue = String(currentValue);
+            }
+            return input({
+                id: events.addEvents({
+                    events: [
+                        {
+                            type: 'change',
+                            handler: function (e) {
+                                validate()
+                                    .then(function (result) {
+                                        if (result.isValid) {
+                                            bus.send({
+                                                type: 'changed',
+                                                newValue: result.value
+                                            });
+                                        } else if (result.diagnosis === 'required-missing') {
+                                    bus.send({
+                                        type: 'changed',
+                                        newValue: result.value
+                                    });
+                                }
+                                        bus.send({
+                                            type: 'validation',
+                                            errorMessage: result.errorMessage,
+                                            diagnosis: result.diagnosis
+                                        });
+                                    });
+                            }
+                        },
+                        {
+                            type: 'focus',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.disable();
+                            }
+                        },
+                        {
+                            type: 'blur',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.enable();
+                            }
+                        }
+                    ]}),
+                class: 'form-control',
+                dataElement: 'input',
+                value: initialControlValue
+            });
+        }
+
+        function render() {
+            Promise.try(function () {
+                var events = Events.make(),
+                    inputControl = makeInputControl(model.value, events, bus);
+
+                $container.find('[data-element="input-container"]').html(inputControl);
+                events.attachEvents(container);
+            })
+                .then(function () {
+                    return autoValidate();
+                });
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+        function autoValidate() {
+            return validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.on('reset-to-defaults', function (message) {
+                    resetModelValue();
+                });
+                bus.on('update', function (message) {
+                    setModelValue(message.value);
+                });
+                bus.send({type: 'sync'});
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                return setModelValue(params.value);
+            });
+            //.then(function () {
+            //    return autoValidate();
+            //});
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/singleIntInput.js
+++ b/nbextensions/methodCell/widgets/input/singleIntInput.js
@@ -1,0 +1,268 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus,
+            model = {
+                value: undefined
+            };
+
+        // Validate configuration.
+        // Nothing to do...
+        
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+        
+        function setModelValue(value) {
+            return Promise.try(function () {
+                if (model.value !== value) {
+                    model.value = value;
+                    return true;
+                }
+                return false;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function unsetModelValue() {
+            return Promise.try(function () {
+                model.value = undefined;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+        
+        function resetModelValue() {
+            if (spec.spec.default_values && spec.spec.default_values.length > 0) {
+                setModelValue(spec.spec.default_values[0]);
+            } else {
+                unsetModelValue();
+            }
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+        
+        function copyProps(from, props) {
+            var newObj = {};
+            props.forEach(function (prop) {
+                newObj[prop] = from[prop];
+            });
+            return newObj;
+        }
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    validationOptions = copyProps(spec.spec.text_options, ['min_int', 'max_int']),
+                    validationResult;
+
+                validationOptions.required = spec.required();
+                validationResult = Validation.validateInteger(rawValue, validationOptions);
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, events, bus) {
+            // CONTROL
+            var initialControlValue;
+            if (currentValue) {
+                initialControlValue = String(currentValue);
+            }
+            return input({
+                id: events.addEvents({
+                    events: [
+                        {
+                            type: 'change',
+                            handler: function (e) {
+                                validate()
+                                    .then(function (result) {
+                                        if (result.isValid) {
+                                            bus.send({
+                                                type: 'changed',
+                                                newValue: result.value
+                                            });
+                                        }
+                                        setModelValue(result.value);
+                                        bus.send({
+                                            type: 'validation',
+                                            errorMessage: result.errorMessage,
+                                            diagnosis: result.diagnosis
+                                        });
+                                    });
+                            }
+                        },
+                        {
+                            type: 'focus',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.disable();
+                            }
+                        },
+                        {
+                            type: 'blur',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.enable();
+                            }
+                        }
+                    ]}),
+                class: 'form-control',
+                dataElement: 'input',
+                value: initialControlValue
+            });
+        }
+
+        function render() {
+            Promise.try(function () {
+                var events = Events.make(),
+                    inputControl = makeInputControl(model.value, events, bus);
+
+                $container.find('[data-element="input-container"]').html(inputControl);
+                events.attachEvents(container);
+            })
+                .then(function () {
+                    return autoValidate();
+                });
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+        function autoValidate() {
+            return validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+                bus.on('reset-to-defaults', function (message) {
+                    resetModelValue();
+                });
+                bus.on('update', function (message) {
+                    setModelValue(message.value);
+                });
+                bus.send({type: 'sync'});
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                return setModelValue(params.value);
+            });
+            //.then(function () {
+            //    return autoValidate();
+            //});
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/singleSelectInput.js
+++ b/nbextensions/methodCell/widgets/input/singleSelectInput.js
@@ -1,0 +1,205 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), select = t('select'), option = t('option');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus;
+
+        // Validate configuration.
+        // Nothing to do...
+        
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    validationResult = Validation.validateText(rawValue, {
+                        required: options.required
+                    });
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+         function makeInputControl(currentValue, data, events, bus) {
+            var selected;
+            // There is an input control, and a dropdown,
+            // TODO select2 after we get a handle on this...
+            var selectOptions = data.map(function (item) {
+                selected = false;
+                if (item.value === currentValue) {
+                    selected = true;
+                }
+
+                return option({
+                    value: item.value,
+                    selected: selected
+                }, item.display);
+            });
+
+            // CONTROL
+            return select({
+                id: events.addEvent({type: 'change', handler: function (e) {
+                        validate()
+                            .then(function (result) {
+                                if (result.isValid) {
+                                    bus.send({
+                                        type: 'changed',
+                                        newValue: result.value
+                                    });
+                                }
+                                bus.send({
+                                    type: 'validation',
+                                    errorMessage: result.errorMessage,
+                                    diagnosis: result.diagnosis
+                                });
+                            });
+                    }}),
+                class: 'form-control',
+                dataElement: 'input'
+            }, [option({value: ''}, '')].concat(selectOptions));
+        }
+
+        function render(input) {
+            var events = Events.make(),                
+                initialValue = input.value || config.initialValue,
+                inputControl = makeInputControl(initialValue, spec.spec.dropdown_options.options, events, bus);
+
+            $container.find('[data-element="input-container"]').html(inputControl);
+            events.attachEvents(container);
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+        
+        function autoValidate() {
+            validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+
+        // LIFECYCLE API
+
+        function init() {
+            // Normalize the parameter specification settings.
+            // TODO: much of this is just silly, we should be able to use the spec 
+            //   directly in most places.
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+            });
+        }
+
+        function run(input) {
+            return Promise.try(function () {
+                return render(input);
+            })
+            .then(function () {
+                return autoValidate();
+            });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/singleTextInput.js
+++ b/nbextensions/methodCell/widgets/input/singleTextInput.js
@@ -1,0 +1,259 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus,
+            model = {
+                value: undefined
+            };
+
+        // Validate configuration.
+        // Nothing to do...
+        
+        options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+        options.multiple = spec.multipleItems();
+        options.required = spec.required();
+        options.enabled = true;
+
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+        
+        function setModelValue(value) {
+            return Promise.try(function () {
+                if (model.value !== value) {
+                    model.value = value;
+                    return true;
+                }
+                return false;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+
+        function unsetModelValue() {
+            return Promise.try(function () {
+                model.value = undefined;
+            })
+                .then(function (changed) {
+                    render();
+                });
+        }
+        
+        function resetModelValue() {
+            if (spec.spec.default_values && spec.spec.default_values.length > 0) {
+                setModelValue(spec.spec.default_values[0]);
+            } else {
+                unsetModelValue();
+            }
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function validate() {
+            return Promise.try(function () {
+                if (!options.enabled) {
+                    return {
+                        isValid: true,
+                        validated: false,
+                        diagnosis: 'disabled'
+                    };
+                }
+
+                var rawValue = getInputValue(),
+                    validationResult = Validation.validateText(rawValue, {
+                        required: options.required
+                    });
+
+                return {
+                    isValid: validationResult.isValid,
+                    validated: true,
+                    diagnosis: validationResult.diagnosis,
+                    errorMessage: validationResult.errorMessage,
+                    value: validationResult.parsedValue
+                };
+            });
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, events, bus) {
+            // CONTROL
+            return input({
+                id: events.addEvents({
+                    events: [
+                        {
+                            type: 'change',
+                            handler: function (e) {
+                                validate()
+                                    .then(function (result) {
+                                        if (result.isValid) {
+                                            bus.send({
+                                                type: 'changed',
+                                                newValue: result.value
+                                            });
+                                        } else if (result.diagnosis === 'required-missing') {
+                                    bus.send({
+                                        type: 'changed',
+                                        newValue: result.value
+                                    });
+                                }
+                                        setModelValue(result.value);
+                                        bus.send({
+                                            type: 'validation',
+                                            errorMessage: result.errorMessage,
+                                            diagnosis: result.diagnosis
+                                        });
+                                    });
+                            }
+                        },
+                        {
+                            type: 'focus',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.disable();
+                            }
+                        },
+                        {
+                            type: 'blur',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.enable();
+                            }
+                        }
+                    ]}),
+                class: 'form-control',
+                dataElement: 'input',
+                value: currentValue
+            });
+        }
+
+        function render() {
+            Promise.try(function () {
+                var events = Events.make(),
+                    inputControl = makeInputControl(model.value, events, bus);
+
+                $container.find('[data-element="input-container"]').html(inputControl);
+                events.attachEvents(container);
+            })
+                .then(function () {
+                    return autoValidate();
+                });
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+        
+        function autoValidate() {
+            return validate()
+                .then(function (result) {
+                    bus.send({
+                        type: 'validation',
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+
+        // LIFECYCLE API
+
+        function init() {
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+         function start() {
+            return Promise.try(function () {
+                bus.on('reset-to-defaults', function (message) {
+                    resetModelValue();
+                });
+                bus.on('update', function (message) {
+                    setModelValue(message.value);
+                });
+                bus.send({type: 'sync'});
+                return null;
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                return setModelValue(params.value);
+            });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/singleTextInput_1.js
+++ b/nbextensions/methodCell/widgets/input/singleTextInput_1.js
@@ -1,0 +1,193 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'base/js/namespace',
+    'kb_common/html',
+    '../validation',
+    '../events',
+    'bootstrap',
+    'css!font-awesome'
+], function (Promise, $, Jupyter, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            parent,
+            container,
+            $container,
+            bus = config.bus;
+
+        // Validate configuration.
+        // Nothing to do...
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+
+        function getInputValue() {
+            return $container.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         * 
+         *
+         */
+
+        function validate() {
+            if (!options.enabled) {
+                return {
+                    isValid: true,
+                    validated: false,
+                    diagnosis: 'disabled'
+                };
+            }
+
+            var rawValue = getInputValue(),
+                validationResult = Validation.validateText(rawValue, {
+                    required: options.required
+                });
+
+            return {
+                isValid: validationResult.isValid,
+                validated: true,
+                diagnosis: validationResult.diagnosis,
+                errorMessage: validationResult.errorMessage,
+                value: validationResult.parsedValue
+            };
+        }
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function makeInputControl(currentValue, events, bus) {
+            // CONTROL
+            return input({
+                id: events.addEvents({
+                    events: [
+                        {
+                            type: 'change',
+                            handler: function (e) {
+                                var result = validate();
+                                if (result.isValid) {
+                                    bus.send({
+                                        type: 'changed',
+                                        newValue: result.value
+                                    });
+                                }
+                                bus.send({
+                                    type: 'validation',
+                                    errorMessage: result.errorMessage,
+                                    diagnosis: result.diagnosis
+                                });
+                            }
+                        },
+                        {
+                            type: 'focus',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.disable();
+                            }
+                        },
+                        {
+                            type: 'blur',
+                            handler: function (e) {
+                                Jupyter.keyboard_manager.disable();
+                            }
+                        }
+                    ]}),
+                class: 'form-control',
+                dataElement: 'input',
+                value: currentValue
+            });
+        }
+
+        function render(params) {
+            var events = Events.make(),
+                inputControl = makeInputControl(params.value, events, bus);
+
+            $container.find('[data-element="input-container"]').html(inputControl);
+            events.attachEvents(container);
+        }
+
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({dataElement: 'input-container'})
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+
+        // LIFECYCLE API
+
+        function init() {
+            // Normalize the parameter specification settings.
+            // TODO: much of this is just silly, we should be able to use the spec 
+            //   directly in most places.
+            options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+            options.multiple = spec.multipleItems();
+            options.required = spec.required();
+            options.enabled = true;
+        }
+
+        function attach(node) {
+            return Promise.try(function () {
+                parent = node;
+                container = node.appendChild(document.createElement('div'));
+                $container = $(container);
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+            });
+        }
+
+        function start() {
+            return Promise.try(function () {
+            });
+        }
+
+        function run(params) {
+            return Promise.try(function () {
+                return render(params);
+            });
+        }
+
+        return {
+            init: init,
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/textInput.js
+++ b/nbextensions/methodCell/widgets/input/textInput.js
@@ -1,0 +1,583 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'jquery',
+    'kb_common/html',
+    '../../validation',
+    '../../events',
+    'bootstrap',
+    'css!font-awesome'
+], function ($, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            rows = [],
+            parent,
+            container,
+            $container,
+            places = {
+                addRowController: null,
+                rows: null
+            };
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+        function getInputValues() {
+            return rows.map(function (row) {
+                return row.$input.val();
+            });
+        }
+        
+        function getInputValue($field) {
+            return $field.find('[data-element="input-container"] [data-element="input"]').val();
+        }
+        
+        /*
+         *
+         * Text fields can occur in multiples.
+         * We have a choice, treat single-text fields as a own widget
+         * or as a special case of multiple-entry -- 
+         * with a min-items of 1 and max-items of 1.
+         *
+         */
+        
+         function validate() {
+            if (!options.enabled) {
+                return {
+                    isValid: true,
+                    validated: false,
+                    diagnosis: 'disabled'
+                };
+            }
+
+            var someErrorDetected = false,
+                errorMessage,
+                validationResult,
+                diagnosis;
+            
+            rows.forEach(function (row, index) {
+                var errorMessage,
+                    rawValue = getInputValue(row.$field);
+                    value  = rawValue.trim(),
+                    fieldType,
+                    validationResult;
+                    
+                // REQUIRED
+                if (options.required && !value) {
+                    
+                }
+                
+                // FORMAT CHECK
+                    
+                // Validate if we need to.
+                if (options.required && index === 0 && !value) {
+                    errorMessage = 'required field ' + spec.ui_name + ' missing';
+                } else if (!options.required && value === '') {
+                    // just skip it, it is ok.
+                } else {
+                    if (spec.text_options) {
+                        if (spec.text_options.validate_as) {
+                            // no specific type for text, but we should implement
+                            // regexp -- TODO that
+                        }
+                    }
+                }
+
+            // Validate if we need to.
+            if (options.required && !value) {
+                errorMessage = 'required field ' + spec.label() + ' missing';
+                diagnosis = 'required-missing';
+            } else if (!options.required && value === '') {
+                // just skip it, it is ok.
+                diagnosis = 'optional-empty';
+            } else {
+                // Truth be told, we cannot even get here unless this condition
+                // is met.
+                validationResult = Validation.validateObjectRef(value);
+                if (!validationResult.isValid) {
+                    errorMessage = validationResult.errorMessage;
+                    diagnosis = 'invalid';
+                }
+            }
+
+            return {
+                isValid: !someErrorDetected,
+                validated: true,
+                diagnosis: diagnosis || 'valid',
+                errorMessage: errorMessage,
+                value: validationResult.parsedValue
+            };
+        }
+
+        function validate() {
+            if (!options.enabled) {
+                return {
+                    isValid: true,
+                    errorMessages: []
+                };
+            }
+
+            var values = getParameterValues(),
+                someErrorDetected = false,
+                errorMessages = [];
+
+            values.forEach(function (rawValue, index) {
+                var errorMessage,
+                    value  = rawValue.trim(),
+                    row = rows[index],
+                    fieldType,
+                    validationResult;
+                    
+                // Validate if we need to.
+                if (options.required && index === 0 && !value) {
+                    errorMessage = 'required field ' + spec.ui_name + ' missing';
+                } else if (!options.required && value === '') {
+                    // just skip it, it is ok.
+                } else {
+                    if (spec.text_options) {
+                        if (spec.text_options.validate_as) {
+                            // no specific type for text, but we should implement
+                            // regexp -- TODO that
+                        }
+                    }
+                }
+
+                // todo -- special handling for multiple values.
+                if (errorMessage) {
+                    setRowError(row, errorMessage, spec.ui_name);
+                    if (options.required) {
+                        if (value === '') {
+                            rowFeedbackRequired(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    } else {
+                        rowFeedbackNone(row);
+                    }
+                    errorMessages.push(errorMessage + 'in field ' + spec.ui_name);
+                    someErrorDetected = true;
+                } else {
+                    clearRowError(row);
+                    if (options.required) {
+                        rowFeedbackOk(row);
+                    } else {
+                        if (value === '') {
+                            rowFeedbackNone(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    }
+                }
+            });
+
+            return {
+                isValid: !someErrorDetected,
+                errorMessages: errorMessages
+            };
+        }
+
+        function removeRow(rowId) {
+            rows = rows.map(function (row) {
+                if (row.id === rowId) {
+                    row.$row.remove();
+                    return false;
+                }
+                return row;
+            }).filter(function (row) {
+                return row;
+            });
+        }
+
+
+
+        function addRow(defaultValue, showHint, useRowHighlight) {
+            var placeholder = '',
+                rowId = html.genId(),
+                inputControl, feedbackTip, parameterRow, id,
+                nameCol, inputCol, removalButton, hintCol,
+                events = Events.make();
+            if (spec.text_options && spec.text_options.placeholder) {
+                placeholder = spec.text_options.placeholder.replace(/(\r\n|\n|\r)/gm, '');
+            }
+            defaultValue = defaultValue || '';
+
+            inputControl = input({
+                id: events.addEvent({type: 'change', handler: validate}),
+                placeholder: placeholder,
+                value: defaultValue,
+                type: 'text',
+                dataElement: 'input',
+                style: {width: '100%'},
+                class: 'form-control'
+            });
+
+
+            // this is a column adjacent to the form controls which provides status flags (error, data required, data complete and ok)
+            // TODO: this and other elements should be set up without any styles,
+            // and then the initial evaluation of the parameters vis-a-vis the ui will
+            // set the correct styles...
+            if (options.required && showHint) {
+                feedbackTip = span({
+                    class: 'kb-method-parameter-required-glyph fa fa-arrow-left',
+                    title: 'required field',
+                    dataElement: 'feedback'
+                });
+            } else {
+                feedbackTip = span({dataElement: 'feedback'});
+            }
+
+
+            // paremeter name display
+            var style = {};
+            if (options.environment === 'sidePanel') {
+                style = {
+                    textAlign: 'left', paddingLeft: '10px'
+                };
+            }
+            nameCol = div({
+                class: [options.classes.nameColClass, 'kb-method-parameter-name'].join(' '),
+                style: style
+            }, [(function () {
+                    if (showHint) {
+                        return spec.ui_name;
+                    }
+                })]);
+
+            // Input column display
+            inputCol = div({class: [options.classes.inputColClass, 'kb-method-parameter-input'].join(' ')}, [
+                div({style: {widgth: '100%', display: 'inline-block'}}, [
+                    inputControl
+                ]),
+                div({style: {display: 'inline-block'}}, [
+                    feedbackTip
+                ])
+            ]);
+
+            if (showHint) {
+                var infoTip;
+                if (spec.description && spec.short_hint !== spec.description) {
+                    infoTip = span({
+                        class: 'fa fa-info kb-method-parameter-info',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'auto',
+                        container: 'body',
+                        html: 'true',
+                        title: spec.description
+                    });
+                }
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    spec.short_hint, infoTip
+                ]);
+            } else {
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    button({class: 'kb-default-btn kb-btn-sm', id: events.addEvent({type: 'click', handler: function () {
+                                removeRow(rowId);
+                            }})}, [
+                        span({class: 'kb-parameter-data-row-remove fa fa-remove'}, [
+                            'remove ' + spec.ui_name
+                        ])
+                    ])
+                ]);
+            }
+
+
+            // put it all together.
+
+            // The row itself.
+            parameterRow = div({class: 'row kb-method-parameter-row', dataElement: 'row'}, [
+                nameCol, inputCol, hintCol
+            ]);
+            if (options.useRowHighlight) {
+                events.addEvent({type: 'mouseeneter', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+                events.addEvent({type: 'mouseleave', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+            }
+
+            // Error display
+            var errorRow = div({class: 'row', dataElement: 'error-panel'}, [
+                div({class: options.classes.nameColClass}),
+                div({
+                    class: ['kb-method-parameter-error-message', options.classes.inputColClass].join(' '),
+                    style: {display: 'none'},
+                    dataElement: 'error-message'
+                })
+            ]);
+
+            var row = div({
+                dataElement: 'field',
+                id: rowId
+            }, [parameterRow, errorRow]);
+
+            // Finally, into the DOM!
+            $container.find('[data-element="rows-container"]').append(row);
+
+            events.attachEvents($container.get(0));
+
+            // Now we keep a handy copy of nodes around.
+            // In truth, we could implement this as an api and avoid this junk, which also 
+            // embeds a lot of jquery/dom nonsense.
+            var $field = $container.find('#' + rowId);
+
+            // The row exists to provide mount points for the various ui
+            // elements for this control.
+            rows.push({
+                rowId: rowId,
+                $row: $field.find('[data-element="row"]'),
+                $input: $field.find('[data-element="input"]'),
+                $error: $field.find('[data-element="error-message"]'),
+                $feedback: $field.find('[data-element="feedback"]'),
+                $field: $field,
+                $all: $field,
+                $removalButton: $field.find('[data-element="removal-button"]')
+            });
+
+        }
+
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function render() {
+            var defaultValue = '',
+                defaultValues;
+
+            if (!options.multiple) {
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    // TODO!!!
+                    // the condition for using the first defaultvalue in the defaultValues 
+                    // array is suspect ... 
+                    // this says we use the default value if it is not an empty string or set as undefined
+                    // (because it can't really be undefined or we would not be here)
+                    // so this basically collapses to if it is an empty string use an empty string, otherwise
+                    // use the default value.
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+                addRow(defaultValue, true, true);
+            } else {
+
+                // TODO: the main panel hover bit...
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+
+                // TODO what is the funny bit with using the default value first?
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValues.forEach(function (defaultValue) {
+                        var betterDefaultValue = (defaultValue !== '' && defaultValue !== undefined) ? defaultValue : '';
+                        addRow(betterDefaultValue, false, false);
+                    });
+                }
+
+                // TODO: addTheAddRowController();
+
+            }
+        }
+
+        function layout() {
+            var events = Events.make(),
+                content;
+            if (options.multiple) {
+                content = div({
+                    class: 'kb-method-parameter-row',
+                    dataElement: 'main-panel',
+                    id: events.addEvents({events: [
+                            {
+                                type: 'mouseeneter',
+                                handler: function (e) {
+                                    e.target.classList.add('kb-method-parameter-row-hover');
+                                }
+                            },
+                            {
+                                type: 'mouseleave',
+                                handler: function (e) {
+                                    e.target.classList.remove('kb-method-parameter-row-hover');
+                                }
+                            }
+                        ]})}, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            } else {
+                content = div({
+                    dataElement: 'main-panel'
+                }, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            }
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        // CLIENT API
+
+        function name() {
+            return spec.id;
+        }
+
+        function label() {
+            return spec.ui_name;
+        }
+
+        function hint() {
+            return spec.short_hint;
+        }
+
+        function description() {
+            return spec.description;
+        }
+        
+        function info() {
+            return '';
+        }
+
+        function multipleItems() {
+            return options.multiple;
+        }
+
+        function fieldType() {
+            return spec.field_type;
+        }
+
+        function type() {
+            return spec.type;
+        }
+
+        function dataType() {
+            if (!spec.text_options) {
+                return 'text';
+            }
+            var validateAs = spec.text_options.validate_as;
+            type;
+            if (validateAs) {
+                return validateAs;
+            }
+
+            if (spec.text_options.valid_ws_types) {
+                return 'workspaceObjectReference';
+            }
+
+            return 'unknown';
+        }
+
+        function uiClass() {
+            return spec.ui_class;
+        }
+
+        function required() {
+            return options.required;
+        }
+
+        function control() {
+            return 'control here';
+        }
+
+        // DATA API
+
+        /*
+         * If multiple values are supported, we always return an array
+         * If not, always return an atomic value
+         * // TODO: this data should always be scrubbed!
+         */
+        function value() {
+            console.log('INPUT', rows[0].$input);
+            if (options.multiple) {
+                return rows.map(function (row) {
+                    return row.$input.val();
+                });
+            }
+            return rows[0].$input.val();
+        }
+
+
+        // LIFECYCLE API
+
+        var domId = html.genId();
+        var widgetRootNode;
+        function id() {
+            return domId;
+        }
+
+        function init() {
+            // Normalize the parameter specification settings.
+            // TODO: much of this is just silly, we should be able to use the spec 
+            //   directly in most places.
+            options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+            options.classes = classSets[options.environment];
+            options.multiple = spec.allow_multiple ? true : false;
+            options.required = spec.optional ? false : true;
+            options.isOutputName = spec.text_options && spec.text_options.is_output_name;
+            options.enabled = true;
+            console.log('HMM', spec);
+        }
+
+        function attach(node) {
+            parent = node;
+
+            widgetRootNode = parent.querySelector('#' + domId);
+            if (!widgetRootNode) {
+                throw new Error('The domId for this widget does not exist in the parent context');
+            }
+
+            // container = node.append(document.createElement('div'));
+            $container = $(widgetRootNode);
+            var theLayout = layout();
+            widgetRootNode.innerHTML = theLayout.content;
+            theLayout.events.attachEvents(widgetRootNode);
+        }
+
+        function start(params) {
+            // return render();
+            render(params);
+        }
+
+        return {
+            id: id,
+            init: init,
+            attach: attach,
+            start: start,
+            name: name,
+            label: label,
+            hint: hint,
+            description: description,
+            info: description,
+            multipleItems: multipleItems,
+            fieldType: fieldType,
+            type: type,
+            dataType: dataType,
+            uiClass: uiClass,
+            required: required,
+            control: control,
+            value: value
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/input/textInput_1.js
+++ b/nbextensions/methodCell/widgets/input/textInput_1.js
@@ -1,0 +1,609 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'jquery',
+    'kb_common/html',
+    './validation',
+    './events',
+    'bootstrap',
+    'css!font-awesome'
+], function ($, html, Validation, Events) {
+    'use strict';
+
+    // Constants
+    var classSets = {
+        standard: {
+            nameColClass: 'col-md-2',
+            inputColClass: 'col-md-5',
+            hintColClass: 'col-md-5'
+        },
+        sidePanel: {
+            nameColClass: 'col-md-12',
+            inputColClass: 'col-md-12',
+            hintColClass: 'col-md-12'
+        }
+    },
+    t = html.tag,
+        div = t('div'), input = t('input'), span = t('span'), button = t('button');
+
+
+    function factory(config) {
+        var options = {},
+            spec = config.parameterSpec,
+            rows = [],
+            parent,
+            container,
+            $container,
+            places = {
+                addRowController: null,
+                rows: null
+            };
+
+        /*
+         * If the parameter is optional, and is empty, return null.
+         * If it allows multiple values, wrap single results in an array
+         * There is a weird twist where if it ...
+         * well, hmm, the only consumer of this, isValid, expects the values
+         * to mirror the input rows, so we shouldn't really filter out any
+         * values.
+         */
+        function getParameterValues() {
+
+
+//            if (!options.required) {
+//                // we can handle the general case of rows, since the ui 
+//                // will take care of ensuring at most one row if multiple
+//                // values are not allowed. In the wild case where this 
+//                // fails, we takethe first non-empty row, which is probably
+//                // what the use would expect anyway. On the other hand, we 
+//                // should probably throw an error. TODO: that
+//                return rows.map(function (row) {
+//                    return row.$input.val() || null;
+//                });
+//                //    .filter(function (value) {
+//                //    return value.trim() ? true : false;
+//                //}) || null;
+//            }
+            return rows.map(function (row) {
+                return row.$input.val();
+            });
+        }
+
+
+        function setRowError(row, errorMessage, uiName) {
+            row.$row.addClass('kb-method-parameter-row-error');
+            row.$error
+                .html(errorMessage)
+                .show();
+            row.$feedback.removeClass();
+        }
+
+        function clearRowError(row) {
+            row.$row.removeClass('kb-method-parameter-row-error');
+            row.$error
+                .html('')
+                .hide();
+        }
+
+        function hideError(row, value) {
+            if (!row) {
+                return;
+            }
+            row.$row.removeClass('kb-method-parameter-row-error');
+            row.$error.hide();
+            row.$feedback.removeClass();
+        }
+
+        function rowFeedbackNone(row) {
+            row.$feedback
+                .removeClass()
+                .hide();
+        }
+
+
+        function rowFeedbackOk(row) {
+            row.$feedback
+                .removeClass()
+                .addClass('kb-method-parameter-accepted-glyph fa fa-check')
+                .prop('title', 'required field')
+                .show();
+        }
+
+
+        function rowFeedbackRequired(row) {
+            row.$feedback
+                .removeClass()
+                .addClass('kb-method-parameter-required-glyph fa fa-arrow-left')
+                .prop('title', 'required field')
+                .show();
+        }
+
+        function validate() {
+            if (!options.enabled) {
+                return {
+                    isValid: true,
+                    errorMessages: []
+                };
+            }
+
+            var values = getParameterValues(),
+                someErrorDetected = false,
+                errorMessages = [];
+
+            values.forEach(function (rawValue, index) {
+                var errorMessage,
+                    value  = rawValue.trim(),
+                    row = rows[index],
+                    fieldType,
+                    validationResult;
+                    
+                // Validate if we need to.
+                if (options.required && index === 0 && !value) {
+                    errorMessage = 'required field ' + spec.ui_name + ' missing';
+                } else if (!options.required && value === '') {
+                    // just skip it, it is ok.
+                } else {
+                    if (spec.text_options) {
+                        if (spec.text_options.validate_as) {
+                            fieldType = spec.text_options.validate_as.toLowerCase();
+                            switch (fieldType) {
+                                case 'int':
+                                    validationResult = Validation.validateInteger(value, spec.text_options);
+                                    if (!validationResult.isValid) {
+                                        errorMessage = validationResult.errorMessage;
+                                    } else {
+                                        // Events may be configured by the widget host.
+                                        // TODO: this should be an event and not a callback.
+                                        if (config.events.change) {
+                                            try {
+                                                config.events.change(validationResult.parsedValue);
+                                            } catch (ex) {
+                                                console.error('ERROR', ex);
+                                            }
+                                        }
+                                    }
+                                    break;
+                                case 'float':
+                                    validationResult = Validation.validateFloat(value, spec.text_options);
+                                    if (!validationResult.isValid) {
+                                        errorMessage = validationResult.errorMessage;
+                                    }
+                                    break;
+                            }
+                        } else if (spec.text_options.valid_ws_types) {
+                            // Entry of workspace object names.
+                            // TODO any reason this can't be typed like int and float?         
+                            validationResult = Validation.validateWorkspaceObjectName(value);
+                            if (!validationResult.isValid) {
+                                errorMessage = validationResult.errorMessage;
+                            }
+                        }
+                    }
+                }
+
+                // todo -- special handling for multiple values.
+                if (errorMessage) {
+                    setRowError(row, errorMessage, spec.ui_name);
+                    if (options.required) {
+                        if (value === '') {
+                            rowFeedbackRequired(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    } else {
+                        rowFeedbackNone(row);
+                    }
+                    errorMessages.push(errorMessage + 'in field ' + spec.ui_name);
+                    someErrorDetected = true;
+                } else {
+                    clearRowError(row);
+                    if (options.required) {
+                        rowFeedbackOk(row);
+                    } else {
+                        if (value === '') {
+                            rowFeedbackNone(row);
+                        } else {
+                            rowFeedbackOk(row);
+                        }
+                    }
+                }
+            });
+
+            return {
+                isValid: !someErrorDetected,
+                errorMessages: errorMessages
+            };
+        }
+
+        function removeRow(rowId) {
+            rows = rows.map(function (row) {
+                if (row.id === rowId) {
+                    row.$row.remove();
+                    return false;
+                }
+                return row;
+            }).filter(function (row) {
+                return row;
+            });
+        }
+
+
+
+        function addRow(defaultValue, showHint, useRowHighlight) {
+            var placeholder = '',
+                rowId = html.genId(),
+                inputControl, feedbackTip, parameterRow, id,
+                nameCol, inputCol, removalButton, hintCol,
+                events = Events.make();
+            if (spec.text_options && spec.text_options.placeholder) {
+                placeholder = spec.text_options.placeholder.replace(/(\r\n|\n|\r)/gm, '');
+            }
+            defaultValue = defaultValue || '';
+
+            inputControl = input({
+                id: events.addEvent({type: 'change', handler: validate}),
+                placeholder: placeholder,
+                value: defaultValue,
+                type: 'text',
+                dataElement: 'input',
+                style: {width: '100%'},
+                class: 'form-control'
+            });
+
+
+            // this is a column adjacent to the form controls which provides status flags (error, data required, data complete and ok)
+            // TODO: this and other elements should be set up without any styles,
+            // and then the initial evaluation of the parameters vis-a-vis the ui will
+            // set the correct styles...
+            if (options.required && showHint) {
+                feedbackTip = span({
+                    class: 'kb-method-parameter-required-glyph fa fa-arrow-left',
+                    title: 'required field',
+                    dataElement: 'feedback'
+                });
+            } else {
+                feedbackTip = span({dataElement: 'feedback'});
+            }
+
+
+            // paremeter name display
+            var style = {};
+            if (options.environment === 'sidePanel') {
+                style = {
+                    textAlign: 'left', paddingLeft: '10px'
+                };
+            }
+            nameCol = div({
+                class: [options.classes.nameColClass, 'kb-method-parameter-name'].join(' '),
+                style: style
+            }, [(function () {
+                    if (showHint) {
+                        return spec.ui_name;
+                    }
+                })]);
+
+            // Input column display
+            inputCol = div({class: [options.classes.inputColClass, 'kb-method-parameter-input'].join(' ')}, [
+                div({style: {widgth: '100%', display: 'inline-block'}}, [
+                    inputControl
+                ]),
+                div({style: {display: 'inline-block'}}, [
+                    feedbackTip
+                ])
+            ]);
+
+            if (showHint) {
+                var infoTip;
+                if (spec.description && spec.short_hint !== spec.description) {
+                    infoTip = span({
+                        class: 'fa fa-info kb-method-parameter-info',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'auto',
+                        container: 'body',
+                        html: 'true',
+                        title: spec.description
+                    });
+                }
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    spec.short_hint, infoTip
+                ]);
+            } else {
+                hintCol = div({class: [options.classes.hintColClass, 'kb-method-parameter-hint'].join(' ')}, [
+                    button({class: 'kb-default-btn kb-btn-sm', id: events.addEvent({type: 'click', handler: function () {
+                                removeRow(rowId);
+                            }})}, [
+                        span({class: 'kb-parameter-data-row-remove fa fa-remove'}, [
+                            'remove ' + spec.ui_name
+                        ])
+                    ])
+                ]);
+            }
+
+
+            // put it all together.
+
+            // The row itself.
+            parameterRow = div({class: 'row kb-method-parameter-row', dataElement: 'row'}, [
+                nameCol, inputCol, hintCol
+            ]);
+            if (options.useRowHighlight) {
+                events.addEvent({type: 'mouseeneter', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+                events.addEvent({type: 'mouseleave', selector: '#' + rowId + ' [data-element="row"]', handler: function (e) {
+                        e.target.classList.add('kb-method-parameter-row-hover');
+                    }});
+            }
+
+            // Error display
+            var errorRow = div({class: 'row', dataElement: 'error-panel'}, [
+                div({class: options.classes.nameColClass}),
+                div({
+                    class: ['kb-method-parameter-error-message', options.classes.inputColClass].join(' '),
+                    style: {display: 'none'},
+                    dataElement: 'error-message'
+                })
+            ]);
+
+            var row = div({
+                dataElement: 'field',
+                id: rowId
+            }, [parameterRow, errorRow]);
+
+            // Finally, into the DOM!
+            $container.find('[data-element="rows-container"]').append(row);
+
+            events.attachEvents($container.get(0));
+
+            // Now we keep a handy copy of nodes around.
+            // In truth, we could implement this as an api and avoid this junk, which also 
+            // embeds a lot of jquery/dom nonsense.
+            var $field = $container.find('#' + rowId);
+
+            // The row exists to provide mount points for the various ui
+            // elements for this control.
+            rows.push({
+                rowId: rowId,
+                $row: $field.find('[data-element="row"]'),
+                $input: $field.find('[data-element="input"]'),
+                $error: $field.find('[data-element="error-message"]'),
+                $feedback: $field.find('[data-element="feedback"]'),
+                $field: $field,
+                $all: $field,
+                $removalButton: $field.find('[data-element="removal-button"]')
+            });
+
+        }
+
+
+        /*
+         * Creates the markup
+         * Places it into the dom node
+         * Hooks up event listeners
+         */
+        function render() {
+            var defaultValue = '',
+                defaultValues;
+
+            if (!options.multiple) {
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    // TODO!!!
+                    // the condition for using the first defaultvalue in the defaultValues 
+                    // array is suspect ... 
+                    // this says we use the default value if it is not an empty string or set as undefined
+                    // (because it can't really be undefined or we would not be here)
+                    // so this basically collapses to if it is an empty string use an empty string, otherwise
+                    // use the default value.
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+                addRow(defaultValue, true, true);
+            } else {
+
+                // TODO: the main panel hover bit...
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValue = (defaultValues[0] !== '' && defaultValues[0] !== undefined) ? defaultValues[0] : '';
+                }
+
+                // TODO what is the funny bit with using the default value first?
+
+                if (spec.default_values) {
+                    defaultValues = spec.default_values;
+                    defaultValues.forEach(function (defaultValue) {
+                        var betterDefaultValue = (defaultValue !== '' && defaultValue !== undefined) ? defaultValue : '';
+                        addRow(betterDefaultValue, false, false);
+                    });
+                }
+
+                // TODO: addTheAddRowController();
+
+            }
+        }
+
+        function layout() {
+            var events = Events.make(),
+                content;
+            if (options.multiple) {
+                content = div({
+                    class: 'kb-method-parameter-row',
+                    dataElement: 'main-panel',
+                    id: events.addEvents({events: [
+                            {
+                                type: 'mouseeneter',
+                                handler: function (e) {
+                                    e.target.classList.add('kb-method-parameter-row-hover');
+                                }
+                            },
+                            {
+                                type: 'mouseleave',
+                                handler: function (e) {
+                                    e.target.classList.remove('kb-method-parameter-row-hover');
+                                }
+                            }
+                        ]})}, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            } else {
+                content = div({
+                    dataElement: 'main-panel'
+                }, [
+                    div({dataElement: 'rows-container'})
+                ]);
+            }
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        // CLIENT API
+
+        function name() {
+            return spec.id;
+        }
+
+        function label() {
+            return spec.ui_name;
+        }
+
+        function hint() {
+            return spec.short_hint;
+        }
+
+        function description() {
+            return spec.description;
+        }
+        
+        function info() {
+            return '';
+        }
+
+        function multipleItems() {
+            return options.multiple;
+        }
+
+        function fieldType() {
+            return spec.field_type;
+        }
+
+        function type() {
+            return spec.type;
+        }
+
+        function dataType() {
+            if (!spec.text_options) {
+                return 'text';
+            }
+            var validateAs = spec.text_options.validate_as;
+            type;
+            if (validateAs) {
+                return validateAs;
+            }
+
+            if (spec.text_options.valid_ws_types) {
+                return 'workspaceObjectReference';
+            }
+
+            return 'unknown';
+        }
+
+        function uiClass() {
+            return spec.ui_class;
+        }
+
+        function required() {
+            return options.required;
+        }
+
+        function control() {
+            return 'control here';
+        }
+
+        // DATA API
+
+        /*
+         * If multiple values are supported, we always return an array
+         * If not, always return an atomic value
+         * // TODO: this data should always be scrubbed!
+         */
+        function value() {
+            console.log('INPUT', rows[0].$input);
+            if (options.multiple) {
+                return rows.map(function (row) {
+                    return row.$input.val();
+                });
+            }
+            return rows[0].$input.val();
+        }
+
+
+        // LIFECYCLE API
+
+        var domId = html.genId();
+        var widgetRootNode;
+        function id() {
+            return domId;
+        }
+
+        function init() {
+            // Normalize the parameter specification settings.
+            // TODO: much of this is just silly, we should be able to use the spec 
+            //   directly in most places.
+            options.environment = config.isInSidePanel ? 'sidePanel' : 'standard';
+            options.classes = classSets[options.environment];
+            options.multiple = spec.allow_multiple ? true : false;
+            options.required = spec.optional ? false : true;
+            options.isOutputName = spec.text_options && spec.text_options.is_output_name;
+            options.enabled = true;
+            console.log('HMM', spec);
+        }
+
+        function attach(node) {
+            parent = node;
+
+            widgetRootNode = parent.querySelector('#' + domId);
+            if (!widgetRootNode) {
+                throw new Error('The domId for this widget does not exist in the parent context');
+            }
+
+            // container = node.append(document.createElement('div'));
+            $container = $(widgetRootNode);
+            var theLayout = layout();
+            widgetRootNode.innerHTML = theLayout.content;
+            theLayout.events.attachEvents(widgetRootNode);
+        }
+
+        function start(params) {
+            // return render();
+            render(params);
+        }
+
+        return {
+            id: id,
+            init: init,
+            attach: attach,
+            start: start,
+            name: name,
+            label: label,
+            hint: hint,
+            description: description,
+            info: description,
+            multipleItems: multipleItems,
+            fieldType: fieldType,
+            type: type,
+            dataType: dataType,
+            uiClass: uiClass,
+            required: required,
+            control: control,
+            value: value
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/inputWrapperWidget.js
+++ b/nbextensions/methodCell/widgets/inputWrapperWidget.js
@@ -1,0 +1,95 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'kb_common/html'
+], function (html) {
+    'use strict';
+    var t = html.tag,
+        div = t('div'), span = t('span');
+    function factory(config) {
+        var container,
+            spec = config.spec,
+            wrappedWidget = config.widget,
+            wrappedId = html.genId();
+        function xlayout() {
+            return  [
+                div({class: 'row'}, [
+                    div({class: 'col-md-3'}, [
+                        spec.name(),
+                        '<br>',
+                        span({style: {fontSize: '80%'}}, spec.label())
+                    ]),
+                    div({class: 'col-md-1'}, (spec.required() ? '*' : '-')),
+                    div({class: 'col-md-2'}, spec.fieldType),
+                    div({class: 'col-md-2'}, spec.dataType()),
+                    div({class: 'col-md-4', id: wrappedId})
+                ]),
+                div({class: 'row'}, [
+                    div({class: 'col-md-3'}),
+                    div({class: 'col-md-2'}, (spec.multipleItems() ? 'mult' : 'single')),
+                    div({class: 'col-md-2'}, spec.uiClass()),
+                    div({class: 'col-md-5'})
+                ]),
+                div({class: 'row'}, [
+                    div({class: 'col-md-2'}),
+                    div({class: 'col-md-10'}, spec.hint())
+                ]),
+                div({class: 'row', style: {borderBottom: '1px silver solid'}}, [
+                    div({class: 'col-md-2'}),
+                    div({class: 'col-md-10'}, spec.description())
+                ]),
+                div({class: 'row', style: {borderBottom: '1px silver solid'}}, [
+                    div({class: 'col-md-2'}),
+                    div({class: 'col-md-10'}, spec.info())
+                ])
+            ].join('\n');
+        }
+        
+        function xxlayout() {
+            return  [
+                div({class: 'row'}, [
+                    div({class: 'col-md-3'}, [
+                        spec.name(),
+                        '<br>',
+                        span({style: {fontSize: '80%'}}, spec.label())
+                    ]),
+                    div({class: 'col-md-9', id: wrappedId})
+                ])
+            ].join('\n');
+        }
+        
+        function layout() {
+            return div({id: wrappedId});
+        }
+
+        function attach(node) {
+            container = node;
+            container.innerHTML = layout();
+            // convert our root node to a container for hosting the rows.
+            // TODO: double check this.
+            container.classList.add('container-fluid');
+            return wrappedWidget.attach(container.querySelector('#' + wrappedId));
+        }
+        function start() {
+            if (wrappedWidget.start) {
+                return wrappedWidget.start();
+            }
+        }
+        function run(input) {
+            if (wrappedWidget.run) {
+                return wrappedWidget.run(input);
+            }
+        }
+        return {
+            attach: attach,
+            start: start,
+            run: run
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/undefinedWidget.js
+++ b/nbextensions/methodCell/widgets/undefinedWidget.js
@@ -1,0 +1,24 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    
+], function () {
+    'use strict';
+    
+    function factory(config) {
+        
+        function attach(node) {
+            node.innerHTML = 'Undefined widget';
+        }
+        
+        return {
+            attach: attach
+        };
+    }
+    
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/scripts/install_narrative.sh
+++ b/scripts/install_narrative.sh
@@ -209,3 +209,9 @@ log "Putting new $SCRIPT_TGT command under $d"
 log "Done installing scripts"
 
 console "Done. Run the narrative from your virtual environment $VIRTUAL_ENV with the command: $SCRIPT_TGT"
+
+log "oh, wait, one more thing...installing nbextensions"
+cd nbextensions
+sh install.sh
+cd ../..
+log "now, done."


### PR DESCRIPTION
After attempting a merge, I just manually added the new code and the few changes necessary to support it. Since it is an nbextension, with most new code or changes being local to the extension, the changes have a small footprint. Yes, after a couple hour struggling with bad merges, it only took 15 minutes to manually merge the code. Sigh.
The examples I was working with locally (method cells in a narrative) still work, and now I'll proceed this weekend to wire it up to the method manager and complete the cell lifecycle support (adding, deleting, updating). At present it is only works when a notebook is loaded with the properly configured code cells.
I do want it to also continue working with a local fresh jupyter 4.2 install, so will push back some changes that were made to support the narrative environment to be more generic. E.g. there is a seminal runtime object which provides hooks for auth and config, which can be mocked in a non-narrative environment and would be useful for unit testing.
So the extension lives in /nbextensions/methodCell, and is installed at the end of narrative_install.sh. Currently it is installed as a link to the source, to make development easier.
One caveat is that the JS CDN must be running. I didn't include instructions on that, bad me, but I'll do that this weekend, although it would be the same routine as for the first sprint. The CDN is located at https://github.com/eapearson/kbase-cdn-js and should be available to your browser at http://cdn.kbase.us/cdn (see narrative_paths.js if yo want to change this.) I do plan on more work to rationalize the CDN usage although the way it is being used now works and is simple ... we do in general have a bit of work in the narrative to ensure that dependencies are compatible ...