### PR TITLE
Fixed bug in method code cell setup.

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -320,43 +320,38 @@ define (
         },
 
         buildMethodCodeCell: function(spec, tag) {
-            // TODO: should probably throw an error here
-            // should not even get here!
             var methodName = "Unknown method";
-            // if (spec && spec.behavior && spec.behavior.kb_service_method) {
             if (!spec || !spec.info) {
                 console.error('ERROR build method code cell: ', spec, tag);
                 alert('Sorry, could not find this method');
                 return;
             }
-            // methodName = spec.behavior.kb_service_method;
-            // var moduleName = "Unknown module";
-            //if (spec && spec.behavior && spec.behavior.kb_service_name) {
-            //    // moduleName = spec.behavior.kb_service_name;
-            //    moduleName = spec.info.module_name;
-            // }
-            // TODO: probably should record the git commit hash and/or the version
-            // 
+            // if the id has a '/' in the middle, the "name" is the portion after
+            // the slash.
+            var id = spec.info.id;
+            var slashPos = id.search('/');
+            if (slashPos !== -1)
+                id = id.substring(slashPos + 1);
             var cellMetadata = {
                 kbase: {
                     type: 'method',
                     method: {
                         tag: tag,
-                        name: spec.info.id,
+                        name: id,
                         module: spec.info.module_name,
                         gitCommitHash: spec.info.git_commit_hash,
                         version: spec.info.ver
                     }
                 }
             };
-            // This will also trigger the create.Cell event, which is not very 
+            // This will also trigger the create.Cell event, which is not very
             // useful for us really since we haven't been able to set the
             // metadata yet. Don't worry, I checked, the Jupyter api does not
             // provide a way to set the cell metadata as it is being created.
             var cell = Jupyter.narrative.insertAndSelectCellBelow('code');
-            
+
             cell.metadata = cellMetadata;
-            
+
             // Now we need to invent a way of triggering the cell to set itself up.
             $([Jupyter.events]).trigger('updated.Cell', {
                 cell: cell

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -50,20 +50,20 @@ require.config({
         narrativeDataWidget: 'kbase/js/widgetApi/narrativeDataWidget',
         narrativeDataWidgetIFrame: 'kbase/js/widgetApi/narrativeDataWidgetIFrame',
         widgetService2: 'kbase/js/widgetApi/widgetService2',
-        
+
         /*
          * From CDN
          */
-        kb_common: 'http://cdn.kbase.us/cdn/kbase-common-js/1.5.4/',
-        kb_service: 'http://cdn.kbase.us/cdn/kbase-service-clients-js/1.4.0/',
-        uuid: 'http://cdn.kbase.us/cdn/pure-uuid/1.3.0/uuid',
-        //bluebird: 'http://cdn.kbase.us/cdn/bluebird/3.3.4/bluebird',
-        //underscore: 'http://cdn.kbase.us/cdn/underscore/1.8.3/underscore',
-        text:  'http://cdn.kbase.us/cdn/requirejs-text/2.0.14/text',
-        css: 'http://cdn.kbase.us/cdn/require-css/0.1.8/css',
-        'font-awesome': 'http://cdn.kbase.us/cdn/font-awesome/4.3.0/css/font-awesome',
-        
-        
+        kb_common: 'http://narrative-dev.kbase.us/cdn/kbase-common-js/1.5.4/',
+        kb_service: 'http://narrative-dev.kbase.us/cdn/kbase-service-clients-js/1.4.0/',
+        uuid: 'http://narrative-dev.kbase.us/cdn/pure-uuid/1.3.0/uuid',
+        //bluebird: 'http://narrative-dev.kbase.us/cdn/bluebird/3.3.4/bluebird',
+        //underscore: 'http://narrative-dev.kbase.us/cdn/underscore/1.8.3/underscore',
+        text:  'http://narrative-dev.kbase.us/cdn/requirejs-text/2.0.14/text',
+        css: 'http://narrative-dev.kbase.us/cdn/require-css/0.1.8/css',
+        'font-awesome': 'http://narrative-dev.kbase.us/cdn/font-awesome/4.3.0/css/font-awesome',
+
+
 
         /***
          * CORE NARRATIVE WIDGETS

--- a/scripts/install_narrative.sh
+++ b/scripts/install_narrative.sh
@@ -208,10 +208,10 @@ log "Putting new $SCRIPT_TGT command under $d"
 /bin/mv $SCRIPT_TGT $d
 log "Done installing scripts"
 
-console "Done. Run the narrative from your virtual environment $VIRTUAL_ENV with the command: $SCRIPT_TGT"
-
 log "oh, wait, one more thing...installing nbextensions"
 cd nbextensions
 sh install.sh
 cd ../..
 log "now, done."
+
+console "Done. Run the narrative from your virtual environment $VIRTUAL_ENV with the command: $SCRIPT_TGT"

--- a/src/biokbase/narrative/jobs/methodmanager.py
+++ b/src/biokbase/narrative/jobs/methodmanager.py
@@ -28,7 +28,7 @@ class MethodManager(object):
     njs = clients.get('job_service')
     ws_client = clients.get('workspace')
     spec_manager = SpecManager()
-    _log = kbLogging.get_logger(__name__)
+    _log = kblogging.get_logger(__name__)
     _log.setLevel(logging.INFO)
 
     def __new__(cls):


### PR DESCRIPTION
The `name` field in the metadata needs to be just the method name, not the id (which is module_name/method_name).

Also tweaked the install script to put the final output after installing the extension.

I also installed and updated the CDN on narrative-dev and pointed the narrative_paths.js file there for now.