### PR TITLE
Route job status updates to method cells, various improvements

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
@@ -136,15 +136,23 @@ define([
             content = span({style: {fontWeight: 'bold'}}, status);
         toolbarDiv.append(span({style: {padding: '4px'}}, content));
     }
+    
+    function jobStatus(toolbarDiv, cell) {
+        var jobStatus = getMeta(cell, 'attributes', 'jobStatus'),
+            content = span({style: {fontWeight: 'bold'}}, jobStatus);
+        $(toolbarDiv).append(span({style: {padding: '4px'}}, content));
+    }
+
 
     var register = function (notebook) {
         celltoolbar.CellToolbar.register_callback('kbase-toggle-input', toggleInput);
         celltoolbar.CellToolbar.register_callback('kbase-edit-notebook-metadata', editNotebookMetadata);
         celltoolbar.CellToolbar.register_callback('kbase.menu', makeKBaseMenu);
         celltoolbar.CellToolbar.register_callback('kbase-status', status);
+        celltoolbar.CellToolbar.register_callback('kbase-log-status', jobStatus);
 
         // default.rawedit for the metadata editor
-        celltoolbar.CellToolbar.register_preset('KBase', ['kbase.menu', 'default.rawedit', 'kbase-toggle-input', 'kbase-edit-notebook-metadata', 'kbase-status']);
+        celltoolbar.CellToolbar.register_preset('KBase', ['kbase.menu', 'default.rawedit', 'kbase-toggle-input', 'kbase-edit-notebook-metadata', 'kbase-status', 'kbase-log-status']);
     };
     return {register: register};
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
@@ -149,10 +149,10 @@ define([
         celltoolbar.CellToolbar.register_callback('kbase-edit-notebook-metadata', editNotebookMetadata);
         celltoolbar.CellToolbar.register_callback('kbase.menu', makeKBaseMenu);
         celltoolbar.CellToolbar.register_callback('kbase-status', status);
-        celltoolbar.CellToolbar.register_callback('kbase-log-status', jobStatus);
+        celltoolbar.CellToolbar.register_callback('kbase-job-status', jobStatus);
 
         // default.rawedit for the metadata editor
-        celltoolbar.CellToolbar.register_preset('KBase', ['kbase.menu', 'default.rawedit', 'kbase-toggle-input', 'kbase-edit-notebook-metadata', 'kbase-status', 'kbase-log-status']);
+        celltoolbar.CellToolbar.register_preset('KBase', ['kbase.menu', 'default.rawedit', 'kbase-toggle-input', 'kbase-edit-notebook-metadata', 'kbase-status', 'kbase-job-status']);
     };
     return {register: register};
 });

--- a/nbextensions/methodCell/runtime.js
+++ b/nbextensions/methodCell/runtime.js
@@ -2,11 +2,35 @@
 /*jslint white:true,browser:true*/
 define([
     'base/js/namespace',
-    'narrativeConfig'
-], function (Jupyter, Config) {
+    'narrativeConfig',
+    './microBus'
+], function (Jupyter, Config, Bus) {
     'use strict';
 
     function factory(config) {
+        
+        function createRuntime() {
+            return {
+                created: new Date(),
+                bus: Bus.make()
+            }
+        }
+
+        /*
+         * The runtime hooks into a window
+         */
+        if (!window.kbaseRuntime) {
+            window.kbaseRuntime = createRuntime();
+        }
+        
+        // Global scope
+        
+        function bus() {
+            return window.kbaseRuntime.bus;
+        }
+        
+        
+        // These are still module scope
 
         function authToken() {
             return Jupyter.narrative.authToken;
@@ -31,11 +55,11 @@ define([
             }
             return configRoot;
         }
-
-
+        
         return {
             authToken: authToken,
-            config: getConfig
+            config: getConfig,
+            bus: bus
         };
     }
 

--- a/nbextensions/methodCell/widgets/fieldWidget.js
+++ b/nbextensions/methodCell/widgets/fieldWidget.js
@@ -48,8 +48,6 @@ define([
             bus = config.bus,
             spec = config.parameterSpec;
         
-        console.log('SPEC', spec);
-
         // options.isOutputName = spec.text_options && spec.text_options.is_output_name;
         options.enabled = true;
         options.classes = classSets.standard;

--- a/nbextensions/methodCell/widgets/input/singleCheckbox.js
+++ b/nbextensions/methodCell/widgets/input/singleCheckbox.js
@@ -213,8 +213,7 @@ define([
                     dataElement: 'input',
                     checked: checked,
                     value: valueChecked
-                }),
-                booleanString]);
+                })]);
         }
         function autoValidate() {
             return validate()

--- a/src/biokbase/narrative/jobs/methodmanager.py
+++ b/src/biokbase/narrative/jobs/methodmanager.py
@@ -167,6 +167,11 @@ class MethodManager(object):
 
         method_name = spec['behavior']['kb_service_method']
         service_name = spec['behavior']['kb_service_name']
+        if 'kb_service_version' in spec['behavior']:
+            service_ver = spec['behavior']['kb_service_version']
+        else:
+            service_ver
+        
         service_ver = spec['behavior']['kb_service_version']
         service_url = spec['behavior']['kb_service_url']
         # 3. set up app structure


### PR DESCRIPTION
- added window-global level message bus to the runtime module 
- event to emit log status updates and listener in the method cell controller
- message status shown in toolbar and also not shown but state changes recorded in metadata
- use permanent cell id (cell.metadata.kbase.attributes.id) rather than jupyter cell_id 
- map untyped parameter with select attributes to the select control

- the input widget does not currently do enough useful with job state. E.g. when a job is running the cancel action should be available, when errors access to error message, when completed the cell should be locked but unlock able.

Couple of notes -
- the usage of module state is worrisome, both in our code and in jupyter. although it commonly holds, there is no guarantee that a module instance will be retained for the lifetime of an interpreter instance. e.g.I imagine a smart amd loader could respond to memory pressure, or user settings, to remove seldom used modules from memory.
- the input widget needs optimization -- i've been focusing on prototyping new functionality, data integrity, integration with the module manager and methods in general -- there are visible artifacts like flashing at times.