### PR TITLE
[WIP] Job _repr_ working

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -66,12 +66,11 @@ define([
              */
 
             var cellState = this.getCellState();
-            if (cellState) {
+            if (cellState && cellState.jobId === this.jobId) {
                 // use this and not the state input.
                 this.state = cellState;
             }
 
-            var jobId = this.jobId;
             this.runtime.bus().listen({
                 test: function(msg) {
                     // return true;
@@ -84,7 +83,7 @@ define([
             });
             console.log(this.runtime.bus());
             // render up the panel's view layer.
-            this.makeJobStatusPanel(this.jobId);
+            this.makeJobStatusPanel();
             // wire up the comm channel and turn it loose.
             this.initCommChannel();
 
@@ -107,10 +106,14 @@ define([
                 jobId: this.jobId,
                 state: this.state
             };
-        }
+        },
 
         handleJobStatus: function(message) {
-
+            if (message.type !== 'jobstatus')
+                return;
+            this.state = message.jobState.state;
+            this.setCellState();
+            this.updateJobStatusPanel();
         },
 
         showError: function(message) {
@@ -150,74 +153,74 @@ define([
             }.bind(this));
         },
 
-        updateJobStatusPanel: function(jobInfo, jobState) {
-            info = {
+        updateJobStatusPanel: function() {
+            var info = {
                 jobId: this.jobId,
-                status: "Unknown",
-                creationTime: null,
-                queueTime: null,
-                queuePos: null,
-                execStartTime: null,
-                execEndTime: null,
-                execRunTime: null,
-            }
+                status: this.state.job_state,
+                creationTime: this.state.creation_time,
+                queueTime: this.state.exec_start_time - this.state.creation_time,
+                queuePos: this.state.position ? this.state.position : null,
+                execStartTime: this.state.exec_start_time,
+                execEndTime: this.state.finish_time,
+                execRunTime: this.state.finish_time - this.state.execStartTime
+            };
+            this.$elem.empty().append(this.statusTableTmpl(info));
+
         },
 
         makeJobStatusPanel: function() {
             this.statusTableTmpl = Handlebars.compile(JobStatusTableTemplate);
+            this.updateJobStatusPanel();
 
-            var tableInfo = {
-                jobId: this.jobId,
+            // var tableInfo = {
+            //     jobId: this.jobId,
+            // }
 
-            }
-            var statusTable = statusTable
-            statusTableTmpl
+            // function makeInfoRow(heading, info) {
+            //     return $('<tr>').append($('<th>')
+            //             .append(heading + ':'))
+            //             .append($('<td>')
+            //             .append(info));
+            // }
 
-            function makeInfoRow(heading, info) {
-                return $('<tr>').append($('<th>')
-                        .append(heading + ':'))
-                        .append($('<td>')
-                        .append(info));
-            }
+            // var $infoTable = $('<table class="table table-bordered">')
+            //         .append(makeInfoRow('Job Id', jobId))
+            //         .append(makeInfoRow('Status', statusText));
+            // if (jobState && jobState.state) {
+            //     var state = jobState.state;
+            //     var creationTime = state.start_timestamp;
+            //     var execStartTime = null;
+            //     var finishTime = null;
+            //     var posInQueue = null;
+            //     // console.log(state.step_stats);
+            //     if (state.step_stats) {
+            //         for (var key in state.step_stats) {
+            //             if (state.step_stats.hasOwnProperty(key)) {
+            //                 var stats = state.step_stats[key];
+            //                 // console.log(key, stats);
+            //                 if (stats['creation_time'])
+            //                     creationTime = stats['creation_time'];
+            //                 execStartTime = stats['exec_start_time'];
+            //                 finishTime = stats['finish_time'];
+            //                 posInQueue = stats['pos_in_queue'];
+            //             }
+            //         }
+            //     }
+            //     if (creationTime)
+            //         $infoTable.append(makeInfoRow('Submitted', this.readableTimestamp(creationTime)));
+            //     if (creationTime && execStartTime)
+            //         $infoTable.append(makeInfoRow('Time in queue', ((execStartTime - creationTime) / 1000.0) + " sec."));
+            //     if (posInQueue)
+            //         $infoTable.append(makeInfoRow('Position in queue', posInQueue));
+            //     if (execStartTime)
+            //         $infoTable.append(makeInfoRow('Execution Started', this.readableTimestamp(execStartTime)));
+            //     if (finishTime)
+            //         $infoTable.append(makeInfoRow('Execution Finished', this.readableTimestamp(finishTime)));
+            //     if (execStartTime && finishTime)
+            //         $infoTable.append(makeInfoRow('Execution Time', ((finishTime - execStartTime) / 1000.0) + " sec."));
+            // }
 
-            var $infoTable = $('<table class="table table-bordered">')
-                    .append(makeInfoRow('Job Id', jobId))
-                    .append(makeInfoRow('Status', statusText));
-            if (jobState && jobState.state) {
-                var state = jobState.state;
-                var creationTime = state.start_timestamp;
-                var execStartTime = null;
-                var finishTime = null;
-                var posInQueue = null;
-                // console.log(state.step_stats);
-                if (state.step_stats) {
-                    for (var key in state.step_stats) {
-                        if (state.step_stats.hasOwnProperty(key)) {
-                            var stats = state.step_stats[key];
-                            // console.log(key, stats);
-                            if (stats['creation_time'])
-                                creationTime = stats['creation_time'];
-                            execStartTime = stats['exec_start_time'];
-                            finishTime = stats['finish_time'];
-                            posInQueue = stats['pos_in_queue'];
-                        }
-                    }
-                }
-                if (creationTime)
-                    $infoTable.append(makeInfoRow('Submitted', this.readableTimestamp(creationTime)));
-                if (creationTime && execStartTime)
-                    $infoTable.append(makeInfoRow('Time in queue', ((execStartTime - creationTime) / 1000.0) + " sec."));
-                if (posInQueue)
-                    $infoTable.append(makeInfoRow('Position in queue', posInQueue));
-                if (execStartTime)
-                    $infoTable.append(makeInfoRow('Execution Started', this.readableTimestamp(execStartTime)));
-                if (finishTime)
-                    $infoTable.append(makeInfoRow('Execution Finished', this.readableTimestamp(finishTime)));
-                if (execStartTime && finishTime)
-                    $infoTable.append(makeInfoRow('Execution Time', ((finishTime - execStartTime) / 1000.0) + " sec."));
-            }
-
-            return $infoTable;
+            // return $infoTable;
         },
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -221,11 +221,9 @@ define ([
             var msgType = msg.content.data.msg_type;
             switch (msgType) {
                 case 'new_job':
-                    console.log("Adding new job info:");
                     this.registerKernelJob(msg.content.data.content);
                     break;
                 case 'job_status':
-                    console.log('got job refresh info');
                     var status = {},
                         info = {},
                         content = msg.content.data.content;
@@ -253,16 +251,16 @@ define ([
 
         initCommChannel: function() {
             // init the listener channel.
-            console.info('Registering Job channel with kernel.');
-            console.info('Checking for existing channel?');
+            // console.info('Registering Job channel with kernel.');
+            // console.info('Checking for existing channel?');
 
             this.comm = null;
 
             Jupyter.notebook.kernel.comm_info('KBaseJobs', function(msg) {
-                console.info(msg);
+                // console.info(msg);
                 if (msg.content && msg.content.comms) {
-                    console.info('Found an existing channel!');
-                    console.info(msg);
+                    // console.info('Found an existing channel!');
+                    // console.info(msg);
                     // skim the reply for the right id
                     for (var id in msg.content.comms) {
                         if (msg.content.comms[id].target_name === 'KBaseJobs') {
@@ -939,10 +937,11 @@ define ([
                                .append(jobId));
 
             var status = "Unknown";
-            if (jobState)
-                console.log('JOBSTATE', jobState);
+            if (jobState) {
+                // console.log('JOBSTATE', jobState);
                 status = jobState.status.charAt(0).toUpperCase() +
                          jobState.status.substring(1);
+            }
             var started = "Unknown";
             var position = null;
             var task = null;
@@ -1047,7 +1046,7 @@ define ([
             if (runTime) {
                 $infoTable.append(this.makeInfoRow('Run Time', runTime));
             }
-            if (jobState.state.creation_time) {
+            if (jobState.state && jobState.state.creation_time) {
                 started = $(TimeFormat.prettyTimestamp(jobState.state.creation_time));
                 started.tooltip({
                     container: 'body',

--- a/kbase-extension/static/kbase/templates/job_status_table.html
+++ b/kbase-extension/static/kbase/templates/job_status_table.html
@@ -1,0 +1,42 @@
+<table class="table table-bordered table-condensed">
+    <tr>
+        <td>Job Id</td>
+        <td>{{jobId}}</td>
+    </tr>
+    <tr>
+        <td>Status</td>
+        <td>{{status}}</td>
+    </tr>
+    <tr>
+        <td>Submitted</td>
+        <td>{{#if creationTime}}{{creationTime}}{{else}}Pending...{{/if}}</td>
+    </tr>
+    <tr>
+        <td>Time in queue</td>
+        <td>{{#if queueTime}}{{queueTime}}{{else}}Calculating...{{/if}}</td>
+    </tr>
+    {{#if queuePos}}
+    <tr>
+        <td>Position in queue</td>
+        <td>{{queuePos}}</td>
+    </tr>
+    {{/if}}
+    {{#if execStartTime}}
+    <tr>
+        <td>Execution Started</td>
+        <td>{{execStartTime}}</td>
+    </tr>
+    {{/if}}
+    {{#if execEndTime}}
+    <tr>
+        <td>Execution Finished</td>
+        <td>{{execEndTime}}</td>
+    </tr>
+    {{/if}}
+    {{#if execRunTime}}
+    <tr>
+        <td>Execution Time</td>
+        <td>{{execRunTime}}</td>
+    </tr>
+    {{/if}}
+</table>

--- a/kbase-extension/static/kbase/templates/simple_bootstrap_button.html
+++ b/kbase-extension/static/kbase/templates/simple_bootstrap_button.html
@@ -1,0 +1,1 @@
+<button type="button" class="btn btn-{{buttonStyle}}">{{buttonText}}</button>

--- a/nbextensions/methodCell/pythonInterop.js
+++ b/nbextensions/methodCell/pythonInterop.js
@@ -24,7 +24,7 @@ define([
             }),
             pythonCode = [
                 'from biokbase.narrative.jobs import AppManager',
-                'new_job = AppManager.run_app(\n' + pythonifyInputs(method, params, cellId) + '\n)'
+                'AppManager.run_app(\n' + pythonifyInputs(method, params, cellId) + '\n)'
             ].join('\n');
         cell.set_text(pythonCode);
 
@@ -233,7 +233,7 @@ define([
             runId = new Uuid(4).format(),
             pythonCode = [
                 'from biokbase.narrative.jobs import AppManager',
-                'new_job = AppManager().run_app(\n' + pythonifyInputs(method, params, cellId, runId) + '\n)'
+                'AppManager().run_app(\n' + pythonifyInputs(method, params, cellId, runId) + '\n)'
             ].join('\n');
 
         return pythonCode;
@@ -254,7 +254,7 @@ define([
                 'mm = MethodManager()',
                 'from_javascript = ' + pythonString(runParams, true),
                 'incoming_data = json.loads(from_javascript)',
-                'new_job = AppManager.run_app(\n' + pythonifyInputs(method, params, cellId, runId) + '\n)',
+                'AppManager.run_app(\n' + pythonifyInputs(method, params, cellId, runId) + '\n)',
                 'insert_run_widget(incoming_data[u"cell_id"], incoming_data[u"kbase_cell_id"])'
             ].join('\n');
 

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -19,6 +19,8 @@ from IPython.display import (
     HTML
 )
 from jinja2 import Template
+from ipykernel.comm import Comm
+
 
 class Job(object):
     job_id = None
@@ -26,6 +28,7 @@ class Job(object):
     app_version = None
     cell_id = None
     inputs = None
+    _comm = None
 
     def __init__(self, job_id, app_id, inputs, tag='release', app_version=None, cell_id=None):
         """
@@ -41,6 +44,7 @@ class Job(object):
         # self.job_manager = KBjobManager()
         self.inputs = inputs
         self.njs = clients.get('job_service')
+        self._init_comm()
 
     @classmethod
     def from_state(Job, job_id, job_info, tag='release', cell_id=None):
@@ -152,6 +156,21 @@ class Job(object):
         """
         status = self.status()
         return status.lower() in ['completed', 'error', 'suspend']
+
+    def _init_comm(self):
+        if self._comm is not None:
+            self._comm.close()
+            self._comm = None
+        self._comm = Comm(target_name='KBaseJob-' + self.job_id, data={})
+        self._comm.on_msg(self._handle_comm_message)
+
+    def _handle_comm_message(self, msg):
+        pass
+
+    def _send_comm_message(self, msg_type, msg):
+        if self._comm is None:
+            self.init_comm()
+        self._comm.send({'msg_type':msg_type, 'content':msg})
 
     def __repr__(self):
         return u"KBase Narrative Job - " + unicode(self.job_id)

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -180,7 +180,11 @@ class Job(object):
         element.html("<div id='kb-job-{{job_id}}' class='kb-vis-area'></div>");
 
         require(['jquery', 'kbaseNarrativeJobStatus'], function($, KBaseNarrativeJobStatus) {
-            var w = new KBaseNarrativeJobStatus($('#kb-job-{{job_id}}'), {'jobId': '{{job_id}}'});
+            var w = new KBaseNarrativeJobStatus($('#kb-job-{{job_id}}'), {'jobId': '{{job_id}}', 'state': {{state}}});
         });
         """
-        return Template(tmpl).render(job_id=self.job_id)
+        try:
+            state = self.state()
+        except Exception, e:
+            state = {}
+        return Template(tmpl).render(job_id=self.job_id, state=json.dumps(state))


### PR DESCRIPTION
Got the Job _repr_javascript_ method working. Now, starting a new job should (properly) create and return a Job object. Viewing that Job object (e.g. just doing something like: 
```
my_job = apps.run_app('blahblah', foo='bar')
my_job
```
in a code cell) should put the job status widget in place, as it defaults to _repr_javascript_
`str(my_job)` works, too, and just coughs up the job id. For more, theres `job.info()` for a text view of the job with its inputs or `job.state()` for a more programmatic view of the state, or `job.parameters()` for the set of params used to start the job in the first place.

This hooks a listener onto the bus that now broadcasts from the Jobs Panel. Should behave a little better and just receive updates whenever the Jobs panel does.

Next up, make it behave as the older style did - switch between running and error states, and put the console log in place. On instantiation it sets up a Comm to the Kernel, specifically to its sister Job object in the backend (uses the name "KBaseJob-{{job_id}}" as the channel). This can be used to push log info forward as required.