### PR TITLE
Addressing Narrative Copy problems

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,15 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.1.0 (more notes will follow).
 
+### Version 2.0.8
+__Changes__
+- Numerous small fixes to text and layout of various widgets.
+- Genome view deals with plants and eukaryota better.
+- Proteome comparison widget uses SVG now.
+- Tree browser widget is properly clickable again.
+- Ontologies, Assemblies, and GenomeAnnotations are uploadable.
+- Fixed several issues with Narrative copying (see JIRA tickets KBASE-2034, KBASE-4140, KBASE-4154, KBASE-4159, NAR-849, and NAR-850).
+
 ### Version 2.0.7
 __Changes__
 - Fixed data subsetting parameter input.
@@ -178,7 +187,7 @@ __Changes__
 - Renamed CSV Transform API arguments to TSV
 
 __Bugfixes__
-- JIRA KBASE-1411 fix - render issue for protein comparison widget 
+- JIRA KBASE-1411 fix - render issue for protein comparison widget
 - Fixed case where genome object doesn't have any contig info.
 
 ### Version 0.5.7 - 2/9/2015
@@ -267,7 +276,7 @@ __Changes__
   - Added test script for the backend shutdown command to verify it's only possible for an authenticated user to only shut down their own narrative
   - Added improvements to suggested next steps functionality - now it should pull from the method store instead of being hard-coded
   - Added custom icons for several datatypes
-  
+
 __Bugfixes__
 - JIRA NAR-586 - fixed error with quotation marks not being used correctly in App info boxes, and links not being rendered properly
 - Fixed several font mismatch issues - in kernel menu, new/copy narrative buttons, error buttons

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -74,6 +74,7 @@ function($,
         this.cachedUserIds = {};
         this.workspaceRef = null;
         this.workspaceId = null;
+        this.sidePanel = null;
 
         Jupyter.keyboard_manager.disable();
         return this;
@@ -417,16 +418,16 @@ function($,
                 this.workspaceRef = wsInfo[1] + '/' + wsInfo[2];
                 this.workspaceId = wsInfo[1];
             }
-            var $sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
+            this.sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
             // init the controller
             this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({
                 ws_id: this.getWorkspaceName()
             });
             this.narrController.render()
             .finally(function() {
-                $sidePanel.render();
+                this.sidePanel.render();
                 $('#kb-wait-for-ws').remove();
-            });
+            }.bind(this));
         }
         else {
             KBFatal('Narrative.init', 'Unable to locate workspace name from the Narrative object!');

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -19,6 +19,7 @@ define([
     'kbase-client-api',
     'kbaseNarrativePrestart',
     'ipythonCellMenu',
+    'base/js/namespace',
     'base/js/events',
     'notebook/js/notebook',
     'util/display',
@@ -38,6 +39,7 @@ function($,
          kbaseClient,
          kbaseNarrativePrestart,
          kbaseCellToolbar,
+         Jupyter,
          events,
          Notebook,
          DisplayUtil,
@@ -70,6 +72,8 @@ function($,
         this.dataViewers = null;
         this.profileClient = new UserProfile(Config.url('user_profile'));
         this.cachedUserIds = {};
+        this.workspaceRef = null;
+        this.workspaceId = null;
 
         Jupyter.keyboard_manager.disable();
         return this;
@@ -134,7 +138,7 @@ function($,
             placement : "bottom",
             content: function() {
                 // we do not allow users to leave thier narratives untitled
-                if (Jupyter && Jupyter.notebook) {
+                if (Jupyter.notebook) {
                     var narrName = Jupyter.notebook.notebook_name;
                     if (narrName.trim().toLowerCase()==='untitled' || narrName.trim().length === 0) {
                         Jupyter.save_widget.rename_notebook({notebook: Jupyter.notebook}); //"Your Narrative must be named before you can share it with others.", false);
@@ -398,7 +402,7 @@ function($,
 
         this.authToken = $('#signin-button').kbaseLogin('token');
 
-        if (Jupyter && Jupyter.notebook && Jupyter.notebook.metadata) {
+        if (Jupyter.notebook && Jupyter.notebook.metadata) {
             var creatorId = Jupyter.notebook.metadata.creator || 'KBase User';
             DisplayUtil.displayRealName(creatorId, $('#kb-narr-creator'));
 
@@ -408,6 +412,11 @@ function($,
         if (this.getWorkspaceName() !== null) {
             this.initSharePanel();
 
+            var wsInfo = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
+            if (wsInfo && wsInfo.length === 3) {
+                this.workspaceRef = wsInfo[1] + '/' + wsInfo[2];
+                this.workspaceId = wsInfo[1];
+            }
             var $sidePanel = $('#kb-side-panel').kbaseNarrativeSidePanel({ autorender: false });
             // init the controller
             this.narrController = $('#notebook_panel').kbaseNarrativeWorkspace({

--- a/kbase-extension/static/kbase/js/widgets/kbaseLoginFuncSite.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseLoginFuncSite.js
@@ -67,7 +67,6 @@ define([
             fields: ['name', 'kbase_sessionid', 'user_id', 'token']
         },
         cookieName: 'kbase_session',
-        // narrCookieName: 'kbase_narr_session',
         get_kbase_cookie: function (field) {
             if (!$.cookie(this.cookieName)) {
                 return {};
@@ -612,7 +611,6 @@ define([
                                             '|token=' + data.token.replace(/=/g, 'EQUALSSIGN').replace(/\|/g, 'PIPESIGN');
                                         $.cookie(this.cookieName, cookieString, {path: '/', domain: 'kbase.us', expires: 60});
                                         $.cookie(this.cookieName, cookieString, {path: '/', expires: 60});
-                                        // $.cookie(this.narrCookieName, cookieString, {path: '/', domain: 'kbase.us', expires: 60});
                                     }
 
 
@@ -693,7 +691,6 @@ define([
             localStorage.removeItem('kbase_session');
             $.removeCookie(this.cookieName, {path: '/'});
             $.removeCookie(this.cookieName, {path: '/', domain: 'kbase.us'});
-            // $.removeCookie(this.narrCookieName, {path: '/', domain: 'kbase.us'});
 
             // the rest of this is just housekeeping.
 

--- a/kbase-extension/static/kbase/js/widgets/kbaseLoginFuncSite.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseLoginFuncSite.js
@@ -1,33 +1,33 @@
 /*
- 
+
  KBase Bootstrap plugin to handle all login/session related stuff.
- 
+
  Set up a container on your HTML page. It can be whatever you'd like. For example.
- 
+
  <div id = 'fizzlefazzle'></div>
- 
+
  You don't need to give it that ID. I just populated it with junk because I don't want to
  encourage people to use something generic like 'login', since there's no need. You don't need
  an ID at all, just some way to select it.
- 
+
  Later, in your jquery initialization, do this:
- 
+
  $(function() {
  ...
- 
+
  $(#"fizzlefaszzle").login();
- 
+
  }
- 
+
  And that, my friends, is Jenga. You're done. Sit back and enjoy the fruits of your labor.
- 
+
  There are a couple of useful things to know about. You can extract the user_id and kbase_sessionid:
- 
+
  $(#"fizzlefazzle").login('session', 'user_id');
  $(#"fizzlefazzle").login('session', 'kbase_sessionid');
- 
+
  When you're setting it up, you have a few options:
- 
+
  $('#fizzlefazzle').login(
  {
  style : (button|slim|micro|hidden) // try 'em all out! button is the default.
@@ -38,14 +38,14 @@
  user_id : a string with which to pre-populate the user_id on the forms.
  }
  );
- 
+
  You can also completely inline it.
- 
+
  var $login_doodad = $('<span></span>').login({style : 'hidden'});
  $login_doodad.login('login', 'username', 'password', function (args) {
  console.log("Tried to log in and got back: "); console.log(args);
  });
- 
+
  */
 
 define([
@@ -67,7 +67,7 @@ define([
             fields: ['name', 'kbase_sessionid', 'user_id', 'token']
         },
         cookieName: 'kbase_session',
-        narrCookieName: 'kbase_narr_session',
+        // narrCookieName: 'kbase_narr_session',
         get_kbase_cookie: function (field) {
             if (!$.cookie(this.cookieName)) {
                 return {};
@@ -80,12 +80,12 @@ define([
         /**
          * Decodes a Globus authentication token, transforming the token
          * plain string into a map of field names to values.
-         * 
+         *
          * @function decodeToken
          * @private
-         * 
+         *
          * @param {string} - A globus auth token
-         * 
+         *
          * @returns {GlobusAuthToken} an object representing the decoded
          * token.
          */
@@ -140,9 +140,9 @@ define([
             if (this.ui) {
                 this.$elem.append(this.ui);
             }
-            
-            // Now the drop down has been added, show the correct 
-            
+
+            // Now the drop down has been added, show the correct
+
 
             if (kbaseCookie.user_id) {
                 if (!this.is_token_valid(kbaseCookie.token)) {
@@ -612,7 +612,7 @@ define([
                                             '|token=' + data.token.replace(/=/g, 'EQUALSSIGN').replace(/\|/g, 'PIPESIGN');
                                         $.cookie(this.cookieName, cookieString, {path: '/', domain: 'kbase.us', expires: 60});
                                         $.cookie(this.cookieName, cookieString, {path: '/', expires: 60});
-                                        $.cookie(this.narrCookieName, cookieString, {path: '/', domain: 'kbase.us', expires: 60});
+                                        // $.cookie(this.narrCookieName, cookieString, {path: '/', domain: 'kbase.us', expires: 60});
                                     }
 
 
@@ -693,7 +693,7 @@ define([
             localStorage.removeItem('kbase_session');
             $.removeCookie(this.cookieName, {path: '/'});
             $.removeCookie(this.cookieName, {path: '/', domain: 'kbase.us'});
-            $.removeCookie(this.narrCookieName, {path: '/', domain: 'kbase.us'});
+            // $.removeCookie(this.narrCookieName, {path: '/', domain: 'kbase.us'});
 
             // the rest of this is just housekeeping.
 

--- a/kbase-extension/static/kbase/js/widgets/kbaseSessionSync.js
+++ b/kbase-extension/static/kbase/js/widgets/kbaseSessionSync.js
@@ -7,7 +7,7 @@
         return this;
       }
     },
-    
+
     session: {
       value: null,
       writable: true
@@ -19,10 +19,7 @@
     cookieName: {
       value: 'kbase_session'
     },
-    narrCookieName: {
-      value: 'kbase_narr_session'
-    },
-    
+
     // Note that THIS session just uses the original kbase
     // session object without transforming it to the canonical form
     // used in the real kbaseSession
@@ -31,8 +28,8 @@
         return this.sessionObject;
       }
     },
-   
-    
+
+
     importSessionFromCookie: {
       value: function () {
          var sessionCookie = $.cookie(this.cookieName);
@@ -41,18 +38,18 @@
         }
         // first pass just break out the string into fields.
         var session = this.decodeToken(sessionCookie);
-        
+
         if (! (session.kbase_sessionid && session.un && session.user_id && session.token) ) {
           this.removeAuth();
           return null;
         }
-        
+
         session.token = session.token.replace(/PIPESIGN/g, '|').replace(/EQUALSSIGN/g, '=');
 
         // now we have a session object equivalent to the one returned by the auth service.
-        
+
         session.tokenObject = this.decodeToken(session.token);
-        
+
         if (this.validateSession(session)) {
           return session;
         } else {
@@ -77,7 +74,7 @@
       value: function (s) {
         if (!s || s.length === 0) {
           return null;
-        }        
+        }
         var session = this.decodeToken(s);
         if (!session) {
           return null;
@@ -92,7 +89,7 @@
         return session;
       }
     },
-    
+
     validateSession: {
       value: function (sessionObject) {
         if (sessionObject === undefined) {
@@ -112,9 +109,9 @@
         return true;
       }
     },
-    
+
     hasExpired : {
-      value: function (sessionObject) {          
+      value: function (sessionObject) {
           var expirySec = sessionObject.tokenObject.expiry;
           if (!expirySec) {
             return false;
@@ -136,12 +133,11 @@
       value: function() {
         $.removeCookie(this.cookieName, {path: '/'});
         $.removeCookie(this.cookieName, {path: '/', domain: 'kbase.us'});
-        $.removeCookie(this.narrCookieName, {path: '/', domain: 'kbase.us'});
         // For compatability
         localStorage.removeItem(this.cookieName);
       }
     }
-    
+
   });
   $.KBaseSessionSync = SessionSync;
 }(jQuery));

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -1160,7 +1160,7 @@ function($,
                     workspace: newWsName,
                     meta: newWsMeta,
                     exclude: [{ objid: currentNarrative.info[0] }]
-                }))
+                }));
             }.bind(this))
             .then(function(newWsInfo) {
                 // pop the newWsId into a variable available by closure in the next step.
@@ -1196,11 +1196,11 @@ function($,
             .then(function(newNarInfo) {
                 // now, just update the workspace metadata to point
                 // to the new narrative object
-                newNarId = newNarInfo[0][0]
+                newNarId = newNarInfo[0][0];
                 return Promise.resolve(this.ws.alter_workspace_metadata({
                     wsi: { id: newWsId },
                     new: { narrative: String(newNarId) }
-                }))
+                }));
             }.bind(this))
             .then(function(results) {
                 return {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -1339,8 +1339,18 @@ function($,
                 var newNarMetadata = newNarObj.info[10];
                 newNarMetadata.name = newName;
                 newNarMetadata.ws_name = newWsName;
+                newNarMetadata.job_info = JSON.stringify({queue_time: 0, running: 0, completed: 0, run_time: 0, error: 0});
+
                 newNarObj.data.metadata.name = newName;
                 newNarObj.data.metadata.ws_name = newWsName;
+                newNarObj.data.metadata.job_ids = {
+                    apps: [],
+                    methods: [],
+                    job_usage: {
+                        queue_time: 0,
+                        run_time: 0
+                    }
+                };
 
                 // 2 promises here.
                 // First updates the metadata so it points to the right new workspace

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -1021,12 +1021,12 @@ function($,
                 .click(function(e) {
                     setButtonWorking(true);
                     $newNameInput.val(Jupyter.notebook.get_notebook_name() + ' - Copy')
-                    $alertContainer.show();
+                    $alertContainer.slideDown();
                 });
 
             var $newNameInput = $('<input type="text">')
                 .addClass('form-control')
-                .tooltip({title: 'Gotta have a name!',
+                .tooltip({title: 'Please enter a name.',
                           container: 'body',
                           placement: 'right',
                           trigger: 'manual'})
@@ -1082,7 +1082,8 @@ function($,
                              .append('Cancel')
                              .click(function () {
                                 $doCopyBtn.prop('disabled', false);
-                                $alertContainer.hide();
+                                $alertContainer.slideUp();
+                                $newNameInput.tooltip('hide');
                                 setButtonWorking(false);
                              });
 
@@ -1097,175 +1098,7 @@ function($,
             ).hide();
 
             return $initCopyBtn;
-
-            // var self = this;
-            // var active = '<span class="fa fa-copy"></span> Copy This Narrative';
-            // var $working = $('<span>').append("Copying Narrative...");
-
-            // var $btn = $('<button>').addClass('kb-primary-btn')
-            //     .append(active)
-            //     .on('click', function (e) {
-            //         e.stopPropagation();
-            //         $(this).prop('disabled', true).empty().append($working);
-            //         self.copyThisNarrative($alertContainer, active, null)
-            //         .then(function(result) {
-            //             console.log(result);
-            //         });
-            //     });
-            // return $btn;
         },
-
-        // xcopyThisNarrative: function ($dialog, active, $jump_btn) {
-        //     var self = this;
-        //     $dialog.empty(); // in case user canceled earlier
-        //     self.ws.get_workspace_info({workspace: self.ws_name},
-        //         function (ws_info) {
-        //             self.ws.get_object_info_new({objects: [{ref: ws_info[0] + '/' + ws_info[8]['narrative']}], includeMetadata: 1},
-        //                 function (object_info_list) {
-        //                     var object_info = object_info_list[0];
-        //                     var $newNameInput = $('<input type="text">')
-        //                         .addClass('form-control')
-        //                         .val(ws_info[8]['narrative_nice_name'] + ' - Copy')
-        //                         .on('focus', function () {
-        //                             Jupyter.narrative.disableKeyboardManager();
-        //                         })
-        //                         .on('blur', function () {
-        //                             Jupyter.narrative.enableKeyboardManager();
-        //                         });
-
-
-        //                     var $cancelBtn = $('<button>')
-        //                                      .addClass('kb-default-btn')
-        //                                      .append('Cancel')
-        //                                      .click(function () {
-        //                                         $copyNarButton.prop('disabled', false).empty().append(active);
-        //                                         self.$copyThisNarrBtn.prop('disabled', false).empty().append(active);
-        //                                         $dialog.empty();
-        //                                      });
-
-        //                     var $copyNarButton = $('<button>').addClass('kb-primary-btn')
-
-        //                     // $dialog.append(
-        //                     //     $('<div>').append(
-        //                     //     $('<div>').append("Enter a name for the new Narrative"))
-        //                     //     .append($('<div>').append($newNameInput))
-        //                     //     .append($('<button>').addClass('btn btn-info')
-        //                             .css({'margin-top': '10px'})
-        //                             .append('Copy')
-        //                             .click(function () {
-        //                                 var $thisBtn = $(this);
-        //                                 $thisBtn.prop('disabled', true);
-        //                                 var newMeta = ws_info[8];
-        //                                 newMeta['narrative_nice_name'] = $newNameInput.val();
-
-        //                                 var id = new Date().getTime();
-        //                                 var ws_name = self.my_user_id + ":" + id;
-
-        //                                 self.ws.clone_workspace({
-        //                                     wsi: {id: ws_info[0]},
-        //                                     workspace: ws_name,
-        //                                     meta: newMeta
-        //                                 },
-        //                                     function (new_ws_info) {
-        //                                         // we have to match based on names because when cloning, the object id is not preserved!!! arg!
-        //                                         var new_narrative_ref = new_ws_info[0] + "/" + object_info[1]; //new_ws_info[8].narrative;
-        //                                         // ok, a lot of work just to update the narrative name in the metadata
-        //                                         self.ws.get_objects([{ref: new_narrative_ref}],
-        //                                             function (data) {
-        //                                                 data = data[0]; // only one thing should be returned
-        //                                                 var new_nar_metadata = data.info[10];
-        //                                                 new_nar_metadata.name = newMeta['narrative_nice_name'];
-        //                                                 new_nar_metadata.ws_name = ws_name;
-        //                                                 data.data.metadata.name = newMeta['narrative_nice_name'];
-        //                                                 data.data.metadata.ws_name = ws_name;
-
-        //                                                 // set workspace metadata to point to the correct object id since they can change on clone!!
-        //                                                 self.ws.alter_workspace_metadata({
-        //                                                     wsi: {id: new_ws_info[0]},
-        //                                                     new : {'narrative': String(data.info[0])}
-        //                                                 },
-        //                                                     function () {
-        //                                                         // so much work just to update this name!
-        //                                                         self.ws.save_objects({id: new_ws_info[0], objects: [
-        //                                                                 {
-        //                                                                     type: data.info[2],
-        //                                                                     data: data.data,
-        //                                                                     provenance: data.provenance,
-        //                                                                     name: data.info[1],
-        //                                                                     meta: new_nar_metadata
-        //                                                                 }
-        //                                                             ]},
-        //                                                             function (info) {
-        //                                                                 console.log('copying complete', info);
-        //                                                                 $dialog.empty();
-        //                                                                 if (active) {
-        //                                                                     $thisBtn.prop('disabled', false).empty().append(active);
-        //                                                                     self.refresh();
-        //                                                                 }
-        //                                                                 if ($jump_btn) {
-        //                                                                     var name = info[0][10].name;
-        //                                                                     var copy_id = "ws." + info[0][6] + ".obj." + info[0][0];
-        //                                                                     var oldpath = window.location.pathname;
-        //                                                                     var parts = oldpath.split('/');
-        //                                                                     parts.pop();                    // pop off old id
-        //                                                                     parts.push(copy_id);            // add new one
-        //                                                                     var newpath = parts.join('/'); // rejoin as a path
-        //                                                                     var newurl = window.location.protocol + '//' + window.location.host + newpath;
-        //                                                                     $dialog.append($('<div>').html('Created new copy: <i>' + name + '</i>'));
-        //                                                                     $dialog.append($jump_btn);
-        //                                                                     $jump_btn.click(function () {
-        //                                                                         window.location.replace(newurl);
-        //                                                                     });
-        //                                                                 }
-        //                                                             },
-        //                                                             function (error) {
-        //                                                                 console.error(error);
-        //                                                                 $dialog.empty();
-        //                                                                 $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on data update. " + error.error.message));
-        //                                                             });
-
-        //                                                     },
-        //                                                     function (error) {
-        //                                                         console.error(error);
-        //                                                         $dialog.empty();
-        //                                                         $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on data update. " + error.error.message));
-        //                                                     });
-
-
-        //                                             },
-        //                                             function (error) {
-        //                                                 console.error(error);
-        //                                                 $dialog.empty();
-        //                                                 $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on rename. " + error.error.message));
-        //                                             })
-        //                                     },
-        //                                     function (error) {
-        //                                         console.error(error);
-        //                                         $dialog.empty();
-        //                                         $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
-        //                                     });
-        //                             });
-        //                     $dialog.append(
-        //                         $('<div>').append(
-        //                         $('<div>').append("Enter a name for the new Narrative"))
-        //                         .append($('<div>').append($newNameInput))
-        //                         .append($copyNarButton)
-        //                         .append(active ? $cancelBtn : ''));
-        //                 },
-        //                 function (error) {
-        //                     // error with get_object_info_new
-        //                     console.error(error);
-        //                     $dialog.empty();
-        //                     $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
-        //                 });
-        //         },
-        //         function (error) {
-        //             // error with get_workspace_info
-        //             console.error(error);
-        //             $dialog.empty();
-        //             $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
-        //         });
-        // },
 
         copyThisNarrative: function (newName) { //$dialog, active, $jumpBtn) {
             /* $dialog = element to use as a a dialog area for status, etc.
@@ -1298,10 +1131,20 @@ function($,
              * Just chain together a small pile of ws promises.
              */
 
+            var preCheckError = null;
+            // this.workspaceRef = null;
             if (!this.ws) {
-                return;
+                preCheckError = "Cannot copy - please sign in again.";
             }
-
+            else if (!this.workspaceRef) {
+                preCheckError = "Cannot copy - cannot find Narrative id. Please refresh the page and try again.";
+            }
+            else if (!this.workspaceId) {
+                preCheckError = "Cannot copy - cannot find Narrative data id. Please refresh the page and try again.";
+            }
+            if (preCheckError) {
+                return Promise.reject(preCheckError);
+            }
             // name of the narrative object in the workspace. used for closure.
             var narObjName;
             var newWsName = this.my_user_id + ':' + new Date().getTime();
@@ -1311,6 +1154,8 @@ function($,
                 // add the 'narrative' field later.
             };
             var newWsId;
+
+
 
             // start with getting the object info (we just need the object name)
             return Promise.resolve(this.ws.get_object_info_new({
@@ -1356,8 +1201,8 @@ function($,
                 // First updates the metadata so it points to the right new workspace
                 // Second saves the newly twiddled narrative.
                 return Promise.all([
-                    Promise.resolve(this.ws.alter_workspace_metadat({
-                        wsi: { id: newWsId },
+                    Promise.resolve(this.ws.alter_workspace_metadata({
+                        wsi: { id: null }, //newWsId },
                         new: { 'narrative': String(newNarObj.info[0])}
                     })),
                     Promise.resolve(this.ws.save_objects({
@@ -1381,16 +1226,24 @@ function($,
             .catch(function(error) {
                 //do stuff....
                 console.error(error);
+                var errMessage = "Sorry, an error occurred while copying.";
+                if (error.error && error.error.message) {
+                    //try to parse...
+                    var msg = error.error.message;
+
+                }
                 // if it got to the point that it made a copy,
                 // delete it so it's out of the way - it's broken
                 // if it got here without finishing.
                 if (newWsId) {
                     console.log('deleting new incomplete copy - ' + newWsId);
-                    Promise.resolve(this.ws.delete_workspace({id: newWsId}))
+                    return Promise.resolve(this.ws.delete_workspace({id: newWsId}))
                     .then(function() {
+                        return Promise.reject(error);
                     });
                 }
-                throw error;
+                return Promise.reject(error);
+                // throw error;
             }.bind(this));
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -3,20 +3,24 @@
  * @author Michael Sneddon <mwsneddon@lbl.gov>
  * @public
  */
-define(['jquery', 
+define(['jquery',
+        'base/js/namespace',
         'narrativeConfig',
         'narrativeManager',
         'util/display',
         'bluebird',
-        'narrativeConfig',
-        'kbwidget', 
+        'kbwidget',
         'kbaseNarrativeControlPanel',
         'api/NewWorkspace'],
-function($, 
-         Config, 
+function($,
+         Jupyter,
+         Config,
          NarrativeManager,
          DisplayUtil,
-         Promise) {
+         Promise,
+         KBWidget,
+         ControlPanel,
+         NewWorkspace) {
     'use strict',
     $.KBWidget({
         name: "kbaseNarrativeManagePanel",
@@ -51,25 +55,30 @@ function($,
         init: function (options) {
             this._super(options);
 
-            this.$mainPanel = $('<div>')//.css({'height':'600px'});
+            this.$mainPanel = $('<div>');
             this.body().append(this.$mainPanel);
 
+            // the string name of the workspace.
             this.ws_name = Jupyter.narrative.getWorkspaceName();
 
+            // the workspace ref of this Narrative object. (w/o version)
+            this.workspaceRef = Jupyter.narrative.workspaceRef;
+            this.workspaceId = Jupyter.narrative.workspaceId;
+
             $(document).on(
-                'copyThis.Narrative', $.proxy(function (e, panel, active, jump) {
+                'copyThis.Narrative', function (e, panel, active, jump) {
                     console.debug("CopyThisNarrative triggered, params=",
                         {panel: panel, active: active, jump: jump});
-                    this.copyThisNarrative(panel, active, jump);
-                }, this)
+                    this.copyThisNarrative(panel, active, jump)
+                }.bind(this)
             );
 
             $([Jupyter.events]).on(
-                'notebook_saved.Notebook', $.proxy(function (e) {
+                'notebook_saved.Notebook', function (e) {
                     this.refresh();
-                }, this)
+                }.bind(this)
             );
-            
+
             // doesn't need a title, so just hide it to avoid padding.
             // yes, it's a hack. mea culpa.
             this.$elem.find('.kb-title').hide();
@@ -92,7 +101,7 @@ function($,
             return this;
         },
         refresh: function () {
-            if (!self.$narPanel) {
+            if (!this.$narPanel) {
                 this.renderHeader();
             }
             this.loadDataAndRenderPanel();
@@ -109,6 +118,17 @@ function($,
             var narRefsToLookup = [];
             var wsPermsToLookup = [];
             this.showLoading();
+
+            /**
+             * Loading and rendering flow.
+             * 1. Get users workspace infos (owned and shared, not global)
+             * 2. Look at metadata for 'narrative' tag - if present, that ws has a Narrative.
+             *    a. Add the object id in that tag to the narRefsToLookUp var.
+             *    b. Add that ws to wsPermsToLookup
+             * 3. Make a pile of Promises.
+             *    a. One to fetch all object info for those Narratives (assuming it's under 10000, that'll get fixed if it gets larger)
+             *    b. One for each batch of 1000 workspaces to get permissions for
+             */
             var wsInfoProm = Promise.resolve(this.ws.list_workspace_info({excludeGlobal: 1}));
 
             var narDataProm = wsInfoProm
@@ -169,6 +189,9 @@ function($,
                     }
                 }
                 var newProms = []
+                /*
+                 * set up Promises - first is for all Narrative object info, rest are for WS permissions
+                 */
                 if (narRefsToLookup.length > 0) {
                     var objInfoProm = Promise.resolve(this.ws.get_object_info_new({objects: narRefsToLookup, includeMetadata: 1, ignoreErrors: 1}));
                     newProms.push(objInfoProm);
@@ -180,26 +203,44 @@ function($,
                 return Promise.all(newProms);
             }.bind(this))
             .then(function(results) { //objList = results[0], rest are permList chunks
+                /*
+                 * Now we have a set of objects and permissions for each narrative.
+                 * The arrays are in the same order, so keep them parallel when the permission list gets merged.
+                 */
                 var objList = results.shift();
                 var permList = [];
                 for (var i=0; i<results.length; i++) {
                     permList = permList.concat(results[i].perms);
                 }
+                // If no narratives, we're done!
                 if (!objList)
                     return;
 
                 var errorProms = [];
+                /*
+                 * Go through each object and permission pair, merge them together in this.allNarData.
+                 * If it's not a Narrative object, then create an error.
+                 * In the end, allNarData will be a list like this:
+                 * {
+                 *   nar_info: { get_object_info_new result },
+                 *   perms : { get_permissions_mass result },
+                 *   error : boolean
+                 * }
+                 */
                 for (var i = 0; i < objList.length; i++) {
                     this.allNarData[i].perms = permList[i];
                     if (objList[i] !== null && objList[i][2].indexOf('KBaseNarrative.Narrative') === 0) {
                         this.allNarData[i].nar_info = objList[i];
                     } else {
+                        // If this isn't a KBaseNarrative.Narrative, then it's wrong!
+                        // look up the object, and expect to see an error.
+                        // This is all done as a set of promises, so they'll get dealt with when theyre returned.
                         this.allNarData[i].error = true;
                         var errorIndex = i;
 
                         errorProms.push(Promise.resolve(this.ws.get_object_info_new({
-                            objects: [narRefsToLookup[errorIndex]], 
-                            includeMetadata: 1, 
+                            objects: [narRefsToLookup[errorIndex]],
+                            includeMetadata: 1,
                             ignoreErrors: 0
                         }))
                         .then(function(error_obj_info) {
@@ -210,27 +251,29 @@ function($,
                             } else {
                                 // could give an error message here stating that the workspace is pointing to a non-narrative object
                                 //this.allNarData[errorIndex].error_msg = error.error.message;
-                            }                                
+                            }
                         }.bind(this))
                         .catch(function(error) {
                             this.allNarData[errorIndex].error_msg = error.error.message;
-                            this.allNarData[errorIndex].$div = null;                                
+                            this.allNarData[errorIndex].$div = null;
                         }.bind(this)));
                     }
                 }
                 return Promise.all(errorProms);
             }.bind(this))
             .then(function() {
+                // At this stage, this.allNarData should be fully populated.
                 this.renderPanel();
             }.bind(this))
             .catch(function(error) {
                 console.error(error);
             });
-
         },
+
         showLoading: function () {
             this.$narPanel.html('<br><center><img src="' + this.options.loadingImage + '"/></center><br>');
         },
+
         renderHeader: function () {
             var self = this;
             if (self.$mainPanel) {
@@ -248,6 +291,7 @@ function($,
                 self.$mainPanel.append(self.$narPanel);
             }
         },
+
         advancedSetNarLookup: {},
         sortNarrativesFunc: function (a, b) {
             if (a.error && b.error) {
@@ -265,6 +309,7 @@ function($,
                 return 1;  // sort by date
             return 0;
         },
+
         renderPanel: function () {
             var self = this,
                 divider = '<hr class="kb-data-list-row-hr">';
@@ -468,11 +513,11 @@ function($,
                     .tooltip({title: 'View narrative history to revert changes', 'container': 'body'})
                     .append(
                         $('<span>')
-                        .addClass('fa fa-history')                       
+                        .addClass('fa fa-history')
                         )
                     .click(function (e) {
                         e.stopPropagation();
-                    
+
                         var opened = self.toggleInteractionPanel($interactionPanel, 'history');
                         if (!opened) {
                             return;
@@ -558,7 +603,7 @@ function($,
                     .attr('data-button', 'copy')
                     .append(
                         $('<span>')
-                        .addClass('fa fa-copy')                        
+                        .addClass('fa fa-copy')
                         )
                     .click(function (e) {
                         e.stopPropagation();
@@ -572,14 +617,10 @@ function($,
                             .addClass('form-control')
                             .val(ws_info[8].narrative_nice_name + ' - Copy')
                             .on('focus', function () {
-                                if (Jupyter && Jupyter.narrative) {
-                                    Jupyter.narrative.disableKeyboardManager();
-                                }
+                                Jupyter.narrative.disableKeyboardManager();
                             })
                             .on('blur', function () {
-                                if (Jupyter && Jupyter.narrative) {
-                                    Jupyter.narrative.enableKeyboardManager();
-                                }
+                                Jupyter.narrative.enableKeyboardManager();
                             });
 
                         var $copyDiv = $('<div>')
@@ -775,7 +816,7 @@ function($,
                         $('<span>')
                         .addClass('panel-title')
                         .attr('data-element', 'title')
-                        )                    
+                        )
                     .append(
                         $('<button>')
                         .attr('type', 'button')
@@ -941,181 +982,408 @@ function($,
             //.append($alertContainer)
             //.append($shareContainer);
 
-            var $narDivContainer = $('<div>')                
+            var $narDivContainer = $('<div>')
                 .append($narDiv);
 
             return $narDivContainer;
         },
+
         makeCopyThisNarrativeBtn: function ($alertContainer) {
-            var self = this;
-            var active = '<span class="fa fa-copy"></span> Copy This Narrative';
-//            var $active = $('<span>').addClass('fa fa-copy').append(" Copy Narrative");
-            var $working = $('<span>').append("Copying Narrative...");
+            /* Flow -
+             * 1. Click button.
+             * 2. Button goes dim, turns into "Copying.." message.
+             * 3. Shows input area, pre-populates with name.
+             * 4. Shows "Copy" and "Cancel" buttons.
+             * 5. text area below those for errors.
+             * 6. Click "Copy" - shows 'copying...' text in message area
+             *    - error? show error in message area
+             *    - success? hide everything, clear text, refresh()
+             * 7. Click "Cancel" - same as success.
+             */
 
-            var $btn = $('<button>').addClass('kb-primary-btn')
-                .append(active)
-                .on('click', function (e) {
-                    e.stopPropagation();
-                    $(this).prop('disabled', true).empty().append($working);
-                    self.copyThisNarrative($alertContainer, active, null);
+            var setButtonWorking = function(isWorking) {
+                if (isWorking) {
+                    $initCopyBtn.prop('disabled', true)
+                                 .empty()
+                                 .append('Copying Narrative...');
+                }
+                else {
+                    $initCopyBtn.prop('disabled', false)
+                                 .empty()
+                                 .append('<span class="fa fa-copy"></span> Copy This Narrative');
+                    $doCopyBtn.prop('disabled', false);
+                    $cancelBtn.prop('disabled', false);
+                }
+            };
+
+            var $initCopyBtn = $('<button>')
+                .addClass('kb-primary-btn')
+                .click(function(e) {
+                    setButtonWorking(true);
+                    $newNameInput.val(Jupyter.notebook.get_notebook_name() + ' - Copy')
+                    $alertContainer.show();
                 });
-            return $btn;
-        },
-        copyThisNarrative: function ($dialog, active, $jump_btn) {
-            var self = this;
-            $dialog.empty(); // in case user canceled earlier
-            self.ws.get_workspace_info({workspace: self.ws_name},
-                function (ws_info) {
-                    self.ws.get_object_info_new({objects: [{ref: ws_info[0] + '/' + ws_info[8]['narrative']}], includeMetadata: 1},
-                        function (object_info_list) {
-                            var object_info = object_info_list[0];
-                            var $newNameInput = $('<input type="text">')
-                                .addClass('form-control')
-                                .val(ws_info[8]['narrative_nice_name'] + ' - Copy')
-                                .on('focus', function () {
-                                    if (Jupyter && Jupyter.narrative) {
-                                        Jupyter.narrative.disableKeyboardManager();
+
+            var $newNameInput = $('<input type="text">')
+                .addClass('form-control')
+                .tooltip({title: 'Gotta have a name!',
+                          container: 'body',
+                          placement: 'right',
+                          trigger: 'manual'})
+                .on('focus', function () {
+                    Jupyter.narrative.disableKeyboardManager();
+                })
+                .on('blur', function () {
+                    Jupyter.narrative.enableKeyboardManager();
+                })
+                .on('input', function() {
+                    var v = $newNameInput.val();
+                    if (!v) {
+                        $newNameInput.tooltip('show');
+                        $doCopyBtn.prop('disabled', true);
+                    }
+                    else {
+                        $newNameInput.tooltip('hide');
+                        $doCopyBtn.prop('disabled', false);
+                    }
+                });
+
+            var $errorMessage = $('<div>').css({'color': '#F44336'});
+
+            var $doCopyBtn = $('<button>')
+                             .addClass('kb-primary-btn')
+                             .append('Copy')
+                             .click(function(e) {
+
+                                $errorMessage.empty();
+                                $doCopyBtn.prop('disabled', true);
+                                $cancelBtn.prop('disabled', true);
+                                this.copyThisNarrative($newNameInput.val())
+                                .then(function(result) {
+                                    $alertContainer.hide();
+                                    setButtonWorking(false);
+                                    this.refresh();
+                                    console.log(result);
+                                }.bind(this))
+                                .catch(function(error) {
+                                    if (error && error.error && error.error.message) {
+                                        $errorMessage.append(error.error.message);
                                     }
+                                    else {
+                                        $errorMessage.append('Sorry, an error occurred while copying. Please try again.');
+                                    }
+                                    $doCopyBtn.prop('disabled', false);
+                                    $cancelBtn.prop('disabled', false);
                                 })
-                                .on('blur', function () {
-                                    if (Jupyter && Jupyter.narrative) {
-                                        Jupyter.narrative.enableKeyboardManager();
-                                    }
-                                });
+                             }.bind(this))
 
+            var $cancelBtn = $('<button>')
+                             .addClass('kb-default-btn')
+                             .append('Cancel')
+                             .click(function () {
+                                $doCopyBtn.prop('disabled', false);
+                                $alertContainer.hide();
+                                setButtonWorking(false);
+                             });
 
-                            var $cancelBtn = $('<button>')
-                                             .addClass('kb-default-btn')
-                                             .append('Cancel')
-                                             .click(function () {
-                                                $copyNarButton.prop('disabled', false).empty().append(active);
-                                                self.$copyThisNarrBtn.prop('disabled', false).empty().append(active);
-                                                $dialog.empty();
-                                             });
+            setButtonWorking(false);
+            $alertContainer.append(
+                $('<div>')
+                .append($('<div>').append("Enter a name for the new Narrative"))
+                .append($('<div>').append($newNameInput))
+                .append($doCopyBtn)
+                .append($cancelBtn)
+                .append($errorMessage)
+            ).hide();
 
-                            var $copyNarButton = $('<button>').addClass('kb-primary-btn')
+            return $initCopyBtn;
 
-                            // $dialog.append(
-                            //     $('<div>').append(
-                            //     $('<div>').append("Enter a name for the new Narrative"))
-                            //     .append($('<div>').append($newNameInput))
-                            //     .append($('<button>').addClass('btn btn-info')
-                                    .css({'margin-top': '10px'})
-                                    .append('Copy')
-                                    .click(function () {
-                                        var $thisBtn = $(this);
-                                        $thisBtn.prop('disabled', true);
-                                        var newMeta = ws_info[8];
-                                        newMeta['narrative_nice_name'] = $newNameInput.val();
+            // var self = this;
+            // var active = '<span class="fa fa-copy"></span> Copy This Narrative';
+            // var $working = $('<span>').append("Copying Narrative...");
 
-                                        var id = new Date().getTime();
-                                        var ws_name = self.my_user_id + ":" + id;
-
-                                        self.ws.clone_workspace({
-                                            wsi: {id: ws_info[0]},
-                                            workspace: ws_name,
-                                            meta: newMeta
-                                        },
-                                            function (new_ws_info) {
-                                                // we have to match based on names because when cloning, the object id is not preserved!!! arg!
-                                                var new_narrative_ref = new_ws_info[0] + "/" + object_info[1]; //new_ws_info[8].narrative;
-                                                // ok, a lot of work just to update the narrative name in the metadata
-                                                self.ws.get_objects([{ref: new_narrative_ref}],
-                                                    function (data) {
-                                                        data = data[0]; // only one thing should be returned
-                                                        var new_nar_metadata = data.info[10];
-                                                        new_nar_metadata.name = newMeta['narrative_nice_name'];
-                                                        new_nar_metadata.ws_name = ws_name;
-                                                        data.data.metadata.name = newMeta['narrative_nice_name'];
-                                                        data.data.metadata.ws_name = ws_name;
-
-                                                        // set workspace metadata to point to the correct object id since they can change on clone!!
-                                                        self.ws.alter_workspace_metadata({
-                                                            wsi: {id: new_ws_info[0]},
-                                                            new : {'narrative': String(data.info[0])}
-                                                        },
-                                                            function () {
-                                                                // so much work just to update this name!
-                                                                self.ws.save_objects({id: new_ws_info[0], objects: [
-                                                                        {
-                                                                            type: data.info[2],
-                                                                            data: data.data,
-                                                                            provenance: data.provenance,
-                                                                            name: data.info[1],
-                                                                            meta: new_nar_metadata
-                                                                        }
-                                                                    ]},
-                                                                    function (info) {
-                                                                        console.log('copying complete', info);
-                                                                        $dialog.empty();
-                                                                        if (active) {
-                                                                            $thisBtn.prop('disabled', false).empty().append(active);
-                                                                            self.refresh();
-                                                                        }
-                                                                        if ($jump_btn) {
-                                                                            var name = info[0][10].name;
-                                                                            var copy_id = "ws." + info[0][6] + ".obj." + info[0][0];
-                                                                            var oldpath = window.location.pathname;
-                                                                            var parts = oldpath.split('/');
-                                                                            parts.pop();                    // pop off old id
-                                                                            parts.push(copy_id);            // add new one
-                                                                            var newpath = parts.join('/'); // rejoin as a path
-                                                                            var newurl = window.location.protocol + '//' + window.location.host + newpath;
-                                                                            $dialog.append($('<div>').html('Created new copy: <i>' + name + '</i>'));
-                                                                            $dialog.append($jump_btn);
-                                                                            $jump_btn.click(function () {
-                                                                                window.location.replace(newurl);
-                                                                            });
-                                                                        }
-                                                                    },
-                                                                    function (error) {
-                                                                        console.error(error);
-                                                                        $dialog.empty();
-                                                                        $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on data update. " + error.error.message));
-                                                                    });
-
-                                                            },
-                                                            function (error) {
-                                                                console.error(error);
-                                                                $dialog.empty();
-                                                                $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on data update. " + error.error.message));
-                                                            });
-
-
-                                                    },
-                                                    function (error) {
-                                                        console.error(error);
-                                                        $dialog.empty();
-                                                        $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on rename. " + error.error.message));
-                                                    })
-                                            },
-                                            function (error) {
-                                                console.error(error);
-                                                $dialog.empty();
-                                                $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
-                                            });
-                                    });
-                            $dialog.append(
-                                $('<div>').append(
-                                $('<div>').append("Enter a name for the new Narrative"))
-                                .append($('<div>').append($newNameInput))
-                                .append($copyNarButton)
-                                .append(active ? $cancelBtn : ''));
-                        },
-                        function (error) {
-                            // error with get_object_info_new
-                            console.error(error);
-                            $dialog.empty();
-                            $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
-                        });
-                },
-                function (error) {
-                    // error with get_workspace_info
-                    console.error(error);
-                    $dialog.empty();
-                    $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
-                });
+            // var $btn = $('<button>').addClass('kb-primary-btn')
+            //     .append(active)
+            //     .on('click', function (e) {
+            //         e.stopPropagation();
+            //         $(this).prop('disabled', true).empty().append($working);
+            //         self.copyThisNarrative($alertContainer, active, null)
+            //         .then(function(result) {
+            //             console.log(result);
+            //         });
+            //     });
+            // return $btn;
         },
+
+        // xcopyThisNarrative: function ($dialog, active, $jump_btn) {
+        //     var self = this;
+        //     $dialog.empty(); // in case user canceled earlier
+        //     self.ws.get_workspace_info({workspace: self.ws_name},
+        //         function (ws_info) {
+        //             self.ws.get_object_info_new({objects: [{ref: ws_info[0] + '/' + ws_info[8]['narrative']}], includeMetadata: 1},
+        //                 function (object_info_list) {
+        //                     var object_info = object_info_list[0];
+        //                     var $newNameInput = $('<input type="text">')
+        //                         .addClass('form-control')
+        //                         .val(ws_info[8]['narrative_nice_name'] + ' - Copy')
+        //                         .on('focus', function () {
+        //                             Jupyter.narrative.disableKeyboardManager();
+        //                         })
+        //                         .on('blur', function () {
+        //                             Jupyter.narrative.enableKeyboardManager();
+        //                         });
+
+
+        //                     var $cancelBtn = $('<button>')
+        //                                      .addClass('kb-default-btn')
+        //                                      .append('Cancel')
+        //                                      .click(function () {
+        //                                         $copyNarButton.prop('disabled', false).empty().append(active);
+        //                                         self.$copyThisNarrBtn.prop('disabled', false).empty().append(active);
+        //                                         $dialog.empty();
+        //                                      });
+
+        //                     var $copyNarButton = $('<button>').addClass('kb-primary-btn')
+
+        //                     // $dialog.append(
+        //                     //     $('<div>').append(
+        //                     //     $('<div>').append("Enter a name for the new Narrative"))
+        //                     //     .append($('<div>').append($newNameInput))
+        //                     //     .append($('<button>').addClass('btn btn-info')
+        //                             .css({'margin-top': '10px'})
+        //                             .append('Copy')
+        //                             .click(function () {
+        //                                 var $thisBtn = $(this);
+        //                                 $thisBtn.prop('disabled', true);
+        //                                 var newMeta = ws_info[8];
+        //                                 newMeta['narrative_nice_name'] = $newNameInput.val();
+
+        //                                 var id = new Date().getTime();
+        //                                 var ws_name = self.my_user_id + ":" + id;
+
+        //                                 self.ws.clone_workspace({
+        //                                     wsi: {id: ws_info[0]},
+        //                                     workspace: ws_name,
+        //                                     meta: newMeta
+        //                                 },
+        //                                     function (new_ws_info) {
+        //                                         // we have to match based on names because when cloning, the object id is not preserved!!! arg!
+        //                                         var new_narrative_ref = new_ws_info[0] + "/" + object_info[1]; //new_ws_info[8].narrative;
+        //                                         // ok, a lot of work just to update the narrative name in the metadata
+        //                                         self.ws.get_objects([{ref: new_narrative_ref}],
+        //                                             function (data) {
+        //                                                 data = data[0]; // only one thing should be returned
+        //                                                 var new_nar_metadata = data.info[10];
+        //                                                 new_nar_metadata.name = newMeta['narrative_nice_name'];
+        //                                                 new_nar_metadata.ws_name = ws_name;
+        //                                                 data.data.metadata.name = newMeta['narrative_nice_name'];
+        //                                                 data.data.metadata.ws_name = ws_name;
+
+        //                                                 // set workspace metadata to point to the correct object id since they can change on clone!!
+        //                                                 self.ws.alter_workspace_metadata({
+        //                                                     wsi: {id: new_ws_info[0]},
+        //                                                     new : {'narrative': String(data.info[0])}
+        //                                                 },
+        //                                                     function () {
+        //                                                         // so much work just to update this name!
+        //                                                         self.ws.save_objects({id: new_ws_info[0], objects: [
+        //                                                                 {
+        //                                                                     type: data.info[2],
+        //                                                                     data: data.data,
+        //                                                                     provenance: data.provenance,
+        //                                                                     name: data.info[1],
+        //                                                                     meta: new_nar_metadata
+        //                                                                 }
+        //                                                             ]},
+        //                                                             function (info) {
+        //                                                                 console.log('copying complete', info);
+        //                                                                 $dialog.empty();
+        //                                                                 if (active) {
+        //                                                                     $thisBtn.prop('disabled', false).empty().append(active);
+        //                                                                     self.refresh();
+        //                                                                 }
+        //                                                                 if ($jump_btn) {
+        //                                                                     var name = info[0][10].name;
+        //                                                                     var copy_id = "ws." + info[0][6] + ".obj." + info[0][0];
+        //                                                                     var oldpath = window.location.pathname;
+        //                                                                     var parts = oldpath.split('/');
+        //                                                                     parts.pop();                    // pop off old id
+        //                                                                     parts.push(copy_id);            // add new one
+        //                                                                     var newpath = parts.join('/'); // rejoin as a path
+        //                                                                     var newurl = window.location.protocol + '//' + window.location.host + newpath;
+        //                                                                     $dialog.append($('<div>').html('Created new copy: <i>' + name + '</i>'));
+        //                                                                     $dialog.append($jump_btn);
+        //                                                                     $jump_btn.click(function () {
+        //                                                                         window.location.replace(newurl);
+        //                                                                     });
+        //                                                                 }
+        //                                                             },
+        //                                                             function (error) {
+        //                                                                 console.error(error);
+        //                                                                 $dialog.empty();
+        //                                                                 $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on data update. " + error.error.message));
+        //                                                             });
+
+        //                                                     },
+        //                                                     function (error) {
+        //                                                         console.error(error);
+        //                                                         $dialog.empty();
+        //                                                         $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on data update. " + error.error.message));
+        //                                                     });
+
+
+        //                                             },
+        //                                             function (error) {
+        //                                                 console.error(error);
+        //                                                 $dialog.empty();
+        //                                                 $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! Copied successfully, but error on rename. " + error.error.message));
+        //                                             })
+        //                                     },
+        //                                     function (error) {
+        //                                         console.error(error);
+        //                                         $dialog.empty();
+        //                                         $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
+        //                                     });
+        //                             });
+        //                     $dialog.append(
+        //                         $('<div>').append(
+        //                         $('<div>').append("Enter a name for the new Narrative"))
+        //                         .append($('<div>').append($newNameInput))
+        //                         .append($copyNarButton)
+        //                         .append(active ? $cancelBtn : ''));
+        //                 },
+        //                 function (error) {
+        //                     // error with get_object_info_new
+        //                     console.error(error);
+        //                     $dialog.empty();
+        //                     $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
+        //                 });
+        //         },
+        //         function (error) {
+        //             // error with get_workspace_info
+        //             console.error(error);
+        //             $dialog.empty();
+        //             $dialog.append($('<span>').css({'color': '#F44336'}).append("Error! " + error.error.message));
+        //         });
+        // },
+
+        copyThisNarrative: function (newName) { //$dialog, active, $jumpBtn) {
+            /* $dialog = element to use as a a dialog area for status, etc.
+             * active =
+             * $jumpBtn = button to add on copy completion (optional)
+             * Steps.
+             * 1. Get this workspace's info (get_workspace_info)
+             * 2. Use that to get the object info for this narrative (get_object_info_new)
+             * 3. From there, use the narrative_nice_name field to pre-populate the text input field for the copy's name.
+             * 4. User interaction!
+             *    a. User hits cancel = clear the field, remove input and buttons, return.
+             *    b. User hits copy = goto 5.
+             * 5. Clone the workspace - clone_workspace
+             * 6. Find the reference to the newly copied metadata - generally ws object name.
+             * 7. Update Narrative object in the new workspace with different metadata, ws name, etc.
+             *    (call alter_workspace_metadata, save_objects)
+             * 8. Done! If there's a $jumpBtn, add it to the $dialog
+             */
+
+            /**
+             * Okay, so, refactor.
+             * 1. Viewer part and UI behavior.
+             * User hits "Copy" button - creates textfield pre-populated with name
+             * User can hit 'Cancel' - clears name, hides textfield.
+             * User hits 'Copy' - does the copy.
+             * We already have the name and extant metadata from Jupyter.narrative and Jupyter.notebook.metadata.
+             *
+             * 2. Biz logic.
+             * We just need the old name, really, then the rest can be automatic.
+             * Just chain together a small pile of ws promises.
+             */
+
+            if (!this.ws) {
+                return;
+            }
+
+            // name of the narrative object in the workspace. used for closure.
+            var narObjName;
+            var newWsName = this.my_user_id + ':' + new Date().getTime();
+            var newWsMeta = {
+                is_temporary: 'false',
+                narrative_nice_name: newName
+                // add the 'narrative' field later.
+            };
+            var newWsId;
+
+            // start with getting the object info (we just need the object name)
+            return Promise.resolve(this.ws.get_object_info_new({
+                objects: [{'ref': this.workspaceRef}],
+                includeMetadata: 1
+            }))
+            .then(function(narInfo) {
+                narObjName = narInfo[0][1];
+
+                // next, clone the workspace.
+                return Promise.resolve(this.ws.clone_workspace({
+                    wsi: {id: this.workspaceId},
+                    workspace: newWsName,
+                    meta: newWsMeta
+                }));
+            }.bind(this))
+            .then(function(newWsInfo) {
+                // now, fetch the new narrative object so we can muck with
+                // its metadata.
+                newWsId = newWsInfo[0];
+                return Promise.resolve(this.ws.get_objects([{'ref': newWsId + '/' + narObjName}]));
+            }.bind(this))
+            .then(function(newNarObj) {
+                // update the ref inside the narrative object and the new workspace metadata.
+                newNarObj = newNarObj[0]; // only one thing should be returned
+                var newNarMetadata = newNarObj.info[10];
+                newNarMetadata.name = newName;
+                newNarMetadata.ws_name = newWsName;
+                newNarObj.data.metadata.name = newName;
+                newNarObj.data.metadata.ws_name = newWsName;
+
+                // 2 promises here.
+                // First updates the metadata so it points to the right new workspace
+                // Second saves the newly twiddled narrative.
+                return Promise.all([
+                    Promise.resolve(this.ws.alter_workspace_metadat({
+                        wsi: { id: newWsId },
+                        new: { 'narrative': String(newNarObj.info[0])}
+                    })),
+                    Promise.resolve(this.ws.save_objects({
+                        id: newWsId,
+                        objects: [{
+                            type: newNarObj.info[2],
+                            data: newNarObj.data,
+                            provenance: newNarObj.provenance,
+                            name: newNarObj.info[1],
+                            meta: newNarMetadata
+                        }]
+                    }))
+                ]);
+            }.bind(this))
+            .then(function(results) {
+                return {
+                    status: 'success',
+                    url: window.location.origin + '/narrative/ws.' + newWsId + '.' + results[1][0][0]
+                };
+            })
+            .catch(function(error) {
+                //do stuff....
+                console.error(error);
+                // if it got to the point that it made a copy,
+                // delete it so it's out of the way - it's broken
+                // if it got here without finishing.
+                if (newWsId) {
+                    console.log('deleting new incomplete copy - ' + newWsId);
+                    Promise.resolve(this.ws.delete_workspace({id: newWsId}))
+                    .then(function() {
+                    });
+                }
+                throw error;
+            }.bind(this));
+        },
+
         makeNewNarrativeBtn: function () {
             var self = this;
             var active = '<span class="fa fa-plus"></span> New Narrative';

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -252,21 +252,112 @@ function($,
                 placement: 'bottom'
             });
 
+            /* This is the input box for the new narrative name.
+             * Gets pre-populated with the current narrative name + "- copy"
+             * When empty, prompts to enter a name with a tooltip, and disables the copy btn.
+             */
+            var $newNameInput = $('<input type="text">')
+                .addClass('form-control')
+                .tooltip({title: 'Please enter a name.',
+                          container: 'body',
+                          placement: 'right',
+                          trigger: 'manual'})
+                .on('focus', function () {
+                    Jupyter.narrative.disableKeyboardManager();
+                })
+                .on('blur', function () {
+                    Jupyter.narrative.enableKeyboardManager();
+                })
+                .on('input', function() {
+                    var v = $newNameInput.val();
+                    if (!v) {
+                        $newNameInput.tooltip('show');
+                        $doCopyBtn.prop('disabled', true);
+                    }
+                    else {
+                        $newNameInput.tooltip('hide');
+                        $doCopyBtn.prop('disabled', false);
+                    }
+                });
+
+            var $errorMessage = $('<div>').css({'color': '#F44336', 'padding-top': '5px'});
+
+            /*
+             * Does the actual copy and displays the error if that happens.
+             */
+            var $doCopyBtn = $('<button>')
+                             .addClass('kb-primary-btn')
+                             .append('Copy')
+                             .click(function(e) {
+                                $errorMessage.empty();
+                                $doCopyBtn.prop('disabled', true);
+                                $cancelBtn.prop('disabled', true);
+                                Jupyter.narrative.sidePanel.$narrativesWidget.copyThisNarrative($newNameInput.val())
+                                .then(function(result) {
+                                    Jupyter.narrative.sidePanel.$narrativesWidget.refresh();
+                                    console.log(result);
+                                    // show go-to button
+                                    $cancelBtn.html('Close');
+                                    $jumpButton.click(function() {
+                                        window.location.href = result.url;
+                                    });
+                                    $jumpButton.show();
+                                    $doCopyBtn.prop('disabled', false);
+                                    $cancelBtn.prop('disabled', false);
+                                }.bind(this))
+                                .catch(function(error) {
+                                    if (error && error.error && error.error.message) {
+                                        $errorMessage.append(error.error.message);
+                                    }
+                                    else if (typeof error === 'string') {
+                                        $errorMessage.append(error);
+                                    }
+                                    else {
+                                        $errorMessage.append('Sorry, an error occurred while copying. Please try again.');
+                                    }
+                                    $doCopyBtn.prop('disabled', false);
+                                    $cancelBtn.prop('disabled', false);
+                                })
+                             }.bind(this));
+
+            var $cancelBtn = $('<button>')
+                             .addClass('kb-default-btn')
+                             .append('Cancel')
+                             .click(function() {
+                                $newNameInput.tooltip('hide');
+                                this.copyModal.hide();
+                             }.bind(this));
+
+
+            var $jumpButton = $('<button>')
+                              .addClass('btn btn-info')
+                              .text('Open the new Narrative');
+
+            var $copyModalBody = $('<div>')
+                                 .append($('<div>').append("Enter a name for the new Narrative"))
+                                 .append($('<div>').append($newNameInput))
+                                 .append($errorMessage)
+                                 .append($jumpButton);
+
             this.copyModal = new BootstrapDialog({
                 title: 'Copy a narrative',
-                body: $('<div>'),
-                closeButton: true
+                body: $copyModalBody,
+                closeButton: true,
+                buttons: [
+                    $doCopyBtn,
+                    $cancelBtn
+                ]
             });
 
-            $('#kb-view-only-copy').click(function () {
+            $('#kb-view-only-copy').click(function() {
+                $jumpButton.hide();
+                $doCopyBtn.prop('disabled', false);
+                $cancelBtn.prop('disabled', false);
+                $cancelBtn.html('Cancel');
+                $newNameInput.val(Jupyter.notebook.get_notebook_name() + ' - Copy');
                 this.copyModal.show();
-                var $panel = this.copyModal.getBody();
-                var $jump = $('<div>').css({'margin-top': '20px'})
-                                      .append($("<button>").addClass('btn btn-info')
-                                              .text("Open this narrative"));
-                $(document).trigger('copyThis.Narrative', [$panel, null, $jump]);
-                return '';
             }.bind(this));
+
         },
 
         initDeleteCellModal: function() {

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'mongonbmanager', 'ws_util', 'common', 'kbasewsmanager', 'services']
 
 from semantic_version import Version
-__version__ = Version("2.0.7")
+__version__ = Version("2.0.8")
 version = lambda: __version__
 
 # if run directly:

--- a/src/biokbase/narrative/authhandlers.py
+++ b/src/biokbase/narrative/authhandlers.py
@@ -32,7 +32,6 @@ if os.environ.get('KBASE_DEBUG', False):
     app_log.setLevel(logging.DEBUG)
 
 auth_cookie_name = "kbase_session"
- # all_cookies = (auth_cookie_name, backup_cookie)
 
 class KBaseLoginHandler(LoginHandler):
     """KBase-specific login handler.
@@ -55,10 +54,6 @@ class KBaseLoginHandler(LoginHandler):
         kbase_env.client_ip = client_ip
 
         auth_cookie = self.cookies.get(auth_cookie_name, None)
-        # found_cookies = [self.cookies[c] for c in all_cookies
-        #                  if c in self.cookies]
-        app_log.info("cookie?")
-        app_log.info(auth_cookie.value)
         if auth_cookie:
             # Push the cookie
             cookie_val = urllib.unquote(auth_cookie.value)

--- a/src/biokbase/narrative/authhandlers.py
+++ b/src/biokbase/narrative/authhandlers.py
@@ -31,9 +31,8 @@ if Application.initialized:
 if os.environ.get('KBASE_DEBUG', False):
     app_log.setLevel(logging.DEBUG)
 
-auth_cookie_name = "kbase_narr_session"
-backup_cookie = "kbase_session"
-all_cookies = (auth_cookie_name, backup_cookie)
+auth_cookie_name = "kbase_session"
+ # all_cookies = (auth_cookie_name, backup_cookie)
 
 class KBaseLoginHandler(LoginHandler):
     """KBase-specific login handler.
@@ -54,14 +53,18 @@ class KBaseLoginHandler(LoginHandler):
         ua = http_headers.get('User-Agent', 'unknown')
         # save client ip in environ for later logging
         kbase_env.client_ip = client_ip
-        found_cookies = [self.cookies[c] for c in all_cookies
-                         if c in self.cookies]
-        if found_cookies:
+
+        auth_cookie = self.cookies.get(auth_cookie_name, None)
+        # found_cookies = [self.cookies[c] for c in all_cookies
+        #                  if c in self.cookies]
+        app_log.info("cookie?")
+        app_log.info(auth_cookie.value)
+        if auth_cookie:
             # Push the cookie
-            cookie_val = urllib.unquote(found_cookies[0].value)
+            cookie_val = urllib.unquote(auth_cookie.value)
             cookie_obj = {
                 k: v.replace('EQUALSSIGN', '=').replace('PIPESIGN', '|')
-                for k, v in cookie_regex.findall(cookie_val) 
+                for k, v in cookie_regex.findall(cookie_val)
             }
             if app_log.isEnabledFor(logging.DEBUG):
                 app_log.debug("kbase cookie = {}".format(cookie_val))

--- a/src/config.json
+++ b/src/config.json
@@ -186,5 +186,5 @@
         "showDelay": 750
     },
     "use_local_widgets": true,
-    "version": "2.0.7"
+    "version": "2.0.8"
 }


### PR DESCRIPTION
See tickets: 
* https://atlassian.kbase.us/browse/KBASE-4159
* https://atlassian.kbase.us/browse/KBASE-4154
* https://atlassian.kbase.us/browse/KBASE-2034
* https://atlassian.kbase.us/browse/NAR-849
* https://atlassian.kbase.us/browse/KBASE-4140
* https://atlassian.kbase.us/browse/NAR-850

These are all related to the same two issues:
1. The Narrative copy process is internally kinda complicated and kinda fragile. If anything breaks, you could wind up with a broken copy.
2. Copying a Narrative shouldn't also copy jobs.

Tasks to deal with them:

- [x] Refactor copying code - divorce business logic from view
- [x] Refactor view logic in the Narratives panel 
- [x] Refactor view logic in the Copy button in read-only mode (should use same widget/flow)
- [x] Make failures fail hard - delete the half-complete workspace if a clone was made.
- [x] Delete jobs from newly copied Narrative