### PR TITLE
GenomeAnnotation name display in data panel

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -781,7 +781,7 @@ function ($,
                     metadataText += '<tr><th>' + key + '</th><td>' + metadata[key] + '</td></tr>';
                 }
             }
-            if (type === 'Genome') {
+            if (type === 'Genome' || type === 'GenomeAnnotation') {
                 if (metadata.hasOwnProperty('Name')) {
                     $type.text(type + ': ' + metadata['Name']);
                 }


### PR DESCRIPTION
Duplicate custom name behavior for Genome using workspace metadata to include GenomeAnnotation.