### PR TITLE
app cell inserts output cell and other changes

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -215,6 +215,11 @@ define([
                 this.deleteJob(message.jobId);
             }.bind(this));
 
+            bus.on('request-job-removal', function (message) {
+                this.removeJob(message.jobId);
+            }.bind(this));
+
+
             bus.on('request-job-status', function (message) {
                 this.sendCommMessage(this.JOB_STATUS, message.jobId);
             }.bind(this));
@@ -574,6 +579,14 @@ define([
             }
             // send the comm message.
             this.sendCommMessage(this.DELETE_JOB, jobId);
+        },
+        removeJob: function (jobId) {
+            if (!jobId) {
+                return;
+            }
+            // send the comm message.
+            this.sendCommMessage(this.REMOVE_JOB, jobId);
+            this.removeDeletedJob(jobId);
         },
         removeDeletedJob: function (jobId) {
             // remove the view widget

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -8,11 +8,10 @@ define([
     $,
     KBWidget,
     Jupyter
-) {
+    ) {
     "use strict";
     return KBWidget({
         name: 'kbaseNarrativeOutputCell',
-
         version: '1.0.0',
         options: {
             widget: 'kbaseDefaultNarrativeOutput',
@@ -41,13 +40,11 @@ define([
 
             return this;
         },
-
-        hideInputArea: function() {
+        hideInputArea: function () {
             if (!this.options.cellId)
                 return;
             $('#' + this.options.cellId).closest('.cell').find('.inner_cell .input_area').hide();
         },
-
         render: function () {
             var icon;
             switch (this.options.type) {
@@ -145,41 +142,44 @@ define([
 
             try {
                 require([widget],
-                    // If we successfully Require the widget code, render it:
-                    $.proxy(function (W) {
+                    function (W) {
+                        // If we successfully Require the widget code, render it:
                         this.$outWidget = new W($body, widgetData);
                         // this.$outWidget = $body.find('.panel-body > div')[widget](widgetData);
                         this.$elem.append($body);
-                    }, this),
-                    // If we fail, render the error widget and log the error.
-                    $.proxy(function (err) {
+                    }.bind(this),
+                    function (err) {
+                        // If we fail, render the error widget and log the error.
                         KBError("Output::" + this.options.title, "failed to render output widget: '" + widget);
                         this.options.title = 'App Error';
-                        this.options.data = {'error': {
-                                'msg': 'An error occurred while showing your output:',
-                                'method_name': 'kbaseNarrativeOutputCell.renderCell',
-                                'type': 'Output',
-                                'severity': '',
-                                'traceback': 'Failed while trying to show a "' + widget + '"\n' +
+                        this.options.data = {
+                            error: {
+                                msg: 'An error occurred while showing your output:',
+                                method_name: 'kbaseNarrativeOutputCell.renderCell',
+                                type: 'Output',
+                                severity: '',
+                                traceback: 'Failed while trying to show a "' + widget + '"\n' +
                                     'With inputs ' + JSON.stringify(widgetData) + '\n\n' +
                                     err.message
-                            }};
+                            }
+                        };
                         this.options.widget = this.OUTPUT_ERROR_WIDGET;
                         this.renderErrorOutputCell();
-                    }, this)
-                    );
+                    }.bind(this));
             } catch (err) {
                 KBError("Output::" + this.options.title, "failed to render output widget: '" + widget);
                 this.options.title = 'App Error';
-                this.options.data = {'error': {
-                        'msg': 'An error occurred while showing your output:',
-                        'method_name': 'kbaseNarrativeOutputCell.renderCell',
-                        'type': 'Output',
-                        'severity': '',
-                        'traceback': 'Failed while trying to show a "' + widget + '"\n' +
+                this.options.data = {
+                    error: {
+                        msg: 'An error occurred while showing your output:',
+                        method_name: 'kbaseNarrativeOutputCell.renderCell',
+                        type: 'Output',
+                        severity: '',
+                        traceback: 'Failed while trying to show a "' + widget + '"\n' +
                             'With inputs ' + JSON.stringify(widgetData) + '\n\n' +
                             err.message
-                    }};
+                    }
+                };
                 this.options.widget = this.OUTPUT_ERROR_WIDGET;
                 this.renderErrorOutputCell();
 

--- a/nbextensions/methodCell/main.js
+++ b/nbextensions/methodCell/main.js
@@ -367,7 +367,9 @@ define([
                         code: null,
                         request: null,
                         result: null
-                    }
+                    },
+                    params: null,
+                    output: []
                 }
             };
             cell.metadata = meta;

--- a/nbextensions/methodCell/widgets/jobLogViewer.js
+++ b/nbextensions/methodCell/widgets/jobLogViewer.js
@@ -287,7 +287,6 @@ define([
                         lineNumber: startingLine + index + 1
                     };
                 });
-                console.log('LINES', viewLines);
                 dom.setContent('panel', renderLines(viewLines));
             }
         }
@@ -334,11 +333,9 @@ define([
                 handle: function (message) {
                     // if the job is finished, we don't want to reflect
                     // this in the ui, and disable play/stop controls.
-                    // console.log('LOG JOB STATAUS', message);
                     var jobStatus = message.jobState.status,
                         mode = fsm.getCurrentState().state.mode,
                         newState;
-                    console.log('CLOVER', mode, jobStatus);
                     switch (mode) {
                         case 'new':
                             switch (jobStatus) {
@@ -479,7 +476,6 @@ define([
                 },
                 onNewState: function (fsm) {
                     // save the state?
-                    console.log('NEW STATE!', fsm.getCurrentState());
                     
                     renderFSM();
                 }

--- a/nbextensions/methodCell/widgets/methodExecWidget.js
+++ b/nbextensions/methodCell/widgets/methodExecWidget.js
@@ -138,97 +138,62 @@ define([
         }
 
         function renderJobStatus() {
+            var labelStyle = {
+                textAlign: 'right',
+                border: '1px transparent solid', 
+                padding: '4px', 
+            },
+                dataStyle = {
+                border: '1px silver solid', 
+                padding: '4px', 
+                display: 'inline-block', 
+                minWidth: '20px', 
+                backgroundColor: 'gray', 
+                color: '#FFF'
+            };
             return dom.buildPanel({
                 title: 'Run Status',
                 name: 'runStatus',
                 hidden: false,
                 type: 'primary',
                 body: [
-                    div({style: {lineHeight: '20px'}}, [
-                        span({}, [
-                            span('State:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'state'
-                            })
-                        ]),
-                        span({}, [
-                            span('Run ID:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'run-id'
-                            })
-                        ]),
-                        span({}, [
-                            span('Job ID:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'job-id'
-                            })
-                        ]),
-                        span({style: {marginLeft: '5px'}}, [
-                            span('Last update:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'last-updated-at'
-                            })
-                        ]),
-                        span({style: {marginLeft: '5px'}}, [
-                            span('Phase:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'temporalState'
-                            })
-                        ]),
-                        span({style: {marginLeft: '5px'}}, [
-                            span('Exec:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'executionState'
-                            })
-                        ]),
-                        span({dataElement: 'launch-time', style: {marginLeft: '5px'}}, [
-                            span({dataElement: 'label'}),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF', fontFamily: 'monospace'},
-                                dataElement: 'elapsed'
-                            })
-                        ]),
-                        span({dataElement: 'queue-time', style: {marginLeft: '5px'}}, [
-                            span({dataElement: 'label'}),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF', fontFamily: 'monospace'},
-                                dataElement: 'elapsed'
-                            })
-                        ]),
-                        span({dataElement: 'run-time', style: {marginLeft: '5px'}}, [
-                            span({dataElement: 'label'}),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF', fontFamily: 'monospace'},
-                                dataElement: 'elapsed'
-                            })
-                        ]),
-                        span({dataElement: 'completed', style: {marginLeft: '5px'}}, [
-                            span('Completed:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'completedAt'
-                            })
-                        ]),
-                        span({dataElement: 'success', style: {marginLeft: '5px'}}, [
-                            span('Success:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'flag'
-                            })
-                        ]),
-                        span({dataElement: 'error', style: {marginLeft: '5px'}}, [
-                            span('Error:'),
-                            span({
-                                style: {border: '1px silver solid', padding: '4px', display: 'inline-block', minWidth: '20px', backgroundColor: 'gray', color: '#FFF'},
-                                dataElement: 'flag'
-                            })
-                        ])
+                    
+                    div({class: 'row'}, [
+                        div({class: 'col-md-1', style: labelStyle}, 'State'),
+                        div({class: 'col-md-2', dataElement: 'state', style: dataStyle}),
+                        div({class: 'col-md-1', style: labelStyle}, 'Run Id'),
+                        div({class: 'col-md-2', dataElement: 'run-id', style: dataStyle}),
+                        div({class: 'col-md-1', style: labelStyle}, 'Job Id'),
+                        div({class: 'col-md-2', dataElement: 'job-id', style: dataStyle}),
+                        div({class: 'col-md-1', style: labelStyle}, 'Updated'),
+                        div({class: 'col-md-2', dataElement: 'last-updated-at', style: dataStyle}),
+                    ]),
+                     div({class: 'row'}, [
+                        div({class: 'col-md-1', style: labelStyle}, 'Phase'),
+                        div({class: 'col-md-2', dataElement: 'temporalState', style: dataStyle}),
+                        div({class: 'col-md-1', style: labelStyle}, 'Exec'),
+                        div({class: 'col-md-2', dataElement: 'executionState', style: dataStyle}),
+                    ]),
+                    div({class: 'row', dataElement: 'launch-time'}, [
+                        div({class: 'col-md-1', style: labelStyle}, 'Launch'),
+                        div({class: 'col-md-2', dataElement: 'elapsed', style: dataStyle}),
+                    ]),
+                    div({class: 'row', dataElement: 'queue-time'}, [
+                        div({class: 'col-md-1', style: labelStyle}, 'Queue'),
+                        div({class: 'col-md-2', dataElement: 'elapsed', style: dataStyle})
+                    ]),
+                    div({class: 'row', dataElement: 'run-time'}, [
+                        div({class: 'col-md-1', style: labelStyle}, 'Run'),
+                        div({class: 'col-md-2', dataElement: 'elapsed', style: dataStyle})
+                    ]),
+                    div({class: 'row', dataElement: 'completed'}, [
+                        div({class: 'col-md-1', style: labelStyle}, 'Completed'),
+                        div({class: 'col-md-2', dataElement: 'completedAt', style: dataStyle}),
+                        div({class: 'col-md-1', style: labelStyle}, 'Success'),
+                        div({class: 'col-md-2', dataElement: 'success', style: dataStyle}, span({dataElement: 'flag'})),
+                        div({class: 'col-md-1', style: labelStyle}, 'Error'),
+                        div({class: 'col-md-2', dataElement: 'error', style: dataStyle}, span({dataElement: 'flag'}))
+                        
                     ]),
 //                    div({dataElement: 'error-group'}, [
 //                        dom.buildPanel({

--- a/nbextensions/methodCell/widgets/methodOutputWidget.js
+++ b/nbextensions/methodCell/widgets/methodOutputWidget.js
@@ -1,0 +1,237 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+
+define([
+    'common/runtime',
+    'common/events',
+    'common/dom',
+    'kb_common/html',
+    'base/js/namespace'
+], function (
+    Runtime,
+    Events,
+    Dom,
+    html,
+    Jupyter
+    ) {
+    'use strict';
+
+    var t = html.tag,
+        div = t('div'), button = t('button'),
+        table = t('table'), tr = t('tr'), th = t('td'), td = t('td');
+
+    function factory(config) {
+        var runtime = Runtime.make(),
+            bus = runtime.bus().makeChannelBus(null, 'Output Widget Bus'),
+            cellId = config.cellId,
+            root, container, dom,
+            model = {
+                currentJobState: null,
+                outputs: null
+            };
+
+        function findCellForId(id) {
+            var matchingCells = Jupyter.notebook.get_cells().filter(function (cell) {
+                if (cell.metadata && cell.metadata.kbase) {
+                    return (cell.metadata.kbase.attributes.id === id);
+                }
+                return false;
+            });
+            if (matchingCells.length === 1) {
+                return matchingCells[0];
+            }
+            if (matchingCells.length > 1) {
+                addNotification('Too many cells matched the given id: ' + id);
+            }
+            return null;
+        }
+        function doRemoveOutput(index) {
+            var confirmed = dom.confirmDialog('Are you sure you want to remove the output cell? This is not reversable. (Any associated data will remain in your narrative, and may be found in the Data panel.)', 'Yes', 'No');
+            if (!confirmed) {
+                return;
+            }
+            // remove the output cell
+            var output = model.outputs[index],
+                outputCell = findCellForId(output.cellId),
+                cellIndex;
+
+            if (outputCell) {
+                //alert('Could not find this cell');
+                //return;
+                cellIndex = Jupyter.notebook.find_cell_index(outputCell);
+                Jupyter.notebook.delete_cell(cellIndex);
+            }
+
+            // send a message on the cell bus bus, parent should pick it up, remove the 
+            // output from the model, and update us.
+            bus.bus().send({
+                jobId: output.jobId
+            }, {
+                channel: {
+                    cell: cellId
+                },
+                key: {
+                    type: 'output-cell-removed'
+                }
+            });
+            bus.bus().send({
+                jobId: output.jobId
+            }, {
+                channel: {
+                    cell: cellId
+                },
+                key: {
+                    type: 'delete-job'
+                }
+            });
+
+        }
+        function doDetachOutput(index) {
+            var confirmed = dom.confirmDialog('Are you sure you want to remove the output cell? This is not reversable. (Any associated data will remain in your narrative, and may be found in the Data panel.)', 'Yes', 'No');
+            if (!confirmed) {
+                return;
+            }
+            // remove the output cell
+            var output = model.outputs[index],
+                outputCell = findCellForId(output.cellId),
+                cellIndex;
+
+            if (outputCell) {
+                //alert('Could not find this cell');
+                //return;
+                cellIndex = Jupyter.notebook.find_cell_index(outputCell);
+                Jupyter.notebook.delete_cell(cellIndex);
+            }
+
+            // send a message on the cell bus bus, parent should pick it up, remove the 
+            // output from the model, and update us.
+            bus.bus().send({
+                jobId: output.jobId
+            }, {
+                channel: {
+                    cell: cellId
+                },
+                key: {
+                    type: 'output-cell-removed'
+                }
+            });
+
+
+        }
+
+        function render() {
+            var events = Events.make(),
+                content;
+
+            if (!model.outputs || model.outputs.length === 0) {
+                content = 'No output yet!';
+            } else {
+                content = model.outputs
+                    .sort(function (b, a) {
+                        if (a.createdTime < b.createdTime) {
+                            return -1;
+                        }
+                        if (a.createdTime > b.createdTime) {
+                            return 1;
+                        }
+                        return 0;
+                    })
+                    .map(function (output, index) {
+                        var rowStyle = {
+                            border: '1px silver solid',
+                            padding: '3px'
+                        };
+                        // console.log('JOB MATCH?', output.jobId, model.currentJobState);
+                        if (output.jobId === model.currentJobState.job_id) {
+                            rowStyle.border = '2px blue solid';
+                        }
+                        return div({class: 'row', style: rowStyle}, [
+                            div({class: 'col-md-8'}, [
+                                table({class: 'table table-striped'}, [
+                                    tr([
+                                        th('Job Id'), td(output.jobId)
+                                    ]),
+                                    tr([
+                                        th('Cell Id'), td(output.cellId)
+                                    ]),
+                                    tr([
+                                        th('Created'), td(output.createdTime.toISOString())
+                                    ])
+                                ])
+                            ]),
+                            div({class: 'col-md-4', style: {textAlign: 'right'}}, [
+                                button({
+                                    class: 'btn btn-sm btn-standard',
+                                    type: 'button',
+                                    id: events.addEvent({
+                                        type: 'click',
+                                        handler: function () {
+                                            doRemoveOutput(index);
+                                        }
+                                    })}, 'delete'),
+                                button({
+                                    class: 'btn btn-sm btn-standard',
+                                    type: 'button',
+                                    id: events.addEvent({
+                                        type: 'click',
+                                        handler: function () {
+                                            doDetachOutput(index);
+                                        }
+                                    })}, 'detach')
+
+                            ])
+                        ]);
+                    }).join('\n');
+            }
+            container.innerHTML = content;
+            events.attachEvents(container);
+        }
+
+        function importModel(outputs) {
+            var output;
+            if (outputs.byJob) {
+                model.outputs = Object.keys(outputs.byJob).map(function (jobId) {
+                    output = outputs.byJob[jobId];
+                    // console.log(output);
+                    return {
+                        jobId: jobId,
+                        cellId: output.cell.id,
+                        createdTime: new Date(output.cell.createdAt)
+                    };
+                });
+            }
+        }
+
+        function start() {
+            bus.on('run', function (message) {
+                root = message.node;
+                container = root.appendChild(document.createElement('div'));
+                dom = Dom.make({node: container});
+                model.currentJobState = message.jobState;
+                if (message.output) {
+                    importModel(message.output);
+                }
+
+                render();
+
+                bus.on('update', function (message) {
+                    model.currentJobState = message.jobState;
+                    importModel(message.output);
+                    render();
+                });
+            });
+        }
+
+        var api = Object.freeze({
+            start: start,
+            bus: bus
+        });
+        return api;
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/methodCell/widgets/methodOutputWidget.js
+++ b/nbextensions/methodCell/widgets/methodOutputWidget.js
@@ -142,7 +142,7 @@ define([
                             padding: '3px'
                         };
                         // console.log('JOB MATCH?', output.jobId, model.currentJobState);
-                        if (output.jobId === model.currentJobState.job_id) {
+                        if (model.currentJobState && output.jobId === model.currentJobState.job_id) {
                             rowStyle.border = '2px blue solid';
                         }
                         return div({class: 'row', style: rowStyle}, [

--- a/nbextensions/methodCell/widgets/methodParamsWidget.js
+++ b/nbextensions/methodCell/widgets/methodParamsWidget.js
@@ -228,6 +228,7 @@ define([
                     dom.makePanel('Input Objects', 'input-fields'),
                     dom.makePanel(span(['Parameters', span({dataElement: 'advanced-hidden-message', style: {marginLeft: '6px', fontStyle: 'italic'}})]), 'parameter-fields'),
                     dom.makePanel('Output Objects', 'output-fields')
+                    // dom.makePanel('Output Report', 'output-report')
                 ]);
 
             return {
@@ -349,6 +350,13 @@ define([
                             }
                         }));
                     }
+                })
+                .then(function () {
+                    // Show the user that a report object will be created. Otherwise it may seem weird that there is
+                    // no way to specify the output object
+                    //if (env.methodSpec) {
+                    //    +++
+                   // }
                 })
                 .then(function () {
                     if (parameterParams.length === 0) {

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -134,11 +134,15 @@ class Job(object):
                 elif 'constant_value' in out_param:
                     widget_params[p_id] = out_param['constant_value']
                 elif 'input_parameter' in out_param:
-                    widget_params[p_id] = self.inputs.get(out_param['input_parameter'], None)
+                    widget_params[p_id] = self.inputs[0].get(out_param['input_parameter'], None)
                 elif 'service_method_output_path' in out_param:
                     # widget_params[p_id] = get_sub_path(json.loads(state['step_outputs'][self.app_id]), out_param['service_method_output_path'], 0)
                     widget_params[p_id] = get_sub_path(state['result'], out_param['service_method_output_path'], 0)
             output_widget = app_spec.get('widgets', {}).get('output', 'kbaseDefaultNarrativeOutput')
+            # Yes, sometimes silly people put the string 'null' in their spec.
+            if (output_widget == 'null'):
+                output_widget = 'kbaseDefaultNarrativeOutput'
+            
             return WidgetManager().show_output_widget(output_widget, tag=self.tag, **widget_params)
 
         else:

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -314,6 +314,12 @@ class JobManager(object):
                         self.delete_job(job_id)
                     except Exception, e:
                         pass
+            elif r_type == 'remove_job':
+                if job_id is not None:
+                    try:
+                        self.remove_job(job_id)
+                    except Exception, e:
+                        pass
 
             elif r_type == 'job_logs':
                 if job_id is not None:
@@ -365,6 +371,18 @@ class JobManager(object):
             raise ValueError('Need a job_id to delete!')
         job = self.get_job(job_id)
         job.cancel()
+        del self._running_jobs[job_id]
+        self._send_comm_message('job_deleted', {'job_id': job_id})
+        
+    def remove_job(self, job_id):
+        """
+        If the job_id doesn't exist, raises a ValueError.
+        If the deletion fails and throws an error, that just gets raised, too.
+        """
+        if job_id is None:
+            raise ValueError('Need a job_id to delete!')
+        job = self.get_job(job_id)
+        # job.cancel()
         del self._running_jobs[job_id]
         self._send_comm_message('job_deleted', {'job_id': job_id})
 


### PR DESCRIPTION
The primary change is to insert the output cell after successful app execution. This is handled by the app cell widget (currently named methodCellWidget) upon the first time it is notified that the job has reached a completed state. This may be while after it has started running and has received the job state message, or after it has re-loaded and receives the job state message.
Another more radical change is to keep references to outputs within the app cell. This is exposed in a new output widget within the app cell. 
So the app cell can show a "history" of executions. There is provided for proof of concept -- so it is not fully formed. It is already useful, though, because it allows handling outputs (deleting) directly from the app cell rather than hunting them down in the narrative. 
I added this because it was frustrating to run an app cell multiple times and not know what outputs were still lying around, and also because the app cell does need to maintain some reference to the output cell so that it know that it has been created and avoid doing so again.
A natural extension would be to also show references to objects which were output, but this is delegated to the output cell itself.
