### PR TITLE
Better app startup handling

### DIFF
--- a/src/biokbase/narrative/jobs/app_util.py
+++ b/src/biokbase/narrative/jobs/app_util.py
@@ -1,7 +1,7 @@
 """
 Some utility functions for running KBase Apps or Methods or whatever they are this week.
 """
-__author__ = "Bill Riehl <wjriehl@lbl.gov>"
+__author__ = "Bill Riehl <wjriehl@lbl.gov>, Roman Sutormin <rsutormin@lbl.gov>"
 
 import os
 import re
@@ -59,22 +59,150 @@ def system_variable(var):
         else:
             return None
 
-def map_inputs_from_state(state, app_spec):
+def map_inputs_from_job(job_inputs, app_spec):
     """
-    returns a dict of readable (ish) method inputs - those used for the run_app function - to the input values.
-    narrative_system_variables are ignored, so workspace names and tokens shouldn't show up.
+    Unmaps the actual list of job inputs back to the
+    parameters specified by app_spec.
+    For example, the inputs given to a method might be a list like this:
+    ['input1', {'ws': 'my_workspace', 'foo': 'bar'}]
+    and the input mapping looks like:
+    [{
+        'target_position': 0,
+        'input_parameter': 'an_input'
+    },
+    {
+        'target_position': 1,
+        'target_property': 'ws',
+        'input_parameter': 'workspace'
+    },
+    {
+        'target_position': 1,
+        'target_property': 'foo',
+        'input_parameter': 'baz'
+    }]
+    this would return:
+    {
+        'an_input': 'input1',
+        'workspace': 'my_workspace',
+        'baz': 'bar'
+    }
+    This only covers those parameters from the input_mapping that come with an input_parameter
+    field. system variables, constants, etc., are ignored - this function just goes back to the
+    original inputs set by the user.
     """
     input_dict = dict()
-    inputs = state['original_app']['steps'][0]['input_values'][0]
     spec_inputs = app_spec['behavior']['kb_service_input_mapping']
-    # preprocess so it's O(1) lookup
-    targets_to_inputs = dict()
-    for spec_input in spec_inputs:
-        if 'input_parameter' in spec_input:
-            targets_to_inputs[spec_input['target_property']] = spec_input['input_parameter']
 
-    for target_name in inputs:
-        if target_name in targets_to_inputs:
-            input_dict[targets_to_inputs[target_name]] = inputs[target_name]
+    # expect the inputs to be valid. so things in the expected position should be the
+    # right things (either dict, list, singleton)
+    for param in spec_inputs:
+        if 'input_parameter' not in param:
+            continue;
+        input_param = param.get('input_parameter', None)
+        position = param.get('target_position', 0)
+        prop = param.get('target_property', None)
+        value = job_inputs[position]
+        if prop is not None:
+            value = value[prop]
 
+        # that's the value. Now, if it was transformed, try to transform it back.
+        if 'target_type_transform' in param:
+            transform_type = param['target_type_transform']
+            if transform_type.startswith('list') and isinstance(value, list):
+                inner_transform = transform_type[5:-1]
+                for i in range(len(value)):
+                    value[i] = _untransform(inner_transform, value[i])
+            else:
+                value = _untransform(transform_type, value)
+
+        input_dict[input_param] = value
     return input_dict
+
+def _untransform(transform_type, value):
+    if transform_type == 'ref':
+        # shear off everything before the first '/' - there should just be one.
+        slash = value.find('/')
+        if slash == -1:
+            return value
+        else:
+            return value[slash+1:]
+    else:
+        return value
+
+def map_outputs_from_state(state, params, app_spec):
+    """
+    Returns the dict of output values from a completed app.
+    Also returns the output widget.
+    """
+    widget_params = dict()
+    out_mapping_key = 'kb_service_output_mapping'
+    if out_mapping_key not in app_spec['behavior']:
+        out_mapping_key = 'output_mapping' # for viewers or short-running things, but the inner keys are the same.
+
+    for out_param in app_spec['behavior'].get(out_mapping_key, []):
+        value = None
+        if 'narrative_system_variable' in out_param:
+            value = system_variable(out_param['narrative_system_variable'])
+        elif 'constant_value' in out_param:
+            value = out_param['constant_value']
+        elif 'input_parameter' in out_param:
+            value = params.get(out_param['input_parameter'], None)
+        elif 'service_method_output_path' in out_param:
+            value = get_result_sub_path(state['result'], out_param['service_method_output_path'], 0)
+
+        p_id = out_param.get('target_property', None)
+        if p_id is not None:
+            widget_params[p_id] = value
+        else:
+            widget_params = value
+
+    output_widget = app_spec.get('widgets', {}).get('output', 'kbaseDefaultNarrativeOutput')
+    # Yes, sometimes silly people put the string 'null' in their spec.
+    if (output_widget == 'null'):
+        output_widget = 'kbaseDefaultNarrativeOutput'
+
+    return (output_widget, widget_params)
+
+def get_result_sub_path(result, path, pos):
+    """
+    Peels the right value out of the result with the given path.
+    result - list
+        This is a list of objects - each object is either a singleton, list, or object.
+    path - list
+        This is a list of strings
+    pos - int
+        This is the position in path that we're looking at right now.
+
+    A typical run looks like this:
+    result = [{'report': 'asdf', 'report_ref': 'xyz'}]
+    path = ['0', 'report_ref']
+    pos = 0
+
+    So it recursively works through.
+    look at path[pos] - that's a 0, so get the 0th element of result (the dict that's there.)
+    since result is a list (it almost always is, to start with, since that's what run_job returns), we get:
+    result[path[0]] = {'report': 'asdf', 'report_ref': 'xyz'}
+    path = ['0', 'report_ref']
+    pos = 1
+
+    and do it again.
+    Now, since result is NOT a list (it's the terminal element), do one of 2 things.
+    1. if there's no part of the path left (e.g. path == []), return the result object.
+    2. otherwise (as in this case), continue.
+    now, result = result[path[1]] = result['report_ref'] = 'xyz'
+    path = unchanged
+    pos = 2
+    and repeat
+
+    Finally, pos = 2, pos > len(path), so just return the final result - 'xyz'
+
+    In total, we use path to get to the exact value we want out of the result list.
+    Kinda complex for a few lines of code.
+    """
+    if pos >= len(path):
+        return result
+    if isinstance(result, list):
+        listPos = int(path[pos])
+        return get_result_sub_path(result[listPos], path, pos + 1)
+    return get_result_sub_path(result[path[pos]], path, pos + 1)
+

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -21,7 +21,6 @@ import json
 import re
 from biokbase.narrative.common import kblogging
 import logging
-from ipykernel.comm import Comm
 import datetime
 import traceback
 
@@ -112,9 +111,93 @@ class AppManager(object):
         """
         return self.spec_manager.available_apps(tag)
 
+    def run_local_app(self, app_id, tag="release", version=None, cell_id=None, run_id=None, **kwargs):
+        """
+        Attempts to run a local app. These do not return a Job object, but just the result of the app.
+        In most cases, this will be a Javascript display of the result, but could be anything.
+
+        If the app_spec looks like it makes a service call, then this raises a ValueError.
+        Otherwise, it validates each parameter in **kwargs against the app spec, executes it, and
+        returns the result.
+
+        Parameters:
+        -----------
+        app_id - should be from the app spec, e.g. 'view_expression_profile'
+        tag - optional, one of [release|beta|dev] (default=release)
+        version - optional, a semantic version string. Only released modules have
+                  versions, so if the tag is not 'release', and a version is given,
+                  a ValueError will be raised.
+        **kwargs - these are the set of parameters to be used with the app.
+                   They can be found by using the app_usage function. If any
+                   non-optional apps are missing, a ValueError will be raised.
+
+        Example:
+        run_local_app('NarrativeViewers/view_expression_profile', version='0.0.1', input_expression_matrix="MyMatrix", input_gene_ids="1234")
+        """
+
+        self._send_comm_message('run_status', {
+            'event': 'validating_app',
+            'event_at': datetime.datetime.utcnow().isoformat() + 'Z',
+            'cell_id': cell_id,
+            'run_id': run_id
+        })
+
+        ### TODO: this needs restructuring so that we can send back validation failure
+        ### messages. Perhaps a separate function and catch the errors, or return an
+        ### error structure.
+
+        # Intro tests:
+        self.spec_manager.check_app(app_id, tag, raise_exception=True)
+
+        if version is not None and tag != "release":
+            raise ValueError("App versions only apply to released app modules!")
+
+        # Get the spec & params
+        spec = self.spec_manager.get_spec(app_id, tag)
+
+        if not 'behavior' in spec:
+            raise ValueError("This app appears invalid - it has no defined behavior")
+
+        behavior = spec['behavior']
+
+        if 'kb_service_input_mapping' in behavior:
+            # it's a service! Should run this with run_app!
+            raise ValueError('This app appears to be a long-running job! Please start it using the run_app function instead.')
+
+        if 'script_module' in behavior or 'script_name' in behavior:
+            # It's an old NJS script. These don't work anymore.
+            raise ValueError('This app relies on a service that is now obsolete. Please contact the administrator.')
+
+        # Here, we just deal with two behaviors:
+        # 1. None of the above - it's a viewer.
+        # 2. python_class / python_function. Import and exec the python code.
+
+
+
 
 
     def run_app(self, *args, **kwargs):
+        """
+        Attempts to run the app, returns a Job with the running app info.
+        If this is given a cell_id, then returns None. If not, it returns the generated
+        Job object.
+
+        Parameters:
+        -----------
+        app_id - should be from the app spec, e.g. 'build_a_metabolic_model'
+                    or 'MegaHit/run_megahit'.
+        tag - optional, one of [release|beta|dev] (default=release)
+        version - optional, a semantic version string. Only released modules have
+                  versions, so if the tag is not 'release', and a version is given,
+                  a ValueError will be raised.
+        **kwargs - these are the set of parameters to be used with the app.
+                   They can be found by using the app_usage function. If any
+                   non-optional apps are missing, a ValueError will be raised.
+
+        Example:
+        --------
+        run_app('MegaHit/run_megahit', version=">=1.0.0", read_library_name="My_PE_Library", output_contigset_name="My_Contig_Assembly")
+        """
         try:
             return self._run_app_internal(*args, **kwargs)
         except Exception as e:
@@ -164,8 +247,6 @@ class AppManager(object):
             'run_id': run_id
         })
 
-        viewer_app = False
-
         ### TODO: this needs restructuring so that we can send back validation failure
         ### messages. Perhaps a separate function and catch the errors, or return an
         ### error structure.
@@ -188,10 +269,7 @@ class AppManager(object):
             raise Exception("This app appears invalid - it has no defined behavior")
 
         if not 'kb_service_input_mapping' in spec['behavior']:
-            if 'output_mapping' in spec['behavior']:
-                viewer_app = True
-            else:
-                raise Exception("This app is not SDK-compatible!")
+            raise Exception("This app does not appear to be a long-running job! Please use 'run_local_app' to start this instead.")
 
         # Preflight check the params - all required ones are present, all values are the right type, all numerical values are in given ranges
         spec_params = self.spec_manager.app_params(spec)
@@ -259,95 +337,59 @@ class AppManager(object):
             'run_id': run_id
         })
 
+        input_vals = self._map_inputs(spec['behavior']['kb_service_input_mapping'], params)
 
-        # Now we branch. If it's a viewer, make and register a transient 'ViewerJob' that'll handle the rest.
-        # Otherwise, make a real Job
-        if viewer_app:
-            log_info = {
-                'app_id': app_id,
-                'tag': tag,
-                'version': 'old_viewer',
-                'username': system_variable('user_id'),
-                'wsid': ws_id
-            }
-            self._log.setLevel(logging.INFO)
-            kblogging.log_event(self._log, "run_app", log_info)
-            self._send_comm_message('run_status', {
-                'event': 'launching_job',
-                'event_at': datetime.datetime.utcnow().isoformat() + 'Z',
-                'cell_id': cell_id,
-                'run_id': run_id
-            })
-            new_job = ViewerJob(self.viewer_count, app_id, [params], tag=tag, cell_id=cell_id)
-            self.viewer_count += 1
+        service_method = spec['behavior']['kb_service_method']
+        service_name = spec['behavior']['kb_service_name']
+        service_ver = spec['behavior'].get('kb_service_version', None)
+        service_url = spec['behavior']['kb_service_url']
 
-        else:
-            # Okay, NOW we can start the show
-            input_vals = dict()
-            for param in spec['behavior']['kb_service_input_mapping']:
-                p_value = None
-                p_id = param.get('target_property', 'invalid_mapping')
-                if 'input_parameter' in param:
-                    p_value = params.get(param['input_parameter'], None)
-                elif 'narrative_system_variable' in param:
-                    p_value = system_variable(param['narrative_system_variable'])
-                input_vals[p_id] = p_value
+        # This is what calls the function in the back end - Module.method
+        # This isn't the same as the app spec id.
+        function_name = service_name + '.' + service_method
+        job_meta = {'tag': tag}
+        if cell_id is not None:
+            job_meta['cell_id'] = cell_id
+        if run_id is not None:
+            job_meta['run_id'] = run_id
 
-            service_method = spec['behavior']['kb_service_method']
-            service_name = spec['behavior']['kb_service_name']
-            service_ver = spec['behavior'].get('kb_service_version', None)
-            #if (service_ver == None):
-            #    raise ValueError('Invalid method - service version (behavior.kb_service_version) not found in spec')
+        job_runner_inputs = {
+            'method' : function_name,
+            'service_ver' : service_ver,
+            'params' : input_vals,
+            'app_id' : app_id,
+            'wsid': ws_id,
+            'meta': job_meta
+        }
+        if len(ws_input_refs) > 0:
+            job_runner_inputs['source_ws_objects'] = ws_input_refs
 
-            service_url = spec['behavior']['kb_service_url']
+        log_info = {
+            'app_id': app_id,
+            'tag': tag,
+            'version': service_ver,
+            'username': system_variable('user_id'),
+            'wsid': ws_id
+        }
+        self._log.setLevel(logging.INFO)
+        kblogging.log_event(self._log, "run_app", log_info)
 
-            # This is what calls the function in the back end - Module.method
-            # This isn't the same as the app spec id.
-            function_name = service_name + '.' + service_method
-            job_meta = {'tag': tag}
-            if cell_id is not None:
-                job_meta['cell_id'] = cell_id
-            if run_id is not None:
-                job_meta['run_id'] = run_id
+        self._send_comm_message('run_status', {
+            'event': 'launching_job',
+            'event_at': datetime.datetime.utcnow().isoformat() + 'Z',
+            'cell_id': cell_id,
+            'run_id': run_id
+        })
 
-            job_runner_inputs = {
-                'method' : function_name,
-                'service_ver' : service_ver,
-                'params' : [input_vals],
-                'app_id' : app_id,
-                'wsid': ws_id,
-                'meta': job_meta
-            }
-            if len(ws_input_refs) > 0:
-                job_runner_inputs['source_ws_objects'] = ws_input_refs
+        try:
+            job_id = self.njs.run_job(job_runner_inputs)
+        except Exception as e:
+            log_info.update({'err': str(e)})
+            self._log.setLevel(logging.ERROR)
+            kblogging.log_event(self._log, "run_app_error", log_info)
+            raise
 
-            log_info = {
-                'app_id': app_id,
-                'tag': tag,
-                'version': service_ver,
-                'username': system_variable('user_id'),
-                'wsid': ws_id
-            }
-            self._log.setLevel(logging.INFO)
-            kblogging.log_event(self._log, "run_app", log_info)
-
-            self._send_comm_message('run_status', {
-                'event': 'launching_job',
-                'event_at': datetime.datetime.utcnow().isoformat() + 'Z',
-                'cell_id': cell_id,
-                'run_id': run_id
-            })
-
-            try:
-                job_id = self.njs.run_job(job_runner_inputs)
-            except Exception as e:
-                log_info.update({'err': str(e)})
-                self._log.setLevel(logging.ERROR)
-                kblogging.log_event(self._log, "run_app_error", log_info)
-                raise
-
-            new_job = Job(job_id, app_id, [params], tag=tag, app_version=service_ver, cell_id=cell_id)
-
+        new_job = Job(job_id, app_id, [params], tag=tag, app_version=service_ver, cell_id=cell_id)
 
         self._send_comm_message('run_status', {
             'event': 'launched_job',
@@ -361,6 +403,94 @@ class AppManager(object):
             return
         else:
             return new_job
+
+    def _map_inputs(self, input_mapping, params):
+        """
+        input_mapping is a list of dicts, as defined by NarrativeMethodStore.ServiceMethodInputMapping.
+        params is a dict of key-value-pairs, each key is the input_parameter field of some parameter.
+        """
+        inputs_dict = dict()
+        for p in input_mapping:
+            # 2 steps - figure out the proper value, then figure out the proper position.
+            # value first!
+            p_value = None
+            if 'input_parameter' in p:
+                p_value = params.get(p['input_parameter'], None)
+            elif 'narrative_system_variable' in p:
+                p_value = system_variable(p['narrative_system_variable'])
+            if 'constant_value' in p and p_value is None:
+                p_value = p['constant_value']
+            if 'generated_value' in p and p_value is None:
+                p_value = self._generate_input(generated_value)
+            if 'target_type_transform' in p:
+                p_value = self._transform_input(transform_type, p_value)
+
+            # get position!
+            arg_position = p.get('target_argument_position', 0)
+            target_prop = p.get('target_property', None)
+            if target_prop is not None:
+                final_input = inputs_dict.get(arg_position, dict())
+                final_input[target_prop] = p_value
+                inputs_dict[arg_position] = final_input
+            else:
+                inputs_dict[arg_position] = p_value
+
+        inputs_list = list()
+        keys = sorted(inputs_dict.keys())
+        for k in keys:
+            inputs_list.append(inputs_dict[k])
+        return inputs_list
+
+    def _transform_input(self, transform_type, value):
+        if transform_type == "none" or transform_type is None:
+            return value
+
+        elif transform_type == "ref":
+            # make a workspace ref
+            if value is not None:
+                value = system_variable('workspace') + '/' + value
+            return value
+
+        elif transform_type == "int":
+            # make it an integer, OR 0.
+            if value is None or len(str(value).strip()) == 0:
+                return None
+            return int(value)
+
+        elif transform_type.startswith("list<") and transform_type.endswith(">"):
+            # make it a list of transformed types.
+            list_type = transform_type[5:-1]
+            if isinstance(value, list):
+                ret = []
+                for pos in range(0, len(value)):
+                    ret.append(self._transform_input(list_type, value[pos]))
+                return ret
+            else:
+                return [self._transform_input(list_type, value)]
+
+        else:
+            raise ValueError("Unsupported Transformation type: " + transform_type)
+
+
+    def _generate_input(self, generator):
+        """
+        Generates an input value using rules given by NarrativeMethodStore.AutoGeneratedValue.
+        generator - dict
+            has 3 optional properties:
+            prefix - if present, is prepended to the generated string.
+            symbols - if present is the number of symbols to autogenerate (if not present, default=8)
+            suffix - if present, is appended to the generated string.
+        So, if generator is None or an empty dict, returns an 8-symbol string.
+        """
+        symbols = 8
+        if 'symbols' in generator:
+            symbols = int(generator['symbols'])
+        ret = ''.join([chr(random.randrange(0, 26) + ord('A')) for _ in xrange(symbols)])
+        if 'prefix' in generator:
+            ret = str(generator['prefix']) + ret;
+        if 'suffix' in generator:
+            ret = ret + str(generator['suffix']);
+        return ret
 
     def _check_parameter(self, param, value, workspace):
         """

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -406,6 +406,12 @@ class AppManager(object):
 
     def _map_inputs(self, input_mapping, params):
         """
+        Maps the dictionary of parameters and inputs based on rules provided in the input_mapping.
+        This iterates over the list of input_mappings, and uses them as a filter to apply to each
+        parameter.
+
+        Returns a list of inputs that can be passed directly to NJSW.run_job
+
         input_mapping is a list of dicts, as defined by NarrativeMethodStore.ServiceMethodInputMapping.
         params is a dict of key-value-pairs, each key is the input_parameter field of some parameter.
         """
@@ -423,7 +429,7 @@ class AppManager(object):
             if 'generated_value' in p and p_value is None:
                 p_value = self._generate_input(generated_value)
             if 'target_type_transform' in p:
-                p_value = self._transform_input(transform_type, p_value)
+                p_value = self._transform_input(p['target_type_transform'], p_value)
 
             # get position!
             arg_position = p.get('target_argument_position', 0)
@@ -442,6 +448,16 @@ class AppManager(object):
         return inputs_list
 
     def _transform_input(self, transform_type, value):
+        """
+        Transforms an input according to the rules given in NarrativeMethodStore.ServiceMethodInputMapping
+        Really, there are three types of transforms possible:
+          1. ref - turns the input string into a workspace ref.
+          2. int - tries to coerce the input string into an int.
+          3. list<type> - turns the given list into a list of the given type.
+          (4.) none or None - doesn't transform.
+
+        Returns a transformed (or not) value.
+        """
         if transform_type == "none" or transform_type is None:
             return value
 

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -180,6 +180,33 @@ class AppManager(object):
         spec_params = self.spec_manager.app_params(spec)
         (params, ws_refs) = self._validate_parameters(app_id, tag, spec_params, kwargs)
 
+
+        self._send_comm_message('run_status', {
+            'event': 'validated_app',
+            'event_at': datetime.datetime.utcnow().isoformat() + 'Z',
+            'cell_id': cell_id,
+            'run_id': run_id
+        })
+
+
+        # Log that we're trying to run a job...
+        log_info = {
+            'app_id': app_id,
+            'tag': tag,
+            'version': service_ver,
+            'username': system_variable('user_id'),
+            'wsid': ws_id
+        }
+        self._log.setLevel(logging.INFO)
+        kblogging.log_event(self._log, "run_local_app", log_info)
+
+        self._send_comm_message('run_status', {
+            'event': 'completed_app',
+            'event_at': datetime.datetime.utcnow().isoformat() + 'Z',
+            'cell_id': cell_id,
+            'run_id': run_id
+        })
+
         # now just map onto outputs.
         (output_widget, widget_params) = map_outputs_from_state([], params, spec)
         return WidgetManager().show_output_widget(output_widget, tag=tag, **widget_params)

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -144,31 +144,6 @@ class Job(object):
         spec = self.app_spec()
         return map_outputs_from_state(state, map_inputs_from_job(self.parameters()[0]['params'], spec), spec)
 
-
-
-        # widget_params = dict()
-        # app_spec = self.app_spec()
-        # out_mapping_key = 'kb_service_output_mapping'
-        # if out_mapping_key not in app_spec['behavior']:
-        #     out_mapping_key = 'output_mapping' # for viewers
-        # for out_param in app_spec['behavior'].get(out_mapping_key, []):
-        #     p_id = out_param['target_property']
-        #     if 'narrative_system_variable' in out_param:
-        #         widget_params[p_id] = system_variable(out_param['narrative_system_variable'])
-        #     elif 'constant_value' in out_param:
-        #         widget_params[p_id] = out_param['constant_value']
-        #     elif 'input_parameter' in out_param:
-        #         widget_params[p_id] = self.inputs[0].get(out_param['input_parameter'], None)
-        #     elif 'service_method_output_path' in out_param:
-        #         # widget_params[p_id] = get_sub_path(json.loads(state['step_outputs'][self.app_id]), out_param['service_method_output_path'], 0)
-        #         widget_params[p_id] = get_sub_path(state['result'], out_param['service_method_output_path'], 0)
-        # output_widget = app_spec.get('widgets', {}).get('output', 'kbaseDefaultNarrativeOutput')
-        # # Yes, sometimes silly people put the string 'null' in their spec.
-        # if (output_widget == 'null'):
-        #     output_widget = 'kbaseDefaultNarrativeOutput'
-        # return (output_widget, widget_params)
-
-
     def log(self, first_line=0, num_lines=None):
         """
         Fetch a list of Job logs from the Job Service.

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -7,10 +7,8 @@ import biokbase.narrative.clients as clients
 from .specmanager import SpecManager
 from .app_util import (
     system_variable,
-    map_inputs_from_state
-)
-from biokbase.narrative.common.generic_service_calls import (
-    get_sub_path
+    map_inputs_from_job,
+    map_outputs_from_state
 )
 import json
 import uuid
@@ -143,27 +141,32 @@ class Job(object):
         }
 
     def _get_output_info(self, state):
-        widget_params = dict()
-        app_spec = self.app_spec()
-        out_mapping_key = 'kb_service_output_mapping'
-        if out_mapping_key not in app_spec['behavior']:
-            out_mapping_key = 'output_mapping' # for viewers
-        for out_param in app_spec['behavior'].get(out_mapping_key, []):
-            p_id = out_param['target_property']
-            if 'narrative_system_variable' in out_param:
-                widget_params[p_id] = system_variable(out_param['narrative_system_variable'])
-            elif 'constant_value' in out_param:
-                widget_params[p_id] = out_param['constant_value']
-            elif 'input_parameter' in out_param:
-                widget_params[p_id] = self.inputs[0].get(out_param['input_parameter'], None)
-            elif 'service_method_output_path' in out_param:
-                # widget_params[p_id] = get_sub_path(json.loads(state['step_outputs'][self.app_id]), out_param['service_method_output_path'], 0)
-                widget_params[p_id] = get_sub_path(state['result'], out_param['service_method_output_path'], 0)
-        output_widget = app_spec.get('widgets', {}).get('output', 'kbaseDefaultNarrativeOutput')
-        # Yes, sometimes silly people put the string 'null' in their spec.
-        if (output_widget == 'null'):
-            output_widget = 'kbaseDefaultNarrativeOutput'
-        return (output_widget, widget_params)
+        spec = self.app_spec()
+        return map_outputs_from_state(state, map_inputs_from_job(self.parameters()[0]['params'], spec), spec)
+
+
+
+        # widget_params = dict()
+        # app_spec = self.app_spec()
+        # out_mapping_key = 'kb_service_output_mapping'
+        # if out_mapping_key not in app_spec['behavior']:
+        #     out_mapping_key = 'output_mapping' # for viewers
+        # for out_param in app_spec['behavior'].get(out_mapping_key, []):
+        #     p_id = out_param['target_property']
+        #     if 'narrative_system_variable' in out_param:
+        #         widget_params[p_id] = system_variable(out_param['narrative_system_variable'])
+        #     elif 'constant_value' in out_param:
+        #         widget_params[p_id] = out_param['constant_value']
+        #     elif 'input_parameter' in out_param:
+        #         widget_params[p_id] = self.inputs[0].get(out_param['input_parameter'], None)
+        #     elif 'service_method_output_path' in out_param:
+        #         # widget_params[p_id] = get_sub_path(json.loads(state['step_outputs'][self.app_id]), out_param['service_method_output_path'], 0)
+        #         widget_params[p_id] = get_sub_path(state['result'], out_param['service_method_output_path'], 0)
+        # output_widget = app_spec.get('widgets', {}).get('output', 'kbaseDefaultNarrativeOutput')
+        # # Yes, sometimes silly people put the string 'null' in their spec.
+        # if (output_widget == 'null'):
+        #     output_widget = 'kbaseDefaultNarrativeOutput'
+        # return (output_widget, widget_params)
 
 
     def log(self, first_line=0, num_lines=None):

--- a/src/biokbase/narrative/jobs/tests/test_appmanager.py
+++ b/src/biokbase/narrative/jobs/tests/test_appmanager.py
@@ -7,17 +7,6 @@ import unittest
 import mock
 from traitlets import Instance
 
-class DummyComm(object):
-    def __init__(self, **kwargs):
-        pass
-    def __new__(self, **kwargs):
-        pass
-    def send(self):
-        pass
-    def on_msg(self):
-        pass
-
-
 class AppManagerTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):
@@ -61,29 +50,34 @@ class AppManagerTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as err:
             self.mm.available_apps(self.bad_tag)
 
-    @mock.patch('biokbase.narrative.jobs.appmanager.Comm', spec=DummyComm)
+    @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_good_inputs(self, m):
+        m.return_value._send_comm_message.return_value = None
         pass
         # self.assertFalse("TODO: this test and code with mocking")
 
-    @mock.patch('biokbase.narrative.jobs.appmanager.Comm', spec=DummyComm)
+    @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_bad_id(self, m):
+        m.return_value._send_comm_message.return_value = None
         with self.assertRaises(ValueError) as err:
             self.mm.run_app(self.bad_app_id)
 
-    @mock.patch('biokbase.narrative.jobs.appmanager.Comm', spec=DummyComm)
+    @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_bad_tag(self, m):
+        m.return_value._send_comm_message.return_value = None
         with self.assertRaises(ValueError) as err:
             self.mm.run_app(self.good_app_id, tag=self.bad_tag)
 
-    @mock.patch('biokbase.narrative.jobs.appmanager.Comm', spec=DummyComm)
+    @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_bad_version_match(self, m):
         # fails because a non-release tag can't be versioned
+        m.return_value._send_comm_message.return_value = None
         with self.assertRaises(ValueError) as err:
             self.mm.run_app(self.good_app_id, tag=self.good_tag, version=">0.0.1")
 
-    @mock.patch('biokbase.narrative.jobs.appmanager.Comm', spec=DummyComm)
+    @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_missing_inputs(self, m):
+        m.return_value._send_comm_message.return_value = None
         with self.assertRaises(ValueError) as err:
             self.mm.run_app(self.good_app_id, tag=self.good_tag)
 

--- a/src/biokbase/narrative/jobs/viewer_job.py
+++ b/src/biokbase/narrative/jobs/viewer_job.py
@@ -1,8 +1,7 @@
 from .job import Job
 from .specmanager import SpecManager
 from .app_util import (
-    system_variable,
-    map_inputs_from_state
+    system_variable
 )
 from biokbase.narrative.common.generic_service_calls import (
     get_sub_path


### PR DESCRIPTION
This introduces a few things.  
* `AppManager.run_local_app` - this is for running synchronous, fast-running apps. It'll still register a log call for the app run, but it'll return the Widget with the result immediately. It's mainly meant for viewers, but can be adapted for other locally running code eventually.
* Fixed issues with positional parameters from method specs.
* Fixed issue with mapping fetched parameters that are stored in job info, back onto the output widgets.
* Fixed issues with parameter mapping and transforming (making explicit ws refs from input names, etc)
* Fixed issues with error handling on run_app - shouldn't throw a stacktrace, just print an error message.
* Removed the ViewerJob idiom and branching... because that was silly. The viewerjob file will get removed next.