### PR TITLE
Update job deletion management

### DIFF
--- a/kbase-extension/static/kbase/js/util/bootstrapDialog.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapDialog.js
@@ -95,7 +95,7 @@ define (
     };
 
     BootstrapDialog.prototype.getButtons = function () {
-        console.log("get buttons");
+        return this.$footer.children();
     };
 
     BootstrapDialog.prototype.getTitle = function () {
@@ -116,6 +116,15 @@ define (
 
     BootstrapDialog.prototype.getElement = function() {
         return this.$modal;
+    };
+
+    /**
+     * Removes this modal from the DOM and removes any associated content.
+     */
+    BootstrapDialog.prototype.destroy = function() {
+        this.$modal.remove();
+        this.$modal = null;
+        return null;
     };
 
     return BootstrapDialog;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -327,20 +327,20 @@ define([
                     this.sendCellMessage('run-status', msg.content.data.content.cell_id, msg.content.data.content);
                     break;
                 case 'job_err':
-
                     this.sendJobMessage('job-error', msg.content.job_id, {
                         jobId: msg.content.job_id,
                         message: msg.content.message
                     });
-
                     console.error('Job Error', msg);
                     break;
+
                 case 'job_deleted':
                     var deletedId = msg.content.data.content.job_id;
                     this.sendJobMessage('job-deleted', deletedId, {jobId: deletedId});
                     // console.info('Deleted job ' + deletedId);
                     this.removeDeletedJob(deletedId);
                     break;
+
                 case 'job_logs':
                     // console.log('GOT JOB LOGS', msg);
                     var jobId = msg.content.data.content.job_id;
@@ -351,12 +351,39 @@ define([
                         latest: msg.content.data.content.latest
                     });
                     break;
+
                 case 'job_comm_error':
                     var content = msg.content.data.content;
                     if (content) {
                         switch (content.request_type) {
                             case 'delete_job':
-                                alert('Job already deleted!');
+                                var modal = new BootstrapDialog({
+                                    title: 'foo bar.',
+                                    body: $('<div>').append(content.message),
+                                    buttons: [
+                                        $('<a type="button" class="btn btn-default">')
+                                        .append("OK")
+                                        .click(function (event) {
+                                            modal.hide();
+                                        })
+                                    ]
+                                });
+                                modal.getElement().on('hidden.bs.modal', function() {
+                                    modal.destroy();
+                                });
+                                modal.show();
+
+
+                                // var currentButtons = this.jobsModal.getButtons();
+                                // this.jobsModal.setButtons([
+                                //     $('<a type="button" class="btn btn-default">')
+                                //     .append("OK")
+                                //     .click(function (event) {
+                                //         this.jobsModal.hide();
+                                //         this.jobsModal.setButtons(currentButtons);
+                                //     }.bind(this))]);
+                                // this.jobsModal.setBody($('<div>').append(content.message));
+                                // this.jobsModal.show();
                                 break;
                             case 'job_logs':
                                 this.sendJobMessage('job-log-deleted', content.job_id, {jobId: content.job_id});
@@ -377,9 +404,6 @@ define([
                                     request: content.requestType
                                 });
                                 break;
-                        }
-                        if (content.request_type === 'delete_job') {
-                            alert('Job already deleted!');
                         }
                     }
                     console.error('Error from job comm:', msg);
@@ -849,6 +873,7 @@ define([
                 });
             }
             this.jobsModal.setBody($modalBody);
+            this.jobsModal.setTitle('Job Error');
             this.jobsModal.show();
         }
     });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -358,8 +358,8 @@ define([
                         switch (content.request_type) {
                             case 'delete_job':
                                 var modal = new BootstrapDialog({
-                                    title: 'foo bar.',
-                                    body: $('<div>').append(content.message),
+                                    title: 'Job Deletion Error',
+                                    body: $('<div>').append('<b>An error occurred while deleting your job:</b><br>' + content.message),
                                     buttons: [
                                         $('<a type="button" class="btn btn-default">')
                                         .append("OK")
@@ -372,18 +372,6 @@ define([
                                     modal.destroy();
                                 });
                                 modal.show();
-
-
-                                // var currentButtons = this.jobsModal.getButtons();
-                                // this.jobsModal.setButtons([
-                                //     $('<a type="button" class="btn btn-default">')
-                                //     .append("OK")
-                                //     .click(function (event) {
-                                //         this.jobsModal.hide();
-                                //         this.jobsModal.setButtons(currentButtons);
-                                //     }.bind(this))]);
-                                // this.jobsModal.setBody($('<div>').append(content.message));
-                                // this.jobsModal.show();
                                 break;
                             case 'job_logs':
                                 this.sendJobMessage('job-log-deleted', content.job_id, {jobId: content.job_id});

--- a/kbase-extension/static/kbase/templates/job_panel/job_error.html
+++ b/kbase-extension/static/kbase/templates/job_panel/job_error.html
@@ -1,5 +1,5 @@
 <div>
-    An error has been detected in this job!
+    <b>An error has been detected in this job!</b>
     <table class="table table-bordered">
         <tr>
             <th>Id:</th>

--- a/kbase-extension/static/kbase/templates/job_panel/job_info.html
+++ b/kbase-extension/static/kbase/templates/job_panel/job_info.html
@@ -1,3 +1,6 @@
+<div>
+    <hr class="kb-data-list-row-hr" style="text-align: center">
+</div>
 <div class="kb-data-list-obj-row {{#if error}}kb-jobs-error{{/if}}">
     <div class="kb-data-list-name kb-data-list-job-name">
         {{name}}

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -193,7 +193,7 @@ class Job(object):
         (No way to cancel something started with run_job right now).
         """
         status = self.status()
-        if status in ['completed', 'error', 'suspend']:
+        if status in ['completed']:
             clients.get('user_and_job_state').delete_job(self.job_id)
         else:
             raise Exception('Currently unable to cancel running jobs!')

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -192,7 +192,11 @@ class Job(object):
         Cancels a currently running job. Fails silently if there's no job running.
         (No way to cancel something started with run_job right now).
         """
-        clients.get('user_and_job_state').delete_job(self.job_id)
+        status = self.status()
+        if status in ['completed', 'error', 'suspend']:
+            clients.get('user_and_job_state').delete_job(self.job_id)
+        else:
+            raise Exception('Currently unable to cancel running jobs!')
 
     def is_finished(self):
         """

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -193,7 +193,7 @@ class Job(object):
         (No way to cancel something started with run_job right now).
         """
         status = self.status()
-        if status in ['completed']:
+        if status in ['completed', 'error', 'suspend']:
             clients.get('user_and_job_state').delete_job(self.job_id)
         else:
             raise Exception('Currently unable to cancel running jobs!')

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -317,12 +317,6 @@ class JobManager(object):
                         self.delete_job(job_id)
                     except Exception as e:
                         pass
-            elif r_type == 'remove_job':
-                if job_id is not None:
-                    try:
-                        self.remove_job(job_id)
-                    except Exception as e:
-                        pass
 
             elif r_type == 'job_logs':
                 if job_id is not None:
@@ -372,18 +366,6 @@ class JobManager(object):
             raise ValueError('Need a job_id to delete!')
         job = self.get_job(job_id)
         job.cancel()
-        del self._running_jobs[job_id]
-        self._send_comm_message('job_deleted', {'job_id': job_id})
-
-    def remove_job(self, job_id):
-        """
-        If the job_id doesn't exist, raises a ValueError.
-        If the deletion fails and throws an error, that just gets raised, too.
-        """
-        if job_id is None:
-            raise ValueError('Need a job_id to delete!')
-        job = self.get_job(job_id)
-        # job.cancel()
         del self._running_jobs[job_id]
         self._send_comm_message('job_deleted', {'job_id': job_id})
 

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -316,7 +316,7 @@ class JobManager(object):
                     try:
                         self.delete_job(job_id)
                     except Exception as e:
-                        pass
+                        self._send_comm_message('job_comm_error', {'message': str(e), 'request_type': r_type, 'job_id': job_id})
 
             elif r_type == 'job_logs':
                 if job_id is not None:
@@ -363,7 +363,7 @@ class JobManager(object):
         If the deletion fails and throws an error, that just gets raised, too.
         """
         if job_id is None:
-            raise ValueError('Need a job_id to delete!')
+            raise ValueError('Job id required for deletion!')
         job = self.get_job(job_id)
         job.cancel()
         del self._running_jobs[job_id]


### PR DESCRIPTION
* Only one function now - delete_job (removed 'remove_job'). (the request-job-removal Bus message still works)
* If a job can't be deleted (currently, we can't cancel running jobs), it produces a popup.
* More complete error handling for canceling jobs.