### PR TITLE
Viewer cell and updater fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ EXPOSE 8888
 RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y python-tornado
 
 # TEMPORARY!
-RUN apt-get install python-dev libffi-dev libssl-dev \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python-dev libffi-dev libssl-dev \
     && pip install pyopenssl ndg-httpsclient pyasn1 \
     && pip install requests --upgrade \
     && pip install 'requests[security]' --upgrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@ EXPOSE 8888
 # Remove Debian's older Tornado package
 RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y python-tornado
 
+# TEMPORARY!
+RUN apt-get install python-dev libffi-dev libssl-dev \
+    && pip install pyopenssl ndg-httpsclient pyasn1 \
+    && pip install requests --upgrade \
+    && pip install 'requests[security]' --upgrade
+
 # Copy in the narrative repo
 ADD ./ /kb/dev_container/narrative
 ADD ./kbase-logdb.conf /tmp/kbase-logdb.conf

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,12 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-2
+__Changes__
+- Fix updater so that it updates the Markdown cell version of viewer cells into pre-executed code cells that generate viewers. (So, updated viewers should work again)
+- Fix Docker image so that it doesn't spam the annoying SSL errors in all cells.
+- Put code area toggle on all code cells at all times. (Just to give Erik and I something to argue about)
+
 ### Version 3.0.0-alpha-1
 __Major Updates__
 - Apps and Methods not made as part of KBase SDK modules are now obsolete and will no longer run. Those apps have been replaced with Markdown cells that note their obsolescence, but still give the name and set of parameters used in the apps for reference. This also gives suggestions for updated apps (that will be available in production eventually...)

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
@@ -95,14 +95,14 @@ define([
         function doDeleteCell() {
             //if (window.confirm('Delete cell?')) {
             //    $(cell.element).trigger('deleteCell.Narrative', Jupyter.notebook.find_cell_index(cell));
-            //} 
+            //}
             var content = div([
                 p([
-                    'Deleting this cell will not remove any output cells or data objects it may have created. ', 
+                    'Deleting this cell will not remove any output cells or data objects it may have created. ',
                     'Any input parameters or other configuration of this cell will be lost.'
                 ]),
                 p([
-                    'Note: It is not possible to "undo" the deletion of a cell, ', 
+                    'Note: It is not possible to "undo" the deletion of a cell, ',
                     'but if the cell has not been saved you can refresh the page ',
                     'to load it from a previous state.'
                 ]),
@@ -147,7 +147,7 @@ define([
             cell.element.trigger('toggleCodeArea.cell');
             // $(cell.element).find('.input_area').toggle();
         }
-        
+
         function doToggleCellSettings() {
             cell.element.trigger('toggleCellSettings.cell');
         }
@@ -155,14 +155,14 @@ define([
         function renderToggleCodeView(events) {
             var runtime = Runtime.make();
             // Only render if actually a code cell and in dev mode.
-            // TODO: add cell extension to toggle code view, since this may 
+            // TODO: add cell extension to toggle code view, since this may
             // depend on cell state (or subtype)
             if (cell.cell_type !== 'code') {
                 return;
             }
-            if (!ui.isDeveloper()) {
-                return;
-            }
+            // if (!ui.isDeveloper()) {
+            //     return;
+            // }
 
             return button({
                 type: 'button',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -34,6 +34,7 @@ define([
 
             this.render();
 
+            this.$elem.trigger('toggleCodeArea.cell');
             return this;
         },
         hideInputArea: function () {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -34,7 +34,6 @@ define([
 
             this.render();
 
-            // this.hideInputArea();
             return this;
         },
         hideInputArea: function () {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -474,7 +474,7 @@ define (
             })) {
                 return 'view';
             }
-            
+
             // A very small class of methods are just non-app-calling widgets.
             switch (spec.info.id) {
                 case 'edit_media':
@@ -1965,6 +1965,7 @@ define (
             }
             var title = (data.info && data.info.name) ? data.info.name : 'Data Viewer';
             var type = 'viewer';
+            $(cell.element).trigger('toggleCodeArea.cell');
             var cellText = ['from biokbase.narrative.widgetmanager import WidgetManager',
                             'WidgetManager().show_output_widget(',
                             '    "kbaseNarrativeDataCell",',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -813,6 +813,7 @@ define (
          * @private
          */
         removeCellEditFunction: function(cell) {
+            return;
             // remove its double-click and return functions. sneaky!
             $(cell.element).off('dblclick');
             $(cell.element).off('keydown');
@@ -1965,7 +1966,7 @@ define (
             }
             var title = (data.info && data.info.name) ? data.info.name : 'Data Viewer';
             var type = 'viewer';
-            $(cell.element).trigger('toggleCodeArea.cell');
+            // $(cell.element).trigger('toggleCodeArea.cell');
             var cellText = ['from biokbase.narrative.widgetmanager import WidgetManager',
                             'WidgetManager().show_output_widget(',
                             '    "kbaseNarrativeDataCell",',

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-1",
+    "version": "3.0.0-alpha-2",
     "dev_mode": true,
     "git_commit_hash": "9554d90",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
* The Narrative updater properly turns old Markdown'd viewer cells into code cells that have been pre-executed
* Added some installation lines to the Dockerfile to update requests-security (get rid of SSL errors showing up all over the place - thanks @MrCreosote !)
