### PR TITLE
Fixed strange reversion in the importer panel.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,11 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-3
+__Changes__
+- Replace RNA-Seq viewers that had wandered off
+- Display SDK methods for various uploaders
+
 ### Version 3.0.0-alpha-2
 __Changes__
 - Fix updater so that it updates the Markdown cell version of viewer cells into pre-executed code cells that generate viewers. (So, updated viewers should work again)

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
@@ -180,17 +180,28 @@ define (
                         }
                         if (aTypes[key]["import_method_ids"].length > 0) {
                             self.types[key] = aTypes[key];
-                            var methodIdList = aTypes[key]["import_method_ids"];
-                            aTypes[key]["import_method_ids"] = []
-                            for (var methodPos in methodIdList) {
-                                var methodId = methodIdList[methodPos];
-                                if (methodId.indexOf("/") > 0)
-                                    continue;
+                            for (var methodPos in aTypes[key]["import_method_ids"]) {
+                                var methodId = aTypes[key]["import_method_ids"][methodPos];
                                 methodIds.push(methodId);
-                                aTypes[key]["import_method_ids"].push(methodId);
                             }
                         }
                     }
+
+
+
+                    //     if (aTypes[key]["import_method_ids"].length > 0) {
+                    //         self.types[key] = aTypes[key];
+                    //         var methodIdList = aTypes[key]["import_method_ids"];
+                    //         aTypes[key]["import_method_ids"] = []
+                    //         for (var methodPos in methodIdList) {
+                    //             var methodId = methodIdList[methodPos];
+                    //             // if (methodId.indexOf("/") > 0)
+                    //             //     continue;
+                    //             methodIds.push(methodId);
+                    //             aTypes[key]["import_method_ids"].push(methodId);
+                    //         }
+                    //     }
+                    // }
                     self.methClient.get_method_full_info({ 'ids' : methodIds, 'tag' : 'dev' },
                         $.proxy(function(fullInfoList) {
                             self.methodFullInfo = {};
@@ -643,12 +654,12 @@ define (
             cell.metadata = meta;
             cell.execute();
         },
-        
+
         runImport: function(callback) {
             var self = this;
             var methodId = self.getSelectedTabId();
             var methodSpec = self.methods[methodId];
-            
+
             if (methodId.indexOf('/') > 0) {
                 var paramValueArray = self.getInputWidget().getParameters();
                 var params = {};
@@ -658,7 +669,7 @@ define (
                     params[paramId] = paramValue;
                 }
                 //var ver = methodSpec.info.git_commit_hash;
-                var pythonCode = PythonInterop.buildAppRunner(null, null, 
+                var pythonCode = PythonInterop.buildAppRunner(null, null,
                         {tag: 'dev', version: null, id: methodId}, params);
                 pythonCode += ".job_id.encode('ascii','ignore')";
                 var callbacks = {

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-2",
+    "version": "3.0.0-alpha-3",
     "dev_mode": true,
     "git_commit_hash": "9554d90",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
Importer should show SDK import methods again.

Git decided to overwrite that with an old version in a merge that happened yesterday. This reverts the reversion.