### PR TITLE
Fixed typo in outputCell extension

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,12 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-5
+__Changes__
+- Fixed issue when starting SDK jobs from the upload panel with numeric parameters.
+- Fixed crash bug when trying to unpack a finished job that has incomplete inputs.
+- Shut off Jupyter command-mode quick keys when a text parameter input is focused.
+
 ### Version 3.0.0-alpha-4
 __Changes__
 - Improve error reporting when failing to load a viewer.

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
@@ -11,7 +11,7 @@ define([
     'narrativeConfig',
     'kbaseNarrativeParameterInput',
     'common/runtime',
-    
+    'base/js/namespace',
     'select2',
     'bootstrap'
 ], function (
@@ -19,7 +19,8 @@ define([
     $,
     Config,
     kbaseNarrativeParameterInput,
-    Runtime
+    Runtime,
+    Jupyter
     ) {
     'use strict';
     return KBWidget({
@@ -195,7 +196,7 @@ define([
                 ' value="' + defaultValue + '" type="text" style="width:100%"/>').addClass("form-control")
                 .on("input", function () {
                     self.isValid()
-                });
+                })
 
             if (spec.text_options) {
                 if (spec.text_options.valid_ws_types) {
@@ -209,6 +210,12 @@ define([
                     }
                 }
             }
+            $input.on('focus', function(e) {
+                Jupyter.narrative.disableKeyboardManager();
+            })
+            .on('blur', function(e) {
+                Jupyter.narrative.enableKeyboardManager();
+            });
 
             var $feedbackTip = $("<span>").removeClass();
             if (self.required && showHint) {  // it must be required, and it must be the first element (showHint is only added on first row)
@@ -291,7 +298,7 @@ define([
         },
         updateDataList: function (workspaceObjectInfo) {
             var lookupTypes = this.getLookupTypes();
-                
+
             this.validDataObjectList = workspaceObjectInfo
                 .filter(function (info) {
                     var type = info[2].split('-')[0];
@@ -335,7 +342,7 @@ define([
                 return;
             }
 
-            // update the validDataObjectList 
+            // update the validDataObjectList
             this.trigger('dataLoadedQuery.Narrative', [lookupTypes, this.IGNORE_VERSION, $.proxy(
                     function (objects) {
                         // we know from each parameter what each input type is.
@@ -484,16 +491,12 @@ define([
                 )
                 .on("select2-focus",
                     function (e) {
-                        if (Jupyter && Jupyter.notebook) {
-                            Jupyter.narrative.disableKeyboardManager();
-                        }
+                        Jupyter.narrative.disableKeyboardManager();
                     }
                 )
                 .on("select2-blur",
                     function (e) {
-                        if (Jupyter && Jupyter.notebook) {
-                            Jupyter.narrative.enableKeyboardManager();
-                        }
+                        Jupyter.narrative.enableKeyboardManager();
                     }
                 );
 

--- a/nbextensions/outputCell/main.js
+++ b/nbextensions/outputCell/main.js
@@ -7,7 +7,7 @@ define([
     'base/js/namespace',
     'common/utils',
     'common/appUtils',
-    'common/Props',
+    'common/props',
     'common/cellUtils',
     'common/pythonInterop',
     'kb_common/html'
@@ -23,7 +23,7 @@ define([
     html
     ) {
     'use strict';
-    
+
     var t = html.tag, div = t('div');
 
     function specializeCell(cell) {
@@ -48,7 +48,7 @@ define([
             }
             outputArea.removeClass('hidden');
         };
-        cell.renderIcon = function () {            
+        cell.renderIcon = function () {
             var inputPrompt = this.element[0].querySelector('[data-element="icon"]');
 
             if (inputPrompt) {
@@ -63,7 +63,7 @@ define([
             // Hide the code input area.
             this.input.find('.input_area').addClass('hidden');
             utils.setCellMeta(this, 'kbase.outputCell.user-settings.showCodeInputArea', false);
-            
+
             // And add our own!
             var prompt = document.createElement('div');
             prompt.innerHTML = div({dataElement: 'icon', class: 'prompt'});
@@ -83,7 +83,7 @@ define([
             }
         }
     }
-    
+
     function setupCell(cell) {
         if (cell.cell_type !== 'code') {
             return;
@@ -94,7 +94,7 @@ define([
         if (cell.metadata.kbase.type !== 'output') {
             return;
         }
-        
+
         specializeCell(cell);
 
         // The kbase property is only used for managing runtime state of the cell
@@ -104,11 +104,11 @@ define([
 
         // Update metadata.
         utils.setMeta(cell, 'attributes', 'lastLoaded', (new Date()).toUTCString());
-        
+
         // The output cell just needs to inhibit the input area.
         // The input code and associated output (a widget) is already
         // to be found in this cell (during insertion).
-        
+
         cell.hidePrompts();
         cell.renderMinMax();
         cell.renderIcon();
@@ -139,7 +139,7 @@ define([
             };
             cell.metadata = meta;
 
-            // We just need to generate, set, and execute the output 
+            // We just need to generate, set, and execute the output
             // the first time (for now).
             outputCode = PythonInterop.buildOutputRunner(data.kbase.widget.name, data.kbase.widget.tag, data.kbase.widget.params);
             cell.set_text(outputCode);
@@ -171,7 +171,7 @@ define([
                     });
             }
         });
-        
+
         Jupyter.notebook.get_cells().forEach(function (cell) {
             try {
                 setupCell(cell);

--- a/src/biokbase/narrative/app_util.py
+++ b/src/biokbase/narrative/app_util.py
@@ -103,7 +103,7 @@ def map_inputs_from_job(job_inputs, app_spec):
         prop = param.get('target_property', None)
         value = job_inputs[position]
         if prop is not None:
-            value = value[prop]
+            value = value.get(prop, None)
 
         # that's the value. Now, if it was transformed, try to transform it back.
         if 'target_type_transform' in param:

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-4",
+    "version": "3.0.0-alpha-5",
     "dev_mode": true,
     "git_commit_hash": "9554d90",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
Co-opting this for fixing Job running things that @MrCreosote exposed

- [x] text inputs in uploader panel should shut off the Jupyter keyboard manager on focus
- [x] completed jobs should only map their outputs together from inputs that exist, and not throw Exceptions
- [x] uploader panel modules need to add all of their parameters to the run function