### PR TITLE
kernel-side app validation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,17 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-6
+__Changes__
+- App parameter validation updates:
+  - Empty strings in either text fields or dropdowns get transformed to null before starting the app
+  - Empty strings in checkboxes get transformed to false
+- Log view in App cells has blocky whitespace removed
+- Multiple textarea inputs (currently unused?) has improved support
+- App cell layout has been updated to remove most excess whitespace
+- Improved error and warning handling for Apps. (e.g. pre-existing output object names can be overwritten again, but now there's a warning)
+- '-' characters are not allowed in App parameter ids. They must be representable as variable names (still up for debate, but that's how it is now)
+
 ### Version 3.0.0-alpha-5
 __Changes__
 - Fixed issue when starting SDK jobs from the upload panel with numeric parameters.

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -514,7 +514,7 @@ define([
             fsm,
             saveMaxFrequency = config.saveMaxFrequency || 5000;
 
-        
+
 
         // DATA API
 
@@ -847,7 +847,7 @@ define([
                     }, [
                         div({dataElement: 'widget', style: {display: 'block', width: '100%'}}, [
                             div({class: 'container-fluid'}, [
-                                
+
                                 ui.buildPanel({
                                     title: 'Error',
                                     name: 'fatal-error',
@@ -932,7 +932,7 @@ define([
                                     classes: ['kb-panel-container'],
                                     body: div({dataElement: 'widget'})
                                 }),
-                               
+
                                 div({class: 'btn-toolbar kb-btn-toolbar-cell-widget'}, [
                                     div({class: 'btn-group'}, [
                                         ui.makeButton('Run', 'run-app', {events: events, type: 'primary'}),
@@ -1396,7 +1396,7 @@ define([
                         // the job will be deleted form the notebook when the job cancellation
                         // event is received.
                     }
-                    
+
                     // tear down all the sub widgets.
                     Object.keys(widgets).forEach(function (widgetId) {
                         var widget = widgets[widgetId];
@@ -1428,10 +1428,10 @@ define([
                         // the job will be deleted form the notebook when the job cancellation
                         // event is received.
                     }
-                    
+
                     // Remove all of the execution state when we reset the app.
                     model.deleteItem('exec');
-                    
+
                     reloadExecutionWidget();
 
                     // TODO: evaluate the params again before we do this.
@@ -1444,7 +1444,7 @@ define([
         function updateFromLaunchEvent(message) {
 
             // Update the exec state.
-            // NB we need to do this because the launch events are only 
+            // NB we need to do this because the launch events are only
             // sent once from the narrative back end.
 
             // Update FSM
@@ -1519,7 +1519,7 @@ define([
                     node: container,
                     bus: bus
                 });
-                
+
                 // TODO: better place/way to do this:
                 if (ui.isDeveloper()) {
                     settings.showDeveloper = {
@@ -1529,7 +1529,7 @@ define([
                         element: 'developer-options'
                     };
                 }
-                
+
                 var layout = renderLayout();
                 container.innerHTML = layout.content;
                 layout.events.attachEvents(container);
@@ -1762,6 +1762,9 @@ define([
                 outputCell, notification,
                 outputCreated = model.getItem(['exec', 'outputCreated']);
 
+            // widgets named 'no-display' are a trigger to skip the output cell process.
+            var skipOutputCell = model.getItem('exec.outputWidgetInfo.name') === 'no-display';
+
 
             // New app -- check the existing exec state, see if the
             // output has been created already, and if so just exit.
@@ -1784,16 +1787,18 @@ define([
                 return;
             }
 
-            // If not created yet, create it.
-            outputCellId = createOutputCell(jobId);
-            model.setItem(['output', 'byJob', jobId], {
-                cell: {
-                    id: outputCellId,
-                    created: true,
-                    createdAt: new Date().toGMTString()
-                },
-                params: model.copyItem('params')
-            });
+            if (!skipOutputCell) {
+                // If not created yet, create it.
+                outputCellId = createOutputCell(jobId);
+                model.setItem(['output', 'byJob', jobId], {
+                    cell: {
+                        id: outputCellId,
+                        created: true,
+                        createdAt: new Date().toGMTString()
+                    },
+                    params: model.copyItem('params')
+                });
+            }
 
             widgets.outputWidget.instance.bus().emit('update', {
                 jobState: model.getItem('exec.jobState'),
@@ -1826,8 +1831,8 @@ define([
                 bus.on('edit-notebook-metadata', function () {
                     doEditNotebookMetadata();
                 });
-                
-                // the settings toggle is now emitted from the toolbar, which 
+
+                // the settings toggle is now emitted from the toolbar, which
                 // doesn't have a reference to the bus (yet).
                 cell.element.on('toggleCellSettings.cell', function () {
                     var showing = toggleSettings(cell),
@@ -2350,7 +2355,7 @@ define([
                 makeIcon()
             ]);
         }
-        
+
         function evaluateAppState() {
             var validationResult = validateModel();
             if (validationResult.isValid) {
@@ -2389,11 +2394,11 @@ define([
                 .then(function () {
                     // if we start out in 'new' state, then we need to promote to
                     // editing...
-                    
+
                     if (fsm.getCurrentState().state.mode === 'new') {
                         fsm.newState({mode: 'editing', params: 'incomplete'});
                         evaluateAppState();
-                        // 
+                        //
                     } else {
                         renderUI();
                     }

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -594,6 +594,9 @@ class AppManager(object):
             p_value = None
             if 'input_parameter' in p:
                 p_value = params.get(p['input_parameter'], None)
+                # turn empty strings into None
+                if isinstance(p_value, basestring) and len(p_value) == 0:
+                    p_value = None
             elif 'narrative_system_variable' in p:
                 p_value = system_variable(p['narrative_system_variable'])
             if 'constant_value' in p and p_value is None:
@@ -759,8 +762,8 @@ class AppManager(object):
             return (ws_ref, None)
 
         # Also, for strings, last I heard, an empty string is the same as null/None
-        if param['type'] == 'string' and isinstance(value, basestring) and value == '':
-            return (ws_ref, '')
+        if param['type'] in ['string', 'dropdown'] and isinstance(value, basestring) and value == '':
+            return (ws_ref, None)
 
         # cases - value == list, int, float, others get rejected
         if not (isinstance(value, basestring) or

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -508,7 +508,7 @@ class AppManager(object):
         service_name = spec['behavior']['kb_service_name']
         service_ver = spec['behavior'].get('kb_service_version', None)
         service_url = spec['behavior']['kb_service_url']
-        
+
 
         # Let the given version override the spec's version.
         if version is not None:
@@ -762,10 +762,10 @@ class AppManager(object):
             return (ws_ref, None)
 
         # Also, for strings, last I heard, an empty string is the same as null/None
-        if param['type'] in ['string', 'dropdown'] and isinstance(value, basestring) and value == '':
+        if param['type'] in ['string', 'dropdown', 'checkbox'] and isinstance(value, basestring) and value == '':
             return (ws_ref, None)
 
-        # cases - value == list, int, float, others get rejected
+        # cases - value == list (checked by wrapping function, _check_parameter), int, float, others get rejected
         if not (isinstance(value, basestring) or
                 isinstance(value, int) or
                 isinstance(value, float)):

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-5",
+    "version": "3.0.0-alpha-6",
     "dev_mode": true,
     "git_commit_hash": "9554d90",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
The App param validation is maybe a little too strict in how it adheres to the app specs. This has some updates to loosen things up a bit.

- [x] Empty strings (for string inputs and dropdowns) should become `null` before being sent to jobs. These should also be a valid entry (except for required parameters)
- [x] Empty strings for checkboxes should be treated as 'falsy' and get interpreted as `False`, with the appropriate value being used for the job
- [x] Treat 'no-display' as a valid output widget name, and ignore the display if that's the case.