### PR TITLE
Update run_app and show_output_widget signatures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,12 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-7
+__Changes__
+- Updated invocation signatures for AppManage.run_app, .run_local_app, WidgetManager.show_output_widget -- inputs to apps (and widgets) must now be a map where the keys are the input ids and the values are the inputs themselves.
+- Newly generated output cells auto-hide their input areas (still not ideal, since it's the generated widget, but... it's a start).
+- Fixed a couple UI typos
+
 ### Version 3.0.0-alpha-6
 __Changes__
 - App parameter validation updates:

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -108,7 +108,7 @@ define([
     'common/utils',
     'kb_common/html',
     'narrativeConfig',
-    
+
     'components/requirejs/require',
     'narrative_paths'
 ], function (
@@ -294,7 +294,7 @@ define([
     };
 
     // CELL
-    
+
     (function () {
         var p = cell.Cell.prototype;
 
@@ -324,22 +324,22 @@ define([
             var $cellNode = $(this.element),
                 metaToggleMode = utils.getCellMeta(this, 'kbase.cellState.toggleMinMax'),
                 toggleMode = $cellNode.data('toggleMinMax');
-            
+
             if (metaToggleMode) {
-                if (!toggleMode) {                    
+                if (!toggleMode) {
                     // The first time an existing cell is rendered after loading a
                     // notebook, the node data for toggleMinMax
                     // will be empty, so we need to initialize it. This is an auto-initialize.
                     toggleMode = metaToggleMode;
-                    $cellNode.data('toggleMinMax', toggleMode);                    
+                    $cellNode.data('toggleMinMax', toggleMode);
                 }
             } else if (!toggleMode) {
                 // If there is neither a data attribute on the node nor a metadata
                 // property, then this is a new cell, and it will be maximized.
                 toggleMode = 'maximized';
-                $cellNode.data('toggleMinMax', toggleMode);                
+                $cellNode.data('toggleMinMax', toggleMode);
             }
-            
+
             switch (toggleMode) {
                 case 'maximized':
                     if (!this.maximize) {
@@ -409,10 +409,10 @@ define([
         }());
 
     }());
-    
-    
+
+
     // RAW CELL
-    
+
      (function () {
         var p = textCell.RawCell.prototype;
 
@@ -841,13 +841,24 @@ define([
                 utils.setCellMeta(cell, 'kbase.cellState.selected', true);
                 $menu.trigger('selected.toolbar');
             });
-            
-            
+
+
             $cellNode.on('toggleCodeArea.cell', function () {
                 thisCell.toggleCodeInputArea();
             });
+
+            $cellNode.on('hideCodeArea.cell', function () {
+                thisCell.hideCodeInputArea();
+            });
         };
-        
+
+        p.hideCodeInputArea = function () {
+            var codeInputArea = this.input.find('.input_area')[0];
+            if (codeInputArea) {
+                codeInputArea.classList.add('hidden');
+            }
+        }
+
         p.toggleCodeInputArea = function() {
             var codeInputArea = this.input.find('.input_area')[0];
             if (codeInputArea) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -29,6 +29,7 @@ define([
             this.data = this.options.data;
             this.options.type = this.options.type.toLowerCase();
             this.cell = Jupyter.narrative.getCellByKbaseId(this.$elem.attr('id'));
+            this.cell.element.trigger('hideCodeArea.cell');
             if (this.options.widget.toLowerCase() === "null") {
                 this.options.widget = 'kbaseDefaultNarrativeOutput';
             }
@@ -36,11 +37,6 @@ define([
             this.render();
 
             return this;
-        },
-        hideInputArea: function () {
-            if (!this.options.cellId)
-                return;
-            $('#' + this.options.cellId).closest('.cell').find('.inner_cell .input_area').hide();
         },
         render: function () {
             var icon;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -38,7 +38,8 @@ define (
 		'kbaseNarrativeSidePanel',
 		'kbaseNarrativeDataPanel',
         'kbaseNarrativeOutputCell',
-        'kbaseTabs'
+        'kbaseTabs',
+        'common/pythonInterop'
 	], function(
         Jupyter,
 		KBWidget,
@@ -56,7 +57,8 @@ define (
 		kbaseNarrativeSidePanel,
 		kbaseNarrativeDataPanel,
         kbaseNarrativeOutputCell,
-        kbaseTabs
+        kbaseTabs,
+        PythonInterop
 	) {
 
     return KBWidget({
@@ -1967,6 +1969,7 @@ define (
             var title = (data.info && data.info.name) ? data.info.name : 'Data Viewer';
             var type = 'viewer';
             // $(cell.element).trigger('toggleCodeArea.cell');
+
             var cellText = ['from biokbase.narrative.widgetmanager import WidgetManager',
                             'WidgetManager().show_output_widget(',
                             '    "kbaseNarrativeDataCell",',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -1970,10 +1970,10 @@ define (
             var cellText = ['from biokbase.narrative.widgetmanager import WidgetManager',
                             'WidgetManager().show_output_widget(',
                             '    "kbaseNarrativeDataCell",',
+                            '    {"info": ' + StringUtil.safeJSONStringify(data.info) + '},',
                             '    check_widget=False,',
                             '    title="' + title + '",',
                             '    type="viewer",',
-                            '    info=' + StringUtil.safeJSONStringify(data.info) + ',',
                             ')'].join('\n');
 
             cell.set_text(cellText);

--- a/nbextensions/appCell/widgets/appOutputWidget.js
+++ b/nbextensions/appCell/widgets/appOutputWidget.js
@@ -47,7 +47,7 @@ define([
             }
             return null;
         }
-        
+
         function doRemoveOutputCell(index) {
             var content = div([
                 p('This will remove the output cell from the Narrative, as well as this output record. This action is not reversable. Any associated data will remain in your narrative, and may be found in the Data panel.'),
@@ -70,7 +70,7 @@ define([
                     Jupyter.notebook.delete_cell(cellIndex);
                 }
 
-                // send a message on the cell bus bus, parent should pick it up, remove the 
+                // send a message on the cell bus bus, parent should pick it up, remove the
                 // output from the model, and update us.
                 bus.bus().send({
                     jobId: output.jobId
@@ -151,8 +151,8 @@ define([
                                         handler: function () {
                                             doRemoveOutputCell(index);
                                         }
-                                    })}, 'Remove Ouput Cell'),
-                                
+                                    })}, 'Remove Output Cell'),
+
                                 div({style: {marginTop: '20px'}, dataElement: 'message'}, message)
 
                             ])
@@ -197,7 +197,7 @@ define([
                 });
             });
         }
-        
+
         function getBus() {
             return bus;
         }

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -158,7 +158,7 @@ class AppManager(object):
             # raise
             print("Error while trying to start your app (run_local_app)!\n-------------------------------------\n" + str(e))
 
-    def _run_local_app_internal(self, params, app_id, tag, version, cell_id, run_id, **kwargs):
+    def _run_local_app_internal(self, app_id, params, tag, version, cell_id, run_id, **kwargs):
         self._send_comm_message('run_status', {
             'event': 'validating_app',
             'event_at': datetime.datetime.utcnow().isoformat() + 'Z',
@@ -221,7 +221,7 @@ class AppManager(object):
 
         # now just map onto outputs.
         (output_widget, widget_params) = map_outputs_from_state([], params, spec)
-        return WidgetManager().show_output_widget(output_widget, tag=tag, **widget_params)
+        return WidgetManager().show_output_widget(output_widget, widget_params, tag=tag)
 
     def run_widget_app(self, app_id, tag="release", version=None, cell_id=None, run_id=None):
         """

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -116,7 +116,7 @@ class Job(object):
         except Exception as e:
             raise Exception("Unable to fetch info for job {} - {}".format(self.job_id, e))
 
-    def output_viewer(self, state=None):
+    def show_output_widget(self, state=None):
         """
         For a complete job, returns the job results.
         An incomplete job throws an exception
@@ -126,7 +126,7 @@ class Job(object):
             state = self.state()
         if state['job_state'] == 'completed' and 'result' in state:
             (output_widget, widget_params) = self._get_output_info(state)
-            return WidgetManager().show_output_widget(output_widget, tag=self.tag, **widget_params)
+            return WidgetManager().show_output_widget(output_widget, widget_params, tag=self.tag)
         else:
             return "Job is incomplete! It has status '{}'".format(state['job_state'])
 
@@ -203,7 +203,7 @@ class Job(object):
         False if its running/queued.
         """
         status = self.status()
-        return status.lower() in ['completed', 'error', 'suspend']
+        return status.lower() in ['completed', 'error', 'suspend', 'cancelled']
 
     def __repr__(self):
         return u"KBase Narrative Job - " + unicode(self.job_id)

--- a/src/biokbase/narrative/jobs/tests/test_appmanager.py
+++ b/src/biokbase/narrative/jobs/tests/test_appmanager.py
@@ -59,27 +59,23 @@ class AppManagerTestCase(unittest.TestCase):
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_bad_id(self, m):
         m.return_value._send_comm_message.return_value = None
-        with self.assertRaises(ValueError) as err:
-            self.mm.run_app(self.bad_app_id)
+        self.assertIsNone(self.mm.run_app(self.bad_app_id, None))
 
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_bad_tag(self, m):
         m.return_value._send_comm_message.return_value = None
-        with self.assertRaises(ValueError) as err:
-            self.mm.run_app(self.good_app_id, tag=self.bad_tag)
+        self.assertIsNone(self.mm.run_app(self.good_app_id, None, tag=self.bad_tag))
 
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_bad_version_match(self, m):
         # fails because a non-release tag can't be versioned
         m.return_value._send_comm_message.return_value = None
-        with self.assertRaises(ValueError) as err:
-            self.mm.run_app(self.good_app_id, tag=self.good_tag, version=">0.0.1")
+        self.assertIsNone(self.mm.run_app(self.good_app_id, None, tag=self.good_tag, version=">0.0.1"))
 
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     def test_run_app_missing_inputs(self, m):
         m.return_value._send_comm_message.return_value = None
-        with self.assertRaises(ValueError) as err:
-            self.mm.run_app(self.good_app_id, tag=self.good_tag)
+        self.assertIsNone(self.mm.run_app(self.good_app_id, None, tag=self.good_tag))
 
     def test_app_description(self):
         desc = self.mm.app_description(self.good_app_id, tag=self.good_tag)

--- a/src/biokbase/narrative/tests/test_widgetmanager.py
+++ b/src/biokbase/narrative/tests/test_widgetmanager.py
@@ -50,11 +50,11 @@ class WidgetManagerTestCase(unittest.TestCase):
             self.wm.get_widget_constants(self.bad_widget)
 
     def test_show_output_widget(self):
-        self.assertIsInstance(self.wm.show_output_widget(self.good_widget, obj='TestObject'), IPython.core.display.Javascript)
+        self.assertIsInstance(self.wm.show_output_widget(self.good_widget, {'obj': 'TestObject'}), IPython.core.display.Javascript)
 
     def test_show_output_widget_bad(self):
         with self.assertRaises(ValueError) as err:
-            self.wm.show_output_widget(self.bad_widget)
+            self.wm.show_output_widget(self.bad_widget, {'bad': 'inputs'})
 
     def test_show_external_widget(self):
         widget = self.wm.show_external_widget('contigSet', 'My ContigSet View', {'objectRef': '6402/3/8'}, {})

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -276,7 +276,7 @@ class WidgetManager(object):
                     constants[p] = params[p]["allowed_values"][0]
         return constants
 
-    def show_output_widget(self, widget_name, tag="release", title="", type="method", check_widget=True, **kwargs):
+    def show_output_widget(self, widget_name, params, tag="release", title="", type="method", check_widget=True, **kwargs):
         """
         Renders a widget using the generic kbaseNarrativeOutputWidget container.
 
@@ -284,6 +284,8 @@ class WidgetManager(object):
         ----------
         widget_name : string
             The name of the widget to print the widgets for.
+        params : dict
+            The dictionary of parameters that gets fed into the widget.
         tag : string, default="release"
             The version tag to use when looking up widget information.
         type : string, default="method"
@@ -306,7 +308,7 @@ class WidgetManager(object):
             input_data = self.get_widget_constants(widget_name, tag)
 
         # Let the kwargs override constants
-        input_data.update(kwargs)
+        input_data.update(params)
 
         input_template = """
         element.html("<div id='{{input_id}}' class='kb-vis-area'></div>");
@@ -329,8 +331,8 @@ class WidgetManager(object):
                                              cell_title=title,
                                              timestamp=int(round(time.time()*1000)))
         return Javascript(data=js, lib=None, css=None)
-    
-    
+
+
     def show_custom_widget(self, widget_id, app_id, app_version, app_tag, spec):
         input_template = """
         element.html('<div id="{{widget_root_id}}" class="kb-custom-widget">');
@@ -370,9 +372,9 @@ class WidgetManager(object):
         #    widget_name = widget
 
         # Note: All Python->Javascript data flow is serialized as JSON strings.
-        
+
         widget_root_id = self._cell_id_prefix + str(uuid.uuid4())
-        
+
         widget_arg = {
             'app': {
                 'id': app_id,
@@ -387,7 +389,7 @@ class WidgetManager(object):
                 'rootId': widget_root_id
             }
         }
-        
+
         #widget_def = {
         #    'id': self._cell_id_prefix + str(uuid.uuid4()),
         #    'package': widget_package,
@@ -402,14 +404,14 @@ class WidgetManager(object):
 
         # context - Data for building the Javascript prior to insertion is provided
         # input_data - raw widget input data as provided by the caller
-        
+
         js = Template(input_template).render(widget_root_id=widget_root_id,
                                              widget_arg=json.dumps(widget_arg).replace('\\', '\\\\'))
-                                             
+
         # print(repr(js))
 
         return Javascript(data=js, lib=None, css=None)
-        
+
 
 
     def show_external_widget(self, widget, widget_title, objects, options, auth_required=True):

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-6",
+    "version": "3.0.0-alpha-7",
     "dev_mode": true,
     "git_commit_hash": "9554d90",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
Using keyword args for run_app (and others) doesn't work. Parameter names are defined by method spec, and can (and should!) be arbitrary strings. The problem here, is that there are other keyword args in those methods that should be retained, since it's useful to provide defaults values, or just make them optional without requiring a user to put in "None".

The solution is to change that list of keyword args for param ids into a single, positional dictionary. So we turn an app call like this:
```Python
AppManager().run_app(
    "MyModule/my_app",
    tag="dev",
    version="xyz",
    cell_id="foo",
    param1="a",
    param2="b",
    param3="c"
)
```
into this:
```Python
AppManager().run_app(
    "MyModule/my_app",
    {
        "param1": "a",
        "param2": "b",
        "param3": "c"
    },
    tag="dev",
    version="xyz",
    cell_id="foo",
)
```
or, more generally:
```Python
AppManager.run_app(app_id, tag="release", version=None, cell_id=None, run_id=None, **kwargs)
```
into:
```Python
AppManager.run_app(app_id, params, tag="release", version=None, cell_id=None, run_id=None)
```

The same applies to running an output widget viewer.

Checklist of things to update
- [x] AppManager (run_app, run_local_app, _run_app_internal, _run_local_app_internal)
- [x] AppManager tests
- [x] Job (show_output_widget)
- [x] Job tests
- [x] WidgetManager (show_output_widget)
- [x] WidgetManager tests
- [x] Data panel invoked widgets (clicking/drag & drop)
- [x] Output widgets from the App Cell
- [x] Output widgets from the Viewer Cell
- [x] Output widgets from the Widget Cell (kind of a debug/test thing, still needs updating)