### PR TITLE
Job related changes and other fixes

### DIFF
--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -299,6 +299,7 @@ span#notebook_name:hover {
 }
 
 .kb-btn-icon {
+    display: inline-block;
     padding: 4px;
 }
 .kb-btn-icon .fa {

--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -58,7 +58,7 @@
 }
 .kb-app-cell .kb-app-parameter-input {
     vertical-align:middle;
-    white-space: nowrap;
+    xwhite-space: nowrap;
     xpadding-left:10px;
     border-bottom: 1px #ccc dotted;
 }

--- a/kbase-extension/static/kbase/js/common/events.js
+++ b/kbase-extension/static/kbase/js/common/events.js
@@ -60,7 +60,7 @@ define([
             events.forEach(function (event) {
                 var node = root.querySelector(event.selector);
                 if (!node) {
-                    console.error('could not find node for ' + event.selector);
+                    console.error('could not find node', event.selector, root);
                     throw new Error('could not find node for ' + event.selector);
                 }
                 if (event.jquery) {

--- a/kbase-extension/static/kbase/js/common/monoBus.js
+++ b/kbase-extension/static/kbase/js/common/monoBus.js
@@ -226,7 +226,7 @@ define([
             listenerRegistry[id] = listener;
             return id;
         }
-
+        
         function removeListener(id) {
             var listenerToRemove = listenerRegistry[id],
                 channel, listeners, newListeners;
@@ -485,7 +485,7 @@ define([
             //     },
             //     handle: handler
             // });
-            listen({
+            return listen({
                 channel: channel,
                 key: JSON.stringify({type: type}),
                 handle: handler

--- a/kbase-extension/static/kbase/js/common/props.js
+++ b/kbase-extension/static/kbase/js/common/props.js
@@ -161,6 +161,12 @@ define([
             setDataItem(obj, path, value);
             run();
         }
+        
+        function reset() {
+            resetHistory();
+            obj = {};
+            run();
+        }
 
         function incrItem(path, increment) {
             if (typeof path === 'string') {
@@ -254,6 +260,7 @@ define([
             incrItem: incrItem,
             deleteItem: deleteItem,
             pushItem: pushItem,
+            reset: reset,
             getRawObject: function () {
                 return obj;
             },

--- a/kbase-extension/static/kbase/js/common/ui.js
+++ b/kbase-extension/static/kbase/js/common/ui.js
@@ -11,6 +11,7 @@ define([
     './events',
     'google-code-prettify/prettify',
     'css!google-code-prettify/prettify.css',
+    'bootstrap'
 ], function ($, Promise, html, Jupyter, Runtime, Events, PR) {
     'use strict';
     var t = html.tag,
@@ -35,6 +36,21 @@ define([
             }).join(' ');
 
             return container.querySelector(selector);
+        }
+        
+        function qsa(node, selector) {
+            return Array.prototype.slice.call(node.querySelectorAll(selector, 0));
+        }
+        
+        function getElements(names) {
+            if (typeof names === 'string') {
+                names = names.split('.');
+            }
+            var selector = names.map(function (name) {
+                return '[data-element="' + name + '"]';
+            }).join(' ');
+
+            return qsa(container, selector);
         }
 
         function getButton(name) {
@@ -527,10 +543,20 @@ define([
         }
 
         function setContent(path, content) {
-            var node = getElement(path);
-            if (node) {
+            var node = getElements(path);
+            node.forEach(function (node) {
                 node.innerHTML = content;
+            });
+        }
+        
+        function enableTooltips(path) {
+            var node = getElement(path);
+            if (!node) {
+                return;
             }
+            qsa(node, '[data-toggle="tooltip"]').forEach(function (node) {
+                $(node).tooltip();
+            });
         }
         
         function addClass(path, klass) {
@@ -796,7 +822,8 @@ define([
             addClass: addClass,
             removeClass: removeClass,
             buildTabs: buildTabs,
-            jsonBlockWidget: jsonBlockWidget()
+            jsonBlockWidget: jsonBlockWidget(),
+            enableTooltips: enableTooltips
         };
     }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleSubdata.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleSubdata.js
@@ -244,31 +244,52 @@ define([
                                     return span({
                                         class: 'kb-btn-icon',
                                         type: 'button',
+                                        dataToggle: 'tooltip',
+                                        title: 'Remove from selected',
                                         id: events.addEvent({
                                             type: 'click',
                                             handler: function () {
                                                 doRemoveSelectedAvailableItem(item.id);
                                             }
                                         })
-                                    }, span({class: 'fa fa-minus-circle', style: {color: 'red', fontSize: '200%'}}));
+                                    }, [
+                                        span({
+                                            class: 'fa fa-minus-circle',
+                                            style: {
+                                                color: 'red',
+                                                fontSize: '200%'
+                                            }
+                                        })
+                                    ]);
                                 }
                                 if (allowSelection) {
                                     return span({
                                         class: 'kb-btn-icon',
                                         type: 'button',
+                                        dataToggle: 'tooltip',
+                                        title: 'Add to selected',
                                         dataItemId: item.id,
                                         id: events.addEvent({
                                             type: 'click',
                                             handler: function () {
                                                 doAddItem(item.id);
                                             }
-                                        })}, span({class: 'fa fa-plus-circle', style: {color: 'green', fontSize: '200%'}}));
+                                        })}, [span({
+                                            class: 'fa fa-plus-circle',
+                                            style: {
+                                                color: 'green',
+                                                fontSize: '200%'
+                                            }
+                                        })
+                                    ]);
                                 }
                                 return span({
                                     class: 'kb-btn-icon',
                                     type: 'button',
+                                    dataToggle: 'tooltip',
+                                    title: 'Can\'t add - remove one first',
                                     dataItemId: item.id
-                                    }, span({class: 'fa fa-plus-circle', style: {color: 'silver', fontSize: '200%'}}));
+                                }, span({class: 'fa fa-ban', style: {color: 'silver', fontSize: '200%'}}));
                             }())
 
                         ])
@@ -279,6 +300,7 @@ define([
 
             ui.setContent('available-items', content);
             events.attachEvents();
+            ui.enableTooltips('available-items');
         }
 
         function renderSelectedItems() {
@@ -299,7 +321,7 @@ define([
                     }
 
                     return div({class: 'row', style: {border: '1px #CCC solid', borderCollapse: 'collapse', boxSizing: 'border-box'}}, [
-                         div({
+                        div({
                             class: 'col-md-2',
                             style: {
                                 xdisplay: 'inline-block',
@@ -337,6 +359,8 @@ define([
                             span({
                                 class: 'kb-btn-icon',
                                 type: 'button',
+                                dataToggle: 'tooltip',
+                                title: 'Remove from selected',
                                 id: events.addEvent({
                                     type: 'click',
                                     handler: function () {
@@ -350,6 +374,7 @@ define([
             }
             ui.setContent('selected-items', content);
             events.attachEvents();
+            ui.enableTooltips('selected-items');
         }
 
         function renderSearchBox() {
@@ -360,39 +385,39 @@ define([
             //if (items.length === 0) {
             //    content = '';
             //} else {
-                content = input({
-                    class: 'form-contol',
-                    style: {xwidth: '100%'},
-                    placeholder: 'search',
-                    value: model.getItem('filter') || '',
-                    id: events.addEvents({events: [
-                            {
-                                type: 'keyup',
-                                handler: function (e) {
-                                    doSearchKeyUp(e);
-                                }
-                            },
-                            {
-                                type: 'focus',
-                                handler: function () {
-                                    Jupyter.narrative.disableKeyboardManager();
-                                }
-                            },
-                            {
-                                type: 'blur',
-                                handler: function () {
-                                    console.log('SingleSubData Search BLUR');
-                                    // Jupyter.narrative.enableKeyboardManager();
-                                }
-                            },
-                            {
-                                type: 'click',
-                                handler: function () {
-                                    Jupyter.narrative.disableKeyboardManager();
-                                }
+            content = input({
+                class: 'form-contol',
+                style: {xwidth: '100%'},
+                placeholder: 'search',
+                value: model.getItem('filter') || '',
+                id: events.addEvents({events: [
+                        {
+                            type: 'keyup',
+                            handler: function (e) {
+                                doSearchKeyUp(e);
                             }
-                        ]})
-                });
+                        },
+                        {
+                            type: 'focus',
+                            handler: function () {
+                                Jupyter.narrative.disableKeyboardManager();
+                            }
+                        },
+                        {
+                            type: 'blur',
+                            handler: function () {
+                                console.log('SingleSubData Search BLUR');
+                                // Jupyter.narrative.enableKeyboardManager();
+                            }
+                        },
+                        {
+                            type: 'click',
+                            handler: function () {
+                                Jupyter.narrative.disableKeyboardManager();
+                            }
+                        }
+                    ]})
+            });
             //}
 
             ui.setContent('search-box', content);
@@ -405,17 +430,21 @@ define([
                 content;
 
             if (availableItems.length === 0) {
-                content = '';
+                content = span({style: {fontStyle: 'italic'}}, [
+                    ' - no available items'
+                ]);
             } else {
-                content = div([
-                    span({dataElement: 'filtered-items-count'}), ' of ',
-                    span({dataElement: 'available-items-count'})
+                content = span({style: {fontStyle: 'italic'}}, [
+                    ' - showing ',
+                    span([
+                        String(filteredItems.length),
+                        ' of ',
+                        String(availableItems.length)
+                    ])
                 ]);
             }
 
             ui.setContent('stats', content);
-            ui.setContent('available-items-count', String(availableItems.length));
-            ui.setContent('filtered-items-count', String(filteredItems.length));
         }
 
         function renderToolbar() {
@@ -585,72 +614,54 @@ define([
 //                        }, 'Selected')
 //                    ])
 //                ]),
-                div({class: 'row'}, [
-                    div({
-                        class: 'col-md-6'                        
-                    }, [
-                        'Search: ',
-                        span({dataElement: 'search-box'})
-                    ]),
-//                    div({
-//                        class: 'col-md-3',
-//                        style: {textAlign: 'center'},
-//                        dataElement: 'stats'
-//                    }),
-                    div({
-                        class: 'col-md-6',
-                        style: {textAlign: 'right'},
-                        dataElement: 'toolbar'
+                ui.buildCollapsiblePanel({
+                    title: span(['Available Items', span({dataElement: 'stats'})]),
+                    classes: ['kb-panel-light'],
+                    body: div({dataElement: 'available-items-area', style: {marginTop: '10px'}}, [
+                        div({class: 'row'}, [
+                            div({
+                                class: 'col-md-6'
+                            }, [
+                                span({dataElement: 'search-box'})
+                            ]),
+//                            div({
+//                                class: 'col-md-3'
+//                            }, [
+//                                span({
+//                                    dataElement: 'stats',
+//                                    style: {
+//                                        fontStyle: 'italic'
+//                                    }
+//                                })
+//                            ]),
+                            div({
+                                class: 'col-md-6',
+                                style: {textAlign: 'right'},
+                                dataElement: 'toolbar'
+                            })
+                        ]),
+                        div({class: 'row', style: {marginTop: '4px'}}, [
+                            div({class: 'col-md-12'},
+                                div({
+                                    style: {
+                                        border: '1px silver solid'
+                                    },
+                                    dataElement: 'available-items'
+                                }))
+                        ])
+                    ])
+                }),
+                ui.buildPanel({
+                    title: 'Selected Items',
+                    classes: ['kb-panel-light'],
+                    body: div({
+                        style: {
+                            border: '1px silver solid'
+                        },
+                        dataElement: 'selected-items'
                     })
-                ]),              
-                div({class: 'row', style: {marginTop: '20px'}}, [
-                    div({class: 'col-md-12', style: {
-                        textAlign: 'center'                            
-                    }}, [
-                        span({
-                            style: {
-                                fontWeight: 'bold',
-                                textDecoration: 'underline',
-                                fontStyle: 'italic'
-                            }
-                        }, 'Available'),
-                        ' ',
-                        span({
-                            dataElement: 'stats',
-                            style: {
-                                fontStyle: 'italic'
-                            }
-                        })
-                    ]),
-                    div({class: 'col-md-12'},
-                        div({
-                            style: {
-                                border: '1px silver solid'
-                            },
-                            dataElement: 'available-items'
-                        }))
-                ]),
-                div({class: 'row', style: {marginTop: '20px'}}, [
-                    div({class: 'col-md-12', style: {
-                        textAlign: 'center'
-                    }}, [
-                        span({
-                            style: {
-                                fontWeight: 'bold',
-                                textDecoration: 'underline',
-                                fontStyle: 'italic'
-                            }
-                        }, 'Selected')
-                    ]),
-                    div({class: 'col-md-12'},
-                        div({
-                            style: {
-                                border: '1px silver solid'
-                            },
-                            dataElement: 'selected-items'
-                        }))
-                ])               
-                
+                })
+
 //                div({class: 'row'}, [
 //                    div({class: 'col-md-6'},
 //                        div({
@@ -1050,13 +1061,13 @@ define([
                 model.setItem('availableValues', []);
                 model.setItem('referenceObjectName', null);
                 doFilterItems();
-                
+
                 renderSearchBox();
                 renderStats();
                 renderToolbar();
                 renderAvailableItems();
                 renderSelectedItems();
-                
+
                 // updateInputControl('availableValues');
                 // updateInputControl('value');
             });
@@ -1165,26 +1176,26 @@ define([
 
 
         }
-        
+
         // MODIFICATION EVENTS
-        
+
         /*
-        * More refinement of modifications. 
-        * 
-        * - initial run
-        * - reference data updated
-        *   - added "reset" method to props (model) to allow graceful zapping
-        *     of the model state.
-        * - item added to selected
-        * - item removed from selected
-        * - search term available
-        * - search term removed
-        * - filtered data updated
-        * 
-        */
-       
-       
-        
+         * More refinement of modifications. 
+         * 
+         * - initial run
+         * - reference data updated
+         *   - added "reset" method to props (model) to allow graceful zapping
+         *     of the model state.
+         * - item added to selected
+         * - item removed from selected
+         * - search term available
+         * - search term removed
+         * - filtered data updated
+         * 
+         */
+
+
+
 
         // LIFECYCLE API
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleSubdata.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleSubdata.js
@@ -48,8 +48,7 @@ define([
     // Constants
     var t = html.tag,
         div = t('div'), p = t('p'), span = t('span'),
-        select = t('select'), input = t('input'),
-        table = t('table'), tr = t('tr'), td = t('td'),
+        input = t('input'),
         option = t('option'), button = t('button');
 
     function factory(config) {
@@ -195,27 +194,28 @@ define([
             didChange();
         }
 
-        function renderAvailableItems(events) {
-            var selected = model.getItem('selectedItems', []);
-            if (!(selected instanceof Array)) {
-                selected = [ selected ];
-            }
-            var allowSelection = (spec.spec.allow_multiple || selected.length === 0);
-            var items = model.getItem('filteredAvailableItems', []),
+        function renderAvailableItems() {
+            var selected = model.getItem('selectedItems', []),
+                allowSelection = (spec.spec.allow_multiple || selected.length === 0),
+                items = model.getItem('filteredAvailableItems', []),
                 from = model.getItem('showFrom'),
                 to = model.getItem('showTo'),
                 itemsToShow = items.slice(from, to),
+                events = Events.make({node: container}),
+                content;
+
+            if (itemsToShow.length === 0) {
+                content = div({style: {textAlign: 'center'}}, 'no available values');
+            } else {
                 content = itemsToShow.map(function (item, index) {
                     var isSelected = selected.some(function (id) {
                         return (item.id === id);
                     }),
                         disabled = isSelected;
-                    return div({class: 'row', style: {border: '1px #CCC solid', width: '100%'}}, [
+                    return div({class: 'row', style: {border: '1px #CCC solid'}}, [
                         div({
                             class: 'col-md-2',
                             style: {
-                                xdisplay: 'inline-block',
-                                xwidth: '20%',
                                 verticalAlign: 'middle',
                                 borderRadius: '3px',
                                 padding: '2px',
@@ -227,19 +227,13 @@ define([
                             }
                         }, String(from + index + 1)),
                         div({
-                            class: allowSelection ? 'col-md-7' : 'col-md-10',
+                            class: 'col-md-8',
                             style: {
-                                xdisplay: 'inline-block',
-                                xwidth: '70%',
-                                padding: '2px',
-                                overflowY: 'auto'
+                                padding: '2px'
                             }
                         }, item.label),
-                        div({ class: 'col-md-3' + (allowSelection ? '' : ' hidden'),
+                        div({class: 'col-md-2',
                             style: {
-                                xdisplay: 'inline-block',
-                                xwidth: '10%',
-                                //minWidth: '5em',
                                 padding: '2px',
                                 textAlign: 'right',
                                 verticalAlign: 'top'
@@ -258,34 +252,44 @@ define([
                                         })
                                     }, span({class: 'fa fa-minus-circle', style: {color: 'red', fontSize: '200%'}}));
                                 }
+                                if (allowSelection) {
+                                    return span({
+                                        class: 'kb-btn-icon',
+                                        type: 'button',
+                                        dataItemId: item.id,
+                                        id: events.addEvent({
+                                            type: 'click',
+                                            handler: function () {
+                                                doAddItem(item.id);
+                                            }
+                                        })}, span({class: 'fa fa-plus-circle', style: {color: 'green', fontSize: '200%'}}));
+                                }
                                 return span({
                                     class: 'kb-btn-icon',
                                     type: 'button',
-                                    dataItemId: item.id,
-                                    id: events.addEvent({
-                                        type: 'click',
-                                        handler: function () {
-                                            doAddItem(item.id);
-                                        }
-                                    })}, span({class: 'fa fa-plus-circle', style: {color: 'green', fontSize: '200%'}}));
+                                    dataItemId: item.id
+                                    }, span({class: 'fa fa-plus-circle', style: {color: 'silver', fontSize: '200%'}}));
                             }())
 
                         ])
                     ]);
                 })
-                .join('\n');
+                    .join('\n');
+            }
 
-            ui.setContent('available-items-count', String(items.length));
             ui.setContent('available-items', content);
-            ui.setContent('filtered-items-count', items.length);
+            events.attachEvents();
         }
 
-        function renderSelectedItems(events) {
-            var selectedItems = model.getItem('selectedItems', []);
-            if (!(selectedItems instanceof Array)) {
-                selectedItems = [selectedItems];
-            }
-            var valuesMap = model.getItem('availableValuesMap', {}),
+        function renderSelectedItems() {
+            var selectedItems = model.getItem('selectedItems', []),
+                valuesMap = model.getItem('availableValuesMap', {}),
+                events = Events.make({node: container}),
+                content;
+
+            if (selectedItems.length === 0) {
+                content = div({style: {textAlign: 'center'}}, 'no selected values');
+            } else {
                 content = selectedItems.map(function (itemId, index) {
                     var item = valuesMap[itemId];
                     if (item === undefined || item === null) {
@@ -294,18 +298,32 @@ define([
                         };
                     }
 
-                    return div({class: 'row', style: {border: '1px #CCC solid', borderCollapse: 'collapse'}}, [
+                    return div({class: 'row', style: {border: '1px #CCC solid', borderCollapse: 'collapse', boxSizing: 'border-box'}}, [
+                         div({
+                            class: 'col-md-2',
+                            style: {
+                                xdisplay: 'inline-block',
+                                xwidth: '20%',
+                                verticalAlign: 'middle',
+                                borderRadius: '3px',
+                                padding: '2px',
+                                backgroundColor: '#EEE',
+                                color: '#444',
+                                textAlign: 'right',
+                                paddingRight: '6px',
+                                fontFamily: 'monospace'
+                            }
+                        }, String(index + 1)),
                         div({
-                            class: 'col-md-9',
+                            class: 'col-md-8',
                             style: {
                                 xdisplay: 'inline-block',
                                 xwidth: '90%',
-                                padding: '2px',
-                                overflowY: 'auto'
+                                padding: '2px'
                             }
                         }, item.label),
                         div({
-                            class: 'col-md-3',
+                            class: 'col-md-2',
                             style: {
                                 xdisplay: 'inline-block',
                                 xwidth: '10%',
@@ -329,7 +347,135 @@ define([
                         ])
                     ]);
                 }).join('\n');
+            }
             ui.setContent('selected-items', content);
+            events.attachEvents();
+        }
+
+        function renderSearchBox() {
+            var items = model.getItem('availableValues', []),
+                events = Events.make({node: container}),
+                content;
+
+            //if (items.length === 0) {
+            //    content = '';
+            //} else {
+                content = input({
+                    class: 'form-contol',
+                    style: {xwidth: '100%'},
+                    placeholder: 'search',
+                    value: model.getItem('filter') || '',
+                    id: events.addEvents({events: [
+                            {
+                                type: 'keyup',
+                                handler: function (e) {
+                                    doSearchKeyUp(e);
+                                }
+                            },
+                            {
+                                type: 'focus',
+                                handler: function () {
+                                    Jupyter.narrative.disableKeyboardManager();
+                                }
+                            },
+                            {
+                                type: 'blur',
+                                handler: function () {
+                                    console.log('SingleSubData Search BLUR');
+                                    // Jupyter.narrative.enableKeyboardManager();
+                                }
+                            },
+                            {
+                                type: 'click',
+                                handler: function () {
+                                    Jupyter.narrative.disableKeyboardManager();
+                                }
+                            }
+                        ]})
+                });
+            //}
+
+            ui.setContent('search-box', content);
+            events.attachEvents();
+        }
+
+        function renderStats() {
+            var availableItems = model.getItem('availableValues', []),
+                filteredItems = model.getItem('filteredAvailableItems', []),
+                content;
+
+            if (availableItems.length === 0) {
+                content = '';
+            } else {
+                content = div([
+                    span({dataElement: 'filtered-items-count'}), ' of ',
+                    span({dataElement: 'available-items-count'})
+                ]);
+            }
+
+            ui.setContent('stats', content);
+            ui.setContent('available-items-count', String(availableItems.length));
+            ui.setContent('filtered-items-count', String(filteredItems.length));
+        }
+
+        function renderToolbar() {
+            var items = model.getItem('filteredAvailableItems', []),
+                events = Events.make({node: container}),
+                content;
+
+            if (items.length === 0) {
+                content = '';
+            } else {
+                content = div([
+                    button({
+                        type: 'button',
+                        class: 'btn btn-default',
+                        style: {xwidth: '100%'},
+                        id: events.addEvent({
+                            type: 'click',
+                            handler: function () {
+                                doFirstPage();
+                            }
+                        })
+                    }, ui.buildIcon({name: 'step-forward', rotate: 270})),
+                    button({
+                        class: 'btn btn-default',
+                        type: 'button',
+                        style: {xwidth: '50%'},
+                        id: events.addEvent({
+                            type: 'click',
+                            handler: function () {
+                                doPreviousPage();
+                            }
+                        })
+                    }, ui.buildIcon({name: 'caret-up'})),
+                    button({
+                        class: 'btn btn-default',
+                        type: 'button',
+                        style: {xwidth: '100%'},
+                        id: events.addEvent({
+                            type: 'click',
+                            handler: function () {
+                                doNextPage();
+                            }
+                        })
+                    }, ui.buildIcon({name: 'caret-down'})),
+                    button({
+                        type: 'button',
+                        class: 'btn btn-default',
+                        style: {xwidth: '100%'},
+                        id: events.addEvent({
+                            type: 'click',
+                            handler: function () {
+                                doLastPage();
+                            }
+                        })
+                    }, ui.buildIcon({name: 'step-forward', rotate: 90}))
+                ]);
+            }
+
+            ui.setContent('toolbar', content);
+            events.attachEvents();
         }
 
         function setPageStart(newFrom) {
@@ -413,212 +559,117 @@ define([
                     }
                 }, 'Items will be available after selecting a value for ' + subdataOptions.subdata_selection.parameter_id);
             }
-            //if (availableValues.length === 0) {
-            //    return 'No items found';
-            //}
 
             selectOptions = buildOptions();
 
             return div([
+//                div({class: 'row'}, [
+//                    div({class: 'col-md-6', style: {paddingBottom: '6px'}}, [
+//                        div({
+//                            style: {
+//                                fontWeight: 'bold',
+//                                textDecoration: 'underline',
+//                                fontStyle: 'italic',
+//                                textAlign: 'center'
+//                            }
+//                        }, 'Available')
+//                    ]),
+//                    div({class: 'col-md-6'}, [
+//                        div({
+//                            style: {
+//                                fontWeight: 'bold',
+//                                textDecoration: 'underline',
+//                                fontStyle: 'italic',
+//                                textAlign: 'center'
+//                            }
+//                        }, 'Selected')
+//                    ])
+//                ]),
                 div({class: 'row'}, [
-                    div({class: 'col-md-6', style: {paddingBottom: '6px'}}, [
-                        div({
-                            style: {
-                                fontWeight: 'bold',
-                                textDecoration: 'underline',
-                                fontStyle: 'italic',
-                                textAlign: 'center'
-                            }
-                        }, 'Available')
+                    div({
+                        class: 'col-md-6'                        
+                    }, [
+                        'Search: ',
+                        span({dataElement: 'search-box'})
                     ]),
-                    div({class: 'col-md-6'}, [
-                        div({
+//                    div({
+//                        class: 'col-md-3',
+//                        style: {textAlign: 'center'},
+//                        dataElement: 'stats'
+//                    }),
+                    div({
+                        class: 'col-md-6',
+                        style: {textAlign: 'right'},
+                        dataElement: 'toolbar'
+                    })
+                ]),              
+                div({class: 'row', style: {marginTop: '20px'}}, [
+                    div({class: 'col-md-12', style: {
+                        textAlign: 'center'                            
+                    }}, [
+                        span({
                             style: {
                                 fontWeight: 'bold',
                                 textDecoration: 'underline',
-                                fontStyle: 'italic',
-                                textAlign: 'center'
+                                fontStyle: 'italic'
+                            }
+                        }, 'Available'),
+                        ' ',
+                        span({
+                            dataElement: 'stats',
+                            style: {
+                                fontStyle: 'italic'
+                            }
+                        })
+                    ]),
+                    div({class: 'col-md-12'},
+                        div({
+                            style: {
+                                border: '1px silver solid'
+                            },
+                            dataElement: 'available-items'
+                        }))
+                ]),
+                div({class: 'row', style: {marginTop: '20px'}}, [
+                    div({class: 'col-md-12', style: {
+                        textAlign: 'center'
+                    }}, [
+                        span({
+                            style: {
+                                fontWeight: 'bold',
+                                textDecoration: 'underline',
+                                fontStyle: 'italic'
                             }
                         }, 'Selected')
                     ]),
-                ]),
-//                 div({class: 'row'}, [
-//                     div({class: 'col-md-6'}, [
-//                         div({class: 'row'}, [
-//                             div({class: 'col-md-6'}, 'col 1'),
-//                             div({class: 'col-md-6'}, 'col 1')
-//                         ])
-//                    ]),
-//                    div({class: 'col-md-6'}, [
-//                    ])
-//                ]),
-                div({class: 'row'},
-                (function () {
-                    if (availableValues.length === 0) {
-                        return [div({class: 'col-md-6'}, '')];
-                    }
-                    return  [
-                        div({class: 'col-md-3'}, [
-                            div({class: ''}, [
-                                input({
-                                    class: 'form-contol',
-                                    style: {width: '100%'},
-                                    placeholder: 'search',
-                                    value: model.getItem('filter') || '',
-                                    id: events.addEvents({ events : [{
-                                        type: 'keyup',
-                                        handler: function (e) {
-                                            doSearchKeyUp(e);
-                                        }
-                                    },
-                                    {
-                                        type: 'focus',
-                                        handler: function(e) {
-                                            Jupyter.narrative.disableKeyboardManager();
-                                        }
-                                    },
-                                    {
-                                        type: 'blur',
-                                        handler: function(e) {
-                                            console.log('SingleSubData Search BLUR');
-                                            // Jupyter.narrative.enableKeyboardManager();
-                                        }
-                                    },
-                                    {
-                                        type: 'click',
-                                        handler: function(e) {
-                                            Jupyter.narrative.disableKeyboardManager();
-                                        }
-                                    }]})
-                                })
-                            ])
-                        ]),
-                        div({class: 'col-md-3', style: {textAlign: 'center'}}, [
-                            span({dataElement: 'filtered-items-count'}), ' of ',
-                            span({dataElement: 'available-items-count'})
-                        ])
-                    ];
-                }()).concat([
-                    div({class: 'col-md-6'}, '')
-                ])),
-                div({class: 'row'}, [
-                    (function () {
-                        if (availableValues.length === 0) {
-                            return [div({class: 'col-md-6'}, '')];
-                        }
-                        return [
-                            div({class: 'col-md-6'}, [
-                                div([
-                                    button({
-                                        type: 'button',
-                                        class: 'btn btn-default',
-                                        style: {xwidth: '100%'},
-                                        id: events.addEvent({
-                                            type: 'click',
-                                            handler: function () {
-                                                doFirstPage();
-                                            }
-                                        })
-                                    }, ui.buildIcon({name: 'step-forward', rotate: 270})),
-                                    button({
-                                        class: 'btn btn-default',
-                                        type: 'button',
-                                        style: {xwidth: '50%'},
-                                        id: events.addEvent({
-                                            type: 'click',
-                                            handler: function () {
-                                                doPreviousPage();
-                                            }
-                                        })
-                                    }, ui.buildIcon({name: 'caret-up'})),
-                                    button({
-                                        class: 'btn btn-default',
-                                        type: 'button',
-                                        style: {xwidth: '100%'},
-                                        id: events.addEvent({
-                                            type: 'click',
-                                            handler: function () {
-                                                doNextPage();
-                                            }
-                                        })
-                                    }, ui.buildIcon({name: 'caret-down'})),
-                                    button({
-                                        type: 'button',
-                                        class: 'btn btn-default',
-                                        style: {xwidth: '100%'},
-                                        id: events.addEvent({
-                                            type: 'click',
-                                            handler: function () {
-                                                doLastPage();
-                                            }
-                                        })
-                                    }, ui.buildIcon({name: 'step-forward', rotate: 90}))
-                                ])
-                            ])
-                        ];
-                    }()).concat([div({class: 'col-md-6'}, '')])
-                ]),
-                div({class: 'row'}, [
-                    div({class: 'col-md-6'},
-                    (function () {
-                        if (availableValues.length === 0) {
-                            return div({style: {textAlign: 'center'}}, 'no available values');
-                        }
-                        return div({
-                            style: {border: '1px silver solid', xheight: '100px'},
-                            dataElement: 'available-items'
-                        });
-                    }())),
-                    div({class: 'col-md-6'},
-                    (function () {
-                        if (value.length === 0) {
-                            return div({style: {textAlign: 'center'}}, 'no selected values');
-                        }
-                        return div({
+                    div({class: 'col-md-12'},
+                        div({
                             style: {
-                                border: 'silverpx red solid', xheight: '100px'
+                                border: '1px silver solid'
                             },
                             dataElement: 'selected-items'
-                        });
-                    }()))
-                ])
+                        }))
+                ])               
+                
+//                div({class: 'row'}, [
+//                    div({class: 'col-md-6'},
+//                        div({
+//                            style: {
+//                                border: '1px silver solid',
+//                                xheight: '100px'
+//                            },
+//                            dataElement: 'available-items'
+//                        })),
+//                    div({class: 'col-md-6'},
+//                        div({
+//                            style: {
+//                                border: '1px silver solid',
+//                                xheight: '100px'
+//                            },
+//                            dataElement: 'selected-items'
+//                        }))
+//                ])
             ]);
-
-            // CONTROL
-//            return div({style: {border: '1px silver solid'}}, [
-//                div({style: {fontStyle: 'italic'}, dataElement: 'count'}, buildCount()),
-//                select({
-//                    id: events.addEvent({
-//                        type: 'change',
-//                        handler: function (e) {
-//                            validate()
-//                                .then(function (result) {
-//                                    if (result.isValid) {
-//                                        model.setItem('value', result.value);
-//                                        updateInputControl('value');
-//                                        bus.emit('changed', {
-//                                            newValue: result.value
-//                                        });
-//                                    } else if (result.diagnosis === 'required-missing') {
-//                                        model.setItem('value', result.value);
-//                                        updateInputControl('value');
-//                                        bus.emit('changed', {
-//                                            newValue: result.value
-//                                        });
-//                                    }
-//                                    bus.emit('validation', {
-//                                        errorMessage: result.errorMessage,
-//                                        diagnosis: result.diagnosis
-//                                    });
-//                                });
-//                        }
-//                    }),
-//                    size: size,
-//                    multiple: multiple,
-//                    class: 'form-control',
-//                    dataElement: 'input'
-//                }, selectOptions)
-//            ]);
         }
 
         /*
@@ -683,6 +734,7 @@ define([
         }
 
         function resetModelValue() {
+            model.reset();
             if (spec.spec.default_values && spec.spec.default_values.length > 0) {
                 // nb i'm assuming here that this set of strings is actually comma
                 // separated string on the other side.
@@ -732,7 +784,7 @@ define([
 
         function makeLabel(item, showSourceObjectName) {
             return div({style: {wordWrap: 'break-word'}}, [
-                div({style: {fontWeight: 'bold', xOverflow: 'auto'}}, item.id),
+                div({style: {fontWeight: 'bold'}}, item.id),
                 item.desc,
                 (function () {
                     if (showSourceObjectName && item.objectName) {
@@ -754,18 +806,18 @@ define([
             }
             var options = spec.spec.textsubdata_options;
             var subObjectIdentity = {
-                    ref: referenceObjectRef,
-                    included: options.subdata_selection.subdata_included
-                };
+                ref: referenceObjectRef,
+                included: options.subdata_selection.subdata_included
+            };
             var ret;
             if (options.subdata_selection.service_function) {
                 var swUrl = runtime.config('services.workspace.url').replace("ws", "service_wizard");
                 var genericClient = new GenericClient(swUrl, {
                     token: runtime.authToken()
                 });
-                ret = genericClient.sync_call(options.subdata_selection.service_function, 
-                        [[subObjectIdentity]], null, null, 
-                        options.subdata_selection.service_version);
+                ret = genericClient.sync_call(options.subdata_selection.service_function,
+                    [[subObjectIdentity]], null, null,
+                    options.subdata_selection.service_version);
             } else {
                 var workspace = new Workspace(runtime.config('services.workspace.url'), {
                     token: runtime.authToken()
@@ -793,34 +845,34 @@ define([
                         if (!result) {
                             return;
                         }
-                        
+
                         // Check if some generic wrapping is used which wasn't unwrapped by GenericClient
                         if (result.constructor === Array)
                             result = result[0];
-                        
+
                         var subdata = Props.getDataItem(result.data, options.subdata_selection.path_to_subdata);
 
                         if (!subdata) {
                             return;
                         }
 
-                // if(subdata instanceof Array) {
-                //     for(var k=0; k<subdata.length; k++) {
-                //         var dname = datainfo[1];
-                //         if(includeWsId) { dname = datainfo[6] + '/' + datainfo[1]; }
-                //         var id = subdata[k]; // default id is just the value
-                //         // if the selection_id is set, and the object is an object of somekind, then use that value
-                //         if(selection_id && typeof id === 'object') {
-                //             id = subdata[k][selection_id];
-                //         }
-                //         var autofill = {
-                //             id: id,
-                //             desc: hb_template(subdata[k]),
-                //             dref: datainfo[6] + '/' + datainfo[0] + '/' + datainfo[4],
-                //             dname: dname
-                //         };
-                //         self.autofillData.push(autofill);
-                //     }
+                        // if(subdata instanceof Array) {
+                        //     for(var k=0; k<subdata.length; k++) {
+                        //         var dname = datainfo[1];
+                        //         if(includeWsId) { dname = datainfo[6] + '/' + datainfo[1]; }
+                        //         var id = subdata[k]; // default id is just the value
+                        //         // if the selection_id is set, and the object is an object of somekind, then use that value
+                        //         if(selection_id && typeof id === 'object') {
+                        //             id = subdata[k][selection_id];
+                        //         }
+                        //         var autofill = {
+                        //             id: id,
+                        //             desc: hb_template(subdata[k]),
+                        //             dref: datainfo[6] + '/' + datainfo[0] + '/' + datainfo[4],
+                        //             dname: dname
+                        //         };
+                        //         self.autofillData.push(autofill);
+                        //     }
 
                         if (subdata instanceof Array) {
                             // For arrays we pluck off the "selectionId" property from
@@ -941,7 +993,7 @@ define([
         function render() {
             return Promise.try(function () {
                 // check to see if we have to render inputControl.
-                var events = Events.make(),
+                var events = Events.make({node: container}),
                     inputControl = makeInputControl(events, bus),
                     content = div({
                         class: 'input-group',
@@ -951,17 +1003,20 @@ define([
                     }, inputControl);
 
                 ui.setContent('input-container', content);
-                renderAvailableItems(events);
-                renderSelectedItems(events);
+                renderSearchBox();
+                renderStats();
+                renderToolbar();
+                renderAvailableItems();
+                renderSelectedItems();
 
-                events.attachEvents(container);
+                events.attachEvents();
             })
-            .then(function () {
-                return autoValidate();
-            })
-            .catch(function (err) {
-                console.error('ERROR in render', err);
-            });
+                .then(function () {
+                    return autoValidate();
+                })
+                .catch(function (err) {
+                    console.error('ERROR in render', err);
+                });
         }
 
         /*
@@ -990,12 +1045,20 @@ define([
              */
             bus.on('reset-to-defaults', function (message) {
                 resetModelValue();
+                // model.reset();
                 // TODO: this should really be set when the linked field is reset...
                 model.setItem('availableValues', []);
                 model.setItem('referenceObjectName', null);
                 doFilterItems();
-                updateInputControl('availableValues');
-                updateInputControl('value');
+                
+                renderSearchBox();
+                renderStats();
+                renderToolbar();
+                renderAvailableItems();
+                renderSelectedItems();
+                
+                // updateInputControl('availableValues');
+                // updateInputControl('value');
             });
 
             /*
@@ -1040,6 +1103,8 @@ define([
                     if (message.newValue === '') {
                         newValue = null;
                     }
+                    // reset the entire model.
+                    model.reset();
                     model.setItem('referenceObjectName', newValue);
                     syncAvailableValues()
                         .then(function () {
@@ -1061,6 +1126,7 @@ define([
                     if (message.newValue === '') {
                         newValue = null;
                     }
+                    model.reset();
                     model.setItem('referenceObjectName', newValue);
                     syncAvailableValues()
                         .then(function () {
@@ -1099,6 +1165,26 @@ define([
 
 
         }
+        
+        // MODIFICATION EVENTS
+        
+        /*
+        * More refinement of modifications. 
+        * 
+        * - initial run
+        * - reference data updated
+        *   - added "reset" method to props (model) to allow graceful zapping
+        *     of the model state.
+        * - item added to selected
+        * - item removed from selected
+        * - search term available
+        * - search term removed
+        * - filtered data updated
+        * 
+        */
+       
+       
+        
 
         // LIFECYCLE API
 
@@ -1167,7 +1253,7 @@ define([
                             } else {
                                 var selectedItems = paramValue.value;
                                 if (!(selectedItems instanceof Array)) {
-                                    selectedItems = [ selectedItems ];
+                                    selectedItems = [selectedItems];
                                 }
                                 model.setItem('selectedItems', selectedItems);
                             }
@@ -1176,7 +1262,6 @@ define([
                             if (referencedParamValue) {
                                 model.setItem('referenceObjectName', referencedParamValue.value);
                             }
-                            console.log('syncing...');
                             return syncAvailableValues()
                                 .then(function () {
                                     updateInputControl('availableValues');
@@ -1206,7 +1291,15 @@ define([
             }
             ,
             onUpdate: function (props) {
-                render();
+                // cheap version
+                //renderSearchBox();
+                renderStats();
+                renderToolbar();
+
+                renderAvailableItems();
+                renderSelectedItems();
+                // renderNavbar();
+                // render();
                 // updateInputControl(props);
             }
         });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -251,38 +251,78 @@ define([
         handleCommMessages: function (msg) {
             var msgType = msg.content.data.msg_type,
                 bus = this.runtime.bus();
+            
             switch (msgType) {
                 case 'new_job':
                     // this.registerKernelJob(msg.content.data.content);
                     Jupyter.notebook.save_checkpoint();
                     break;
+                /*
+                 * The job status for one or more jobs. See job_status_all
+                 * for a message which covers all active jobs.
+                 * Note that these messages are additive to the job panel
+                 * cache, but the reverse logic does not apply.
+                 */
                 case 'job_status':
-                    var status = {},
-                        info = {},
-                        content = msg.content.data.content;
+                    var incomingJobs = msg.content.data.content;
+                    
+                    /*
+                     * Ensure there is a locally cached copy of each job.
+                     * 
+                     */
                     for (var jobId in content) {
-                        var jobStateMessage = content[jobId];
+                        var jobStateMessage = incomingJobs[jobId];
                         // We could just copy the entire message into the job
                         // states cache, but referencing each individual property
-                        // is more explicity about the structure.
+                        // is more explicit about the structure.
                         this.jobStates[jobId] = {
                             state: jobStateMessage.state,
                             spec: jobStateMessage.spec,
                             widgetParameters: jobStateMessage.widget_info
-                        }
+                        };
 
-                        // The job state includes both the job state info and the
-                        // app spec. Not sure why...
-                        // WJR - because the renderer needs info from the app spec
-                        // like its name and such.
-                        // EAP - what i mean was why it is sent with each job state
-                        // message. I can see that given that job_status may be
-                        // issued at any arbitrary front end state, and the spec
-                        // will be useful on the first message received, it might
-                        // be better to just bite the bullet and require that any
-                        // element which needs the app spec fetch that
-                        // independently, or rather perhaps the appmanager could
-                        // arbitrate those requets.
+                        /*
+                         * Notify the front end about the changed or new job
+                         * states.
+                         */
+                        this.sendJobMessage('job-status', jobId, {
+                            jobId: jobId,
+                            jobState: jobStateMessage.state,
+                            outputWidgetInfo: jobStateMessage.widget_info
+                        });
+                    }
+                    this.populateJobsPanel(); //status, info, content);
+                    break;
+                /*
+                 * This message must carry all jobs linked to this narrative.
+                 * The "job-deleted" logic, specifically, requires that the job
+                 * actually not exist in the job service.
+                 * NB there is logic in the job management back end to allow
+                 * job notification to be turned off per job -- this would 
+                 * be incompatible with the logic here and we should address
+                 * that. 
+                 * E.g. if that behavior is allowed, then deletion detection
+                 * would need to move to the back end, since that is the only
+                 * place that would truly know about all jobs for this narrative.
+                 */
+                case 'job_status_all':
+                    var incomingJobs = msg.content.data.content;
+                    
+                    /*
+                     * Ensure there is a locally cached copy of each job.
+                     * 
+                     */
+                    for (var jobId in content) {
+                        var jobStateMessage = incomingJobs[jobId];
+                        // We could just copy the entire message into the job
+                        // states cache, but referencing each individual property
+                        // is more explicit about the structure.
+                        this.jobStates[jobId] = {
+                            state: jobStateMessage.state,
+                            spec: jobStateMessage.spec,
+                            widgetParameters: jobStateMessage.widget_info
+                        };
+
                         this.sendJobMessage('job-status', jobId, {
                             jobId: jobId,
                             jobState: jobStateMessage.state,
@@ -292,24 +332,29 @@ define([
 
                     // Remove jobs which are in the local cache but not in the
                     // job_status message.
+                    /*
+                     * This is for maintenance of the local job state cache.
+                     * This loop used to take care of the case in which a
+                     * cached job is not found in the incoming notifications.
+                     * This would signal a "job-deleted" message. 
+                     * Although it could be the case that a+++
+                     */
+                    // NB: this implies that t
                     Object.keys(this.jobStates).forEach(function (jobId) {
-                        var jobState = this.jobStates[jobId];
-                        // HMM the first condition covers jobs in the cache
-                        // which have been set to falsy? Not sure how that
-                        // is possible. But if so, they could not be in the
-                        // message anyway, since we just synced the cache
-                        // from the messages...
-                        //if (!jobState || !content[jobState.state.job_id]) {
-                        if (!content[jobState.state.job_id]) {
-                            this.sendJobMessage('job-deleted', jobState.state.job_id, {
-                                jobId: jobState.state.job_id
+                        if (!incomingJobs[jobId]) {
+                            // If ths job is not found in the incoming list of all
+                            // jobs, then we must both delete it locally, and 
+                            // notify any interested parties.
+                            this.sendJobMessage('job-deleted', jobId, {
+                                jobId: jobId,
+                                via: 'no_longer_exists'
                             });
                             // it is safe to delete properties here
                             delete this.jobStates[jobId];
                         }
                     }.bind(this));
                     this.populateJobsPanel(); //status, info, content);
-                    break;
+                    break;                    
                 case 'run_status':
                     // Send job status notifications on the default channel,
                     // with a key on the message type and the job id, sending
@@ -334,7 +379,7 @@ define([
 
                 case 'job_deleted':
                     var deletedId = msg.content.data.content.job_id;
-                    this.sendJobMessage('job-deleted', deletedId, {jobId: deletedId});
+                    this.sendJobMessage('job-deleted', deletedId, {jobId: deletedId, via: 'job_deleted'});
                     // console.info('Deleted job ' + deletedId);
                     this.removeDeletedJob(deletedId);
                     break;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -198,10 +198,11 @@ define([
                 this.deleteJob(message.jobId);
             }.bind(this));
 
-            bus.on('request-job-removal', function (message) {
-                this.deleteJob(message.jobId);
+            bus.on('request-job-cancellation', function (message) {
+                // this.deleteJob(message.jobId);
+                alert('Job cancellation not yet support.');
             }.bind(this));
-
+            
             bus.on('request-job-status', function (message) {
                 this.sendCommMessage(this.JOB_STATUS, message.jobId);
             }.bind(this));
@@ -270,7 +271,7 @@ define([
                      * Ensure there is a locally cached copy of each job.
                      * 
                      */
-                    for (var jobId in content) {
+                    for (var jobId in incomingJobs) {
                         var jobStateMessage = incomingJobs[jobId];
                         // We could just copy the entire message into the job
                         // states cache, but referencing each individual property
@@ -312,7 +313,7 @@ define([
                      * Ensure there is a locally cached copy of each job.
                      * 
                      */
-                    for (var jobId in content) {
+                    for (var jobId in incomingJobs) {
                         var jobStateMessage = incomingJobs[jobId];
                         // We could just copy the entire message into the job
                         // states cache, but referencing each individual property

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -50,7 +50,7 @@ define([
     var t = html.tag,
         div = t('div'), span = t('span'), a = t('a'),
         table = t('table'), tr = t('tr'), th = t('th'), td = t('td'),
-        pre = t('pre'), input = t('input'), img = t('img'), p = t('p'),
+        pre = t('pre'), input = t('input'), img = t('img'), p = t('p'), blockquote = t('blockquote'),
         appStates = [
             {
                 state: {
@@ -1319,7 +1319,7 @@ define([
 
                 // This is now fire and forget.
                 // TODO: close the loop on this.
-                runtime.bus().emit('request-job-removal', {
+                runtime.bus().emit('request-job-deletion', {
                     jobId: jobId
                 });
                 resolve();
@@ -1343,7 +1343,7 @@ define([
          * narrative metadata.
          */
         function cancelJob(jobId) {
-            runtime.bus().emit('request-job-removal', {
+            runtime.bus().emit('request-job-cancellation', {
                 jobId: jobId
             });
         }
@@ -1423,7 +1423,11 @@ define([
          */
         function doCancel() {
             var confirmationMessage = div([
-                p('Canelling the job will halt the job processing and remove it from the job queue.'),
+                p([
+                    'Cancelling the job will halt the job processing.',
+                    'Any output objects already created will remain in your narrative and can be removed from the Data panel.'
+                ]),
+                blockquote('Note that canceling the job will not delete the job, you will need to do that from the Jobs Panel.'),
                 p('Continue to Cancel the running job?')
             ]);
             ui.showConfirmDialog('Cancel Job?', confirmationMessage, 'Yes', 'No')
@@ -1564,7 +1568,6 @@ define([
                     type: 'job-status'
                 },
                 handle: function (message) {
-                    console.log('job-status', message);
                     var existingState = model.getItem('exec.jobState'),
                         newJobState = message.jobState,
                         outputWidgetInfo = message.outputWidgetInfo;
@@ -1968,7 +1971,7 @@ define([
                 // TODO: only turn this on when we need it!
                 cellBus.on('run-status', function (message) {
                     updateFromLaunchEvent(message);
-
+                    
                     model.setItem('exec.launchState', message);
 
                     // Save this to the exec state change log.
@@ -2141,9 +2144,7 @@ define([
                 var value = params[key],
                     paramSpec = env.parameterMap[key];
 
-                console.log('param spec', paramSpec);
                 if (paramSpec.spec.field_type === 'textsubdata') {
-                    console.log('GOT ITTT', value);
                     if (value && value instanceof Array) {
                         value = value.join(',');
                     }

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -1343,14 +1343,12 @@ define([
          * narrative metadata.
          */
         function cancelJob(jobId) {
-            console.log('cancelling job', jobId);
             runtime.bus().emit('request-job-removal', {
                 jobId: jobId
             });
         }
         
         function resetToEditMode(source) {
-            console.log('Resetting to edit mode', source);
             // only do this if we are not editing.
             
              model.deleteItem('exec');

--- a/nbextensions/appCell/widgets/appExecWidget.js
+++ b/nbextensions/appCell/widgets/appExecWidget.js
@@ -92,7 +92,7 @@ define([
 
         function renderJobLog() {
             return ui.buildPanel({
-                title: 'Job Log',
+                // title: 'Job Log',
                 name: 'job-log',
                 hidden: false,
                 type: 'primary',
@@ -291,6 +291,7 @@ define([
         
         function showJobDetails() {
             //if (showToggleElement('job-details')) {
+            updateJobDetails();
             var details = model.getItem('jobDetails');
             if (details) {
                 Object.keys(details).forEach(function (key) {
@@ -444,142 +445,158 @@ define([
          * A map to make adding and removing easier...
          */
         
+        function renderSummaryWidget() {
+            return div({
+                style: {
+                    border: '1px silver solid',
+                    padding: '4px'
+                }
+            }, [
+                'summary widget here'
+            ]);
+        }
+        
 
         function render() {
-            var tabs = ui.buildTabs({
-                id: html.genId(),
-                fade: true,
-                style: {
-                    padding: '10px 0 0 0'
-                },
-                tabs: [
-                    {
-                        name: 'stats',
-                        label: 'Stats',
-                        content: renderExecStats(),
-                        icon: ui.buildIcon({name: 'clock-o'}),
-                        events: [
-                            {
-                                type: 'shown',
-                                handler: function (e) {
-                                    execStateListeners.stats = showExecStats;
-                                    showExecState();
-                                }
-                            },
-                            {
-                                type: 'hidden',
-                                handler: function (e) {
-                                    delete execStateListeners.stats;
-                                }
-                            }
-                        ]
+            var events = Events.make({node: container}),
+                tabs = ui.buildTabs({
+                    id: html.genId(),
+                    fade: true,
+                    style: {
+                        padding: '10px 0 0 0'
                     },
-                    ui.ifAdvanced(function () {
-                        return {
-                            label: 'Details',
-                            content: renderJobDetails(),
+                    tabs: [
+                        {
+                            name: 'stats',
+                            label: 'Stats',
+                            content: renderExecStats(),
+                            icon: ui.buildIcon({name: 'clock-o'}),
                             events: [
                                 {
                                     type: 'shown',
                                     handler: function (e) {
-                                        execStateListeners.detail = showJobDetails;
+                                        execStateListeners.stats = showExecStats;
                                         showExecState();
                                     }
                                 },
                                 {
                                     type: 'hidden',
                                     handler: function (e) {
-                                        delete execStateListeners.detail;
+                                        delete execStateListeners.stats;
                                     }
                                 }
                             ]
-                        };
-                    }),
-                    ui.ifAdvanced(function () {
-                        return {
-                            label: 'Raw',
-                            content: renderRawJobState(),
+                        },
+                        ui.ifAdvanced(function () {
+                            return {
+                                label: 'Details',
+                                content: renderJobDetails(),
+                                events: [
+                                    {
+                                        type: 'shown',
+                                        handler: function (e) {
+                                            execStateListeners.detail = showJobDetails;
+                                            showExecState();
+                                        }
+                                    },
+                                    {
+                                        type: 'hidden',
+                                        handler: function (e) {
+                                            delete execStateListeners.detail;
+                                        }
+                                    }
+                                ]
+                            };
+                        }),
+                        ui.ifAdvanced(function () {
+                            return {
+                                label: 'Raw',
+                                content: renderRawJobState(),
+                                events: [
+                                    {
+                                        type: 'shown',
+                                        handler: function (e) {
+                                            execStateListeners.detail = showRawJobState;
+                                            showExecState();
+                                        }
+                                    },
+                                    {
+                                        type: 'hidden',
+                                        handler: function (e) {
+                                            delete execStateListeners.detail;
+                                        }
+                                    }
+                                ]
+                            };
+                        }),
+                        {
+                            label: 'Log',
+                            content: renderJobLog(),
+                            icon: ui.buildIcon({name: 'list'}),
                             events: [
                                 {
                                     type: 'shown',
                                     handler: function (e) {
-                                        execStateListeners.detail = showRawJobState;
-                                        showExecState();
+                                        var panelId = e.target.getAttribute('data-panel-id'),
+                                            panel = document.getElementById(panelId);
+                                        showJobLog({node: panel});
+                                        // execStateListeners.log = showJobLog;
+                                        // showExecState();
                                     }
                                 },
                                 {
                                     type: 'hidden',
                                     handler: function (e) {
-                                        delete execStateListeners.detail;
+                                        var panelId = e.target.getAttribute('data-panel-id'),
+                                            panel = document.getElementById(panelId);
+                                        hideJobLog({node: panel});
+                                        // delete execStateListeners.log;
                                     }
                                 }
                             ]
-                        };
-                    }),
-                    {
-                        label: 'Log',
-                        content: renderJobLog(),
-                        icon: ui.buildIcon({name: 'list'}),
-                        events: [
-                            {
-                                type: 'shown',
-                                handler: function (e) {
-                                    var panelId = e.target.getAttribute('data-panel-id'),
-                                        panel = document.getElementById(panelId);
-                                    showJobLog({node: panel});
-                                    // execStateListeners.log = showJobLog;
-                                    // showExecState();
-                                }
-                            },
-                            {
-                                type: 'hidden',
-                                handler: function (e) {
-                                    var panelId = e.target.getAttribute('data-panel-id'),
-                                        panel = document.getElementById(panelId);
-                                    hideJobLog({node: panel});
-                                    // delete execStateListeners.log;
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        label: 'Result',
-                        content: renderJobResult(),
-                        // icon: renderJobResultIcon(),
-                        icon: ui.buildIcon({name: 'check'}),
-                        events: [
-                            {
-                                type: 'shown',
-                                handler: function (e) {
-                                    var panelId = e.target.getAttribute('data-panel-id'),
-                                        panel = document.getElementById(panelId);
-                                    execStateListeners.result = function () {
+                        },
+                        {
+                            label: 'Result',
+                            content: renderJobResult(),
+                            // icon: renderJobResultIcon(),
+                            icon: ui.buildIcon({name: 'check'}),
+                            events: [
+                                {
+                                    type: 'shown',
+                                    handler: function (e) {
+                                        var panelId = e.target.getAttribute('data-panel-id'),
+                                            panel = document.getElementById(panelId);
+                                        execStateListeners.result = function () {
+                                            showJobResult({node: panel});
+                                        };
                                         showJobResult({node: panel});
-                                    };
-                                    showJobResult({node: panel});
+                                    }
+                                },
+                                {
+                                    type: 'hidden',
+                                    handler: function (e) {
+                                        var panelId = e.target.getAttribute('data-panel-id'),
+                                            panel = document.getElementById(panelId);
+                                        panel.innerHTML = '';
+                                        delete execStateListeners.result;
+                                    }
                                 }
-                            },
-                            {
-                                type: 'hidden',
-                                handler: function (e) {
-                                    var panelId = e.target.getAttribute('data-panel-id'),
-                                        panel = document.getElementById(panelId);
-                                    panel.innerHTML = '';
-                                    delete execStateListeners.result;
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }),
-                events = Events.make({node: container});
+                            ]
+                        }
+                    ]
+                });
 
-            container.innerHTML = tabs.content;
+            container.innerHTML = div({}, [                
+                div({style: {marginBottom: '4px'}}, [
+                    renderSummaryWidget()
+                ]),
+                tabs.content
+            ]);
             tabs.events.forEach(function (event) {
                 events.addEvent(event);
             });
             events.attachEvents();
-            $('#' + tabs.map['stats']).tab('show');
+            $('#' + tabs.map.stats).tab('show');
         }
 
         // DATA FETCH
@@ -738,17 +755,20 @@ define([
                 error: error,
                 success: null
             };
+
             model.setItem('runState', newRunState);
         }
 
-        function updateRunStateFromJobState() {
+        function updateRunStateFromJobState(source) {
             var jobState = model.getItem('jobState'),
                 runState = model.getItem('runState'),
                 now = new Date().getTime(),
                 newRunState,
                 temporalState,
                 submitTime, startTime, completedTime,
-                elapsedQueueTime, elapsedRunTime;
+                elapsedQueueTime, elapsedRunTime,
+                position;
+            
             if (!jobState) {
                 return;
             }
@@ -833,6 +853,7 @@ define([
                     console.warn('STRANGE - no launchState', launchState);
                 }
                 
+                position = jobState.position;
                 if (jobState.exec_start_time) {
                     startTime = jobState.exec_start_time;
                     elapsedQueueTime = startTime - submitTime;
@@ -1011,6 +1032,7 @@ define([
                 jobState: jobState,
                 elapsedLaunchTime: runState.elapsedLaunchTime,
                 elapsedQueueTime: elapsedQueueTime,
+                position: position,
                 elapsedRunTime: elapsedRunTime,
                 completedTime: completedTime,
                 error: error,
@@ -1127,15 +1149,15 @@ define([
             // TODO: the controller should meter this for us!
             model.setItem('jobStateLastUpdatedTime', new Date().getTime());
             var currentJobState = model.getItem('jobState');
-            if (!currentJobState || currentJobState.job_state !== jobState.job_state) {
+            //if (!currentJobState || currentJobState.job_state !== jobState.job_state) {
                 model.setItem('jobStateLastUpdatedTime', new Date().getTime());
                 model.setItem('jobState', jobState);
-                updateRunStateFromJobState();
-                updateJobDetails();
+                updateRunStateFromJobState('process new job state');
+                //updateJobDetails();
                 // renderRunState();
 
                 showExecState();
-            }
+            //}
             // If any.
             // showJobError();
         }
@@ -1154,13 +1176,14 @@ define([
 
             // INTERNAL EVENTS
 
-            bus.on('show-job-report', function (message) {
+            ev = bus.on('show-job-report', function (message) {
                 getJobReport(message.reportRef)
                     .then(function (jobReport) {
                         model.setItem('jobReport', jobReport);
                         showJobReport();
                     });
             });
+            listeners.push(ev);
 
             // CELL EVENTS
             /*
@@ -1184,6 +1207,7 @@ define([
              * This was done, rather thanhave
              */
             ev = cellBus.on('job-state', function (message) {
+                console.log('NEW JOB STATE pos', message.jobState.position);
                 processNewJobState(message.jobState);
             });
             listeners.push(ev);
@@ -1203,7 +1227,7 @@ define([
                 // return;
                 var runState = model.getItem('runState');
                 if (runState && runState.executionState === 'processing') {
-                    updateRunStateFromJobState();
+                    updateRunStateFromJobState('clock');
                 }
                 // renderRunState();
                 showExecState();

--- a/nbextensions/appCell/widgets/appOutputWidget.js
+++ b/nbextensions/appCell/widgets/appOutputWidget.js
@@ -18,7 +18,8 @@ define([
 
     var t = html.tag,
         div = t('div'), button = t('button'),
-        table = t('table'), tr = t('tr'), th = t('td'), td = t('td'), p = t('p');
+        table = t('table'), tr = t('tr'), th = t('td'), td = t('td'), p = t('p'),
+        ul = t('ul'), li = t('li');
 
     function factory(config) {
         var runtime = Runtime.make(),
@@ -29,7 +30,7 @@ define([
                 currentJobState: null,
                 outputs: null
             },
-            api;
+        api;
 
         function findCellForId(id) {
             var matchingCells = Jupyter.notebook.get_cells().filter(function (cell) {
@@ -49,47 +50,76 @@ define([
         }
 
         function doRemoveOutputCell(index) {
-            var content = div([
-                p('This will remove the output cell from the Narrative, as well as this output record. This action is not reversable. Any associated data will remain in your narrative, and may be found in the Data panel.'),
-                p('Are you sure you want to remove the output cell?')
-            ]);
+            var output = model.outputs[index],
+                currentOutput, content;
+
+            if (model.currentJobState && output.jobId === model.currentJobState.job_id) {
+                currentOutput = true;
+            } else {
+                currentOutput = false;
+            }
+
+            if (currentOutput) {
+                content = div([
+                    p('This will:'),
+                    ul([
+                        li('Remove the output cell from the Narrative'),
+                        li('Remove this output record'),
+                        li('Remove the associated job'),
+                        li('Reset the app to edit mode')
+                    ]),
+                    p('Note: This action is not reversable.'),
+                    p('Data produced in this output will remain in your narrative, and may be found in the Data panel.'),
+                    p('Are you sure you want to remove the output cell?')
+                ]);
+            } else {
+                content = div([
+                    p('This will:'),
+                    ul([
+                        li('Remove the output cell from the Narrative'),
+                        li('Remove this output record'),
+                        li('Remove the associated job')
+                    ]),
+                    p('Note: This action is not reversable.'),
+                    p('Data produced in this output will remain in your narrative, and may be found in the Data panel.'),
+                    p('Are you sure you want to remove the output cell?')
+                ]);
+            }
             ui.showConfirmDialog('Confirm Deletion of Cell Output', content, 'Yes', 'No')
                 .then(function (answer) {
                     if (!answer) {
                         return;
                     }
-                // remove the output cell
-                var output = model.outputs[index],
-                    outputCell = findCellForId(output.cellId),
-                    cellIndex;
+                    // remove the output cell
+                    var output = model.outputs[index],
+                        outputCell = findCellForId(output.cellId),
+                        cellIndex;
 
-                if (outputCell) {
-                    //alert('Could not find this cell');
-                    //return;
-                    cellIndex = Jupyter.notebook.find_cell_index(outputCell);
-                    Jupyter.notebook.delete_cell(cellIndex);
-                }
+                    if (outputCell) {
+                        cellIndex = Jupyter.notebook.find_cell_index(outputCell);
+                        Jupyter.notebook.delete_cell(cellIndex);
+                    }
 
-                // send a message on the cell bus bus, parent should pick it up, remove the
-                // output from the model, and update us.
-                bus.bus().send({
-                    jobId: output.jobId
-                }, {
-                    channel: {
-                        cell: cellId
-                    },
-                    key: {
-                        type: 'output-cell-removed'
-                    }
+                    // send a message on the cell bus bus, parent should pick it up, remove the
+                    // output from the model, and update us.
+                    bus.bus().send({
+                        jobId: output.jobId
+                    }, {
+                        channel: {
+                            cell: cellId
+                        },
+                        key: {
+                            type: 'output-cell-removed'
+                        }
+                    });
+                    bus.bus().send({
+                        jobId: output.jobId
+                    }, {
+                        key: {
+                            type: 'request-job-deletion'
+                        }
+                    });
                 });
-                bus.bus().send({
-                    jobId: output.jobId
-                }, {
-                    key: {
-                        type: 'request-job-deletion'
-                    }
-                });
-            });
         }
 
         function render() {
@@ -134,15 +164,6 @@ define([
                                 ])
                             ]),
                             div({class: 'col-md-4', style: {textAlign: 'right'}}, [
-//                                button({
-//                                    class: 'btn btn-sm btn-standard',
-//                                    type: 'button',
-//                                    id: events.addEvent({
-//                                        type: 'click',
-//                                        handler: function () {
-//                                            doRemoveOutput(index);
-//                                        }
-//                                    })}, 'delete'),
                                 button({
                                     class: 'btn btn-sm btn-standard',
                                     type: 'button',
@@ -151,8 +172,7 @@ define([
                                         handler: function () {
                                             doRemoveOutputCell(index);
                                         }
-                                    })}, 'Remove Output Cell'),
-
+                                    })}, '&times;'),
                                 div({style: {marginTop: '20px'}, dataElement: 'message'}, message)
 
                             ])

--- a/nbextensions/appCell/widgets/appParamsViewWidget.js
+++ b/nbextensions/appCell/widgets/appParamsViewWidget.js
@@ -220,7 +220,7 @@ define([
             return Promise.resolve()
                 .then(function () {
                     if (inputParams.length === 0) {
-                        places.inputFields.innerHTML = 'No inputs';
+                        places.inputFields.innerHTML = span({style: {fontStyle: 'italic'}}, 'No input objects for this app');
                     } else {
                         return Promise.all(inputParams.map(function (spec) {
                             var fieldWidget = makeFieldWidget(spec, model.getItem(['params', spec.name()])),
@@ -234,7 +234,7 @@ define([
                 })
                 .then(function () {
                     if (outputParams.length === 0) {
-                        places.outputFields.innerHTML = 'No outputs';
+                        places.outputFields.innerHTML = span({style: {fontStyle: 'italic'}}, 'No output objects for this app');
                     } else {
                         return Promise.all(outputParams.map(function (spec) {
                             var fieldWidget = makeFieldWidget(spec, model.getItem(['params', spec.name()])),
@@ -248,7 +248,7 @@ define([
                 })
                 .then(function () {
                     if (parameterParams.length === 0) {
-                        places.parameterFields.innerHTML = 'No parameters';
+                        ui.setContent('parameter-fields', span({style: {fontStyle: 'italic'}}, 'No parameters for this app'));
                     } else {
                         return Promise.all(parameterParams.map(function (spec) {
                             var fieldWidget = makeFieldWidget(spec, model.getItem(['params', spec.name()])),

--- a/nbextensions/appCell/widgets/jobLogViewer.js
+++ b/nbextensions/appCell/widgets/jobLogViewer.js
@@ -71,6 +71,10 @@ define([
                         auto: false
                     },
                     {
+                        mode: 'active',
+                        auto: true
+                    },
+                    {
                         mode: 'complete'
                     },
                     {

--- a/nbextensions/appCell/widgets/jobLogViewer.js
+++ b/nbextensions/appCell/widgets/jobLogViewer.js
@@ -452,7 +452,8 @@ define([
                     if (message.logs.lines.length === 0) {
                         // TODO: add an alert area and show a dismissable alert.
                         if (!looping) {
-                            alert('No log entries returned');
+                            // alert('No log entries returned');
+                            console.warn('No log entries returned', message);
                         }
                     } else {                    
                         model.setItem('lines', message.logs.lines);

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -211,7 +211,7 @@ class JobManager(object):
                     'job_id': job_id,
                     'message': str(e)
                 })
-        self._send_comm_message('job_status', status_set)
+        self._send_comm_message('job_status_all', status_set)
 
     def _lookup_job_status_loop(self):
         """

--- a/test2/specs/active/props-Spec.js
+++ b/test2/specs/active/props-Spec.js
@@ -2,11 +2,11 @@
 /*jslint white:true,browser:true*/
 define([
     'common/props'
-], function(Props) {
+], function (Props) {
     'use strict';
-    
-    describe('Props core functions', function() {
-        it('Is alive', function() {
+
+    describe('Props core functions', function () {
+        it('Is alive', function () {
             var alive;
             if (Props) {
                 alive = true;
@@ -15,28 +15,35 @@ define([
             }
             expect(alive).toBeTruthy();
         });
-        it('Set and get a simple string property', function() {
+        it('Set and get a simple string property', function () {
             var props = Props.make();
             props.setItem('color', 'green');
             expect(props.getItem('color')).toEqual('green');
         });
-        it('Set and get a simple number property', function() {
+        it('Set and reset a simple string property', function () {
+            var props = Props.make();
+            props.setItem('color', 'green');
+            expect(props.getItem('color')).toEqual('green');
+            props.reset();
+            expect(props.getItem('color')).toBeUndefined();
+        });
+        it('Set and get a simple number property', function () {
             var props = Props.make();
             props.setItem('themeaningoflife', 42);
             expect(props.getItem('themeaningoflife')).toEqual(42);
         });
-        it('Set and get a simple boolean property', function() {
+        it('Set and get a simple boolean property', function () {
             var props = Props.make();
             props.setItem('buggy', true);
             expect(props.getItem('buggy')).toEqual(true);
         });
-        
-        it('Set and get a simple object property', function() {
+
+        it('Set and get a simple object property', function () {
             var props = Props.make();
             props.setItem('pet', {type: 'dog', name: 'peet'});
             expect(props.getItem('pet')).toEqual({type: 'dog', name: 'peet'});
         });
-        it('History should undefined', function() {
+        it('History should undefined', function () {
             var props = Props.make();
             expect(props.getHistoryCount()).toBeUndefined;
         });
@@ -45,8 +52,8 @@ define([
 //            props.setItem('color', 'red');
 //            expect(props.getHistoryCount()).toEqual(1);
 //        });
-        
-        it('Update callback should be called', function(done) {
+
+        it('Update callback should be called', function (done) {
             var props = Props.make({
                 onUpdate: function (props) {
                     expect(true).toEqual(true);
@@ -54,10 +61,10 @@ define([
                 }
             });
             props.setItem('color', 'red');
-            
+
         });
-        
-        it('History should be 1 after one change', function(done) {
+
+        it('History should be 1 after one change', function (done) {
             var props = Props.make({
                 onUpdate: function (props) {
                     if (props.getHistoryCount() === 1) {
@@ -67,9 +74,9 @@ define([
                 }
             });
             props.setItem('color', 'red');
-            
+
         });
-        it('Set and get a simple string property, check last value', function(done) {
+        it('Set and get a simple string property, check last value', function (done) {
             var props = Props.make({
                 onUpdate: function (props) {
                     if (props.getHistoryCount() === 1) {
@@ -78,32 +85,34 @@ define([
                     }
                     var raw = props.getRawObject(),
                         last = props.getLastRawObject();
-                    
+
                     expect(last.color).toEqual('red');
                     done();
                 }
             });
             props.setItem('color', 'red');
         });
-    });
-    it('Copy a property -- it unaffected by changes to the original', function () {
-        var props = Props.make({
-            data: {
-                prop1: {
-                    propA: 42
+
+        it('Copy a property -- it unaffected by changes to the original', function () {
+            var props = Props.make({
+                data: {
+                    prop1: {
+                        propA: 42
+                    }
                 }
-            }
-        }),
-            propCopy = props.copyItem('prop1');
-            
-        props.setItem('prop1.propA', 53);
-        
-        expect(propCopy.propA).toEqual(42);
-        expect(props.getItem('prop1.propA')).toEqual(53);
-    });
-    it('Set and get a simple string property using data methods', function() {
+            }),
+                propCopy = props.copyItem('prop1');
+
+            props.setItem('prop1.propA', 53);
+
+            expect(propCopy.propA).toEqual(42);
+            expect(props.getItem('prop1.propA')).toEqual(53);
+        });
+        it('Set and get a simple string property using data methods', function () {
             var data = {};
             Props.setDataItem(data, 'color', 'green');
             expect(Props.getDataItem(data, 'color')).toEqual('green');
         });
+    });
+
 });

--- a/test2/test-main.js
+++ b/test2/test-main.js
@@ -19,8 +19,8 @@ require.config({
         'font-awesome': 'http://cdn.kbase.us/cdn/font-awesome/4.3.0/css/font-awesome',
         bluebird: 'http://cdn.kbase.us/cdn/bluebird/3.3.4/bluebird',
         jquery: 'http://cdn.kbase.us/cdn/jquery/2.2.2/jquery',
-        bootstrap: 'http://cdn.kbase.us/cdn/jquery/3.3.6/js/bootstrap',
-        bootstrap_css: 'http://cdn.kbase.us/cdn/jquery/3.3.6/css/bootstrap'
+        bootstrap: 'http://cdn.kbase.us/cdn/bootstrap/3.3.6/js/bootstrap',
+        bootstrap_css: 'http://cdn.kbase.us/cdn/bootstrap/3.3.6/css/bootstrap'
         
     },
     // dynamically load all test files


### PR DESCRIPTION
- job cancellation invokes request-job-cancellation (which does nothing yet)
- back end job status events split into job_status and job_status_all
  - this allows the "detection of deleted job" in the job panel to work since the logic requires that all known jobs be included in the message (which is what job_status_all is for)
  - this is a [wip] but fixes a problem with new jobs issuing a job-deleted message
- fixes to properly remove event handlers