### PR TITLE
Fixes to problems exposed by testing 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,13 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-15
+__Changes__
+- fix output param marked as parameter triggering error and blocking app cell insertion
+- improve error message when checkbox is misconfigured
+- improve checkbox rules display
+
+
 ### Version 3.0.0-alpha-14
 __Changes__
 - fix job cell (as produced by JobManager()->job_info())

--- a/kbase-extension/static/kbase/js/common/parameterSpec.js
+++ b/kbase-extension/static/kbase/js/common/parameterSpec.js
@@ -592,6 +592,10 @@ define([
             
         }
         
+        function paramClass() {
+            return attributes.paramClass;
+        }
+        
         setupParamClass();
         
         // NEW -- validate and completely set up normalized param first,
@@ -617,7 +621,8 @@ define([
             isEmpty: isEmpty,
             nullValue: nullValue,
             defaultValue: defaultValue,
-            getConstraints: getConstraints
+            getConstraints: getConstraints,
+            paramClass: paramClass
         };
     }
 

--- a/kbase-extension/static/kbase/js/common/ui.js
+++ b/kbase-extension/static/kbase/js/common/ui.js
@@ -19,6 +19,11 @@ define([
         ul = t('ul'), li = t('li'), a = t('a'),
         button = t('button'), pre = t('pre');
 
+    // "static" methods
+    function na() {
+        return span({style: {fontStyle: 'italic', color: 'orange'}}, 'NA');
+    }
+
     function factory(config) {
         var container = config.node,
             bus = config.bus,
@@ -608,10 +613,6 @@ define([
             }
         }
 
-        function na() {
-            return span({style: {fontStyle: 'italic', color: 'orange'}}, 'NA');
-        }
-
         function getUserSetting(settingKey, defaultValue) {
             var settings = Jupyter.notebook.metadata.kbase.userSettings,
                 setting;
@@ -934,6 +935,8 @@ define([
     return {
         make: function (config) {
             return factory(config);
-        }
+        },
+        // "static" methods
+        na: na
     };
 });

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/fieldWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/fieldWidget.js
@@ -16,9 +16,10 @@ define([
     'kb_common/html',
     'common/events',
     'common/ui',
+    'common/props',
     './input/errorInput',
     'css!google-code-prettify/prettify.css'
-], function (Promise, $, PR, html, Events, UI, ErrorControlFactory) {
+], function (Promise, $, PR, html, Events, UI, Props, ErrorControlFactory) {
     'use strict';
     var t = html.tag,
         div = t('div'), span = t('span'), label = t('label'), button = t('button'),
@@ -204,8 +205,8 @@ define([
                     // just for now ...
                     if (spec.spec.field_type === 'checkbox') {
                         return [
-                            tr([th('Min'), td(String(0))]),
-                            tr([th('Max'), td(String(1))])
+                            tr([th('Value when checked'), td(Props.getDataItem(spec.spec, 'checkbox_options.checked_value', UI.na()))]),
+                            tr([th('Value when un-checked'), td(Props.getDataItem(spec.spec, 'checkbox_options.unchecked_value', UI.na()))])
                         ];
                     }
                     return [

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleCheckbox.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleCheckbox.js
@@ -19,11 +19,11 @@ define([
     function factory(config) {
         var options = {},
             spec = config.parameterSpec,
+            checkboxOptions,
             container,
             $container,
             bus = config.bus,
-            valueChecked = spec.spec.checkbox_options.checked_value,
-            valueUnchecked = spec.spec.checkbox_options.unchecked_value,
+            constraints,
             model = {
                 updates: 0,
                 value: undefined
@@ -31,9 +31,28 @@ define([
 
         // Validate configuration.
         // Nothing to do...
+        
+        // validate
+        if (!spec.spec.checkbox_options) {
+            throw new Error('Checkbox control does not have checkbox_options configured');
+        }
+        checkboxOptions = spec.spec.checkbox_options.checked_value;
+        if ( (typeof checkboxOptions.checked_value !== 'string') ||
+             (checkboxOptions.checked_value.length === 0) ) {
+            throw new Error('Checkbox spec option checked_value is not configured');
+        }
+        if ( (typeof checkboxOptions.unchecked_value !== 'string') ||
+             (checkboxOptions.checked_value.length === 0) ) {
+            throw new Error('Checkbox spec option unchecked_value is not configured');
+        }
 
         options.enabled = true;
-        
+
+        constraints = {
+            valueChecked: checkboxOptions.checked_value,
+            valueUnchecked: checkboxOptions.unchecked_value
+        };
+
         // Is this a valid spec?
         
         //if (spec.required() && spec.defaultValue() === null) {
@@ -54,9 +73,9 @@ define([
         function getInputValue() {
             var checkbox = container.querySelector('[data-element="input-container"] [data-element="input"]');
             if (checkbox.checked) {
-                return valueChecked;
+                return constraints.valueChecked;
             }
-            return valueUnchecked;
+            return constraints.valueUnchecked;
         }
 
         /*
@@ -104,15 +123,15 @@ define([
         function resetModelValue() {
             if (spec.spec.default_values && spec.spec.default_values.length > 0) {
                 if (meansChecked(spec.spec.default_values[0])) {
-                    setModelValue(valueChecked);
+                    setModelValue(constraints.valueChecked);
                 } else {
-                    setModelValue(valueUnchecked);
+                    setModelValue(constraints.valueUnchecked);
                 }
             } else {
                 // NOTE: we set the checkbox explicitly to the "unchecked value" 
                 // if no default value is provided.
                 // unsetModelValue();
-                setModelValue(valueUnchecked);
+                setModelValue(constraints.valueUnchecked);
             }
         }
 
@@ -150,7 +169,7 @@ define([
                     // such in the spec.
                     validationOptions = {
                         required: spec.required(),
-                        values: [valueChecked, valueUnchecked]
+                        values: [constraints.valueChecked, constraints.valueUnchecked]
                     },
                 validationResult;
 
@@ -169,7 +188,7 @@ define([
             // CONTROL
             var checked = false,
                 booleanString = 'no';
-            if (model.value === valueChecked) {
+            if (model.value === constraints.valueChecked) {
                 checked = true;
                 booleanString = 'yes';
             }
@@ -211,7 +230,7 @@ define([
                     type: 'checkbox',
                     dataElement: 'input',
                     checked: checked,
-                    value: valueChecked
+                    value: constraints.valueChecked
                 })]);
         }
         function autoValidate() {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleObjectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleObjectInput.js
@@ -129,6 +129,9 @@ define([
             })
                 .then(function (changed) {
                     return render();
+                })
+                .then(function () {
+                    autoValidate();
                 });
         }
 
@@ -138,6 +141,9 @@ define([
             })
                 .then(function (changed) {
                     render();
+                })
+                .then(function () {
+                    autoValidate();
                 });
         }
 
@@ -229,10 +235,7 @@ define([
 
                 dom.setContent('input-container', content);
                 events.attachEvents(container);
-            })
-                .then(function () {
-                    // return autoValidate();
-                });
+            });
         }
 
         /*
@@ -281,11 +284,14 @@ define([
                                 return true;
                             }
                             return false;
-                        })
+                        });
                         if (matching.length === 0) {
                             model.value = null;
                         }
-                        render();
+                        render()
+                            .then(function () {
+                                autoValidate();
+                            });
                     }
                 });
 
@@ -311,7 +317,6 @@ define([
                             render();
                         })
                         .then(function () {
-
                             bus.on('reset-to-defaults', function (message) {
                                 resetModelValue();
                             });

--- a/nbextensions/appCell/widgets/appParamsWidget.js
+++ b/nbextensions/appCell/widgets/appParamsWidget.js
@@ -371,13 +371,13 @@ define([
             return Promise.try(function () {
                 var params = validateParameterSpecs(model.getItem('parameters')),
                     inputParams = params.filter(function (spec) {
-                        return (spec.spec.ui_class === 'input');
+                        return (spec.paramClass() === 'input');
                     }),
                     outputParams = params.filter(function (spec) {
-                        return (spec.spec.ui_class === 'output');
+                        return (spec.paramClass() === 'output');
                     }),
                     parameterParams = params.filter(function (spec) {
-                        return (spec.spec.ui_class === 'parameter');
+                        return (spec.paramClass() === 'parameter');
                     });
 
                 return Promise.resolve()

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-14",
+    "version": "3.0.0-alpha-15",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
- blocker was an alert and refusal to insert app cell when a parameter which is specified to contain an output object name is also specified as "parameter" type. It should be "output". This is an app spec error, but we are working around this by allowing  the output object name setting to override the parameter "ui_class" (input, output, parameter).
- improve error message when a checkbox is specified without providing the values associated with checked or unchecked state.