### PR TITLE
Fixes NAR-864 - handle severe app errors or version mismatch

### DIFF
--- a/kbase-extension/static/kbase/css/bootstrapHelper.css
+++ b/kbase-extension/static/kbase/css/bootstrapHelper.css
@@ -69,7 +69,7 @@
 .panel.kb-panel-container > .panel-heading {
     background-color: transparent;
     font-weight: bold;
-    color: #2e618d;
+    xcolor: #2e618d;
     padding-left: 0;
     padding-bottom: 2px;
     border-bottom: 2px #CCC solid;

--- a/kbase-extension/static/kbase/js/common/error.js
+++ b/kbase-extension/static/kbase/js/common/error.js
@@ -1,0 +1,84 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+
+define([
+], function () {
+    'use strict';
+    
+    
+    function KBError(arg) {
+        this.type = arg.type;
+        this.message = arg.message;
+        this.reason = arg.reason;
+        this.original = arg.original;
+        this.detail = arg.detail;
+        this.info =arg.info;
+        this.advice = arg.advice;
+
+        this.blame = arg.blame;
+        this.code = arg.code;
+        this.suggestion = arg.suggestion;
+    }
+    KBError.prototype = new Error();
+
+    function grokError(err) {
+        if (err instanceof KBError) {
+            return err;
+        }
+        if (err instanceof Error) {
+            return new KBError({
+                type: 'js-error',
+                name: err.name,
+                message: err.message,
+                original: err
+            });
+        }
+
+        switch (typeof err) {
+            case 'string':
+                return new KBError({
+                    type: 'string-error',
+                    message: err,
+                    original: err
+                });
+            case 'object':
+                if (err.error) {
+                    // this is a kbase service client style error
+                    return new KBError({
+                        type: 'kbase-client-error',
+                        name: err.error.name,
+                        message: err.error.message,
+                        detail: err.error.error,
+                        original: err
+                    });
+                } else if (err.message) {
+                    return new KBError({
+                        type: 'js-error',
+                        name: err.name,
+                        message: err.message,
+                        original: err
+                    });
+                } else {
+                    return new KBError({
+                        type: 'unknown-error',
+                        name: 'Unknown',
+                        message: 'An unknown error occurred',
+                        original: err
+                    });
+                }
+            default:
+                return new KBError({
+                    type: 'unknown-error',
+                    name: 'Unknown',
+                    message: 'An unknown error occurred',
+                    original: err
+                });
+        }
+    }
+
+
+    return {
+        grokError: grokError,
+        KBError: KBError
+    };
+});

--- a/kbase-extension/static/kbase/js/common/fsm.js
+++ b/kbase-extension/static/kbase/js/common/fsm.js
@@ -3,9 +3,9 @@
 
 /*
  * fsm.js
- * 
+ *
  *  A simple finite state machine.
- *  
+ *
  */
 
 define([
@@ -30,7 +30,7 @@ define([
 
             // ...
         }
-        
+
         function run() {
             if (!newStateHandler) {
                 return;
@@ -47,7 +47,7 @@ define([
                 }
             }, 0);
         }
-        
+
         function findState(stateToFind) {
             var foundStates = allStates.filter(function (stateDef) {
                 if (utils.isEqual(stateToFind, stateDef.state)) {
@@ -58,8 +58,9 @@ define([
                 return foundStates[0];
             }
             if (foundStates.length > 1) {
+                console.error('state error: multiple states found:', stateToFind, foundStates)
                 throw new Error('state error: multiple states found');
-            }            
+            }
 
         }
         function doMessages(changeType) {
@@ -76,17 +77,17 @@ define([
                 }
             }
         }
-        
+
         function doResumeState() {
             doMessages('resume');
         }
-        
+
         function doEnterState() {
-            doMessages('enter');            
+            doMessages('enter');
         }
 
         function doLeaveState() {
-            doMessages('leave');            
+            doMessages('leave');
         }
 
 
@@ -102,10 +103,10 @@ define([
 
             // make it the current state
             currentState = state;
-            
+
             doResumeState();
         }
-        
+
         function findNextState(stateList, stateToFind) {
             var foundStates = stateList.filter(function (state) {
                 if (utils.isEqual(state, stateToFind)) {
@@ -117,13 +118,13 @@ define([
             }
             if (foundStates.length > 1) {
                 throw new Error('Multiple next states found');
-            }            
+            }
         }
 
         function newState(nextState) {
             var state = findNextState(currentState.next, nextState);
             if (!state) {
-                // console.error('Could not find new state', nextState, currentState);
+                console.error('Cannot not find new state', nextState, currentState);
                 throw new Error('Cannot find the new state');
             }
 
@@ -131,33 +132,33 @@ define([
             if (!newState) {
                 throw new Error('Next state found, but that state does not exist');
             }
-            
+
             if (utils.isEqual(newState.state, currentState.state)) {
                 return;
             }
-            
+
             doMessages('exit');
-            
+
             // make it the current state
             currentState = newState;
 
             doMessages('enter');
-            
-            
+
+
             run();
         }
 
         function getCurrentState() {
             return currentState;
         }
-        
+
         api = {
             start: start,
             newState: newState,
             getCurrentState: getCurrentState,
             findState: findState
         };
-        
+
         return api;
     }
 

--- a/kbase-extension/static/kbase/js/common/ui.js
+++ b/kbase-extension/static/kbase/js/common/ui.js
@@ -890,6 +890,16 @@ define([
                 }
             };
         }
+        
+        function buildGridTable(arg) {
+            return arg.table.map(function (row) {
+                return div({class: 'row', style: arg.row.style}, arg.cols.map(function (col, index) {
+                    return div({class: 'col-md-' + String(col.width), style: col.style}, row[index]);
+                }));
+            });
+        }
+
+
 
         return {
             getElement: getElement,
@@ -928,7 +938,8 @@ define([
             buildTabs: buildTabs,
             jsonBlockWidget: jsonBlockWidget(),
             enableTooltips: enableTooltips,
-            updateTab: updateTab
+            updateTab: updateTab,
+            buildGridTable: buildGridTable
         };
     }
 

--- a/nbextensions/appCell/main.js
+++ b/nbextensions/appCell/main.js
@@ -473,7 +473,7 @@ define([
                 })
                 .catch(function (err) {
                     console.error('ERROR starting app cell', err);
-                    alert('Error starting app cell');
+                    alert('Error starting app cell: ' + err.message);
                 });
         });
     }

--- a/nbextensions/appCell/main.js
+++ b/nbextensions/appCell/main.js
@@ -457,8 +457,6 @@ define([
                 })
                 .then(function () {
                     return appCellWidget.run({
-                        appId: appId,
-                        appTag: appTag,
                         authToken: runtime.authToken()
                     });
                 })

--- a/nbextensions/appCell/widgets/appCellWidget-fsm.js
+++ b/nbextensions/appCell/widgets/appCellWidget-fsm.js
@@ -1,10 +1,10 @@
 /*global define*/
 /*jslint white:true,browser:true*/
 
-define([    
+define([
 ], function () {
    'use strict';
-   
+
    var appStates = [
             {
                 state: {
@@ -33,24 +33,6 @@ define([
             },
             {
                 state: {
-                    mode: 'fatal-error'
-                },
-                ui: {
-                    buttons: {
-                        enabled: [],
-                        disabled: ['run-app'],
-                        hidden: ['re-run-app', 'cancel']
-                    },
-                    elements: {
-                        show: ['fatal-error'],
-                        hide: ['parameters-group', 'output-group', 'parameters-display-group', 'exec-group']
-                    }
-                },
-                next: []
-
-            },
-            {
-                state: {
                     mode: 'editing',
                     params: 'incomplete'
                 },
@@ -74,6 +56,9 @@ define([
                     {
                         mode: 'editing',
                         params: 'incomplete'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -132,6 +117,9 @@ define([
                     },
                     {
                         mode: 'error'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -194,6 +182,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -246,6 +237,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -285,6 +279,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -320,6 +317,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -355,6 +355,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -383,6 +386,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
 
@@ -412,6 +418,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
 
@@ -441,6 +450,9 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             },
@@ -468,11 +480,36 @@ define([
                         mode: 'editing',
                         params: 'complete',
                         code: 'built'
+                    },
+                    {
+                        mode: 'fatal-error'
+                    }
+                ]
+            },
+            // A fatal error represents an app cell which cannot operate.
+            {
+                state: {
+                    mode: 'fatal-error'
+                },
+                ui: {
+                    buttons: {
+                        enabled: [],
+                        disabled: [],
+                        hidden: ['re-run-app', 'run-app', 'cancel']
+                    },
+                    elements: {
+                        show: ['fatal-error'],
+                        hide: ['parameters-group', 'parameters-display-group', 'exec-group', 'output-group']
+                    }
+                },
+                next: [
+                    {
+                        mode: 'fatal-error'
                     }
                 ]
             }
+
         ];
-   
+
    return appStates;
 });
-

--- a/nbextensions/appCell/widgets/appCellWidget-fsm.js
+++ b/nbextensions/appCell/widgets/appCellWidget-fsm.js
@@ -14,7 +14,7 @@ define([
                     buttons: {
                         enabled: [],
                         disabled: ['run-app'],
-                        hidden: ['re-run-app', 'cancel']
+                        hidden: ['re-run-app', 'cancel', 'report-error']
                     },
                     elements: {
                         show: [],
@@ -40,7 +40,7 @@ define([
                     buttons: {
                         enabled: [],
                         disabled: ['run-app'],
-                        hidden: ['re-run-app', 'cancel']
+                        hidden: ['re-run-app', 'cancel', 'report-error']
                     },
                     elements: {
                         show: ['parameters-group', 'output-group'],
@@ -72,7 +72,7 @@ define([
                     buttons: {
                         enabled: ['run-app'],
                         disabled: [],
-                        hidden: ['re-run-app', 'cancel']
+                        hidden: ['re-run-app', 'cancel', 'report-error']
                     },
                     elements: {
                         show: ['parameters-group', 'output-group'],
@@ -136,7 +136,7 @@ define([
                     buttons: {
                         enabled: ['cancel'],
                         disabled: [],
-                        hidden: ['run-app', 're-run-app']
+                        hidden: ['run-app', 're-run-app', 'report-error']
                     },
                     elements: {
                         show: ['parameters-display-group', 'exec-group', 'output-group'],
@@ -197,7 +197,7 @@ define([
                     buttons: {
                         enabled: ['cancel'],
                         disabled: [],
-                        hidden: ['run-app', 're-run-app']
+                        hidden: ['run-app', 're-run-app', 'report-error']
                     },
                     elements: {
                         show: ['parameters-display-group', 'exec-group', 'output-group'],
@@ -252,7 +252,7 @@ define([
                     buttons: {
                         enabled: ['cancel'],
                         disabled: [],
-                        hidden: ['run-app', 're-run-app']
+                        hidden: ['run-app', 're-run-app', 'report-error']
                     },
                     elements: {
                         show: ['parameters-display-group', 'exec-group', 'output-group'],
@@ -294,7 +294,7 @@ define([
                     buttons: {
                         enabled: ['cancel'],
                         disabled: [],
-                        hidden: ['run-app', 're-run-app']
+                        hidden: ['run-app', 're-run-app', 'report-error']
                     },
                     elements: {
                         show: ['parameters-display-group', 'exec-group', 'output-group'],
@@ -331,7 +331,7 @@ define([
                     buttons: {
                         enabled: ['re-run-app'],
                         disabled: [],
-                        hidden: ['run-app', 'cancel']
+                        hidden: ['run-app', 'cancel', 'report-error']
                     },
                     elements: {
                         show: ['parameters-display-group', 'exec-group', 'output-group'],
@@ -368,7 +368,7 @@ define([
                 },
                 ui: {
                     buttons: {
-                        enabled: ['re-run-app'],
+                        enabled: ['re-run-app', 'report-error'],
                         disabled: [],
                         hidden: ['run-app', 'cancel']
                     },
@@ -400,7 +400,7 @@ define([
                 },
                 ui: {
                     buttons: {
-                        enabled: ['re-run-app'],
+                        enabled: ['re-run-app', 'report-error'],
                         disabled: [],
                         hidden: ['run-app', 'cancel']
                     },
@@ -432,7 +432,7 @@ define([
                 },
                 ui: {
                     buttons: {
-                        enabled: ['re-run-app'],
+                        enabled: ['re-run-app', 'report-error'],
                         disabled: [],
                         hidden: ['run-app', 'cancel']
                     },
@@ -463,7 +463,7 @@ define([
                 },
                 ui: {
                     buttons: {
-                        enabled: ['re-run-app'],
+                        enabled: ['re-run-app', 'report-error'],
                         disabled: [],
                         hidden: ['run-app', 'cancel']
                     },
@@ -493,7 +493,7 @@ define([
                 },
                 ui: {
                     buttons: {
-                        enabled: [],
+                        enabled: ['report-error'],
                         disabled: [],
                         hidden: ['re-run-app', 'run-app', 'cancel']
                     },

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -71,11 +71,6 @@ define([
             model,
             // HMM. Sync with metadata, or just keep everything there?
             settings = {
-//                showAdvanced: {
-//                    label: 'Show advanced parameters',
-//                    defaultValue: false,
-//                    type: 'custom'
-//                },
                 showNotifications: {
                     label: 'Show the Notifications panel',
                     help: 'The notifications panel may contain informational, warning, or error messages emitted during the operation of the app cell',
@@ -193,6 +188,7 @@ define([
         function syncFatalError() {
             ui.setContent('fatal-error.title', model.getItem('fatalError.title'));
             ui.setContent('fatal-error.message', model.getItem('fatalError.message'));
+            ui.setContent('fatal-error.detail', model.getItem('fatalError.detail'));
         }
 
         function showFatalError(arg) {
@@ -432,21 +428,6 @@ define([
                         div({dataElement: 'widget', style: {display: 'block', width: '100%'}}, [
                             div({class: 'container-fluid'}, [
                                 ui.buildPanel({
-                                    title: 'Error',
-                                    name: 'fatal-error',
-                                    hidden: true,
-                                    type: 'danger',
-                                    classes: ['kb-panel-container'],
-                                    body: div([
-                                        table({class: 'table table-striped'}, [
-                                            tr([
-                                                th('Title'), td({dataElement: 'title'}),
-                                                td('Message', td({dataElement: 'message'}))
-                                            ])
-                                        ])
-                                    ])
-                                }),
-                                ui.buildPanel({
                                     title: 'App Cell Settings',
                                     name: 'settings',
                                     hidden: true,
@@ -498,23 +479,6 @@ define([
                                         ]
                                     });
                                 }()),
-                                ui.buildCollapsiblePanel({
-                                    title: 'Input ' + span({class: 'fa fa-arrow-right'}),
-                                    name: 'parameters-group',
-                                    hidden: false,
-                                    type: 'default',
-                                    classes: ['kb-panel-container'],
-                                    body: div({dataElement: 'widget'})
-                                }),
-                                ui.buildCollapsiblePanel({
-                                    title: 'Parameters (display)',
-                                    name: 'parameters-display-group',
-                                    hidden: false,
-                                    collapsed: true,
-                                    type: 'default',
-                                    classes: ['kb-panel-container'],
-                                    body: div({dataElement: 'widget'})
-                                }),
                                 div({class: 'btn-toolbar kb-btn-toolbar-cell-widget'}, [
                                     div({class: 'btn-group'}, [
                                         ui.buildButton({
@@ -552,6 +516,23 @@ define([
                                         //    ui.makeButton('Remove', 'remove', {events: events, type: 'danger'})
                                         //])
                                 ]),
+                                ui.buildCollapsiblePanel({
+                                    title: 'Input ' + span({class: 'fa fa-arrow-right'}),
+                                    name: 'parameters-group',
+                                    hidden: false,
+                                    type: 'default',
+                                    classes: ['kb-panel-container'],
+                                    body: div({dataElement: 'widget'})
+                                }),
+                                ui.buildCollapsiblePanel({
+                                    title: 'Parameters (display)',
+                                    name: 'parameters-display-group',
+                                    hidden: false,
+                                    collapsed: true,
+                                    type: 'default',
+                                    classes: ['kb-panel-container'],
+                                    body: div({dataElement: 'widget'})
+                                }),
                                 ui.buildPanel({
                                     title: 'App Execution ' + span({class: 'fa fa-bolt'}),
                                     name: 'exec-group',
@@ -567,6 +548,35 @@ define([
                                     type: 'default',
                                     classes: ['kb-panel-container'],
                                     body: div({dataElement: 'widget'})
+                                }),
+                                ui.buildPanel({
+                                    title: 'Error',
+                                    name: 'fatal-error',
+                                    hidden: true,
+                                    type: 'danger',
+                                    classes: ['kb-panel-container'],
+                                    body: div([
+                                        div({class: 'alert alert-danger'}, 'This App cell could not load due to errors described below'),
+                                        ui.buildGridTable({
+                                            row: {
+                                                style: {marginBottom: '6px'}
+                                            },
+                                            cols: [
+                                                {
+                                                    width: 2,
+                                                    style: {fontWeight: 'bold'}
+                                                },
+                                                {
+                                                    width: 10
+                                                }
+                                            ],
+                                            table: [
+                                                ['Title', div({dataElement: 'title'})],
+                                                ['Message', div({dataElement: 'message'})],
+                                                ['Details', div({dataElement: 'detail', style: {maxHeight: '300px', maxWidth: '100%', overflow: 'scroll', fontFamily: 'monospace'}})]
+                                            ]
+                                        })
+                                    ])
                                 })
                             ])
                         ])
@@ -577,7 +587,7 @@ define([
                 events: events
             };
         }
-
+        
         function validateModel() {
             /*
              * Validation is currently very simple.
@@ -922,8 +932,7 @@ define([
                 if (curMode === 'processing') {
                     startListeningForJobMessages();
                 }
-            }
-            else {
+            } else {
                 // Hide the job starting/modifying buttons
                 // It'd be nice to put all the elements in view-only mode,
                 // to mimic a running state, right? Maybe that's another
@@ -986,7 +995,7 @@ define([
                 jobId: jobId
             });
         }
-        
+
         function requestJobStatus(jobId) {
             runtime.bus().emit('request-job-status', {
                 jobId: jobId
@@ -1170,7 +1179,7 @@ define([
         //       to the kernel)
         function doRun() {
             fsm.newState({mode: 'execute-requested'});
-            
+
             // Save this to the exec state change log.
             var execLog = model.getItem('exec.log');
             if (!execLog) {
@@ -1184,7 +1193,7 @@ define([
                 }
             });
             model.setItem('exec.log', execLog);
-            
+
             cell.execute();
         }
 
@@ -1293,7 +1302,7 @@ define([
                     //  reset the cell into edit mode
                     var state = fsm.getCurrentState();
                     if (state.state.mode === 'editing') {
-                        console.warn('in edit mode, so not resetting ui')
+                        console.warn('in edit mode, so not resetting ui');
                         return;
                     }
 
@@ -1313,7 +1322,7 @@ define([
                     //  reset the cell into edit mode
                     var state = fsm.getCurrentState();
                     if (state.state.mode === 'editing') {
-                        console.warn('in edit mode, so not resetting ui')
+                        console.warn('in edit mode, so not resetting ui');
                         return;
                     }
 
@@ -1664,16 +1673,16 @@ define([
 //                }
 
                 // Regardless of what the FSM says, if we are not listening for a
-                // job update and we already have an execution job state, let's 
+                // job update and we already have an execution job state, let's
                 // see if there is anything new, even if we don't expect anything
                 // new...
                 //if (!listeningForJobUpdates) {
-                    var jobId = model.getItem('exec.jobState.job_id');
-                    if (jobId) {
-                        startListeningForJobMessages(jobId);
-                    }
+                var jobId = model.getItem('exec.jobState.job_id');
+                if (jobId) {
+                    startListeningForJobMessages(jobId);
+                }
                 //}
-                
+
 
 
                 // TODO: only turn this on when we need it!
@@ -1808,7 +1817,7 @@ define([
 //                    }
 //                });
 
-                runtime.bus().on('read-only-changed', function(msg) {
+                runtime.bus().on('read-only-changed', function (msg) {
                     toggleReadOnlyMode(msg.readOnly);
                 });
 
@@ -1854,6 +1863,11 @@ define([
             Object.keys(params).forEach(function (key) {
                 var value = params[key],
                     paramSpec = env.parameterMap[key];
+
+                if (!paramSpec) {
+                    console.error('Parameter ' + key + ' is not defined in the parameter map', env.parameterMap, env.parameters);
+                    throw new Error('Parameter ' + key + ' is not defined in the parameter map');
+                }
 
                 if (paramSpec.spec.field_type === 'textsubdata') {
                     if (value && value instanceof Array) {
@@ -2175,16 +2189,78 @@ define([
                     }
                 })
                 .catch(function (err) {
-                    console.error('ERROR loading main widgets', err);
-                    addNotification('Error loading main widgets: ' + err.message);
+                    var error = grokError(err);
+                    console.error('ERROR loading main widgets', error);
+                    addNotification('Error loading main widgets: ' + error.message);
+
                     model.setItem('fatalError', {
                         title: 'Error loading main widgets',
-                        message: err.message
+                        message: error.message,
+                        detail: error.detail
                     });
                     syncFatalError();
                     fsm.newState({mode: 'fatal-error'});
                     renderUI();
                 });
+        }
+
+        /*
+         Grok a sensible error structure out of something returned by something.
+         */
+        function grokError(err) {
+            if (err instanceof Error) {
+                return {
+                    type: 'js-error',
+                    name: err.name,
+                    message: err.message,
+                    original: err
+                };
+            }
+            if (err instanceof KBError) {
+                return err;
+            }
+
+            switch (typeof err) {
+                case 'string':
+                    return {
+                        type: 'string-error',
+                        message: err,
+                        original: err
+                    };
+                    break;
+                case 'object':
+                    if (err.error) {
+                        // this is a kbase service client style error
+                        return {
+                            type: 'kbase-client-error',
+                            name: err.error.name,
+                            message: err.error.message,
+                            detail: err.error.error,
+                            original: err
+                        };
+                    } else if (err.message) {
+                        return {
+                            type: 'js-error',
+                            name: err.name,
+                            message: err.message,
+                            original: err
+                        };
+                    } else {
+                        return {
+                            type: 'unknown-error',
+                            name: 'Unknown',
+                            message: 'An unknown error occurred',
+                            original: err
+                        };
+                    }
+                default:
+                    return {
+                        type: 'unknown-error',
+                        name: 'Unknown',
+                        message: 'An unknown error occurred',
+                        original: err
+                    };
+            }
         }
 
         // INIT


### PR DESCRIPTION
In https://atlassian.kbase.us/browse/NAR-864, two different conditions were reported to cause an error popup upon loading a narrative.

These were due to, 
- in one case an incorrectly specified app cell. This was due to an app cell inserted some time during development of the app cell. The specific cause was a null tag.
- in the second case an app cell containing a dev app which had been updated, and the parameters changed. This triggered an unexpected condition (a parameter lookup returned undefined).
- another case discovered during testing was an app cell from several weeks ago which had an incomplete app spec.

In all cases, the implementation of the fatal-error condition with detailed error messaging will be more helpful to a user who encounters this. In the case of the invalid parameter, the more general case is a dev or beta app whose commit hash has changed. This is now detected and throws a similar error.

These errors should not occur in production. The fatal-error state is a catch-all for errors caught early in the startup of the app cell, so will provide a safer haven for these types of errors in general.

Also includes a seminal "report error" button, which currently does nothing useful.

What is not addressed is released apps whose version changes. These should continue to work. Future work should enable an app update action to enable updating an app cell in-situ to a more recent version. 