### PR TITLE
Hide the Jobs Panel

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionAnalysis.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionAnalysis.js
@@ -23,8 +23,8 @@
 		bootstrap,
 		$,
 		Plotly,
-		kbaseAuthenticatedWidget,
-		KBModeling
+		kbaseAuthenticatedWidget
+		// KBModeling
 	) {
 
     return KBWidget({

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionAnalysis.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionAnalysis.js
@@ -30,7 +30,7 @@
     return KBWidget({
         name: "kbaseExpressionAnalysis",
         parent : kbaseAuthenticatedWidget,
-        version: "1.0.0",
+        version: "1.0.1",
         options: {},
         init: function(input) {
             var self = this;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -158,9 +158,9 @@ define([
 
             this.addButton($refreshBtn);
 
-            this.body().append(this.$jobsPanel)
-                .append(this.$loadingPanel)
-                .append(this.$errorPanel);
+            // this.body().append(this.$jobsPanel)
+            //     .append(this.$loadingPanel)
+            //     .append(this.$errorPanel);
 
             this.showMessage('Initializing...', true);
             this.handleBusMessages();
@@ -269,7 +269,7 @@ define([
                  */
                 case 'job_status':
                     var incomingJobs = msg.content.data.content;
-                    
+
                     /*
                      * Ensure there is a locally cached copy of each job.
                      *
@@ -289,7 +289,7 @@ define([
                          * Notify the front end about the changed or new job
                          * states.
                          */
-                        
+
                         this.sendJobMessage('job-status', jobId, {
                             jobId: jobId,
                             jobState: jobStateMessage.state,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -27,7 +27,7 @@ define (
     'use strict';
     return KBWidget({
         name: 'kbaseNarrativeSidePanel',
-        
+
         options: {
             loadingImage: Config.get('loading_gif'),
             autorender: true,
@@ -58,7 +58,7 @@ define (
                 {
                     name : 'kbaseNarrativeDataPanel',
                     params : {
-                        collapseCallback: $.proxy(function(isMinimized) { 
+                        collapseCallback: $.proxy(function(isMinimized) {
                                 this.handleMinimizedDataPanel(isMinimized);
                             }
                             ,this)
@@ -66,9 +66,9 @@ define (
                 },
                 {
                     name : 'kbaseNarrativeMethodPanel',
-                    params : { 
-                        autopopulate: false , 
-                        collapseCallback: $.proxy(function(isMinimized) { 
+                    params : {
+                        autopopulate: false ,
+                        collapseCallback: $.proxy(function(isMinimized) {
                                 this.handleMinimizedMethodPanel(isMinimized);
                             }
                             ,this)
@@ -108,10 +108,10 @@ define (
                     tabName : 'Narratives',
                     content: $managePanel
                 },
-                {
-                    tabName : this.$jobsWidget.title,
-                    content: $jobsPanel
-                }
+                // {
+                //     tabName : this.$jobsWidget.title,
+                //     content: $jobsPanel
+                // }
             ], true);
 
             this.$elem.addClass('kb-side-panel');
@@ -156,11 +156,11 @@ define (
         setReadOnlyMode: function(readOnly) {
             // toggle off the methods and jobs panels
             this.$methodsWidget.$elem.toggle(!readOnly);
-            this.$jobsWidget.$elem.toggle(!readOnly);
+            // this.$jobsWidget.$elem.toggle(!readOnly);
 
             // toggle off the jobs header
-            this.$tabs.header.find('div:nth-child(4).kb-side-header').toggle(!readOnly); // hide the jobs header
-            this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? ((100-this.hideButtonSize)/2)+'%' : ((100-this.hideButtonSize)/3)+'%')});
+            // this.$tabs.header.find('div:nth-child(4).kb-side-header').toggle(!readOnly); // hide the jobs header
+            // this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? ((100-this.hideButtonSize)/2)+'%' : ((100-this.hideButtonSize)/3)+'%')});
 
             this.$dataWidget.setReadOnlyMode(readOnly);
             this.handleMinimizedMethodPanel(readOnly);


### PR DESCRIPTION
We had a pretty detailed discussion about removing the Jobs Panel (@eapearson, @scanon , @psdehal ) for a few reasons.

1. That information is easily available in each App Cell.
2. As that panel grows, and gets clogged with completed jobs, it's very difficult to navigate.
3. Even putting toggles to only show Jobs in a particular running state wouldn't solve most UX problems.
4. We'll be migrating all of that Job viewer functionality outside of the Narrative eventually.
5. There's no real way to actually manage running jobs yet, or any system for dealing with Job management (other than starting and canceling).
6. We want to remove the ability for a user to delete the Job record. There's enough rich information there that's useful for other things that probably shouldn't be deleted.
7. It helps clean up and simplify the overall interface.

I think there could be issues with Navigating to App cells with a running job, especially if you have several that are active. A separate navigation might be implemented elsewhere in the page. Also, since all job information is stored outside the Narrative in UJS now, that should be reasonably easy to put into a page on the Dashboard.