### PR TITLE
Docker API Fixes

### DIFF
--- a/docker/docker.lua
+++ b/docker/docker.lua
@@ -14,6 +14,7 @@ local json = require('json')
 -- For creating new containers the config object must contain certain fields
 -- Example config contains:
 local function config()
+   local hc = { Binds={}}
    local config = { Hostname = "",
 		    User = "nobody",
 		    Memory = 0,
@@ -30,6 +31,7 @@ local function config()
 		    Cmd = {'/bin/bash'},
 		    Dns = json.util.null,
 		    Image = "base",
+		    HostConfig=hc,
 		    Volumes = {},
 		    VolumesFrom = json.util.null,
 		    WorkingDir = ""
@@ -88,7 +90,6 @@ local client = Spore.new_from_string [[{ "name" : "docker remote api",
 						"required_params" : [
 						   "id"
 						],
-						"optional_payload" : true,
 					     },
 					     "stop_container" : { 
 						"path" : "/containers/:id/stop",


### PR DESCRIPTION
Fixes to support newer versions of the Docker API which deprecates some options for start_container

This seems to do the right thing, but would probably benefit from some more review.  Tested with Docker 1.12 on next.