### PR TITLE
improvements to custom widget and custom subdata widgets.

### DIFF
--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -104,6 +104,7 @@ define([
     'notebook/js/celltoolbar',
     'base/js/dialog',
     'base/js/keyboard',
+    'notebook/js/keyboardmanager',
     'notebook/js/cell',
     'common/utils',
     'kb_common/html',
@@ -124,6 +125,7 @@ define([
     cellToolbar,
     dialog,
     keyboard,
+    keyboardManager,
     cell,
     utils,
     html,
@@ -152,6 +154,7 @@ define([
 
             Jupyter.narrative = new Narrative();
             Jupyter.narrative.init();
+            Jupyter.narrative.disableKeyboardManager();
 
             /*
              * Override the move-cursor-down-or-next-cell and
@@ -769,6 +772,29 @@ define([
             //     "header will appear as the cell title." +
             //     "-->"
     };
+    
+    // KEYBOARD MANAGER
+    
+    /*
+     * Ensure that the keyboard manager does not reactivate during interaction
+     * with the Narrative.
+     * 
+     * Although we disable the keyboard manager at the outset, Jupyter will 
+     * hook into the blur event for inputs  within an inserted dom node.
+     * This causes havoc when kbase widgets manipulate the dom by inserting
+     * form controls.
+     * 
+     * So ... we just disable this behavior by overriding the register_events
+     * method.
+     * 
+     */
+    
+    (function () {
+        keyboardManager.KeyboardManager.prototype.register_events = function (e) {
+            // NOOP
+            return;
+        };
+    }());
 
 
 

--- a/kbase-extension/static/kbase/js/common/jupyter.js
+++ b/kbase-extension/static/kbase/js/common/jupyter.js
@@ -2,9 +2,11 @@
 /*jslint white:true,browser:true*/
 
 define([
-    'base/js/namespace' 
+    'base/js/namespace',
+    'base/js/dialog'
 ], function (
-    Jupyter    
+    Jupyter,
+    dialog
     ) {
 
     function deleteCell(cellOrIndex) {
@@ -17,8 +19,44 @@ define([
         Jupyter.notebook.delete_cell(cellIndex);
     }
 
+    function editNotebookMetadata() {
+        Jupyter.notebook.edit_metadata({
+            notebook: Jupyter.notebook,
+            keyboard_manager: Jupyter.notebook.keyboard_manager
+        });
+    }
+
+    function editCellMetadata(cell) {
+        dialog.edit_metadata({
+            md: cell.metadata,
+            callback: function (md) {
+                cell.metadata = md;
+            },
+            name: 'Cell',
+            notebook: Jupyter.notebook,
+            keyboard_manager: Jupyter.keyboard_manager
+        });
+    }
+    
+    function saveNotebook() {
+        Jupyter.notebook.save_checkpoint();
+    }
+    
+    function findCellIndex(cell) {
+        return Jupyter.notebook.find_cell_index(cell);
+    }
+    
+    function getCells() {
+        Jupyter.notebook.get_cells();
+    }
+
     return {
-        deleteCell: deleteCell
+        deleteCell: deleteCell,
+        editNotebookMetadata: editNotebookMetadata,
+        editCellMetadata: editCellMetadata,
+        saveNotebook: saveNotebook,
+        findCellIndex: findCellIndex,
+        getCells: getCells
     };
 });
 

--- a/kbase-extension/static/kbase/js/common/pythonInterop.js
+++ b/kbase-extension/static/kbase/js/common/pythonInterop.js
@@ -156,19 +156,16 @@ define([
                 'WidgetManager().show_data_widget(' + buildNiceArgsList(args) + ')'
             ].join('\n');
 
-            console.log('CODE', pythonCode);
-
-
         return pythonCode;
     }
 
-    function buildCustomWidgetRunner(appId, appVersion, appTag, cellId, runId) {
-        var positionalArgs = [appId].map(function (arg) {
-                return pythonifyValue(arg);
-            }),
+    function buildCustomWidgetRunner(cellId, runId, app) {
+        var positionalArgs = [
+                pythonifyValue(app.id)
+            ],            
             namedArgs = objectToNamedArgs({
-                version: appVersion,
-                tag: appTag,
+                tag: app.tag,
+                version: app.version,
                 cell_id: cellId,
                 run_id: runId
             }),

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -147,7 +147,7 @@ define(
     };
 
     Narrative.prototype.enableKeyboardManager = function () {
-        Jupyter.keyboard_manager.enable();
+        // Jupyter.keyboard_manager.enable();
     };
 
     /**
@@ -175,7 +175,7 @@ define(
         // }.bind(this));
 
         $([Jupyter.events]).on('delete.Cell', function () {
-            this.enableKeyboardManager();
+            // this.enableKeyboardManager();
         }.bind(this));
 
         $([Jupyter.events]).on('notebook_save_failed.Notebook', function (event, data) {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/customWidgetWrapper.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/customWidgetWrapper.js
@@ -4,25 +4,31 @@
 define([
     'bluebird',
     'kb_common/html',
-    'base/js/namespace'
+    'base/js/namespace',
+    'common/runtime'
 ], function (
     Promise,
     html,
-    Jupyter
+    Jupyter,
+    Runtime
     ) {
     'use strict';
-    
+
     var t = html.tag,
         div = t('div'), pre = t('pre');
 
     function factory(config) {
         var parent, container,
+            cellId = config.cellId,
+            cellBus,
+            runtime = Runtime.make(),
             // our state
-            appId = config.app.id, 
-            appVersion = config.app.version, 
+            appId = config.app.id,
+            appVersion = config.app.version,
             appTag = config.app.tag,
-            appSpec = config.app.spec;
-        
+            appSpec = config.app.spec,
+            wrappedWidget;
+
         /*
          * This is a fake widget finder for now...
          * At the moment widget ids are still jquery widget ids which operate
@@ -34,16 +40,34 @@ define([
                 modulePath: widgetId
             };
         }
-        
+
         function runCustomWidget() {
             var widgetDef = findWidget(appSpec.widgets.input);
             require([
                 widgetDef.modulePath
             ], function (Widget) {
-                
-                new Widget($(container), {
+                wrappedWidget = new Widget($(container), {
                     appSpec: appSpec,
                     workspaceName: Jupyter.narrative.getWorkspaceName()
+                });
+                appSpec.parameters.forEach(function (parameter) {
+                    wrappedWidget.addInputListener(parameter.id, function (data) {
+                        runtime.bus().send({
+                            id: parameter.id,
+                            value: data.val
+                        }, {
+                            channel: {
+                                cell: cellId
+                            },
+                            key: {
+                                type: 'parameter-changed'
+                            }
+                        });
+
+                        // changedParameters[parameter.id] = data.val;
+                        // console.log('CHANGED', data);
+                        // Update the param in the metadata ...
+                    });
                 });
             });
         }
@@ -57,6 +81,30 @@ define([
                 // Get sorted out with the app and the input widget.
                 // container.innerHTML = render();
                 runCustomWidget();
+                
+                runtime.bus().send({}, {
+                    channel: {
+                        cell: cellId
+                    },
+                    key: {
+                        type: 'sync-params'
+                    }
+                });
+                runtime.bus().listen({
+                    channel: {
+                        cell: cellId
+                    },
+                    key: {
+                        type: 'parameter-value'
+                    },
+                    handle: function (message) {
+                        wrappedWidget.setParameterValue(message.id, message.value);
+                    }                    
+                })
+                
+                runtime.bus().on('workspace-changed', function () {
+                    wrappedWidget.refresh();
+                });
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleBooleanInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleBooleanInput.js
@@ -109,53 +109,6 @@ define([
          * Places it into the dom node
          * Hooks up event listeners
          */
-        function xmakeInputControl(currentValue, events, bus) {
-            // CONTROL
-            var initialControlValue;
-            if (currentValue) {
-                initialControlValue = String(currentValue);
-            }
-            return input({
-                id: events.addEvents({
-                    events: [
-                        {
-                            type: 'change',
-                            handler: function (e) {
-                                validate()
-                                    .then(function (result) {
-                                        if (result.isValid) {
-                                            bus.send({
-                                                type: 'changed',
-                                                newValue: result.value
-                                            });
-                                        }
-                                        bus.send({
-                                            type: 'validation',
-                                            errorMessage: result.errorMessage,
-                                            diagnosis: result.diagnosis
-                                        });
-                                    });
-                            }
-                        },
-                        {
-                            type: 'focus',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.disable();
-                            }
-                        },
-                        {
-                            type: 'blur',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.enable();
-                            }
-                        }
-                    ]}),
-                type: 'checkbox',
-                class: 'form-control',
-                dataElement: 'input',
-                value: initialControlValue
-            });
-        }
         
         function makeInputControl(currentValue, data, events, bus) {
             var selectOptions = [

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleCheckbox.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleCheckbox.js
@@ -211,18 +211,6 @@ define([
                                             });
                                         });
                                 }
-                            },
-                            {
-                                type: 'focus',
-                                handler: function (e) {
-                                    Jupyter.keyboard_manager.disable();
-                                }
-                            },
-                            {
-                                type: 'blur',
-                                handler: function (e) {
-                                    Jupyter.keyboard_manager.enable();
-                                }
                             }
                         ]}),
                     type: 'checkbox',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleFileInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleFileInput.js
@@ -401,18 +401,6 @@ define([
                                         });
                                     });
                             }
-                        },
-                        {
-                            type: 'focus',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.disable();
-                            }
-                        },
-                        {
-                            type: 'blur',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.enable();
-                            }
                         }
                     ]}),
                 class: 'form-control',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleFloatInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleFloatInput.js
@@ -154,18 +154,6 @@ define([
                                                 });
                                             });
                                     }
-                                },
-                                {
-                                    type: 'focus',
-                                    handler: function (e) {
-                                        Jupyter.keyboard_manager.disable();
-                                    }
-                                },
-                                {
-                                    type: 'blur',
-                                    handler: function (e) {
-                                        Jupyter.keyboard_manager.enable();
-                                    }
                                 }
                             ]}),
                         class: 'form-control',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleIntInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleIntInput.js
@@ -159,18 +159,6 @@ define([
                                                 bus.emit('validation', result);
                                             });
                                     }
-                                },
-                                {
-                                    type: 'focus',
-                                    handler: function (e) {
-                                        Jupyter.keyboard_manager.disable();
-                                    }
-                                },
-                                {
-                                    type: 'blur',
-                                    handler: function (e) {
-                                        Jupyter.keyboard_manager.enable();
-                                    }
                                 }
                             ]}),
                         class: 'form-control',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleNewObjectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleNewObjectInput.js
@@ -181,19 +181,7 @@ define([
                                         });
                                     });
                             }
-                        }, changeOnPause(),
-                        {
-                            type: 'focus',
-                            handler: function () {
-                                Jupyter.keyboard_manager.disable();
-                            }
-                        },
-                        {
-                            type: 'blur',
-                            handler: function () {
-                                Jupyter.keyboard_manager.enable();
-                            }
-                        }
+                        }, changeOnPause()
                     ]}),
                 class: 'form-control',
                 dataElement: 'input',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleTextInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleTextInput.js
@@ -194,20 +194,9 @@ define([
                                         });
                                     });
                             }
-                        },
-                        // changeOnPause(),
-                        {
-                            type: 'focus',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.disable();
-                            }
-                        },
-                        {
-                            type: 'blur',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.enable();
-                            }
                         }
+                        // changeOnPause(),
+                       
                     ]}),
                 class: 'form-control',
                 dataElement: 'input',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleTextareaInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleTextareaInput.js
@@ -184,19 +184,7 @@ define([
                                         });
                                     });
                             }
-                        }, changeOnPause(),
-                        {
-                            type: 'focus',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.disable();
-                            }
-                        },
-                        {
-                            type: 'blur',
-                            handler: function (e) {
-                                Jupyter.keyboard_manager.enable();
-                            }
-                        }
+                        }, changeOnPause()
                     ]}),
                 class: 'form-control',
                 dataElement: 'input',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleToggleButton.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets/input/singleToggleButton.js
@@ -129,18 +129,6 @@ define([
                                             });
                                         });
                                 }
-                            },
-                            {
-                                type: 'focus',
-                                handler: function (e) {
-                                    Jupyter.keyboard_manager.disable();
-                                }
-                            },
-                            {
-                                type: 'blur',
-                                handler: function (e) {
-                                    Jupyter.keyboard_manager.enable();
-                                }
                             }
                         ]})
                 })]);

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditMedia.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditMedia.js
@@ -19,6 +19,7 @@ define([
     'kbaseNarrativeInput',
     'kbaseNarrativeParameterTextInput',
     'kb_service/client/workspace',
+    'base/js/namespace',
     'bootstrap'
 ], function (
     KBWidget,
@@ -28,7 +29,8 @@ define([
     kbaseNarrativeMethodInput,
     kbaseNarrativeInput,
     kbaseNarrativeParameterTextInput,
-    Workspace
+    Workspace,
+    Jupyter
     ) {
     'use strict';
     return KBWidget({
@@ -67,17 +69,22 @@ define([
 
             // Creates the media chooser widget, which is just a 'text' input
             // This was originally designed to deal with the parameter spec object.
-            this.mediaChooserWidget = new kbaseNarrativeParameterTextInput(this.$mediaChooserPanel, {
+            this.mediaChooserWidget = new kbaseNarrativeParameterTextInput(this.$mediaChooserPanel, {                
                 loadingImage: Config.get('loading_gif'),
                 parsedParameterSpec: this.options.appSpec.parameters[0],
                 isInSidePanel: false
             });
+            
+            this.parameterIdLookup = {};
+            this.parameterIdLookup[this.options.appSpec.parameters[0].id] = this.mediaChooserWidget;
+
 
             // Simple listener that just plops the input value in this panel.
             // Listener gets triggered whenever anything in the chooser widget
             // changes.
 
             this.mediaChooserWidget.addInputListener(function () {
+                // Jupyter.keyboard_manager.disable();
                 this.mediaName = this.mediaChooserWidget.getParameterValue();
                 this.updateDisplayPanel(this.mediaName);
             }.bind(this));

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditModel.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseEditModel.js
@@ -8,39 +8,40 @@
 
 /*global define*/
 /*jslint white: true*/
-define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
-		'narrativeConfig',
-		'bluebird',
-		'kbaseModelEditor',
-		'kbaseNarrativeMethodInput',
-		'kbaseNarrativeInput',
-		'kbaseNarrativeParameterTextInput',
-		'kbase-client-api'
-	], function(
-		KBWidget,
-		bootstrap,
-		$,
-		Config,
-		Promise,
-		kbaseModelEditor,
-		kbaseNarrativeMethodInput,
-		kbaseNarrativeInput,
-		kbaseNarrativeParameterTextInput,
-		kbase_client_api
-	) {
+define(
+    [
+        'kbwidget',
+        'jquery',
+        'narrativeConfig',
+        'bluebird',
+        'kbaseModelEditor',
+        'kbaseNarrativeMethodInput',
+        'kbaseNarrativeInput',
+        'kbaseNarrativeParameterTextInput',
+        'base/js/namespace',
+        'kb_service/client/workspace',
+        
+        'kbase-client-api',        
+        'bootstrap'
+    ], function (
+    KBWidget,
+    $,
+    Config,
+    Promise,
+    KBaseModelEditor,
+    kbaseNarrativeMethodInput,
+    kbaseNarrativeInput,
+    KBaseNarrativeParameterTextInput,
+    Jupyter,
+    Workspace
+    ) {
     'use strict';
     return KBWidget({
         name: 'kbaseEditModel',
-        parent : kbaseNarrativeMethodInput,
-
+        parent: kbaseNarrativeMethodInput,
         modelChooserWidget: null,
         $modelDisplayPanel: null,
         wsClient: null,
-
         init: function (options) {
             this._super(options);
 
@@ -49,9 +50,10 @@ define (
 
             return this;
         },
-
         render: function (options) {
-            this.wsClient = new Workspace(Config.url('workspace'), { token:this.authToken() });
+            this.wsClient = new Workspace(Config.url('workspace'), {
+                token: this.authToken()
+            });
 
             this.container = $('<div>');
 
@@ -59,7 +61,7 @@ define (
             this.$modelDisplayPanel = $('<div>');
 
             this.container.append(this.$modelChooserPanel)
-                     .append(this.$modelDisplayPanel);
+                .append(this.$modelDisplayPanel);
             this.$elem.append(this.container);
 
             // For now, spit up the method spec to console.log so you can read it.
@@ -68,26 +70,25 @@ define (
 
             // Creates the media chooser widget, which is just a 'text' input
             // This was originally designed to deal with the parameter spec object.
-            this.modelChooserWidget =  new kbaseNarrativeParameterTextInput(this.$modelChooserPanel, {
-                    loadingImage: Config.get('loading_gif'),
-                    parsedParameterSpec: this.options.method.parameters[0],
-                    isInSidePanel: false
-                }
+            this.modelChooserWidget = new KBaseNarrativeParameterTextInput(this.$modelChooserPanel, {
+                loadingImage: Config.get('loading_gif'),
+                parsedParameterSpec: this.options.appSpec.parameters[0],
+                isInSidePanel: false
+            }
             );
 
             // Simple listener that just plops the input value in this panel.
             // Listener gets triggered whenever anything in the chooser widget
             // changes.
-            this.modelChooserWidget.addInputListener(function() {
+            this.modelChooserWidget.addInputListener(function () {
                 this.modelName = this.modelChooserWidget.getParameterValue();
                 this.updateDisplayPanel(this.modelName);
             }.bind(this));
         },
-
         /**
          * adds model widget (and a horizontal line above it)
          */
-        updateDisplayPanel: function(modelName) {
+        updateDisplayPanel: function (modelName) {
             this.$modelDisplayPanel.remove();
 
             if (modelName) {
@@ -95,19 +96,20 @@ define (
                 var modelWidget = $('<div>');
 
                 var self = this;
-                 new kbaseModelEditor(modelWidget, {
+                new KBaseModelEditor(modelWidget, {
                     ws: Jupyter.narrative.getWorkspaceName(),
                     obj: modelName,
-                    onSave: function () { self.trigger('updateData.Narrative') }
+                    onSave: function () {
+                        self.trigger('updateData.Narrative');
+                    }
                 });
 
                 this.$modelDisplayPanel.append('<hr>');
-                this.$modelDisplayPanel.append(modelWidget)
+                this.$modelDisplayPanel.append(modelWidget);
 
                 this.container.append(this.$modelDisplayPanel);
             }
         },
-
         /**
          * Refresh should pass along the command to each of its parameters,
          * or otherwise refresh itself. Called by the controller at startup, and
@@ -116,7 +118,6 @@ define (
         refresh: function () {
             this.modelChooserWidget.refresh();
         },
-
         /**
          * Should return some state that can be refreshed into the widget.
          * Typically, the minimal object that can be stored in the narrative itself,
@@ -126,8 +127,6 @@ define (
         getState: function () {
             return {'model': this.modelName};
         },
-
-
         /**
          * Should do something with the state that gets returned.
          */
@@ -135,41 +134,36 @@ define (
             this.modelChooserWidget.loadState(state.model);
             this.updateDisplayPanel(state.model);
         },
-
         /**
          * Should disable a single parameter editing (used when input is part of an app)
          */
         disableParameterEditing: function (paramId) {
 
         },
-
         /**
          * Enables a single parameter editing (used when input is part of an app)
          */
         enableParameterEditing: function (paramId) {
 
         },
-
         /**
          * Sets a single parameter value (only one in this widget, right?).
          * paramId is from the method spec.
          */
-        setParameterValue: function(paramId, value) {
+        setParameterValue: function (paramId, value) {
             this.modelChooserWidget.setParameterValue(value);
         },
-
         /**
          * Gets a single parameter value from the id set by the method spec.
          */
-        getParameterValue: function(paramId) {
+        getParameterValue: function (paramId) {
             return this.modelChooserWidget.getParameterValue();
         },
-
         /**
          * Needed to run the function. Parameter ids need to map onto what's expected
          * from the method spec. Needs to be returned as a list.
          */
-        getAllParameterValues: function() {
+        getAllParameterValues: function () {
             return [
                 {
                     id: this.options.method.parameters[0].id,
@@ -177,7 +171,6 @@ define (
                 }
             ];
         },
-
         /*
          * This is called when this method is run to allow you to check if the parameters
          * that the user has entered is correct.  You need to return an object that indicates
@@ -185,26 +178,24 @@ define (
          * called, you should visually indicate which parameters are invalid by marking them
          * red (see kbaseNarrativeMethodInput for default styles).
          */
-        isValid: function() {
-            var isValidRet = { isValid:true, errormssgs: [] };
+        isValid: function () {
+            var isValidRet = {isValid: true, errormssgs: []};
             var paramStatus = this.modelChooserWidget.isValid();
             if (!paramStatus.isValid()) {
                 isValidRet.isValid = false;
-                for (var i=0; i<paramStatus.errormssgs.length; i++) {
+                for (var i = 0; i < paramStatus.errormssgs.length; i++) {
                     isValidRet.errormssgs.push(paramStatus.errormssgs[i]);
                 }
             }
             return isValidRet;
         },
-
         /*
          * This function is invoked every time we run app or method. This is the difference between it
          * and getAllParameterValues/getParameterValue which could be invoked many times before running
          * (e.g. when widget is rendered).
          */
-        prepareDataBeforeRun: function() {
+        prepareDataBeforeRun: function () {
 
         },
-
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeMethodInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/kbaseNarrativeMethodInput.js
@@ -68,6 +68,8 @@ define ([
             var self = this;
             var method = this.options.method;
             var params = method.parameters;
+            
+            console.log('list params', params);
 
             var $inputParameterContainer = $('<div>');
             var $optionsDiv = $('<div>');
@@ -414,6 +416,7 @@ define ([
          * so that when it changes, something else can be updated.
          */
         addInputListener: function(parameterId, onChangeFunc) {
+            console.log('adding input listener ...', this.parameterIdLookup);
             if (this.parameterIdLookup) {
                 var widget = this.parameterIdLookup[parameterId];
                 if (widget) {

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
@@ -215,10 +215,10 @@ define([
                 }
             }
             $input.on('focus', function(e) {
-                Jupyter.narrative.disableKeyboardManager();
+                // Jupyter.narrative.disableKeyboardManager();
             })
             .on('blur', function(e) {
-                Jupyter.narrative.enableKeyboardManager();
+                // Jupyter.narrative.enableKeyboardManager();
             });
 
             var $feedbackTip = $("<span>").removeClass();
@@ -495,12 +495,12 @@ define([
                 )
                 .on("select2-focus",
                     function (e) {
-                        Jupyter.narrative.disableKeyboardManager();
+                        // Jupyter.narrative.disableKeyboardManager();
                     }
                 )
                 .on("select2-blur",
                     function (e) {
-                        Jupyter.narrative.enableKeyboardManager();
+                        // Jupyter.narrative.enableKeyboardManager();
                     }
                 );
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -492,7 +492,10 @@ define([
 
             // A very small class of methods are just non-app-calling widgets.
             switch (spec.info.id) {
-                case 'edit_media':
+                //case 'model_support/edit_model':
+                case 'fba_tools/edit_metabolic_model':
+                case 'fba_tools/create_or_edit_media':
+                //case 'model_support/edit_media':
                     return 'widget';
             }
 

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -11,6 +11,7 @@ define([
     'common/runtime',
     'common/events',
     'common/error',
+    'common/jupyter',
     'kb_common/html',
     'common/props',
     'kb_service/client/narrativeMethodStore',
@@ -37,6 +38,7 @@ define([
     Runtime,
     Events,
     ToErr,
+    JupyterProxy,
     html,
     Props,
     NarrativeMethodStore,
@@ -816,22 +818,11 @@ define([
         // LIFECYCYLE API
 
         function doEditNotebookMetadata() {
-            Jupyter.notebook.edit_metadata({
-                notebook: Jupyter.notebook,
-                keyboard_manager: Jupyter.notebook.keyboard_manager
-            });
+            JupyterProxy.editNotebookMetadata();
         }
 
         function doEditCellMetadata() {
-            dialog.edit_metadata({
-                md: cell.metadata,
-                callback: function (md) {
-                    cell.metadata = md;
-                },
-                name: 'Cell',
-                notebook: Jupyter.notebook,
-                keyboard_manager: Jupyter.keyboard_manager
-            });
+            JupyterProxy.editCellMetadata(cell);
         }
 
         function initCodeInputArea() {
@@ -1059,7 +1050,7 @@ define([
             }
             saveTimer = window.setTimeout(function () {
                 saveTimer = null;
-                Jupyter.notebook.save_checkpoint();
+                JupyterProxy.saveNotebook();
             }, saveMaxFrequency);
         }
 

--- a/nbextensions/dataCell/widgets/dataCell.js
+++ b/nbextensions/dataCell/widgets/dataCell.js
@@ -60,14 +60,14 @@ define([
         
         // Widget API
         
-        bus.on('run', function (message) {                
+        eventManager.add(bus.on('run', function (message) {                
             container = message.node;
             ui = UI.make({node:container});
 
             // Events for comm from the parent.
-            bus.on('stop', function () {
+            eventManager.add(bus.on('stop', function () {
                 eventManager.removeAll();
-            });
+            }));
 
 
             // The cell bus is for communication via the common id.
@@ -78,11 +78,11 @@ define([
                 cell: Props.getDataItem(cell.metadata, 'kbase.attributes.id')
             }, 'A cell channel');
 
-            cellBus.on('delete-cell', function () {
+            eventManager.add(cellBus.on('delete-cell', function () {
                 doDeleteCell();
-            });
+            }));
 
-        });
+        }));
 
         return {
             bus: bus

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -322,7 +322,7 @@ class AppManager(object):
 
         # now just map onto outputs.
         custom_widget = spec.get('widgets', {}).get('input', None)
-        return WidgetManager().show_custom_widget(custom_widget, app_id, version, tag, spec)
+        return WidgetManager().show_custom_widget(custom_widget, app_id, version, tag, spec, cell_id)
 
     def _validate_parameters(self, app_id, tag, spec_params, params):
         """

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -373,7 +373,7 @@ class WidgetManager(object):
 
 
 
-    def show_custom_widget(self, widget_id, app_id, app_version, app_tag, spec):
+    def show_custom_widget(self, widget_id, app_id, app_version, app_tag, spec, cell_id):
         input_template = """
         element.html('<div id="{{widget_root_id}}" class="kb-custom-widget">');
 
@@ -385,7 +385,8 @@ class WidgetManager(object):
                 widgetParentNode = document.getElementById(widgetArg.env.rootId),
                 widget = CustomWidgetWrapper.make({
                     widget: widgetArg.widget,
-                    app: widgetArg.app
+                    app: widgetArg.app,
+                    cellId: widgetArg.env.cellId
                 });
 
             widget.start({root: widgetParentNode})
@@ -394,7 +395,7 @@ class WidgetManager(object):
                 })
                 .catch(function (err) {
                     console.error('ERROR', err);
-                    widgetParentNode.innerHTML = 'ERROR! ' + err.message);
+                    widgetParentNode.innerHTML = 'ERROR! ' + err.message;
                     // dataWidget.showErrorMessage(err.message);
                 });
         });
@@ -426,7 +427,8 @@ class WidgetManager(object):
                 'id': widget_id
             },
             'env': {
-                'rootId': widget_root_id
+                'rootId': widget_root_id,
+                'cellId': cell_id
             }
         }
 

--- a/test2/specs/active/props-Spec.js
+++ b/test2/specs/active/props-Spec.js
@@ -43,6 +43,13 @@ define([
             props.setItem('pet', {type: 'dog', name: 'peet'});
             expect(props.getItem('pet')).toEqual({type: 'dog', name: 'peet'});
         });
+        it('Set two object propertyes', function () {
+            var props = Props.make();
+            props.setItem(['pet', 'coco'], 'yellow');
+            props.setItem(['pet', 'peet'], 'black');
+            expect(props.getItem('pet.coco')).toEqual('yellow');
+            expect(props.getItem('pet.peet')).toEqual('black');
+        })
         it('History should undefined', function () {
             var props = Props.make();
             expect(props.getHistoryCount()).toBeUndefined;


### PR DESCRIPTION
The custom input widget is now mostly functional. The remaining item is to synchronize the cell parameters with the media editor (mostly relevant at cell startup time.) 

However, we may not support the custom input widget going forward, so this may not see the light of day. There are two instances of custom widget, the media editor and fba model editor, and they are in the process of being updated to use server side apps for the object updating. This change would allow the editor widget to function as a parameter widget rather than an entire input area widget.

On a related note, custom subdata widgets had gone wonky with an ill-advised attempt at a 
reset method, and this is fixed in this PR. 

Curing custom widget work, the keyboard manager was causing problems. Efforts to disable the keyboard manager were being undone while operating the custom input widgets. It ends up that Jupyter now detects when new dom nodes are inserted, and will hook the keyboard manager events into any new inputs that are inserted. Since blurring on an input will cause the keyboard manager to become enabled, it just takes a short interaction with a newly inserted form control to re-enable the keyboard manager and render the narrative unusable.

The keyboard manager was ultimately disabled by overriding the default dom event hooks which tend to revive it even after it has been disabled. This was done in custom.js, in which the other jupyter monkeypatching takes place.

Also, for many widgets I'm beginning to wrap any jupyter direct calls into a jupyter proxy object to avoid sprinkling these dependencies around. Maybe this code should live in an existing module, but for the moment I'm just trying to avoid that hardcoded jupyter dependency and put it into one module (common/jupyter).