### PR TITLE
Adds some more detailed error trapping when backend services are unreachable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ __Changes__
 - Updated Dockerfiles to use new versions of a few dependencies.
 - Fixed DomainAnnotation viewer widget.
 - Updated Data API-based widgets to use latest clients.
+- Added prompt with report option (not working yet) when the JobManager fails to initialize.
 
 ### Version 3.0.0-alpha-19
 __Changes__

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,15 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-20
+__Changes__
+- Fixed custom parameter widgets.
+- Improved error catching within App Cell.
+- Updated Docker container invocation methods on Narrative Server.
+- Updated Dockerfiles to use new versions of a few dependencies.
+- Fixed DomainAnnotation viewer widget.
+- Updated Data API-based widgets to use latest clients.
+
 ### Version 3.0.0-alpha-19
 __Changes__
 - add latest workspace python client

--- a/kbase-extension/static/kbase/templates/job_panel/job_init_error.html
+++ b/kbase-extension/static/kbase/templates/job_panel/job_init_error.html
@@ -1,0 +1,17 @@
+<div>
+    <div style="margin-bottom:10px">
+        <b>An error occurred while looking up running Apps!</b>
+    </div>
+    <div style="margin-bottom:10px">
+        {{message}}
+        <br><br>
+        Running App information will be unavailable until this is resolved. You can try refreshing this page, or contact KBase with the button below.
+    </div>
+    <div style="margin-bottom:10px">
+        <button type="button" class="btn btn-primary" id="kb-job-err-report">
+            <span data-element="icon" style="vertical-align: middle" class="fa fa-envelope-o fa-2x"></span>&nbsp;
+            <span style="vertical-align: middle">Report Error</span>
+        </button>
+    </div>
+    <div id="kb-job-err-trace"></div>
+</div>

--- a/src/biokbase/narrative/app_util.py
+++ b/src/biokbase/narrative/app_util.py
@@ -28,8 +28,9 @@ def system_variable(var):
 
     Parameters
     ----------
-    var: string, one of "workspace", "token", "user_id"
+    var: string, one of "workspace", "workspace_id", "token", "user_id"
         workspace - returns the KBase workspace name
+        workspace_id - returns the numerical id of the current workspace
         token - returns the current user's token credential
         user_id - returns the current user's id
 
@@ -58,6 +59,8 @@ def system_variable(var):
             return m.group(1)
         else:
             return None
+    else:
+        return None
 
 def map_inputs_from_job(job_inputs, app_spec):
     """
@@ -134,6 +137,8 @@ def map_outputs_from_state(state, params, app_spec):
     Returns the dict of output values from a completed app.
     Also returns the output widget.
     """
+    if 'behavior' not in app_spec:
+        raise ValueError("Invalid app spec - unable to map outputs")
     widget_params = dict()
     out_mapping_key = 'kb_service_output_mapping'
     if out_mapping_key not in app_spec['behavior']:

--- a/src/biokbase/narrative/exception_util.py
+++ b/src/biokbase/narrative/exception_util.py
@@ -1,0 +1,47 @@
+from requests.exceptions import HTTPError
+from biokbase.NarrativeJobService.Client import ServerError as NJSServerError
+from biokbase.userandjobstate.baseclient import ServerError as UJSServerError
+
+class NarrativeException(Exception):
+    def __init__(self, code, message, name, source):
+        self.code = code
+        self.message = message
+        self.name = name
+        self.source = source
+
+    def __str__(self):
+        return self.message
+
+def transform_job_exception(e):
+    """
+    Transforms a job exception from one of several forms into
+    something more obvious and manageable.
+
+    Assigns a standard HTTP error code, regardless of error (500 if nothing else).
+
+    Returns a slightly modified exception that
+
+    Types of exceptions:
+    ServerError - thrown by the server, usually due to a 500 (ish) exception
+    HTTPError - a more mundane HTTP exception
+    """
+    if isinstance(e, NJSServerError):
+        return NarrativeException(e.code, e.message, e.name, 'njs')
+    elif isinstance(e, UJSServerError):
+        return NarrativeException(e.code, e.message, e.name, 'ujs')
+    elif isinstance(e, HTTPError):
+        code = e.response.status_code
+        if code == 404 or code == 502 or code == 503:
+            # service not found
+            msg = 'The KBase App service is currently unavailable.'
+        elif code == 504 or code == 598 or code == 599:
+            # service timeout
+            msg = 'There was a temporary network connection error.'
+        elif code == 500:
+            # internal error. dunno what to do.
+            msg = 'An internal error occurred in the KBase service.'
+        else:
+            msg = 'An untracked error occurred.'
+        return NarrativeException(e.response.status_code, msg, 'HTTPError', 'network')
+    else:
+        return NarrativeException(-1, str(e), 'Exception', 'unknown')

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -76,7 +76,7 @@ class JobManager(object):
                 'error': 'Unable to get initial jobs list',
                 'message': getattr(new_e, 'message', 'Unknown reason'),
                 'code': getattr(new_e, 'code', -1),
-                'source': getattr(new_e, 'source', 'JobManager'),
+                'source': getattr(new_e, 'source', 'jobmanager'),
                 'name': getattr(new_e, 'name', type(e).__name__)
             }
             self._send_comm_message('job_init_err', error)
@@ -100,7 +100,7 @@ class JobManager(object):
                     'job_id': job_id,
                     'message': getattr(new_e, 'message', 'Unknown reason'),
                     'code': getattr(new_e, 'code', -1),
-                    'source': getattr(new_e, 'source', 'JobManager'),
+                    'source': getattr(new_e, 'source', 'jobmanager'),
                     'name': getattr(new_e, 'name', type(e).__name__)
                 }
                 self._send_comm_message('job_init_lookup_err', error)

--- a/src/config.json
+++ b/src/config.json
@@ -63,7 +63,7 @@
         "gene_families": "https://ci.kbase.us/services/gene_families",
         "genomeCmp": "https://ci.kbase.us/services/genome_comparison/jsonrpc",
         "invocation": "",
-        "job_service": "https://ci.kbase.us/services/asdfnjs_wrapper",
+        "job_service": "https://ci.kbase.us/services/njs_wrapper",
         "landing_pages": "/#dataview/",
         "log_proxy_host": "172.17.42.1",
         "log_proxy_port": 32001,

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-19",
+    "version": "3.0.0-alpha-20",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",

--- a/src/config.json
+++ b/src/config.json
@@ -63,7 +63,7 @@
         "gene_families": "https://ci.kbase.us/services/gene_families",
         "genomeCmp": "https://ci.kbase.us/services/genome_comparison/jsonrpc",
         "invocation": "",
-        "job_service": "https://ci.kbase.us/services/njs_wrapper",
+        "job_service": "https://ci.kbase.us/services/asdfnjs_wrapper",
         "landing_pages": "/#dataview/",
         "log_proxy_host": "172.17.42.1",
         "log_proxy_port": 32001,


### PR DESCRIPTION
One of the big issues from last week was that when backend services (UJS/NJS/etc.) go down, it has unpredictable results in the Narrative. This goes some way to trying to fix that.

When the Kernel looks up Job info, and an Exception is thrown, that can be one of two types - either a ServerError (thrown by the Service itself with faulty data or permissions) or a form of network error (represented as requests.exceptions.HTTPError). The change here consolidates those into one exception and returns the error code, message, source of the error where available (either network, UJS, NJS, or somewhere in the kernel), and communicates those to the front end. Effectively, it adds two new fields to the error message comms:

`code` - a numerical code, either a 3-digit HTTP code, a 5-digit negative number (from JSON-RPC services), or a 1-digit negative number (from kernel-side errors)
`source` - the supposed source of the error. Should be one of 'network', 'njs', 'ujs', 'appmanager', or 'jobmanager'

This also adds some more detailed error tracking to the Job initialization steps. Now, if the `UJS.list_jobs2` call fails, or any of the NJSW job info calls fail, that init completely dies, and a dialog is shown.