### PR TITLE
[WIP] Job cancellation and status updates

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -424,6 +424,10 @@ define([
                                 modal.show();
                                 break;
                             case 'cancel_job':
+                                this.sendJobMessage('job-cancel-error', content.job_id, {
+                                    jobId: content.job_id,
+                                    message: content.message
+                                });
                                 break;
                             case 'job_logs':
                                 this.sendJobMessage('job-log-deleted', content.job_id, {jobId: content.job_id});
@@ -471,7 +475,7 @@ define([
                         elements: [{
                             title: 'Detailed Error Information',
                             body: $('<table class="table table-bordered"><tr><th>code:</th><td>' + content.code +
-                                    '</td></tr><tr><th>error:</th><td>' + content.error +
+                                    '</td></tr><tr><th>error:</th><td>' + content.message +
                                     '</td></tr><tr><th>type:</th><td>' + content.name +
                                     '</td></tr><tr><th>source:</th><td>' + content.source + '</td></tr></table>')
                         }]

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -423,6 +423,8 @@ define([
                                 });
                                 modal.show();
                                 break;
+                            case 'cancel_job':
+                                break;
                             case 'job_logs':
                                 this.sendJobMessage('job-log-deleted', content.job_id, {jobId: content.job_id});
                                 break;

--- a/kbase-extension/static/kbase/templates/job_panel/job_init_error.html
+++ b/kbase-extension/static/kbase/templates/job_panel/job_init_error.html
@@ -3,7 +3,7 @@
         <b>An error occurred while looking up running Apps!</b>
     </div>
     <div style="margin-bottom:10px">
-        {{message}}
+        {{error}}
         <br><br>
         Running App information will be unavailable until this is resolved. You can try refreshing this page, or contact KBase with the button below.
     </div>

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -578,7 +578,14 @@ class AppManager(object):
             kblogging.log_event(self._log, "run_app_error", log_info)
             raise transform_job_exception(e)
 
-        new_job = Job(job_id, app_id, [params], system_variable('user_id'), tag=tag, app_version=service_ver, cell_id=cell_id)
+        new_job = Job(job_id,
+                      app_id,
+                      [params],
+                      system_variable('user_id'),
+                      tag=tag,
+                      app_version=service_ver,
+                      cell_id=cell_id,
+                      run_id=run_id)
 
         self._send_comm_message('run_status', {
             'event': 'launched_job',

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -110,6 +110,11 @@ class Job(object):
         """
         try:
             state = self._njs.check_job(self.job_id)
+            if 'cancelled' in state:
+                state[u'canceled'] = state.get('cancelled', 0)
+                del state['cancelled']
+            if state.get('job_state', '') == 'cancelled':
+                state[u'job_state'] = 'canceled'
             state[u'cell_id'] = self.cell_id
             state[u'run_id'] = self.run_id
             return state

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -25,11 +25,12 @@ class Job(object):
     app_id = None
     app_version = None
     cell_id = None
+    run_id = None
     inputs = None
     # _comm = None
     _job_logs = list()
 
-    def __init__(self, job_id, app_id, inputs, owner, tag='release', app_version=None, cell_id=None):
+    def __init__(self, job_id, app_id, inputs, owner, tag='release', app_version=None, cell_id=None, run_id=None):
         """
         Initializes a new Job with a given id, app id, and app app_version.
         The app_id and app_version should both align with what's available in
@@ -40,12 +41,13 @@ class Job(object):
         self.app_version = app_version
         self.tag = tag
         self.cell_id = cell_id
+        self.run_id = run_id
         self.inputs = inputs
         self.owner = owner
         self._njs = clients.get('job_service')
 
     @classmethod
-    def from_state(Job, job_id, job_info, owner, app_id, tag='release', cell_id=None):
+    def from_state(Job, job_id, job_info, owner, app_id, tag='release', cell_id=None, run_id=None):
         """
         Parameters:
         -----------
@@ -64,6 +66,7 @@ class Job(object):
         tag - string
             The Tag (release, beta, dev) used to start the job.
         cell_id - the cell associated with the job (optional)
+        run_id - the front-end id associated with the job (optional)
         """
         return Job(job_id,
                    app_id,
@@ -108,6 +111,7 @@ class Job(object):
         try:
             state = self._njs.check_job(self.job_id)
             state[u'cell_id'] = self.cell_id
+            state[u'run_id'] = self.run_id
             return state
         except Exception as e:
             raise Exception("Unable to fetch info for job {} - {}".format(self.job_id, e))

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -90,7 +90,13 @@ class JobManager(object):
                 job_info = clients.get('job_service').get_job_params(job_id)[0]
                 self._running_jobs[job_id] = {
                     'refresh': True,
-                    'job': Job.from_state(job_id, job_info, user_info[0], app_id=job_info.get('app_id'), tag=job_meta.get('tag', 'release'), cell_id=job_meta.get('cell_id', None))
+                    'job': Job.from_state(job_id,
+                                          job_info,
+                                          user_info[0],
+                                          app_id=job_info.get('app_id'),
+                                          tag=job_meta.get('tag', 'release'),
+                                          cell_id=job_meta.get('cell_id', None),
+                                          run_id=job_meta.get('run_id', None))
                 }
             except Exception as e:
                 kblogging.log_event(self._log, 'init_error', {'err': str(e)})
@@ -184,25 +190,25 @@ class JobManager(object):
         """
         return [j['job'] for j in self._running_jobs.values()]
 
-    def _get_existing_job(self, job_tuple):
-        """
-        creates a Job object from a job_id that already exists.
-        If no job exists, raises an Exception.
+    # def _get_existing_job(self, job_tuple):
+    #     """
+    #     creates a Job object from a job_id that already exists.
+    #     If no job exists, raises an Exception.
 
-        Parameters:
-        -----------
-        job_tuple : The expected 4-tuple representing a Job. The format is:
-            (job_id, set of job inputs (as JSON), version tag, cell id that started the job)
-        """
+    #     Parameters:
+    #     -----------
+    #     job_tuple : The expected 5-tuple representing a Job. The format is:
+    #         (job_id, set of job inputs (as JSON), version tag, cell id that started the job, run id of the job)
+    #     """
 
-        # remove the prefix (if present) and take the last element in the split
-        job_id = job_tuple[0].split(':')[-1]
-        try:
-            job_info = clients.get('job_service').get_job_params(job_id)[0]
-            return Job.from_state(job_id, job_info, app_id=job_tuple[1], tag=job_tuple[2], cell_id=job_tuple[3])
-        except Exception as e:
-            kblogging.log_event(self._log, "get_existing_job.error", {'job_id': job_id, 'err': str(e)})
-            raise
+    #     # remove the prefix (if present) and take the last element in the split
+    #     job_id = job_tuple[0].split(':')[-1]
+    #     try:
+    #         job_info = clients.get('job_service').get_job_params(job_id)[0]
+    #         return Job.from_state(job_id, job_info, app_id=job_tuple[1], tag=job_tuple[2], cell_id=job_tuple[3], run_id=job_tuple[4])
+    #     except Exception as e:
+    #         kblogging.log_event(self._log, "get_existing_job.error", {'job_id': job_id, 'err': str(e)})
+    #         raise
 
     def _construct_job_status(self, job_id):
         """
@@ -228,7 +234,9 @@ class JobManager(object):
                         'error_type': 'ValueError',
                         'error_stacktrace': ''
                     }
-                }
+                },
+                'cell_id': None,
+                'run_id': None
             }
             return {
                 'state': state,
@@ -271,7 +279,8 @@ class JobManager(object):
                     }
                 },
                 'creation_time': 0,
-                'cell_id': None,
+                'cell_id': job.cell_id,
+                'run_id': job.run_id,
                 'job_id': job_id
             }
 


### PR DESCRIPTION
- [x] Job status updates should include the run_id (already stored in Job metadata, so that's painless).
- [x] Job cancellation should put a job in a transient 'canceling' state while trying to cancel.
- [x] Job cancellation errors should propagate forward properly.