### PR TITLE
Added warning for out of date Apps

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,14 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-21
+__Changes__
+- Applied module release version to that module's method specs.
+- Fixed regression preventing cell deletion in some conditions.
+- Added module commit hash to App dropdowns in App Panel for beta and dev Apps.
+- Added 401 error when the Narrative handler is unauthenticated.
+- Addressed issues with job cancellation.
+
 ### Version 3.0.0-alpha-20
 __Changes__
 - Fixed custom parameter widgets.

--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -1,9 +1,14 @@
-/* Wrapper class 
+/* Wrapper class
   All classes below may be wrapped in this class to avoid polluting
   the Narrative styles.
 */
 .kb-app-cell {
 
+}
+
+.kb-app-cell .kb-app-warning {
+    font-family: 'Oxygen', sans-serif;
+    text-align: center;
 }
 
 /** new app parameter styling **/
@@ -82,7 +87,7 @@ in the column in which the icon lives, and does this by shrinking the select
 control with padding, and then scooting the icon back into its column.
 */
 /* .kb-app-cell .kb-app-parameter-input > div {
-     allow space for the required (red arrow), satisfied (green checkbox) icon 
+     allow space for the required (red arrow), satisfied (green checkbox) icon
     padding-right: 20px;
 }
 */

--- a/kbase-extension/static/kbase/js/common/error.js
+++ b/kbase-extension/static/kbase/js/common/error.js
@@ -4,20 +4,22 @@
 define([
 ], function () {
     'use strict';
-    
-    
+
+
     function KBError(arg) {
         this.type = arg.type;
         this.message = arg.message;
         this.reason = arg.reason;
         this.original = arg.original;
         this.detail = arg.detail;
-        this.info =arg.info;
+        this.info = arg.info;
         this.advice = arg.advice;
 
         this.blame = arg.blame;
         this.code = arg.code;
         this.suggestion = arg.suggestion;
+
+        this.severity = arg.severity || 'fatal';
     }
     KBError.prototype = new Error();
 

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -781,7 +781,8 @@ define([
                 case 'dev':
                     return {
                         id: app.id,
-                        tag: app.tag
+                        tag: app.tag,
+                        version: app.gitCommitHash
                     };
                 default:
                     throw new Error('Invalid tag for app ' + app.id);

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -2378,11 +2378,12 @@ define([
                 // Ensure that the current app spec matches our existing one.
                 var warning = checkSpec(appSpec);
                 if (warning && warning.severity === 'warning') {
-                    console.warn('YOU HAVE BEEN WARNED.', warning);
-                    model.setItem('outdated', true);
+                    if (warning.type === 'app-spec-mismatched-commit') {
+                        model.setItem('outdated', warning.catalogCommitHash);
+                    }
                 }
 
-                // Create a map of paramters for easy access
+                // Create a map of parameters for easy access
                 var parameterMap = {};
                 env.parameters = model.getItem('app.spec.parameters').map(function (parameterSpec) {
                     // tee hee

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -2379,7 +2379,7 @@ define([
                 var warning = checkSpec(appSpec);
                 if (warning && warning.severity === 'warning') {
                     if (warning.type === 'app-spec-mismatched-commit') {
-                        model.setItem('outdated', warning.catalogCommitHash);
+                        model.setItem('outdated', true);
                     }
                 }
 

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -524,6 +524,14 @@ define([
                     }, [
                         div({dataElement: 'widget', style: {display: 'block', width: '100%'}}, [
                             div({class: 'container-fluid'}, [
+                                div({
+                                    class: 'kb-app-warning alert alert-warning hidden',
+                                    dataElement: 'outdated',
+                                    role: 'alert'
+                                }, [
+                                    span({style: {'font-weight': 'bold'}}, 'Warning'),
+                                    ': this app appears to be out of date. Running it may cause undesired results. Add a new "<b>' + model.getItem('app.spec.info.name') + '</b>" App for the most recent version.'
+                                ]),
                                 ui.buildPanel({
                                     title: 'App Cell Settings',
                                     name: 'settings',
@@ -1003,6 +1011,10 @@ define([
             renderNotifications();
             renderSettings();
             var state = fsm.getCurrentState();
+
+            if (model.getItem('outdated')) {
+                ui.showElement('outdated');
+            }
 
             // Button state
             state.ui.buttons.enabled.forEach(function (button) {
@@ -2328,7 +2340,8 @@ define([
             }
 
             if (cellAppSpec.info.git_commit_hash !== appSpec.info.git_commit_hash) {
-                throw new ToErr.KBError({
+                return new ToErr.KBError({
+                    severity: 'warning',
                     type: 'app-spec-mismatched-commit',
                     message: 'Mismatching app commit for ' + appSpec.info.id + ', tag=' + model.getItem('app.tag') + ' : ' + cellAppSpec.info.git_commit_hash + ' !== ' + appSpec.info.git_commit_hash,
                     info: {
@@ -2347,12 +2360,7 @@ define([
                 });
             }
 
-            // spec version shouldn't be used, just module.
-            // if (cellAppSpec.info.version !== appSpec.info.version) {
-            //     throw new Error('Mismatching app version: ' + cellAppSpec.info.version + ' !== ' + appSpec.info.version);
-            // }
-
-
+            return null;
         }
 
         function run(params) {
@@ -2368,7 +2376,11 @@ define([
             })
             .then(function (appSpec) {
                 // Ensure that the current app spec matches our existing one.
-                checkSpec(appSpec);
+                var warning = checkSpec(appSpec);
+                if (warning && warning.severity === 'warning') {
+                    console.warn('YOU HAVE BEEN WARNED.', warning);
+                    model.setItem('outdated', true);
+                }
 
                 // Create a map of paramters for easy access
                 var parameterMap = {};

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-20",
+    "version": "3.0.0-alpha-21",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
Whenever an app gets updated on dev/beta, it gets a new git commit hash - that's a tag for the 'version'. The App cell tests for a new version every time it gets the page refreshed.

The old one will still run - it keeps the version information. But the App Cell is tied to whatever version it was when it was inserted into the page. The best thing to do is create a new one if you want to run the updated version.

(you can also manually delete the version parameter from the generated code, if you're feeling brave).