### PR TITLE
Another try at removing command-mode single-key commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,14 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.0.0-alpha-22
+__Changes__
+- First pass at an inline clickable interface tour.
+- Fixed problems with Jupyter's command-mode shortcuts overriding whatever they wanted to.
+- Updated front end tests so they should function more seamlessly.
+- Add GenomeAnnotation support to genome, pangenome, and proteome comparison viewers.
+- Add warning for out of date apps.
+
 ### Version 3.0.0-alpha-21
 __Changes__
 - Applied module release version to that module's method specs.

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -789,17 +789,12 @@ define([
      *
      */
 
-    (function () {
-        keyboardManager.KeyboardManager.prototype.register_events = function (e) {
-            // NOOP
-            return;
-        };
-
-        // keyboardManager.KeyboardManager.prototype.bind_events = function () {
-        //     // also NOOP
-        //     return;
-        // }
-    }());
+    // (function () {
+    //     keyboardManager.KeyboardManager.prototype.register_events = function (e) {
+    //         // NOOP
+    //         return;
+    //     };
+    // }());
 
 
 

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -145,7 +145,29 @@ define(
 
     // Wrappers for the Jupyter/Jupyter function so we only maintain it in one place.
     Narrative.prototype.disableKeyboardManager = function () {
-        Jupyter.keyboard_manager.disable();
+        // Jupyter.keyboard_manager.disable();
+
+        var killTheseShortcuts = ['a', 'b', 'm', 'f', 'y', 'r',
+                                  '1', '2', '3', '4', '5', '6',
+                                  'k', 'j', 'b', 'x', 'c', 'v',
+                                  'z', 'd,d', 's', 'l', 'o', 'h',
+                                  'i', '0,0', 'q'];
+
+        for (var i=0; i<killTheseShortcuts.length; i++) {
+            var shortcut = killTheseShortcuts[i];
+            try {
+                Jupyter.keyboard_manager.command_shortcuts.remove_shortcut(shortcut);
+            }
+            catch (err) {
+                //pass
+            }
+            try {
+                Jupyter.notebook.keyboard_manager.command_shortcuts.remove_shortcut(shortcut);
+            }
+            catch (err) {
+                //pass
+            }
+        }
     };
 
     Narrative.prototype.enableKeyboardManager = function () {

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.0.0-alpha-21",
+    "version": "3.0.0-alpha-22",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
Now all commands are stripped by the narrative module at startup. Supposedly. Unless the keyboard manager wants to resurrect itself, but I haven't found a case where it does that yet.