### PR TITLE
Adjustments to App Cell UI

### DIFF
--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -147,8 +147,8 @@
                     <ul class="dropdown-menu" role="menu" aria-labelledby="kb-nav-menu">
                         <li><a id="kb-tour">Narrative Tour</a></li>
                         <li role="presentation" class="divider"></li>
-                        <li><a href="/functional-site/#/search/?q=*" target="_blank">Search Data</a></li>
-                        <li><a href="/functional-site/#/dashboard" target="_blank">Dashboard</a></li>
+                        <li><a href="/#search/?q=*" target="_blank">Search Data</a></li>
+                        <li><a href="/#dashboard" target="_blank">Dashboard</a></li>
                         <li><a id="kb-status-btn" href="" target="_blank">KBase Service Status</a></li>
                         <li role="presentation" class="divider"></li>
                         <li><a id="kb-about-btn">About the Narrative</a></li>

--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -170,7 +170,18 @@ control with padding, and then scooting the icon back into its column.
     padding: 3px 5px;
 }
 
+.kb-app-cell [data-element="tab-pane"] {
+    border: 1px solid rgb(32, 77, 16);
+    background-color: #f5f5f5;
+}
 
+.kb-app-cell [data-element="tab-pane"] > div:empty {
+    padding: 0px;
+}
+
+.kb-app-cell [data-element="tab-pane"] > div {
+    padding: 4px;
+}
 
 
 .kb-app-cell .panel-title > [data-toggle="collapse"]::before {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -42,7 +42,7 @@ define([
     'kbaseTabs',
     'common/props',
     'kb_service/client/narrativeMethodStore',
-    
+
     'bootstrap',
 ], function(
     Jupyter,
@@ -1507,7 +1507,7 @@ define([
          * @method deleteCell
          * @private
          */
-        
+
         /*
          * The new delete cell
          * Delete cell needs to honor the new cells, but since we are using the
@@ -1524,29 +1524,24 @@ define([
                 return;
             }
             var kbaseCellType = Props.getDataItem(cell.metadata, 'kbase.type');
-            
-            if (!kbaseCellType) {
-                // TODO: Delete anyway...
+            var cellId = Props.getDataItem(cell.metadata, 'kbase.attributes.id');
+
+            if (!kbaseCellType || !cellId) {
                 UI.make({node: this.$elem[0]}).showConfirmDialog({
                     title: 'Confirm Cell Deletion',
-                    content: 'Are you sure you want to delete this cell?'                    
+                    content: 'Are you sure you want to delete this cell?'
                 })
-                    .then(function (confirmed) {
-                        if (confirmed) {
-                            Jupyter.notebook.delete_cell(index);                            
+                .then(function (confirmed) {
+                    if (confirmed) {
+                        if (kbaseCellType && !cellId) {
+                            console.warn('KBase cell without cell id, DELETING ANYWAY!', cell.metadata);
                         }
-                    });
+                        Jupyter.notebook.delete_cell(index);
+                    }
+                });
                 return;
             }
-            
-            var cellId = Props.getDataItem(cell.metadata, 'kbase.attributes.id');
-            if (!cellId) {
-                // TODO: delete anyway
-                alert('no cell id, do not know how to delete you');
-                console.warn('KBase cell without cell id. Not deleting', cell.metadata);
-                return;
-            }
-            console.log('letting cell know we want to delete it', cellId)
+
             this.runtime.bus().send({}, {
                channel: {
                    cell: cellId
@@ -1556,7 +1551,7 @@ define([
                }
             });
         },
-        
+
         xdeleteCell: function(index) {
             if (index !== undefined && index !== null) {
                 var cell = Jupyter.notebook.get_cell(index);

--- a/nbextensions/appCell/widgets/appCellResults.js
+++ b/nbextensions/appCell/widgets/appCellResults.js
@@ -73,20 +73,25 @@ define([
                 container = arg.node;
                 model = arg.model;
 
-                // Very simple for now, just render the results json in a prettier than normal fashion.
-                var result = model.getItem('exec.jobState.result');
                 var result = model.getItem('exec.outputWidgetInfo');
-                console.log('RESULT', result);
+                var finalJobState = model.getItem('exec.jobState');
+                var finishTime = model.getItem('exec.jobState.finish_time');
 
                 var content;
+                var finishedDate = new Date(finishTime);
+                container.innerHTML = div('Results from run finished at ' +
+                                          finishedDate.toLocaleDateString() + ', ' +
+                                          finishedDate.toLocaleTimeString());
                 // If there's a "report_ref" key in the results, load and show the report.
                 if (result.params.report_name) {
                     // do report widget.
-                    container.innerHTML = '<div></div>';
-                    new KBaseReportView($(container), result.params);
+                    var reportDiv = $('<div>');
+                    container.appendChild(reportDiv[0]);
+                    new KBaseReportView(reportDiv, result.params);
                 }
+                // Otherwise... placeholder?
                 else {
-                    container.innerHTML = buildPresentableJson(result);
+                    container.innerHTML += buildPresentableJson(result);
                 }
             });
         }

--- a/nbextensions/appCell/widgets/appCellResults.js
+++ b/nbextensions/appCell/widgets/appCellResults.js
@@ -1,0 +1,111 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+
+define([
+    'jquery',
+    'bluebird',
+    'kb_common/html',
+    'common/runtime',
+    'kbaseReportView'
+], function (
+    $,
+    Promise,
+    html,
+    Runtime,
+    KBaseReportView
+) {
+    'use strict';
+
+    function factory(config) {
+        var container,
+            model,
+            t = html.tag,
+            div = t('div'),
+            span = t('span'),
+            a = t('a'),
+            table = t('table'),
+            tr = t('tr'),
+            th = t('th'),
+            td = t('td'),
+            pre = t('pre'),
+            input = t('input'),
+            img = t('img'),
+            p = t('p'),
+            blockquote = t('blockquote');
+
+        function buildPresentableJson(data) {
+            return JSON.stringify(data);
+
+            switch (typeof data) {
+                case 'string':
+                    return data;
+                case 'number':
+                    return String(data);
+                case 'boolean':
+                    return String(data);
+                case 'object':
+                    if (data === null) {
+                        return 'NULL';
+                    }
+                    if (data instanceof Array) {
+                        return table({class: 'table table-striped'},
+                            data.map(function (datum, index) {
+                                return tr([
+                                    th(String(index)),
+                                    td(buildPresentableJson(datum))
+                                ]);
+                            }).join('\n')
+                            );
+                    }
+                    return table({class: 'table table-striped'},
+                        Object.keys(data).map(function (key) {
+                        return tr([th(key), td(buildPresentableJson(data[key]))]);
+                    }).join('\n')
+                        );
+                default:
+                    return 'Not representable: ' + (typeof data);
+            }
+        }
+
+        function start(arg) {
+            return Promise.try(function () {
+                console.log('starting results widget!');
+                container = arg.node;
+                model = arg.model;
+
+                // Very simple for now, just render the results json in a prettier than normal fashion.
+                var result = model.getItem('exec.jobState.result');
+                var result = model.getItem('exec.outputWidgetInfo');
+                console.log('RESULT', result);
+
+                var content;
+                // If there's a "report_ref" key in the results, load and show the report.
+                if (result.params.report_name) {
+                    // do report widget.
+                    container.innerHTML = '<div></div>';
+                    new KBaseReportView($(container), result.params);
+                }
+                else {
+                    container.innerHTML = buildPresentableJson(result);
+                }
+            });
+        }
+
+        function stop() {
+            return Promise.try(function () {
+                container.innerHTML = 'Bye from results';
+            });
+        }
+
+        return {
+            start: start,
+            stop: stop
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -1375,11 +1375,12 @@ define([
                     ])
                 ]),
                 div({dataElement: 'tab-pane',
-                    style: {
-                        border: '1px rgb(32, 77, 16) solid',
-                        padding: '4px',
-                        backgroundColor: '#f5f5f5'
-                    }}, [
+                    // style: {
+                    //     border: '1px rgb(32, 77, 16) solid',
+                    //     padding: '4px',
+                    //     backgroundColor: '#f5f5f5'
+                    // }
+                }, [
                     div({dataElement: 'widget'})
                 ])
             ]);

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -27,6 +27,7 @@ define([
     'google-code-prettify/prettify',
     'narrativeConfig',
     './appCellWidget-fsm',
+    './appCellResults',
     'css!google-code-prettify/prettify.css',
     'css!font-awesome.css'
 ], function (
@@ -54,7 +55,8 @@ define([
     format,
     PR,
     narrativeConfig,
-    AppStates
+    AppStates,
+    ResultsWidget
     ) {
     'use strict';
     var t = html.tag,
@@ -439,40 +441,40 @@ define([
             }
         }
 
-        function resultsWidget() {
-            function factory(config) {
-                var container;
-                function start(arg) {
-                    return Promise.try(function () {
-                        container = arg.node;
+        // function resultsWidget() {
+        //     function factory(config) {
+        //         var container;
+        //         function start(arg) {
+        //             return Promise.try(function () {
+        //                 container = arg.node;
 
-                        // Very simple for now, just render the results json in a prettier than normal fashion.
-                        var result = model.getItem('exec.jobState.result');
+        //                 // Very simple for now, just render the results json in a prettier than normal fashion.
+        //                 var result = model.getItem('exec.jobState.result');
 
-                        var content = buildPresentableJson(result);
+        //                 var content = buildPresentableJson(result);
 
-                        container.innerHTML = content;
-                    });
-                }
+        //                 container.innerHTML = content;
+        //             });
+        //         }
 
-                function stop() {
-                    return Promise.try(function () {
-                        container.innerHTML = 'Bye from results';
-                    });
-                }
+        //         function stop() {
+        //             return Promise.try(function () {
+        //                 container.innerHTML = 'Bye from results';
+        //             });
+        //         }
 
-                return {
-                    start: start,
-                    stop: stop
-                };
-            }
+        //         return {
+        //             start: start,
+        //             stop: stop
+        //         };
+        //     }
 
-            return {
-                make: function (config) {
-                    return factory(config);
-                }
-            };
-        }
+        //     return {
+        //         make: function (config) {
+        //             return factory(config);
+        //         }
+        //     };
+        // }
 
         function formatError(errorInfo) {
             var errorId = new Uuid(4).format();
@@ -770,7 +772,8 @@ define([
             ui.getElement('run-control-panel.tab-pane.widget').appendChild(node);
 
             return controlBarTabs.selectedTab.widget.start({
-                node: node
+                node: node,
+                model: model
             });
         }
 
@@ -858,7 +861,7 @@ define([
                 results: {
                     label: 'Results',
                     xicon: 'file',
-                    widget: resultsWidget()
+                    widget: ResultsWidget
                 },
                 error: {
                     label: 'Error',

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -441,41 +441,6 @@ define([
             }
         }
 
-        // function resultsWidget() {
-        //     function factory(config) {
-        //         var container;
-        //         function start(arg) {
-        //             return Promise.try(function () {
-        //                 container = arg.node;
-
-        //                 // Very simple for now, just render the results json in a prettier than normal fashion.
-        //                 var result = model.getItem('exec.jobState.result');
-
-        //                 var content = buildPresentableJson(result);
-
-        //                 container.innerHTML = content;
-        //             });
-        //         }
-
-        //         function stop() {
-        //             return Promise.try(function () {
-        //                 container.innerHTML = 'Bye from results';
-        //             });
-        //         }
-
-        //         return {
-        //             start: start,
-        //             stop: stop
-        //         };
-        //     }
-
-        //     return {
-        //         make: function (config) {
-        //             return factory(config);
-        //         }
-        //     };
-        // }
-
         function formatError(errorInfo) {
             var errorId = new Uuid(4).format();
             var errorType, errorMessage, errorDetail;
@@ -1412,11 +1377,8 @@ define([
                 div({dataElement: 'tab-pane',
                     style: {
                         border: '1px rgb(32, 77, 16) solid',
-                        xborderLeft: '1px silver solid',
-                        xborderRight: '1px silver solid',
-                        xborderBottom: '1px silver solid',
                         padding: '4px',
-                        xminHeight: '100px'
+                        backgroundColor: '#f5f5f5'
                     }}, [
                     div({dataElement: 'widget'})
                 ])
@@ -1497,14 +1459,14 @@ define([
                                     });
                                 }()),
                                 buildRunControlPanel(events),
-                                ui.buildCollapsiblePanel({
-                                    title: 'Output ' + span({class: 'fa fa-arrow-left'}),
-                                    name: 'output-group',
-                                    hidden: true,
-                                    type: 'default',
-                                    classes: ['kb-panel-container'],
-                                    body: div({dataElement: 'widget'})
-                                }),
+                                // ui.buildCollapsiblePanel({
+                                //     title: 'Output ' + span({class: 'fa fa-arrow-left'}),
+                                //     name: 'output-group',
+                                //     hidden: true,
+                                //     type: 'default',
+                                //     classes: ['kb-panel-container'],
+                                //     body: div({dataElement: 'widget'})
+                                // }),
                                 ui.buildPanel({
                                     title: 'Error',
                                     name: 'fatal-error',


### PR DESCRIPTION
Inching toward representing the mockups better...

* Hid the "Output" windowblind area.
* Popped the Results tab out into a separate widget - appCellResults in the nbextension area.
* When results happen, if the key "report_name" is present in them, then that's a report. This then adds the report widget.
* Adds a little string of which results are being viewed.
* Fixed @scanon 's issue of cells that can't be deleted.
* Made a few CSS adjustments - the padding on the widget view areas is gone when collapsed, added a light gray background.