### PR TITLE
Hide prompt area, move icon to toolbar

### DIFF
--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -318,3 +318,7 @@ span#notebook_name:hover {
 p {
     margin-bottom: 9px;
 }
+
+.prompt {
+    display: none !important;
+}

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -597,6 +597,18 @@ define([
 //                icon
 //            ]);
         };
+        
+        p.getIcon = function () {
+            return span();
+//            var iconColor = 'silver';
+//
+//            return span({style: ''}, [
+//                span({class: 'fa-stack fa-2x', style: {textAlign: 'center', color: iconColor}}, [
+//                    span({class: 'fa fa-square fa-stack-2x', style: {color: iconColor}}),
+//                    span({class: 'fa fa-inverse fa-stack-1x fa-' + 'paragraph'})
+//                ])
+//            ]);
+        };
 
 
 
@@ -843,6 +855,17 @@ define([
             }
 
             prompt.innerHTML = 'prompt here';
+        };
+        
+        p.getIcon = function () {
+            var iconColor = 'silver';
+
+            return span({style: ''}, [
+                span({class: 'fa-stack fa-2x', style: {textAlign: 'center', color: iconColor}}, [
+                    span({class: 'fa fa-square fa-stack-2x', style: {color: iconColor}}),
+                    span({class: 'fa fa-inverse fa-stack-1x fa-' + 'file-o'})
+                ])
+            ]);
         };
 
         originalMethod = codeCell.CodeCell.prototype.bind_events;

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -1347,6 +1347,14 @@ div#notebook_panel {
     cursor: pointer;
 }
 
+.kb-cell-toolbar {
+    xborder-bottom: 1px silver solid;
+}
+
+.kb-cell-toolbar.collapsed {
+    xborder-bottom: none;
+}
+
 .kb-cell-toolbar .buttons {
     font-weight: bold;
     color: #CECECE !important;
@@ -1354,6 +1362,18 @@ div#notebook_panel {
 
 .kb-cell-toolbar .btn {
     border: none;
+}
+
+.kb-cell-toolbar .icon {
+    display: inline-block;
+    height: 56px;
+    width: 56px;
+    padding: 0; 
+    margin: 0 4px 0 4px;
+    vertical-align: top; 
+    border: 0px red solid;
+    line-height: 56px;
+    overflow: hidden;
 }
 
 .kb-cell-toolbar .title {

--- a/kbase-extension/static/kbase/js/common/appUtils.js
+++ b/kbase-extension/static/kbase/js/common/appUtils.js
@@ -11,6 +11,35 @@ define([
 
     var t = html.tag,
         span = t('span'), img = t('img');
+        
+    function makeToolbarAppIcon(appSpec) {
+        // icon is in the spec ...
+        var runtime = Runtime.make(),
+            nmsBase = runtime.config('services.narrative_method_store_image.url'),
+            iconUrl = Props.getDataItem(appSpec, 'info.icon.url');
+
+        if (iconUrl) {
+            return span({style: {padding: '3px 3px 3px 3px'}}, [
+                img({src: nmsBase + iconUrl, style: {maxWidth: '50px', maxHeight: '50px', margin: '0x'}})
+            ]);
+        }
+
+        return span({class: 'fa-stack fa-2x', style: {verticalAlign: 'top', textAlign: 'center', color: 'rgb(103,58,183)', lineHeight: '56px'}}, [
+                span({class: 'fa fa-square fa-stack-2x', style: {color: 'rgb(103,58,183)', lineHeight: '56px'}}),
+                span({class: 'fa fa-inverse fa-stack-1x fa-cube'})
+            ]);
+    }
+    
+     function makeToolbarGenericIcon(fontAwesomeIconName, color) {
+        var iconColor = color || 'silver';
+
+        return span({style: ''}, [
+            span({class: 'fa-stack fa-2x', style: {verticalAlign: 'top', padding: '0', lineHeight: '56px'}}, [
+                span({class: 'fa fa-square fa-stack-2x', style: {color: iconColor, lineHeight: '56px'}}),
+                span({class: 'fa fa-inverse fa-stack-1x fa-' + fontAwesomeIconName})
+            ])
+        ]);
+    }
 
     function makeAppIcon(appSpec) {
         // icon is in the spec ...
@@ -19,7 +48,7 @@ define([
             iconUrl = Props.getDataItem(appSpec, 'info.icon.url');
 
         if (iconUrl) {
-            return span({class: 'fa-stack fa-2x', style: {padding: '2px 3px 3px 3px'}}, [
+            return span({style: {padding: '3px 3px 3px 3px'}}, [
                 img({src: nmsBase + iconUrl, style: {maxWidth: '50px', maxHeight: '50px', margin: '0x'}})
             ]);
         }
@@ -83,10 +112,41 @@ define([
             ])
         ]);
     }
+    
+    function makeToolbarTypeIcon(typeId) {
+        var type = parseType(typeId),
+            iconSpec = narrativeConfig.get('icons'), 
+            color, iconDef, icon;
+        
+        if (iconSpec) {
+            color = iconSpec.color_mapping[type.name];
+            iconDef = iconSpec.data[type.name];
+        }
+        
+        if (iconDef) {
+            icon = iconDef[0];
+        } else {
+            icon = iconSpec.data.DEFAULT[0];
+        }
+        
+        if (!color) {
+            color = 'black';
+        }
+        
+        return span([
+            span({class: 'fa-stack fa-2x', style: {textAlign: 'center', color: color, lineHeight: '56px'}}, [
+                span({class: 'fa fa-circle fa-stack-2x', style: {color: color, lineHeight: '56px'}}),
+                span({class: 'fa fa-inverse fa-stack-1x ' + icon})
+            ])
+        ]);
+    }
 
     return {
         makeAppIcon: makeAppIcon,
         makeGenericIcon: makeGenericIcon,
-        makeTypeIcon: makeTypeIcon
+        makeToolbarAppIcon: makeToolbarAppIcon,
+        makeToolbarGenericIcon: makeToolbarGenericIcon,
+        makeTypeIcon: makeTypeIcon,
+        makeToolbarTypeIcon: makeToolbarTypeIcon
     };
 });

--- a/kbase-extension/static/kbase/js/common/ui.js
+++ b/kbase-extension/static/kbase/js/common/ui.js
@@ -368,7 +368,8 @@ define([
             var klass = arg.type || 'default',
                 buttonClasses = ['btn', 'btn-' + klass],
                 events = arg.events, icon,
-                title = arg.title || arg.tip || arg.label;
+                title = arg.title || arg.tip || arg.label,
+                attribs;;
 
             if (arg.icon) {
                 if (!arg.icon.classes) {
@@ -395,14 +396,22 @@ define([
             if (!arg.event) {
                 arg.event = {};
             }
-
-            return button({
+            
+            attribs = {
                 type: 'button',
                 class: buttonClasses.join(' '),
                 title: title,
                 dataButton: arg.name,
                 id: addButtonClickEvent(events, arg.event.type || arg.name, arg.event.data)
-            }, [icon, span({style: {verticalAlign: 'middle'}}, arg.label)].join('&nbsp;'));
+            };
+            
+            if (arg.features) {
+                arg.features.forEach(function (feature) {
+                    attribs['data-feature-' + feature] = true;
+                });
+            }
+
+            return button(attribs, [icon, span({style: {verticalAlign: 'middle'}}, arg.label)].join('&nbsp;'));
         }
 
         function enableButton(name) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
@@ -157,7 +157,7 @@ define([
         function renderToggleCellSettings(events) {
             // Only kbase cells have cell settings.
             if (!cell.metadata || !cell.metadata.kbase || !cell.metadata.kbase.type) {
-                return
+                return;
             }
 
             return button({
@@ -173,72 +173,86 @@ define([
             ]);
         }
 
-        function render() {
+        function buildIcon(cell) {
+            if (cell && cell.getIcon) {
+                return cell.getIcon();
+            }
+            return span({class: 'fa fa-file fa-2x', style: {
+                    verticalAlign: 'top', 
+                    xlineHeight: '56px'
+                }
+            });
+        }
+
+        function render(cell) {
             var events = Events.make({node: container}),
                 toggleMinMax = utils.getCellMeta(cell, 'kbase.cellState.toggleMinMax', 'maximized'),
                 toggleIcon = (toggleMinMax === 'maximized' ? 'minus' : 'plus'),
                 buttons = Jupyter.narrative.readonly ? [] : [
-                    div({class: 'buttons pull-right'}, [
-                        span({class: 'kb-func-timestamp'}),
-                        span({class: 'fa fa-circle-o-notch fa-spin', style: {color: 'rgb(42, 121, 191)', display: 'none'}}),
-                        span({class: 'fa fa-exclamation-triangle', style: {color: 'rgb(255, 0, 0)', display: 'none'}}),
-                        renderToggleCodeView(events),
-                        renderToggleCellSettings(events),
-
-                        button({
-                            type: 'button',
-                            class: 'btn btn-default btn-xs',
-                            dataToggle: 'tooltip',
-                            dataPlacement: 'left',
-                            title: true,
-                            dataOriginalTitle: 'Move Cell Up',
-                            id: events.addEvent({type: 'click', handler: doMoveCellUp})
-                        }, [
-                            span({class: 'fa fa-arrow-up', style: 'font-size: 14pt'})
-                        ]),
-                        button({
-                            type: 'button',
-                            class: 'btn btn-default btn-xs',
-                            dataToggle: 'tooltip',
-                            dataPlacement: 'left',
-                            title: true,
-                            dataOriginalTitle: 'Move Cell Down',
-                            id: events.addEvent({type: 'click', handler: doMoveCellDown})
-                        }, [
-                            span({class: 'fa fa-arrow-down', style: 'font-size: 14pt'})
-                        ]),
-                        button({
-                            type: 'button',
-                            class: 'btn btn-default btn-xs',
-                            dataToggle: 'tooltip',
-                            dataPlacement: 'left',
-                            title: true,
-                            dataOriginalTitle: 'Delete Cell',
-                            id: events.addEvent({type: 'click', handler: doDeleteCell})
-                        }, [
-                            span({class: 'fa fa-times-circle', style: {fontSize: '14pt', color: 'red'}})
-                        ]),
-                        button({
-                            type: 'button',
-                            class: 'btn btn-default btn-xs',
-                            dataToggle: 'tooltip',
-                            dataPlacement: 'left',
-                            title: true,
-                            dataOriginalTitle: toggleMinMax === 'maximized' ? 'Collapse Cell' : 'Expand Cell',
-                            id: events.addEvent({type: 'click', handler: doToggleMinMaxCell})
-                        }, [
-                            span({class: 'fa fa-' + toggleIcon + '-square-o', style: {fontSize: '14pt', color: 'orange'}})
-                        ])
-
+                div({class: 'buttons pull-right'}, [
+                    span({class: 'kb-func-timestamp'}),
+                    span({class: 'fa fa-circle-o-notch fa-spin', style: {color: 'rgb(42, 121, 191)', display: 'none'}}),
+                    span({class: 'fa fa-exclamation-triangle', style: {color: 'rgb(255, 0, 0)', display: 'none'}}),
+                    renderToggleCodeView(events),
+                    renderToggleCellSettings(events),
+                    button({
+                        type: 'button',
+                        class: 'btn btn-default btn-xs',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'left',
+                        title: true,
+                        dataOriginalTitle: 'Move Cell Up',
+                        id: events.addEvent({type: 'click', handler: doMoveCellUp})
+                    }, [
+                        span({class: 'fa fa-arrow-up', style: 'font-size: 14pt'})
+                    ]),
+                    button({
+                        type: 'button',
+                        class: 'btn btn-default btn-xs',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'left',
+                        title: true,
+                        dataOriginalTitle: 'Move Cell Down',
+                        id: events.addEvent({type: 'click', handler: doMoveCellDown})
+                    }, [
+                        span({class: 'fa fa-arrow-down', style: 'font-size: 14pt'})
+                    ]),
+                    button({
+                        type: 'button',
+                        class: 'btn btn-default btn-xs',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'left',
+                        title: true,
+                        dataOriginalTitle: 'Delete Cell',
+                        id: events.addEvent({type: 'click', handler: doDeleteCell})
+                    }, [
+                        span({class: 'fa fa-times-circle', style: {fontSize: '14pt', color: 'red'}})
+                    ]),
+                    button({
+                        type: 'button',
+                        class: 'btn btn-default btn-xs',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'left',
+                        title: true,
+                        dataOriginalTitle: toggleMinMax === 'maximized' ? 'Collapse Cell' : 'Expand Cell',
+                        id: events.addEvent({type: 'click', handler: doToggleMinMaxCell})
+                    }, [
+                        span({class: 'fa fa-' + toggleIcon + '-square-o', style: {fontSize: '14pt', color: 'orange'}})
                     ])
-                ],
+
+                ])
+            ],
                 content = div({class: 'kb-cell-toolbar container-fluid'}, [
-                    div({class: 'row'}, [
+                    div({class: 'row', style: {height: '56px'}}, [
                         div({class: 'col-sm-8 title-container'}, [
-                            div({class: 'title', style: {display: 'inline-block'}}, [
-                                div({dataElement: 'title', class: 'title'}, [getCellTitle(cell)]),
-                                div({dataElement: 'subtitle', class: 'subtitle'}, [getCellSubtitle(cell)]),
-                                div({dataElement: 'title', class: 'info-link'}, [getCellInfoLink(cell)])
+                            div({class: 'title', style: {display: 'inline-block', height: '56px', lineHeight: '56px'}}, [
+                                div({dataElement: 'icon', class: 'icon', style: {position: 'relative', top: '0', left: '0', display: 'inline-block', height: '56px', lineHeight: '56px'}}, [
+                                    buildIcon(cell)
+                                ]),
+                                div({style: {display: 'inline-block'}}, [
+                                    div({dataElement: 'title', class: 'title', style: {lineHeight: '20px'}}, [getCellTitle(cell)]),
+                                    div({dataElement: 'subtitle', class: 'subtitle', style: {lineHeight: '20px'}}, [getCellSubtitle(cell)])
+                                ])
                             ])
                         ]),
                         div({class: 'col-sm-4 buttons-container'}, buttons)
@@ -254,12 +268,17 @@ define([
             };
         }
 
+        /*
+         * We are going to try to make this work by creating the layout once,
+         * and then allowing the toolbar widgets to refresh themselves 
+         * upon an event emitted at callback time.
+         */
         function callback(toolbarDiv, parentCell) {
             try {
                 container = toolbarDiv[0];
                 ui = UI.make({node: container});
                 cell = parentCell;
-                var rendered = render();
+                var rendered = render(parentCell);
                 container.innerHTML = rendered.content;
                 $(container).find('button').tooltip();
                 rendered.events.attachEvents();

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -475,12 +475,20 @@ define([
                     new kbaseAccordion($modalBody.find('div#kb-job-err-trace'), {
                         elements: [{
                             title: 'Detailed Error Information',
-                            body: $('<table class="table table-bordered"><tr><th>code:</th><td>' + content.code +
-                                    '</td></tr><tr><th>error:</th><td>' + content.message +
-                                    '</td></tr><tr><th>type:</th><td>' + content.name +
-                                    '</td></tr><tr><th>source:</th><td>' + content.source + '</td></tr></table>')
+                            body: $('<table class="table table-bordered"><tr><th>code:</th><td>' + content.code + '</td></tr>' +
+                                    '<tr><th>error:</th><td>' + content.message + '</td></tr>' +
+                                    (function () {
+                                        if (content.service) {
+                                            return '<tr><th>service:</th><td>' + content.service + '</td></tr>';
+                                        }
+                                        return '';
+                                    }()) +
+                                    '<tr><th>type:</th><td>' + content.name + '</td></tr>' +
+                                    '<tr><th>source:</th><td>' + content.source + '</td></tr></table>')
                             }]
                     });
+                    
+
                     $modalBody.find('button#kb-job-err-report').click(function (e) {
                         alert('reporting error!');
                     });

--- a/nbextensions/appCell/main.js
+++ b/nbextensions/appCell/main.js
@@ -188,8 +188,21 @@ define([
             outputArea.removeClass('hidden');
             viewInputArea.removeClass('hidden');
         };
+        cell.getIcon = function () {
+            var icon = AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'));
+            return icon;
+        };
         cell.renderIcon = function () {
-            var inputPrompt = this.element[0].querySelector('[data-element="prompt"]');
+            var iconNode = this.element[0].querySelector('.celltoolbar [data-element="icon"]'),
+                icon = AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'))
+            console.log('ICON', iconNode, icon);
+            if (iconNode) {
+                iconNode.innerHTML = AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'));
+            } 
+            return;
+            
+            
+            var inputPrompt = this.element[0].querySelector('.celltoolbar [data-element="icon"]');
 
             if (inputPrompt) {
                 inputPrompt.innerHTML = div({

--- a/nbextensions/appCell/widgets/appCellWidget-fsm.js
+++ b/nbextensions/appCell/widgets/appCellWidget-fsm.js
@@ -31,9 +31,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: false
                     }
                 },
                 actionButton: {
@@ -88,9 +85,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: false
                     }
                 },
                 actionButton: {
@@ -106,7 +100,7 @@ define([
                     type: 'pencil'
                 },
                 label: 'editing',
-                message: 'You may edit the parameters for this App and then run it'
+                message: 'You may edit the parameters for this App. All required parameters are not currently entered. When they are complete, you will be able to run the app.'
             },
             next: [
                 {
@@ -151,9 +145,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: false
                     }
                 },
                 actionButton: {
@@ -246,9 +237,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: false
                     }
                 },
                 actionButton: {
@@ -338,9 +326,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: false
                     }
                 },
                 actionButton: {
@@ -430,9 +415,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },                
                 actionButton: {
@@ -531,9 +513,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },            
                 actionButton: {
@@ -626,9 +605,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },            
                 actionButton: {
@@ -700,9 +676,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },                            
                 actionButton: {
@@ -756,9 +729,6 @@ define([
                     error: {
                         enabled: false,
                         hidden: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },               
                 actionButton: {
@@ -839,9 +809,6 @@ define([
                     error: {
                         enabled: true,
                         selected: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },               
                 actionButton: {
@@ -901,9 +868,6 @@ define([
                     error: {
                         enabled: true,
                         selected: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },               
                 actionButton: {
@@ -963,9 +927,6 @@ define([
                     error: {
                         enabled: true,
                         selected: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },               
                 actionButton: {
@@ -1024,9 +985,6 @@ define([
                     error: {
                         enabled: true,
                         selected: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },               
                 actionButton: {
@@ -1084,9 +1042,6 @@ define([
                     error: {
                         enabled: true,
                         selected: true
-                    },
-                    jobState: {
-                        enabled: true
                     }
                 },               
                 actionButton: {

--- a/nbextensions/appCell/widgets/appCellWidget.js
+++ b/nbextensions/appCell/widgets/appCellWidget.js
@@ -496,12 +496,12 @@ define([
                     xicon: 'bar-chart',
                     widget: runStatsTabWidget
                 },
-                jobState: {
-                    label: 'State',
-                    xicon: 'table',
-                    advanced: true,
-                    widget: jobStateTabWidget
-                },
+//                jobState: {
+//                    label: 'State',
+//                    xicon: 'table',
+//                    features: ['developer'],
+//                    widget: jobStateTabWidget
+//                },
                 logs: {
                     label: 'Logs',
                     xicon: 'list',
@@ -978,11 +978,12 @@ define([
                     events: events,
                     type: tab.type || 'primary',
                     hidden: true,
+                    features: tab.features,
                     event: {
                         type: 'control-panel-tab',
                         data: {
                             tab: key
-                        },
+                        }
                     },
                     icon: icon
                 });
@@ -1659,7 +1660,7 @@ define([
 
         function doRerun() {
             var confirmationMessage = div([
-                p('This action will clear the App Execution area and restore the Input Area to edit mode. You may then change inputs and run the app again. (Any output you have already produced will be left intact.)'),
+                p('This action will clear the Results and re-enable the Configure tab for editing. You may then change inputs and run the app again. (Any output you have already produced will be left intact.)'),
                 p('Proceed to Resume Editing?')
             ]);
             ui.showConfirmDialog({title: 'Edit and Re-Run?', body: confirmationMessage})
@@ -1668,21 +1669,10 @@ define([
                         return;
                     }
 
-                    // No longer delete job state. This will be done if/when
-                    // the user deletes the ouput.
-                    //var jobState = model.getItem('exec.jobState');
-                    //if (jobState) {
-                    //    cancelJob(jobState.job_id);
-                    // the job will be deleted form the notebook when the job cancellation
-                    // event is received.
-                    //}
-
                     // Remove all of the execution state when we reset the app.
                     resetToEditMode('do rerun');
                 });
         }
-
-
 
         /*
          * Cancelling a job is the same as deleting it, and the effect of cancelling the job is the same as re-running it.
@@ -1716,16 +1706,6 @@ define([
                         fsm.newState({mode: 'editing', params: 'complete', code: 'built'});
                         renderUI();
                     }
-
-                    // Remove all of the execution state when we reset the app.
-                    //model.deleteItem('exec');
-
-                    //reloadExecutionWidget();
-
-                    // TODO: evaluate the params again before we do this.
-                    //fsm.newState({mode: 'editing', params: 'complete', code: 'built'});
-
-                    //renderUI();
                 });
         }
 
@@ -1854,8 +1834,6 @@ define([
 
         var jobListeners = [];
         function startListeningForJobMessages(jobId) {
-
-
             var ev;
 
             ev = runtime.bus().listen({

--- a/nbextensions/dataCell/main.js
+++ b/nbextensions/dataCell/main.js
@@ -71,6 +71,11 @@ define([
                 ]);
             }
         };
+        cell.getIcon = function () {
+            var type = Props.getDataItem(cell.metadata, 'kbase.dataCell.objectInfo.type'), 
+                icon = AppUtils.makeToolbarTypeIcon(type);
+            return icon;
+        };
         cell.hidePrompts = function () {
             // Hide the code input area.
             this.input.find('.input_area').addClass('hidden');

--- a/nbextensions/outputCell/main.js
+++ b/nbextensions/outputCell/main.js
@@ -65,6 +65,10 @@ define([
                 ]);
             }
         };
+        cell.getIcon = function () {
+            var icon = AppUtils.makeToolbarGenericIcon('arrow-left');
+            return icon;
+        };
         cell.hidePrompts = function () {
             // Hide the code input area.
             this.input.find('.input_area').addClass('hidden');

--- a/nbextensions/viewCell/main.js
+++ b/nbextensions/viewCell/main.js
@@ -397,6 +397,10 @@ define([
                 ]);
             }
         };
+        cell.getIcon = function () {
+           var icon = AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'));
+            return icon;
+        };
     }
 
     function setupCell(cell) {

--- a/src/biokbase/narrative/exception_util.py
+++ b/src/biokbase/narrative/exception_util.py
@@ -33,7 +33,7 @@ def transform_job_exception(e):
         code = e.response.status_code
         if code == 404 or code == 502 or code == 503:
             # service not found
-            msg = 'The KBase App service is currently unavailable.'
+            msg = 'A KBase service is currently unavailable.'
         elif code == 504 or code == 598 or code == 599:
             # service timeout
             msg = 'There was a temporary network connection error.'

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -78,7 +78,8 @@ class JobManager(object):
                 'message': getattr(new_e, 'message', 'Unknown reason'),
                 'code': getattr(new_e, 'code', -1),
                 'source': getattr(new_e, 'source', 'jobmanager'),
-                'name': getattr(new_e, 'name', type(e).__name__)
+                'name': getattr(new_e, 'name', type(e).__name__),
+                'service': 'user_and_job_state'
             }
             self._send_comm_message('job_init_err', error)
             raise new_e
@@ -110,7 +111,8 @@ class JobManager(object):
                     'message': getattr(new_e, 'message', 'Unknown reason'),
                     'code': getattr(new_e, 'code', -1),
                     'source': getattr(new_e, 'source', 'jobmanager'),
-                    'name': getattr(new_e, 'name', type(e).__name__)
+                    'name': getattr(new_e, 'name', type(e).__name__),
+                    'service': 'job_service'
                 }
                 self._send_comm_message('job_init_lookup_err', error)
                 raise new_e # should crash and burn on any of these.


### PR DESCRIPTION
The prompt area is hidden with a single simple css directive.
This required moving the icon into the toolbar. This was not too strenuous, requiring an additional area in the toolbar on the left. Since the toolbar is rendered to the beat of Jupyter, it requires a different method of rendering the icon. Specifically, it must request it from the host cell via our cell extension method "getIcon". This replaces "renderIcon" which was called at cell creation time, not toolbar rendering time. It is possible that there will be flickering at times, since the cell toolbar may be rendered at arbitrary times. E.g. it renders before the cell is even ready, so there is an initial state of no icon, it renders after the cell extensions are loaded, and it can also render when the cell metadata is updated as a cell is being used.
The Jupyter machinery actually wipes out the cell toolbar when it thinks it needs re-rendering, so there does not appear to be much we can do about the flickering, and we will not be able to install long-lived widgets up there (but if they are fast enough it may not matter.)
Also removed the "more..." line from the toolbar since there will be another mechanism for getting app info.
If it looks like this will work, I'll proceed to remove all of the old code for icons to reduce clutter.