### PR TITLE
Cell toolbar - merge individual buttons into dropdown

### DIFF
--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -221,10 +221,6 @@ span#notebook_name:hover {
     color: silver;
 }
 
-.notebook_app .cell .celltoolbar .btn {
-    xbackground-color: transparent;
-}
-
 .text_cell.kb-cell .rendered_html table {
     border: 1px solid #ddd;
 }

--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -218,7 +218,7 @@ span#notebook_name:hover {
 }
 
 .notebook_app .cell .celltoolbar .btn {
-    background-color: transparent;
+    xbackground-color: transparent;
 }
 
 .text_cell.kb-cell .rendered_html table {

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -380,7 +380,7 @@ define([
 
             this.renderMinMax();
 
-            utils.setCellMeta(this, 'kbase.cellState.toggleMinMax', toggleMode);
+            utils.setCellMeta(this, 'kbase.cellState.toggleMinMax', toggleMode, true);
         };
 
         (function () {
@@ -863,7 +863,7 @@ define([
             return span({style: ''}, [
                 span({class: 'fa-stack fa-2x', style: {textAlign: 'center', color: iconColor}}, [
                     span({class: 'fa fa-square fa-stack-2x', style: {color: iconColor}}),
-                    span({class: 'fa fa-inverse fa-stack-1x fa-' + 'file-o'})
+                    span({class: 'fa fa-inverse fa-stack-1x fa-' + 'terminal'})
                 ])
             ]);
         };
@@ -906,14 +906,23 @@ define([
             if (codeInputArea) {
                 codeInputArea.classList.add('hidden');
             }
-        }
+        };
+        
+        p.isCodeShowing = function () {
+            var codeInputArea = this.input.find('.input_area')[0];
+            if (codeInputArea) {
+                return !codeInputArea.classList.contains('hidden');
+            }
+            return false;            
+        };
 
         p.toggleCodeInputArea = function() {
             var codeInputArea = this.input.find('.input_area')[0];
             if (codeInputArea) {
                 codeInputArea.classList.toggle('hidden');
+                this.metadata = this.metadata;
             }
-        }
+        };
     }());
 
     /*

--- a/kbase-extension/static/kbase/js/common/utils.js
+++ b/kbase-extension/static/kbase/js/common/utils.js
@@ -80,10 +80,14 @@ define([
         }
         cell.metadata = temp;
     }
-    function setCellMeta(cell, path, value) {
-        var meta = cell.metadata || {};
-        Props.setDataItem(meta, path, value);
-        cell.metadata = meta;
+    function setCellMeta(cell, path, value, forceRefresh) {
+        if (!cell.metadata) {
+            cell.metadata = {};
+        }
+        Props.setDataItem(cell.metadata, path, value);
+        if (forceRefresh) {
+            cell.metadata = cell.metadata;
+        }
     }
     function getCellMeta(cell, path, defaultValue) {
         return Props.getDataItem(cell.metadata, path, defaultValue);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
@@ -190,15 +190,6 @@ define([
 //                        id: events.addEvent({type: 'click', handler: doHelp})
 //                    },
                     {
-                        name: 'delete-cell',
-                        label: 'Delete',
-                        icon: {
-                            type: 'times',
-                            color: 'red'
-                        },
-                        id: events.addEvent({type: 'click', handler: doDeleteCell})
-                    },
-                    {
                         name: 'toggle-collapse',
                         label: toggleMinMax === 'maximized' ? 'Collapse' : 'Expand',
                         icon: {
@@ -232,6 +223,20 @@ define([
                     id: events.addEvent({type: 'click', handler: doToggleCodeView})
                 });
             }
+            
+            menuItems.push({
+                type: 'separator'
+            });
+            menuItems.push({
+                name: 'delete-cell',
+                label: 'Delete cell',
+                icon: {
+                    type: 'times',
+                    color: 'red'
+                },
+                id: events.addEvent({type: 'click', handler: doDeleteCell})
+            });
+
 
             return span({class: 'dropdown'}, [
                 button({
@@ -244,17 +249,25 @@ define([
                 }, [span({class: 'fa fa-ellipsis-h fa-lg'})]),
                 ul({class: 'dropdown-menu dropdown-menu-right', ariaLabelledby: dropdownId}, [
                     menuItems.map(function (item) {
-                        return li(button({
-                            class: 'btn btn-default',
-                            id: item.id
-                        }, [
-                            span({style: {
-                                    display: 'inline-block',
-                                    width: '25px',
-                                    textAlign: 'left',
-                                    marginRight: '4px'
-                                }}, renderIcon(item.icon)),
-                            span(item.label)]));
+                        switch (item.type) {
+                            case 'separator':
+                                return li({
+                                    role: 'separator',
+                                    class: 'divider'
+                                });
+                            default:
+                                return li(button({
+                                    class: 'btn btn-default',
+                                    id: item.id
+                                }, [
+                                    span({style: {
+                                            display: 'inline-block',
+                                            width: '25px',
+                                            textAlign: 'left',
+                                            marginRight: '4px'
+                                        }}, renderIcon(item.icon)),
+                                    span(item.label)]));
+                        }
                     }).join('')
                 ])
             ]);
@@ -277,8 +290,7 @@ define([
                 div({class: 'buttons pull-right'}, [
                     span({class: 'kb-func-timestamp'}),
                     span({class: 'fa fa-circle-o-notch fa-spin', style: {color: 'rgb(42, 121, 191)', display: 'none'}}),
-                    span({class: 'fa fa-exclamation-triangle', style: {color: 'rgb(255, 0, 0)', display: 'none'}}),
-                    renderOptions(cell, events),
+                    span({class: 'fa fa-exclamation-triangle', style: {color: 'rgb(255, 0, 0)', display: 'none'}}),                   
                     button({
                         type: 'button',
                         class: 'btn btn-default btn-xs',
@@ -300,7 +312,8 @@ define([
                         id: events.addEvent({type: 'click', handler: doMoveCellDown})
                     }, [
                         span({class: 'fa fa-arrow-down fa-lg', style: 'xfont-size: 18px'})
-                    ])
+                    ]),
+                    renderOptions(cell, events)
 //                    button({
 //                        type: 'button',
 //                        class: 'btn btn-default btn-xs',

--- a/nbextensions/appCell/main.js
+++ b/nbextensions/appCell/main.js
@@ -195,7 +195,6 @@ define([
         cell.renderIcon = function () {
             var iconNode = this.element[0].querySelector('.celltoolbar [data-element="icon"]'),
                 icon = AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'))
-            console.log('ICON', iconNode, icon);
             if (iconNode) {
                 iconNode.innerHTML = AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'));
             } 

--- a/nbextensions/dataCell/main.js
+++ b/nbextensions/dataCell/main.js
@@ -95,6 +95,8 @@ define([
             var codeInputArea = this.input.find('.input_area')[0];
             if (codeInputArea) {
                 codeInputArea.classList.toggle('hidden');
+                // NB purely for side effect - toolbar refresh
+                cell.metadata = cell.metadata;
             }
         };
     }
@@ -189,8 +191,6 @@ define([
             if (parentTitle) {
                 Props.setDataItem(cell.metadata, 'kbase.attributes.title', data.objectInfo.name);
             }
-            
-            // console.log('OBJ INF', data.objectInfo);
 
             setupCell(cell);
         });
@@ -198,7 +198,6 @@ define([
 
     function load() {
         $([Jupyter.events]).on('inserted.Cell', function (event, data) {
-          console.log('inserted!', data);
             if (data.kbase && data.kbase.type === 'data') {
                 upgradeCell(data)
                     .catch(function (err) {

--- a/nbextensions/outputCell/main.js
+++ b/nbextensions/outputCell/main.js
@@ -84,12 +84,19 @@ define([
             this.input.find('.input_prompt').hide();
             utils.horribleHackToHideElement(this, '.output_prompt', 10);
         };
-        cell.toggleCodeInputArea = function () {
-            console.log('TOGGLING 2...');
+        cell.isCodeShowing = function () {
             var codeInputArea = this.input.find('.input_area')[0];
-            console.log('TOGGLING 3', codeInputArea);
+            if (codeInputArea) {
+                return !codeInputArea.classList.contains('hidden');
+            }
+            return false;            
+        };
+        cell.toggleCodeInputArea = function () {
+            var codeInputArea = this.input.find('.input_area')[0];
             if (codeInputArea) {
                 codeInputArea.classList.toggle('hidden');
+                // NB purely for side effect - toolbar refresh
+                cell.metadata = cell.metadata;
             }
         }
     }
@@ -118,7 +125,6 @@ define([
         var outputCell = OutputCell.make({
             cell: cell
         });
-        console.log('CELL', cell);
         outputCell.bus.emit('run', {
             node: cell.element
         });


### PR DESCRIPTION
To simplify the cell toolbar, buttons which may be less-used are moved from the toolbar into a dropdown menu on the toolbar. Buttons moved are the delete, collapse (min/max), and code view. The settings button is not in the new design and was removed.
Minor changes from the mockup -- the icon is an ellipsis, not gear, since gear is more commonly used for options and ellipsis for additional items.
Also help not included on menu, since we don't have a help system. 
A note here that the Jupyter toolbar is prone to rendering interruptions. The core code re-renders the toolbar when the cell.metadata property is set (not just updated, it has to be set through direct assignment.) The renderer removes all toolbar nodes, and then calls all toolbar extensions to render themselves. Using a dynamic, persistent control like the dropdown is iffy, because while the dropdown is being displayed, a render event may be triggered, and the dropdown will be removed. This happened (and was patched) in the markdown cell, through a convoluted web of events and actions triggered by clicking on the dropdown, which also as it happens triggers a click on the cell itself (and invokes a cell selection event...)
