### PR TITLE
Provide full object info as input for viewer widgets

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
@@ -150,7 +150,7 @@ define([
             }
             var spec = viewerInfo.specs[methodId];
             var inputParamId = spec['parameters'][0]['id'];
-            var output = {};
+            var output = {'_obj_info':o};
             _.each(spec.behavior.output_mapping, function (mapping) {
                 // Get parameter value
                 var param = getParamValue(o, mapping);


### PR DESCRIPTION
@briehl @eapearson - What do you think about this?

Right now, we capture all the object info and pass it along the long chain to actually render a widget, then we throw it away and only keep parameters from the method spec at the very last step.  So in most cases, we lose version information, and the viewers only show the latest version.  So why don't we just always pass this full object info to all of our viewer widgets (in addition to the other parameters of course, so nothing breaks)?

This would let me make sure the Genome and Assembly viewers respect versions.  And actually, In most cases, this object info is all the viewers need, so we wouldn't even need some complicated parameter mapping for most viewers.

A possible downside is that if these widgets are created in other widgets, or outside of the viewer context, we might not have or need the full object information to populate.  It also looks like you aren't just passing around the WS info array directly, but some structure with that information processed, which means we would probably always have to process things this way in other places.
