### PR TITLE
Changes to wording of "Obsolete App" message

### DIFF
--- a/src/biokbase/narrative/contents/updater.py
+++ b/src/biokbase/narrative/contents/updater.py
@@ -237,10 +237,11 @@ def obsolete_method_cell(cell, app_id, app_name, app_spec, params):
     <div style="font-family: 'OxygenBold', Arial, sans-serif;">
     Obsolete App!
     </div>
-    Sorry, this app is obsolete and can no longer function. But don't worry! Any results produced by running this app have been retained.
-    <br><b>Parameters:</b>
+    Sorry, this app is obsolete and can no longer function. But don't worry! Any data objects that were produced when you ran this app have been saved.
+    <br>Please see the <a href="http://kbase.us/kbase-app-replacement/">App Replacement page</a> for more information.
+    <br><br><b>Parameter settings you used:</b>
     {}
-    <br><b>Suggested Replacements:</b><br>
+    <br><b>Suggested replacement app(s):</b><br>
     {}
 </div>"""
 
@@ -293,10 +294,11 @@ def obsolete_app_cell(cell, app_id, app_name, app_spec, params):
     <div style="font-family: 'OxygenBold', Arial, sans-serif;">
     Obsolete App!
     </div>
-    Sorry, this app is obsolete and can no longer function. But don't worry! Any results produced by running this app have been retained.
-    <br><b>Parameters:</b>
+    Sorry, this app is obsolete and can no longer function. But don't worry! Any data objects that were produced when you ran this app have been saved.
+    <br>Please see the <a href="http://kbase.us/kbase-app-replacement/">App Replacement page</a> for more information.
+    <br><br><b>Parameter settings you used:</b>
     {}
-    <br><b>Suggested Replacements:</b><br>
+    <br><b>Suggested replacement app(s):</b><br>
     {}
 </div>"""
 


### PR DESCRIPTION
Some wording changes as per https://atlassian.kbase.us/browse/KBASE-4399 

I wanted to leave out the internal names from the list of replacement apps (see suggestion #5 in JIRA ticket), but I don't know Python so I wasn't sure what to change or how to test my change. The relevant code is:
       format_sug = "The following replacement apps might help and are available in the Apps menu:<br><ol>"
        for idx, s_list in enumerate(suggestions):
            format_sug += '<li>{}<ul>'.format(s_list['orig_step'])
            format_sug += ''.join(['<li>{}</li>'.format(s) for s in s_list['sug']]) + '</ul></li>'
        format_sug += '</ol>'