### PR TITLE
updated download links in report

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -120,7 +120,7 @@ define(
             var self = this;
             self.loading(true);
 
-               var objIdentity = {ref: this.options.report_ref};
+            var objIdentity = self.buildObjectIdentity(this.options.workspace_name, this.options.report_name, null, this.options.report_ref);
 
             //objIdentity = {ref : "11699/2/6"};
             self.ws.get_objects([objIdentity],

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -95,9 +95,9 @@ define(
               //processData : false
               }
           ).then(function(d) {
-//            console.log("I RETRIEVED DATA ", d);
+
             $('#' + link_id).on('click', function(e) {
-//              console.log("OPENS UP URL ", self.properPreauthURL(d.data.url))
+
               e.stopPropagation();
               self.preauthMagicClick(url, link_id);
               window.location.href = self.properPreauthURL(d.data.url);
@@ -120,8 +120,8 @@ define(
             var self = this;
             self.loading(true);
 
-            // var objIdentity = self.buildObjectIdentity(this.options.workspace_name, this.options.report_name, null, null);
-            var objIdentity = {ref: this.options.report_ref};
+               var objIdentity = self.buildObjectIdentity(this.options.workspace_name, this.options.report_name, null, null);
+            // var objIdentity = {ref: this.options.report_ref};
 
             objIdentity = {ref : "11699/2/6"};
             self.ws.get_objects([objIdentity],
@@ -332,13 +332,21 @@ self.options.showCreatedObjects = true;
 
                 self.$mainPanel.append(someDiv);
 
+                var download_link_id = StringUtil.uuid();
+
                 var sectionTitle = $.jqElem('div')
                   .append('Report &nbsp;&nbsp;')
                   .append(
-                    $.jqElem('a').append("Download")
+                    $.jqElem('a').append("Download").attr('id', download_link_id)
                   )
                   .html();
                 ;
+
+                setTimeout(function() {
+                  $('#' + download_link_id).on('click', function(e) {
+                    e.stopPropagation();
+                    window.location.href = self.importExportLink(self.reportData.html_links[0].URL, 'report.html');
+                  })}, 1);
 
                 ui.setContent('report-section',
                     ui.buildCollapsiblePanel({
@@ -366,7 +374,7 @@ self.options.showCreatedObjects = true;
 
                     var link_id = StringUtil.uuid();
 
-                    self.preauthMagicClick(v.URL + '?download_url', link_id);
+                    //self.preauthMagicClick(v.URL + '?download_url', link_id);
 
 
                     $ul.append(
@@ -383,6 +391,12 @@ self.options.showCreatedObjects = true;
                             .append(v.name || v.URL)
                         )
                     );
+
+                    setTimeout(function() {
+                      $('#' + link_id).on('click', function(e) {
+                        e.stopPropagation();
+                        window.location.href = self.importExportLink(v.URL, v.name || 'download');
+                      })}, 1);
                   }
                 );
 

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -120,10 +120,9 @@ define(
             var self = this;
             self.loading(true);
 
-               var objIdentity = self.buildObjectIdentity(this.options.workspace_name, this.options.report_name, null, null);
-            // var objIdentity = {ref: this.options.report_ref};
+               var objIdentity = {ref: this.options.report_ref};
 
-            objIdentity = {ref : "11699/2/6"};
+            //objIdentity = {ref : "11699/2/6"};
             self.ws.get_objects([objIdentity],
                 function (data) {
                     self.reportData = data[0].data;

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -1,3 +1,4 @@
+//fnar pardon my french
 /**
  * Basic viz for a basic report type.
  * @public

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -1,4 +1,3 @@
-//fnar pardon my french
 /**
  * Basic viz for a basic report type.
  * @public

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -1,4 +1,4 @@
-//fnar, pardon my french. Again.
+//fnar, pardon my french. Again. And yet a third time
 
 /**
  * Basic viz for a basic report type.

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -1,3 +1,5 @@
+//fnar, pardon my french. Again.
+
 /**
  * Basic viz for a basic report type.
  * @public

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -156,9 +156,6 @@ define(
                 }
             }
 
-
-//XXX THIS IS ON FOR DEBUGGING PURPOSES
-self.options.showCreatedObjects = true;
             if (self.options.showCreatedObjects) {
                 var someDiv = div({dataElement : 'created-objects'});
                 self.$mainPanel.append(someDiv);

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -1,5 +1,3 @@
-//fnar, pardon my french. Again. And yet a third time
-
 /**
  * Basic viz for a basic report type.
  * @public


### PR DESCRIPTION
I still don't have pre-auth shock links working properly (they'll work once, but fail to re-generate a new link on every click). So until that's operational, here's a version using the import/export service to construct the URLs.

The token isn't visible in the html page, but will briefly be available in the location bar.

But other than the minor security concern, this should be fully functional.