### PR TITLE
don't add fake reads object when creating new

### DIFF
--- a/nbextensions/editorCell/widgets/editObjectSelector.js
+++ b/nbextensions/editorCell/widgets/editObjectSelector.js
@@ -63,13 +63,15 @@ define([
             selectedReadsSetItem;
         
         function doCreate(e) {
+            e.preventDefault();
+            e.stopPropagation();
             var name = ui.getElement('new-object-name').value;
                 // value = ui.getElement('new-object-type').value;
-            e.preventDefault();
             bus.emit('create-new-set', {
                 name: name
                 // type: value
             });
+            return false;
         }
 
         function renderLayout() {
@@ -86,7 +88,7 @@ define([
                     div({style: {fontStyle: 'italic'}}, 'or'),
                     form({
                         class: 'form-inline',
-                        id: events.addEvent({type: 'submit', handler: 'doCreate'})
+                        id: events.addEvent({type: 'submit', handler: doCreate})
                     }, [
                         span({style: {padding: '0 4px 0 0'}}, 'Create a new set named'),
                         input({dataElement: 'new-object-name', class: 'form-control'}),

--- a/nbextensions/editorCell/widgets/editorCellWidget.js
+++ b/nbextensions/editorCell/widgets/editorCellWidget.js
@@ -1544,9 +1544,6 @@ define([
                         // set with no items.
                         // stuff a sample item in here to start with.
                         items: [
-                            {
-                                ref: '11733/16/4'
-                            }
                         ]
                     }
                 };


### PR DESCRIPTION
This was a remnant to work around the empty-set bug (add one item when creating a new set.) Not necessary now.