### PR TITLE
Added appdev config for narrative_method_store_types

### DIFF
--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -37,7 +37,7 @@ define(
         'common/ui',
         'common/html',
         'narrativeTour',
-        
+
         // for effect
         'bootstrap',
 
@@ -157,7 +157,7 @@ define(
         ],
             commandShortcuts = [],
             editShortcuts = [
-                // remove the command palette 
+                // remove the command palette
                 // since it exposes commands we have "disabled"
                 // by removing keyboard mappings
                 'cmdtrl-shift-p',
@@ -538,7 +538,9 @@ define(
                 var url = Config.url(val).toString();
                 // if url looks like a url (starts with http), include it.
                 // ignore job proxy and submit ticket
-                if (val === 'narrative_job_proxy' || val === 'submit_jira_ticket') {
+                if (val === 'narrative_job_proxy' ||
+                    val === 'submit_jira_ticket' ||
+                    val === 'narrative_method_store_types') {
                     return;
                 }
                 if (url && url.toLowerCase().indexOf('http') === 0) {

--- a/src/config.json
+++ b/src/config.json
@@ -33,6 +33,7 @@
         "login": "https://appdev.kbase.us/services/authorization/Sessions/Login",
         "narrative_job_proxy": "https://appdev.kbase.us/services/narrativejobproxy/",
         "narrative_method_store": "https://appdev.kbase.us/services/narrative_method_store/rpc",
+        "narrative_method_store_types": "https://next.kbase.us/services/narrative_method_store/rpc",
         "profile_page": "/#people/",
         "protein_info": "",
         "reset_password": "https://gologin.kbase.us/ResetPassword",


### PR DESCRIPTION
To patch the busted appdev uploaders.

@rsutormin @scanon 

The `narrative_method_store_types` config piece can be added to any environment block to point just the types to a different service. If it's not present, it'll use the `narrative_method_store` variable instead (see previous PR #807 ).