### PR TITLE
Rewire data slideout

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,12 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.1.0-alpha-4
+__Changes__
+- Adjust visuals in Reads viewer.
+- Adjust tooltip for objects from other Narratives.
+- Changed functionality of object copying in data slideout.
+
 ### Version 3.1.0-alpha-3
 __Changes__
 - Updated ReadsSet viewer and Reads viewer.

--- a/kbase-extension/static/kbase/js/util/display.js
+++ b/kbase-extension/static/kbase/js/util/display.js
@@ -179,7 +179,7 @@ define(
                 $errorPanel.append($('<div>').append('<b>' + key + ':</b> ' + error[key]));
             });
         }
-        else {
+        else if (error) {
             $errorPanel.append('No other information available. Sorry!');
         }
         return $errorPanel;

--- a/kbase-extension/static/kbase/js/util/display.js
+++ b/kbase-extension/static/kbase/js/util/display.js
@@ -14,7 +14,8 @@ define(
         'bluebird',
         'narrativeConfig',
         'util/timeFormat',
-        'kbase-client-api'
+        'kbase-client-api',
+        'kbaseAccordion'
     ], function (
     KBWidget,
     bootstrap,
@@ -23,7 +24,8 @@ define(
     Promise,
     Config,
     TimeFormat,
-    kbase_client_api
+    kbase_client_api,
+    KBaseAccordion
     ) {
     'use strict';
 
@@ -154,11 +156,40 @@ define(
         return $icon;
     }
 
+    /**
+     * errorTitle = a string that'll be in bold at the top of the panel.
+     * errorBody = a string that'll be in standard text, in the error's body area.
+     * if errorBody is an object, ...
+     */
+    function createError(title, error) {
+        var $errorPanel = $('<div>')
+                          .addClass('alert alert-danger')
+                          .append('<b>' + title + '</b><br>Please contact the KBase team at <a href="mailto:help@kbase.us?subject=Narrative%20function%20loading%20error">help@kbase.us</a> with the information below.');
+
+        $errorPanel.append('<br><br>');
+
+        // If it's a string, just dump the string.
+        if (typeof error === 'string') {
+            $errorPanel.append(error);
+        }
+
+        // If it's an object, expect an error object
+        else if (typeof error === 'object') {
+            Object.keys(error).forEach(function(key) {
+                $errorPanel.append($('<div>').append('<b>' + key + ':</b> ' + error[key]));
+            });
+        }
+        else {
+            $errorPanel.append('No other information available. Sorry!');
+        }
+        return $errorPanel;
+    }
 
     return {
         lookupUserProfile: lookupUserProfile,
         displayRealName: displayRealName,
         loadingDiv: loadingDiv,
-        getAppIcon: getAppIcon
+        getAppIcon: getAppIcon,
+        createError: createError
     };
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1,5 +1,5 @@
 /* global define,Jupyter,KBError */
-/* global Workspace, SetAPI */
+/* global Workspace */
 /* jslint white: true */
 /* eslint no-console: 0 */
 /**
@@ -98,7 +98,6 @@ define([
         downloadSpecCache: {tag: 'dev'},
         controlClickHnd: {}, // click handlers for control buttons
         my_user_id: null,
-        setAPI: null,
         serviceClient: null,
 
         objectRowTmpl: Handlebars.compile(ObjectRowHtml),
@@ -242,21 +241,6 @@ define([
         },
 
         /**
-         * Get a list of workspace items which are set/group types.
-         *
-         * @return Promise-wrapped list of items.
-         */
-        getWorkspaceSets: function(ws_id) {
-            try {
-                var params = {workspace: '' + ws_id, include_set_item_info: true};
-                return this.setAPI.list_sets(params);
-            }
-            catch(e) {
-                return Promise.reject('Cannot get sets for workspace ' + ws_id + ' :' + e);
-            }
-        },
-
-        /**
          * @method init
          * Builds the DOM structure for the widget.
          * Includes the tables and panel.
@@ -301,12 +285,10 @@ define([
 
             if (this._attributes.auth) {
                 this.ws = new Workspace(this.options.ws_url, this._attributes.auth);
-                this.initSetAPI(this._attributes.auth);
             }
 
             // listener for refresh
             $(document).on('updateDataList.Narrative', function () {
-                self.initSetAPI(this._attributes.auth);
                 self.refresh();
             })
 
@@ -327,17 +309,6 @@ define([
                     this.$mainListDiv.css({'height': height});
                 }
             }
-        },
-
-        /**
-         * Initialize Set API
-         */
-        initSetAPI: function(auth) {
-            if (!this.setAPI) {
-                var token = {'token': auth.token};
-                this.setAPI = new SetAPI(Config.url('service_wizard'), token, null, null, null, '<1.0.0');
-            }
-            return this.setAPI;
         },
 
         /**

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -778,7 +778,7 @@ define([
                     new kbaseNarrativeDownloadPanel(downloadPanel, {
                         token: self._attributes.auth.token, type: type, wsId: wsId, objId: objId,
                         downloadSpecCache: self.downloadSpecCache});
-                });
+                    });
 
             var $rename = $('<span>')
                 .addClass(btnClasses).css(css)

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -413,7 +413,7 @@ define([
             .catch(function (error) {
                 console.error('DataList: when checking for updates:', error);
                 if (showError) {
-                    this.showBlockingError('Error: Unable to connect to KBase data.');
+                    this.showBlockingError('Sorry, an error occurred while fetching your data.', {'error': 'Unable to connect to KBase database.'});
                 }
             }.bind(this));
         },
@@ -494,12 +494,11 @@ define([
          * This empties out the main data div and injects an error into it.
          * Used mainly when lookups fail.
          */
-        showBlockingError: function (error) {
+        showBlockingError: function (title, error) {
             this.$mainListDiv.empty();
             this.$mainListDiv.append(
-                $('<div>').css({'color': '#F44336', 'margin': '10px'})
-                .append(error)
-                );
+                DisplayUtil.createError(title, error)
+            );
             this.loadingDiv.div.hide();
             this.$mainListDiv.show();
         },
@@ -567,8 +566,6 @@ define([
             )
             .then(function(result) {
                 result = result[0]['data'];
-                console.log('NEW WORKSPACE LIST FUN');
-                console.log(result);
 
                 for (var i=0; i<result.length; i++) {
                     var obj = result[i];
@@ -588,9 +585,10 @@ define([
                 }
             }.bind(this))
             .catch(function (error) {
-                this.showBlockingError(error);
+                this.showBlockingError("Sorry, an error occurred while fetching your data.", error);
                 console.error(error);
-                KBError("kbaseNarrativeDataList.getNextDataChunk", error.error.message);
+                KBError("kbaseNarrativeDataList.fetchWorkspaceData", error.error.message);
+                throw error;
             }.bind(this));
 
         },

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -807,6 +807,12 @@ define([
                             return dataList;
                         });
                     } else {
+                        // return Promise.resolve(serviceClient.sync_call(
+                        //     'NarrativeService.list_objects_with_sets',
+                        //     [{
+                        //
+                        //     }]))
+                        //
                         return Promise.resolve(ws.list_objects(param))
                             .then(function (data) {
                                 // filter out Narrative objects.
@@ -1150,10 +1156,10 @@ define([
                 // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
                 // [9] : int size // [10] : usermeta meta
                 var type_tokens = object_info[2].split('.')
-                var type_module = type_tokens[0];
+                // var type_module = type_tokens[0];
                 var type = type_tokens[1].split('-')[0];
-                var unversioned_full_type = type_module + '.' + type;
-                var logo_name = "";
+                // var unversioned_full_type = type_module + '.' + type;
+                // var logo_name = "";
                 var landingPageLink = self.options.lp_url + object_info[6] + '/' + object_info[1];
                 var icons = self.data_icons;
                 var icon = _.has(icons, type) ? icons[type] : icons['DEFAULT'];

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
@@ -234,26 +234,50 @@ define (
                             $(this).html('<img src="'+self.options.loadingImage+'">');
 
                             var thisBtn = this;
-                            self.ws.copy_object({
-                                to:   {ref: self.narWs     + "/" + object_info[1]},
-                                from: {ref: object_info[6] + "/" + object_info[0]} },
-                                function (info) {
-                                    $(thisBtn).html('Added');
-                                    self.trigger('updateDataList.Narrative');
-                                },
-                                function(error) {
-                                    $(thisBtn).html('Error');
-                                    if (error.error && error.error.message) {
-                                        if (error.error.message.indexOf('may not write to workspace')>=0) {
-                                            self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: you do not have permission to add data to this Narrative.'));
-                                        } else {
-                                            self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: '+error.error.message));
-                                        }
+                            Promise.resolve(self.serviceClient.sync_call("NarrativeService.copy_object",
+                                [{
+                                    ref: object_info[6] + "/" + object_info[0],
+                                    target_ws_name: self.narWs,
+                                    // target_name: object_info[1]
+                                }]
+                            ))
+                            .then(function(info) {
+                                $(thisBtn).html('Added');
+                                self.trigger('updateDataList.Narrative');
+                            })
+                            .catch(function(error) {
+                                $(thisBtn).html('Error');
+                                if (error.error && error.error.message) {
+                                    if (error.error.message.indexOf('may not write to workspace')>=0) {
+                                        self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: you do not have permission to add data to this Narrative.'));
                                     } else {
-                                        self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Unknown error!'));
+                                        self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: '+error.error.message));
                                     }
-                                    console.error(error);
-                                });
+                                } else {
+                                    self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Unknown error!'));
+                                }
+                                console.error(error);
+                            });
+                            // self.ws.copy_object({
+                            //     to:   {ref: self.narWs     + "/" + object_info[1]},
+                            //     from: {ref: object_info[6] + "/" + object_info[0]} },
+                            //     function (info) {
+                            //         $(thisBtn).html('Added');
+                            //         self.trigger('updateDataList.Narrative');
+                            //     },
+                            //     function(error) {
+                            //         $(thisBtn).html('Error');
+                            //         if (error.error && error.error.message) {
+                            //             if (error.error.message.indexOf('may not write to workspace')>=0) {
+                            //                 self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: you do not have permission to add data to this Narrative.'));
+                            //             } else {
+                            //                 self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: '+error.error.message));
+                            //             }
+                            //         } else {
+                            //             self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Unknown error!'));
+                            //         }
+                            //         console.error(error);
+                            //     });
 
                         }));
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
@@ -2,34 +2,36 @@
 /*jslint white: true*/
 /**
  * @author Michael Sneddon <mwsneddon@lbl.gov>
+ * @author Bill Riehl <wjriehl@lbl.gov>
  * @public
  */
-define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
-        'underscore',
-		'bluebird',
-		'narrativeConfig',
-		'kbaseAuthenticatedWidget',
-		'kbaseNarrative',
-        'kbase-generic-client-api',
-        'base/js/namespace',
-        'util/display'
-	], function(
-		KBWidget,
-		bootstrap,
-		$,
-        _,
-		Promise,
-		Config,
-		kbaseAuthenticatedWidget,
-		kbaseNarrative,
-        GenericClient,
-        Jupyter,
-        DisplayUtil
-	) {
+define ([
+	'kbwidget',
+	'bootstrap',
+	'jquery',
+    'underscore',
+	'bluebird',
+	'narrativeConfig',
+	'kbaseAuthenticatedWidget',
+	'kbaseNarrative',
+    'kbase-generic-client-api',
+    'base/js/namespace',
+    'util/display',
+    'util/icon'
+], function (
+	KBWidget,
+	bootstrap,
+	$,
+    _,
+	Promise,
+	Config,
+	kbaseAuthenticatedWidget,
+	kbaseNarrative,
+    GenericClient,
+    Jupyter,
+    DisplayUtil,
+    Icon
+) {
     'use strict';
     return KBWidget({
         name: 'kbaseNarrativeExampleDataTab',
@@ -37,7 +39,6 @@ define (
         version: '1.0.0',
         options: {
             ws_name: null, // must be the WS name, not the WS Numeric ID
-            ws_url: Config.url('workspace'),
             loadingImage: Config.get('loading_gif'),
             $importStatus: $('<div>')
         },
@@ -89,17 +90,13 @@ define (
                 return;
             }
 
-            if (this.narWs && this.ws) {
+            if (this.narWs) {
                 Promise.resolve(this.serviceClient.sync_call(
                     "NarrativeService.list_objects_with_sets",
                     [{
                         ws_name: this.dataConfig.ws
                     }]
                 ))
-                // Promise.resolve(this.ws.list_objects({
-                //     workspaces : [this.dataConfig.ws],
-                //     includeMetadata: 1
-                // }))
                 .then(function(infoList) {
                     infoList = infoList[0]['data'];
                     this.objectList = [];
@@ -124,11 +121,9 @@ define (
                 }.bind(this))
                 .catch(function(error) {
                     this.showError('Sorry, we\'re unable to load example data', error);
-                    // console.error(error);
                     alert(error);
                 }.bind(this));
             }
-
         },
 
         showError: function(title, error) {
@@ -157,21 +152,22 @@ define (
                 }
             }
             var $tc = $('<div>')
-                            .append($('<div>').css({'margin':'15px'})
-                                .append($('<div>').css({'margin':'4px','margin-top':'15px','color':'#555','font-size':'large','font-weight':'bold'})
-                                        .append('Other Examples'))
-                                .append($('<div>').css({'margin':'4px','color':'#555'})
-                                        .append('Assorted data types used in more advanced analyses')));
+                      .append($('<div>').css({'margin':'15px'})
+                          .append($('<div>').css({'margin':'4px','margin-top':'15px','color':'#555','font-size':'large','font-weight':'bold'})
+                                  .append('Other Examples'))
+                          .append($('<div>').css({'margin':'4px','color':'#555'})
+                                  .append('Assorted data types used in more advanced analyses')));
             typeDivs['other.types'] = $tc;
 
             var hasOthers = false;
-            self.objectList.sort(function(a,b) {
-                                        if (a.info[2].toUpperCase() > b.info[2].toUpperCase()) return -1; // sort by type
-                                        if (a.info[2].toUpperCase() < b.info[2].toUpperCase()) return 1;
-                                        if (a.info[1].toUpperCase() > b.info[1].toUpperCase()) return -1; // then by name
-                                        if (a.info[1].toUpperCase() < b.info[1].toUpperCase()) return 1;
-                                        return 0;
-                                    });
+            self.objectList.sort(
+                function(a,b) {
+                    if (a.info[2].toUpperCase() > b.info[2].toUpperCase()) return -1; // sort by type
+                    if (a.info[2].toUpperCase() < b.info[2].toUpperCase()) return 1;
+                    if (a.info[1].toUpperCase() > b.info[1].toUpperCase()) return -1; // then by name
+                    if (a.info[1].toUpperCase() < b.info[1].toUpperCase()) return 1;
+                    return 0;
+                });
             for (var k=0; k<self.objectList.length; k++) {
                 var obj = self.objectList[k];
                 var typeName='';
@@ -221,7 +217,6 @@ define (
                 type='Genome';
             } else {
                 var type_tokens = object_info[2].split('.')
-                var type_module = type_tokens[0];
                 type = type_tokens[1].split('-')[0];
             }
 
@@ -261,10 +256,6 @@ define (
 
             var shortName = object_info[1],
                 isShortened=false;
-            /*if (shortName.length>this.options.max_name_length) {
-                shortName = shortName.substring(0,this.options.max_name_length-3)+'...';
-                isShortened=true;
-            }*/
             var $name = $('<span>').addClass("kb-data-list-name").append(shortName);
             if (isShortened) {
                 $name.tooltip({title:object_info[1], placement:'bottom'});
@@ -272,19 +263,11 @@ define (
             var $type = $('<span>').addClass("kb-data-list-type").append(type);
 
             var metadata = object_info[10] || {};
-            var metadataText = '';
-            for(var key in metadata) {
-                if (metadata.hasOwnProperty(key)) {
-                    metadataText += '<tr><th>'+ key +'</th><td>'+ metadata[key] + '</td></tr>';
-                }
-            }
             if (type==='Genome') {
                 if (metadata.hasOwnProperty('Name')) {
                     $type.html('Genome: '+metadata['Name']);
                 }
             }
-            var icons = this.data_icons;
-            var icon = _.has(icons, type) ? icons[type] : icons['DEFAULT'];
             var $logo = $('<span>');
             var $topTable = $('<table>')
                 .css({'width':'100%','background':'#fff'})  // set background to white looks better on DnD
@@ -294,29 +277,21 @@ define (
                         .append($addDiv.hide()))
                     .append($('<td>')
                         .css({'width':'50px'})
-                        .append($logo))/*$('<span>')
-                              .addClass("kb-data-list-logo")
-                              .css({'background-color':this.logoColorLookup(type)})
-                              .append(type.substring(0,1))))*/
+                        .append($logo))
                     .append($('<td>')
                          .append($name).append('<br>').append($type)));
 
-	    var $row = $('<div>')
-                                .css({margin:'2px',padding:'4px','margin-bottom': '5px'})
-                                //.addClass('kb-data-list-obj-row')
-                                .append($('<div>').addClass('kb-data-list-obj-row-main')
-                                            .append($topTable))
-                                .mouseenter(function(){
-                                    $addDiv.show();
-                                })
-                                .mouseleave(function(){
-                                    $addDiv.hide();
-                                });
-            // set icon
-            $(document).trigger("setDataIcon.Narrative", {
-                elt: $logo,
-                type: type
-            });
+            var $row = $('<div>')
+                        .css({margin:'2px',padding:'4px','margin-bottom': '5px'})
+                        .append($('<div>').addClass('kb-data-list-obj-row-main')
+                                    .append($topTable))
+                        .mouseenter(function(){
+                            $addDiv.show();
+                        })
+                        .mouseleave(function(){
+                            $addDiv.hide();
+                        });
+            Icon.buildDataIcon($logo, type);
 
             return $row;
         },
@@ -332,17 +307,13 @@ define (
         },
 
         loggedInCallback: function(event, auth) {
-            this.ws = new Workspace(this.options.ws_url, auth);
             this.serviceClient = new GenericClient(Config.url('service_wizard'), auth);
             return this;
         },
 
-        loggedOutCallback: function(event, auth) {
-            this.ws = null;
+        loggedOutCallback: function(event) {
             this.isLoggedIn = false;
             return this;
         },
-
     })
-
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
@@ -229,7 +229,8 @@ define ([
                             $(this).html('<img src="'+self.options.loadingImage+'">');
 
                             var thisBtn = this;
-                            Promise.resolve(self.serviceClient.sync_call("NarrativeService.copy_object",
+                            Promise.resolve(self.serviceClient.sync_call(
+                                "NarrativeService.copy_object",
                                 [{
                                     ref: object_info[6] + "/" + object_info[0],
                                     target_ws_name: self.narWs,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeExampleDataTab.js
@@ -238,7 +238,6 @@ define (
                                 [{
                                     ref: object_info[6] + "/" + object_info[0],
                                     target_ws_name: self.narWs,
-                                    // target_name: object_info[1]
                                 }]
                             ))
                             .then(function(info) {
@@ -258,27 +257,6 @@ define (
                                 }
                                 console.error(error);
                             });
-                            // self.ws.copy_object({
-                            //     to:   {ref: self.narWs     + "/" + object_info[1]},
-                            //     from: {ref: object_info[6] + "/" + object_info[0]} },
-                            //     function (info) {
-                            //         $(thisBtn).html('Added');
-                            //         self.trigger('updateDataList.Narrative');
-                            //     },
-                            //     function(error) {
-                            //         $(thisBtn).html('Error');
-                            //         if (error.error && error.error.message) {
-                            //             if (error.error.message.indexOf('may not write to workspace')>=0) {
-                            //                 self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: you do not have permission to add data to this Narrative.'));
-                            //             } else {
-                            //                 self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Error: '+error.error.message));
-                            //             }
-                            //         } else {
-                            //             self.options.$importStatus.html($('<div>').css({'color':'#F44336','width':'500px'}).append('Unknown error!'));
-                            //         }
-                            //         console.error(error);
-                            //     });
-
                         }));
 
             var shortName = object_info[1],

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -1,26 +1,33 @@
+/* global define */
+/* eslint-env browser */
 /**
  * Widget for displaying a list of Narratives and basic narrative management (copy, delete, share)
  * @author Michael Sneddon <mwsneddon@lbl.gov>
  * @public
  */
-define(['jquery',
-        'base/js/namespace',
-        'narrativeConfig',
-        'narrativeManager',
-        'util/display',
-        'bluebird',
-        'kbwidget',
-        'kbaseNarrativeControlPanel',
-        'api/NewWorkspace'],
-function($,
-         Jupyter,
-         Config,
-         NarrativeManager,
-         DisplayUtil,
-         Promise,
-         KBWidget,
-         ControlPanel,
-         NewWorkspace) {
+define([
+    'jquery',
+    'base/js/namespace',
+    'narrativeConfig',
+    'narrativeManager',
+    'util/display',
+    'bluebird',
+    'kbwidget',
+    'kbaseNarrativeControlPanel',
+    'api/NewWorkspace',
+    'kbase-generic-client-api'
+], function (
+    $,
+    Jupyter,
+    Config,
+    NarrativeManager,
+    DisplayUtil,
+    Promise,
+    KBWidget,
+    ControlPanel,
+    NewWorkspace,
+    GenericClient
+) {
     'use strict';
     return new KBWidget({
         name: "kbaseNarrativeManagePanel",
@@ -47,6 +54,7 @@ function($,
         },
         ws: null,
         manager: null,
+        serviceClient: null,
         ws_name: null,
         nar_name: null,
         $mainPanel: null,
@@ -88,8 +96,9 @@ function($,
         my_user_id: null,
         loggedInCallback: function (event, auth) {
             this.ws = new Workspace(this.options.ws_url, auth);
-
             this.manager = new NarrativeManager({ws_url: this.options.ws_url, nms_url: this.options.nms_url}, auth);
+            this.serviceClient = new GenericClient(Config.url('service_wizard'), auth);
+
             this.my_user_id = auth.user_id;
             this.refresh();
             return this;
@@ -1138,104 +1147,137 @@ function($,
                 return Promise.reject(preCheckError);
             }
             // name of the narrative object in the workspace. used for closure.
-            var narObjName;
-            var newWsName = this.my_user_id + ':' + new Date().getTime();
-            var newWsMeta = {
-                is_temporary: 'false',
-                narrative_nice_name: newName
-                // add the 'narrative' field later.
-            };
-            var newWsId;
-            var newNarId;
-            var currentNarrative;
 
-            // start with getting the existing narrative object.
-            return Promise.resolve(this.ws.get_objects([{ref: this.workspaceRef}]))
-            .then(function(narrativeObject) {
-                // stash the object in a variable with scope external to the Promise.
-                currentNarrative = narrativeObject[0];
-                // next clone the workspace EXCEPT for this object.
-                return Promise.resolve(this.ws.clone_workspace({
-                    wsi: { id: this.workspaceId },
-                    workspace: newWsName,
-                    meta: newWsMeta,
-                    exclude: [{ objid: currentNarrative.info[0] }]
-                }));
-            }.bind(this))
-            .then(function(newWsInfo) {
-                // pop the newWsId into a variable available by closure in the next step.
-                newWsId = newWsInfo[0];
-                // update the ref inside the narrative object and the new workspace metadata.
-                var newNarMetadata = currentNarrative.info[10];
-                newNarMetadata.name = newName;
-                newNarMetadata.ws_name = newWsName;
-                newNarMetadata.job_info = JSON.stringify({queue_time: 0, running: 0, completed: 0, run_time: 0, error: 0});
-
-                currentNarrative.data.metadata.name = newName;
-                currentNarrative.data.metadata.ws_name = newWsName;
-                currentNarrative.data.metadata.job_ids = {
-                    apps: [],
-                    methods: [],
-                    job_usage: {
-                        queue_time: 0,
-                        run_time: 0
-                    }
-                };
-                // save the shiny new Narrative so it's at version 1
-                return Promise.resolve(this.ws.save_objects({
-                    id: newWsId,
-                    objects: [{
-                        type: currentNarrative.info[2],
-                        data: currentNarrative.data,
-                        provenance: currentNarrative.provenance,
-                        name: currentNarrative.info[1],
-                        meta: newNarMetadata
-                    }]
-                }));
-            }.bind(this))
-            .then(function(newNarInfo) {
-                // now, just update the workspace metadata to point
-                // to the new narrative object
-                newNarId = newNarInfo[0][0];
-                return Promise.resolve(this.ws.alter_workspace_metadata({
-                    wsi: { id: newWsId },
-                    new: { narrative: String(newNarId) }
-                }));
-            }.bind(this))
-            .then(function(results) {
+            return Promise.resolve(this.serviceClient.sync_call(
+                'NarrativeService.copy_narrative',
+                [{
+                    workspaceRef: this.workspaceRef,
+                    newName: newName
+                }]
+            ))
+            .then(function(result) {
                 return {
                     status: 'success',
-                    url: window.location.origin + '/narrative/ws.' + newWsId + '.obj.' + newNarId
+                    url: [window.location.origin,
+                          '/narrative/ws.',
+                          result.newWsId,
+                          '.obj.',
+                          result.newNarId].join('')
                 };
-            })
-            .catch(function(error) {
-                console.error(error);
-                var errMessage = "Sorry, an error occurred while copying.";
-                if (error.error && error.error.message) {
-                    //try to parse...
-                    // search for function that failed in error.
-                    if (error.error.error) {
-                        var trace = error.error.error;
-                        // in order:
-                        if (trace.search('getObjectInfoNew') > -1) {
-
-                        }
-                    }
-                    var msg = error.error.message;
-                }
-                // if it got to the point that it made a copy,
-                // delete it so it's out of the way - it's broken
-                // if it got here without finishing.
-                if (newWsId) {
-                    console.log('Deleting new incomplete copy - ' + newWsId);
-                    return Promise.resolve(this.ws.delete_workspace({id: newWsId}))
-                    .then(function() {
-                        return Promise.reject(error);
-                    });
-                }
-                return Promise.reject(error);
-                // throw error;
-            }.bind(this));
+            });
+            //
+            // var preCheckError = null;
+            // if (!this.ws) {
+            //     preCheckError = "Cannot copy - please sign in again.";
+            // }
+            // else if (!this.workspaceRef) {
+            //     preCheckError = "Cannot copy - cannot find Narrative id. Please refresh the page and try again.";
+            // }
+            // else if (!this.workspaceId) {
+            //     preCheckError = "Cannot copy - cannot find Narrative data id. Please refresh the page and try again.";
+            // }
+            // if (preCheckError) {
+            //     return Promise.reject(preCheckError);
+            // }
+            // // name of the narrative object in the workspace. used for closure.
+            // var narObjName;
+            // var newWsName = this.my_user_id + ':' + new Date().getTime();
+            // var newWsMeta = {
+            //     is_temporary: 'false',
+            //     narrative_nice_name: newName
+            //     // add the 'narrative' field later.
+            // };
+            // var newWsId;
+            // var newNarId;
+            // var currentNarrative;
+            //
+            // // start with getting the existing narrative object.
+            // return Promise.resolve(this.ws.get_objects([{ref: this.workspaceRef}]))
+            // .then(function(narrativeObject) {
+            //     // stash the object in a variable with scope external to the Promise.
+            //     currentNarrative = narrativeObject[0];
+            //     // next clone the workspace EXCEPT for this object.
+            //     return Promise.resolve(this.ws.clone_workspace({
+            //         wsi: { id: this.workspaceId },
+            //         workspace: newWsName,
+            //         meta: newWsMeta,
+            //         exclude: [{ objid: currentNarrative.info[0] }]
+            //     }));
+            // }.bind(this))
+            // .then(function(newWsInfo) {
+            //     // pop the newWsId into a variable available by closure in the next step.
+            //     newWsId = newWsInfo[0];
+            //     // update the ref inside the narrative object and the new workspace metadata.
+            //     var newNarMetadata = currentNarrative.info[10];
+            //     newNarMetadata.name = newName;
+            //     newNarMetadata.ws_name = newWsName;
+            //     newNarMetadata.job_info = JSON.stringify({queue_time: 0, running: 0, completed: 0, run_time: 0, error: 0});
+            //
+            //     currentNarrative.data.metadata.name = newName;
+            //     currentNarrative.data.metadata.ws_name = newWsName;
+            //     currentNarrative.data.metadata.job_ids = {
+            //         apps: [],
+            //         methods: [],
+            //         job_usage: {
+            //             queue_time: 0,
+            //             run_time: 0
+            //         }
+            //     };
+            //     // save the shiny new Narrative so it's at version 1
+            //     return Promise.resolve(this.ws.save_objects({
+            //         id: newWsId,
+            //         objects: [{
+            //             type: currentNarrative.info[2],
+            //             data: currentNarrative.data,
+            //             provenance: currentNarrative.provenance,
+            //             name: currentNarrative.info[1],
+            //             meta: newNarMetadata
+            //         }]
+            //     }));
+            // }.bind(this))
+            // .then(function(newNarInfo) {
+            //     // now, just update the workspace metadata to point
+            //     // to the new narrative object
+            //     newNarId = newNarInfo[0][0];
+            //     return Promise.resolve(this.ws.alter_workspace_metadata({
+            //         wsi: { id: newWsId },
+            //         new: { narrative: String(newNarId) }
+            //     }));
+            // }.bind(this))
+            // .then(function(results) {
+            //     return {
+            //         status: 'success',
+            //         url: window.location.origin + '/narrative/ws.' + newWsId + '.obj.' + newNarId
+            //     };
+            // })
+            // .catch(function(error) {
+            //     console.error(error);
+            //     var errMessage = "Sorry, an error occurred while copying.";
+            //     if (error.error && error.error.message) {
+            //         //try to parse...
+            //         // search for function that failed in error.
+            //         if (error.error.error) {
+            //             var trace = error.error.error;
+            //             // in order:
+            //             if (trace.search('getObjectInfoNew') > -1) {
+            //
+            //             }
+            //         }
+            //         var msg = error.error.message;
+            //     }
+            //     // if it got to the point that it made a copy,
+            //     // delete it so it's out of the way - it's broken
+            //     // if it got here without finishing.
+            //     if (newWsId) {
+            //         console.log('Deleting new incomplete copy - ' + newWsId);
+            //         return Promise.resolve(this.ws.delete_workspace({id: newWsId}))
+            //         .then(function() {
+            //             return Promise.reject(error);
+            //         });
+            //     }
+            //     return Promise.reject(error);
+            //     // throw error;
+            // }.bind(this));
         },
 
         makeNewNarrativeBtn: function () {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePublicTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePublicTab.js
@@ -228,58 +228,6 @@ define (
                     this.totalPanel.empty();
                     this.totalPanel.append($('<span>').addClass("kb-data-list-type").append("Total results: 0"));
                 }.bind(this));
-
-        // // list_objects: function(ws, type, query, okCallback, errorCallback) {
-        // //     this.wsClient.list_objects({workspaces: [ws], type: type, includeMetadata: 1}, function(data) {
-
-        //         self.list_objects(ws, type, self.currentQuery, function(data, origQuery) {
-        //             if (thisQuery !== self.currentQuery)
-        //                 return;
-        //             //console.log(data);
-        //             var query = self.currentQuery.replace(/[\*]/g,' ').trim().toLowerCase();
-        //             for (var i in data) {
-        //                 var info = data[i];
-        //                 // object_info:
-        //                 // [0] : obj_id objid // [1] : obj_name name // [2] : type_string type
-        //                 // [3] : timestamp save_date // [4] : int version // [5] : username saved_by
-        //                 // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
-        //                 // [9] : int size // [10] : usermeta meta
-        //                 var name = info[1];
-        //                 var id = info[1];
-        //                 var metadata = {};
-        //                 if (self.currentCategory === 'media') {
-        //                     metadata['Size'] = info[9];
-        //                 } else if (self.currentCategory === 'plant_gnms') {
-        //                     if (info[10].Name) {
-        //                         metadata['ID'] = id;
-        //                         name = info[10].Name;
-        //                     }
-        //                     metadata['Source'] = info[10].Source;
-        //                     metadata['Genes'] = info[10]['Number features'];
-        //                 }
-        //                 if (name.toLowerCase().indexOf(query) == -1)
-        //                     continue;
-        //                 self.objectList.push({
-        //                     $div: null,
-        //                     info: info,
-        //                     id: id,
-        //                     name: name,
-        //                     metadata: metadata,
-        //                     ws: cat.ws,
-        //                     type: cat.type,
-        //                     attached: false
-        //                 });
-        //                 self.attachRow(self.objectList.length - 1);
-        //             }
-        //             data.totalResults = self.objectList.length;
-        //             self.totalPanel.empty();
-        //             self.totalPanel.append($('<span>').addClass("kb-data-list-type")
-        //                     .append("Total results: " + data.totalResults));
-        //         }, function(error) {
-        //             //console.log(error);
-        //             self.totalPanel.empty();
-        //             self.totalPanel.append($('<span>').addClass("kb-data-list-type").append("Total results: 0"));
-        //         });
             } else {
                 this.currentPage++;
                 this.search(this.currentCategory, this.currentQuery, this.itemsPerPage, this.currentPage, function(query, data) {
@@ -328,47 +276,9 @@ define (
                             });
                             this.attachRow(this.objectList.length - 1);
                         }
-                    } /*else {
-                        for (var i in data.items) {
-                            var id = data.items[i].object_name;
-                            var name = data.items[i].object_name;
-                            var metadata = {};
-                            if (this.currentCategory === 'gwas_populations') {
-                                metadata['Genome'] = data.items[i].kbase_genome_name;
-                                metadata['Source'] = data.items[i].source_genome_name;
-                            } else if (this.currentCategory === 'gwas_population_kinships') {
-                                metadata['Genome'] = data.items[i].kbase_genome_name;
-                                metadata['Source'] = data.items[i].source_genome_name;
-                            } else if (this.currentCategory === 'gwas_population_variations') {
-                                metadata['Originator'] = data.items[i].originator;
-                                metadata['Assay'] = data.items[i].assay;
-                            } else if (this.currentCategory === 'gwas_top_variations') {
-                                metadata['Trait'] = data.items[i].trait_name;
-                                metadata['Ontology'] = data.items[i].trait_ontology_id;
-                                metadata['Genome'] = data.items[i].kbase_genome_name;
-                            } else if (this.currentCategory === 'gwas_population_traits') {
-                                metadata['Trait'] = data.items[i].trait_name;
-                                metadata['Ontology'] = data.items[i].trait_ontology_id;
-                                metadata['Genome'] = data.items[i].kbase_genome_name;
-                            } else if (this.currentCategory === 'gwas_gene_lists') {
-                                metadata['Genes'] = data.items[i].gene_count;
-                                metadata['SNPs'] = data.items[i].gene_snp_count;
-                            }
-                            this.objectList.push({
-                                $div: null,
-                                info: null,
-                                id: id,
-                                name: name,
-                                metadata: metadata,
-                                ws: cat.ws,
-                                type: cat.type,
-                                attached: false
-                            });
-                            this.attachRow(this.objectList.length - 1);
-                        }
-                    }*/
+                    }
                     this.totalPanel.append($('<span>').addClass("kb-data-list-type")
-                            .append("Total results: " + data.totalResults + " (" + this.objectList.length + " shown)"));
+                        .append("Total results: " + data.totalResults + " (" + this.objectList.length + " shown)"));
                 }.bind(this), function(error) {
                     //console.log(error);
                     if (this.objectList.length == 0) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -475,7 +475,7 @@ define([
         },
 
         determineMethodCellType: function(spec) {
-            
+
             // Should be working after this PR will be deployed:
             // https://github.com/kbase/narrative_method_store/pull/36
             switch (spec.info.app_type) {
@@ -518,7 +518,7 @@ define([
             switch (spec.info.id) {
                 //case 'model_support/edit_model':
                 //case 'fba_tools/edit_metabolic_model':
-                //case 'fba_tools/create_or_edit_media':                
+                //case 'fba_tools/create_or_edit_media':
                 //case 'model_support/edit_media':
                 case 'ReadGroupEditor/ReadGroupEditor':
                     return 'editor';
@@ -2544,13 +2544,9 @@ define([
          */
         setDataIcon: function($logo, type, stacked, indent) {
             if (indent === undefined || indent === null) {
-                console.debug('indent not given for type', type);
                 indent = 0;
             }
 
-            if ($logo.hasClass('exampleDataIcon')) {
-                console.debug("SET EXAMPLE ICON");
-            }
             var icons = this.data_icons;
             var icon = _.has(icons, type) ? icons[type] : icons.DEFAULT;
             // background circle
@@ -2560,11 +2556,10 @@ define([
             // For 'stacked' (set) icons, add a shifted-over
             // circle first, as the bottom layer, then also add a border
             // to the top one.
-            var circle_classes = 'fa fa-circle fa-stack-2x'; 
+            var circle_classes = 'fa fa-circle fa-stack-2x';
             var circle_color = this.logoColorLookup(type);
             var cmax = function(x) { return x > 255 ? 255 : x; };
             if (stacked) {
-                console.debug('@@ circle color', circle_color);
                 var parsed_color, r, g, b;
                 var cstep = 20; // color-step for overlapped circles
                 var num_stacked_circles = 1; // up to 2
@@ -2584,7 +2579,7 @@ define([
                 }
                 // Add circles with lighter colors
                 for (var i=num_stacked_circles; i > 0; i--) {
-                    var stacked_color = 'rgb(' + cmax(r + i * cstep)  + ',' + 
+                    var stacked_color = 'rgb(' + cmax(r + i * cstep)  + ',' +
                         cmax(g + i * cstep) + ',' + cmax(b + i * cstep) + ')';
                     $logo.append($('<i>')
                         .addClass(circle_classes + ' kb-data-list-logo-shiftedx' + i)

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.1.0-alpha-3",
+    "version": "3.1.0-alpha-4",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
Work in progress for rewiring Workspace calls from the data list to go to the NarrativeService
(see https://atlassian.kbase.us/browse/TASK-76)

Main Data Panel
- [x] list_objects functions
- [ ] get_workspace_info
- [ ] get_object_history
- [ ] revert_object
- [ ] rename_object
- [ ] delete_objects

My Data / Shared With Me (same widget)
- [x] list_objects (needs list of workspaces, type filtering)
- [x] copy_object
- [ ] list_workspace_info

Public Panel
- [x] list_objects (needs type filtering)
- [x] copy_object
- [ ] get_object_info_new (might be able to skip with new NS.copy_object)

Example Panel
- [x] list_objects
- [x] copy_object