### PR TITLE
persist the reads set selection, restore upon reload

### DIFF
--- a/nbextensions/editorCell/main.js
+++ b/nbextensions/editorCell/main.js
@@ -217,8 +217,8 @@ define([
             // TODO: the code cell input widget should instantiate its state
             // from the cell!!!!
             var cellBus = runtime.bus().makeChannelBus(null, 'Parent comm for The Cell Bus'),
-                appId = utils.getMeta(cell, 'editorCell', 'app').id,
-                appTag = utils.getMeta(cell, 'editorCell', 'app').tag,
+                appId = utils.getCellMeta(cell, 'kbase.editorCell.app.id'),
+                appTag = utils.getCellMeta(cell, 'kbase.editorCell.app.tag'),
                 editorCellWidget = EditorCellWidget.make({
                     bus: cellBus,
                     cell: cell,
@@ -365,6 +365,7 @@ define([
             })
             .catch(function (err) {
                 console.error('ERROR setting up notebook', err);
+                alert('Error loading editor cell extension');
             });
     }
 


### PR DESCRIPTION
added "Currently Editing" section to show object info, collapsible
pass around object info rather than reference to avoid extra info queries
The object selection and current set info are both collapsible. They can be tinkered with now to see how it would work if they were automatically controlled. E.g. if an editor cell is loaded with a prior selection, the only open panel should be the Editor, after selecting a reads set to edit, the selection could collapse. Of course, collapse could also be "hide" with buttons to control hide/show.