### PR TITLE
Updates to reads set viewer

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReadsSetView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReadsSetView.js
@@ -55,7 +55,6 @@ define (
                     $self.link_ref = $self.obj_info.ws_id + '/' +
                                      $self.obj_info.name + '/' +
                                      $self.obj_info.version;
-                    console.log($self.obj_info);
                     $self.update_overview_info_from_nar_info($self.obj_info);
                 } else {
                     $self.obj_ref = $self.options.wsId + '/' +

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReadsSetView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReadsSetView.js
@@ -1,10 +1,10 @@
 define (
     [
         'kbwidget',
-        'bootstrap',
         'jquery',
         'SetAPI-client-api',
         'jquery-dataTables',
+        'jquery-dataTables-bootstrap',
         'kbaseAuthenticatedWidget',
         'kbaseTable',
         'kbaseTabs',
@@ -13,10 +13,10 @@ define (
         'numeral',
     ], function(
         KBWidget,
-        bootstrap,
         $,
         SetAPI_client_api,
         jquery_dataTables,
+        bootstrap,
         kbaseAuthenticatedWidget,
         kbaseTable,
         kbaseTabs,
@@ -34,7 +34,18 @@ define (
             loadingImage: Config.get('loading_gif'),
             init: function (options) {
                 var $self = this;
-                this._super(options);
+                $self._super(options);
+
+                /* Setup default data for the overview tab */
+                $self.set_overview = {
+                            'link_ref': '',
+                            'name': '',
+                            'description':'',
+                            'n_read_libraries':'',
+                            'total_reads':'',
+                            'avg_reads_per_library':''
+                        };
+                $self.set_items = [];
 
                 if (options._obj_info) {
                     $self.obj_info = options._obj_info;
@@ -44,63 +55,133 @@ define (
                     $self.link_ref = $self.obj_info.ws_id + '/' +
                                      $self.obj_info.name + '/' +
                                      $self.obj_info.version;
+                    console.log($self.obj_info);
+                    $self.update_overview_info_from_nar_info($self.obj_info);
                 } else {
                     $self.obj_ref = $self.options.wsId + '/' +
                                     $self.options.objId;
                     $self.link_ref = $self.obj_ref;
+                    $self.set_overview.name = $self.options.objId;
+                    $self.set_overview.link_ref = $self.link_ref;
                 }
+                $self.render();
 
-                this.setAPI = new SetAPI(Config.url('service_wizard'),
-                                         {'token': this.authToken()},
-                                         "dev");
-                this.wsClient = new Workspace(Config.url('workspace'),
-                                              {'token': this.authToken()});
+                $self.setAPI = new SetAPI(
+                                    Config.url('service_wizard'),
+                                    {'token': this.authToken()});
 
                 return Promise.resolve($self.setAPI.get_reads_set_v1({
-                    'ref': $self.obj_ref,
-                    'include_item_info': 1
+                        'ref': $self.obj_ref,
+                        'include_item_info': 1
                     }))
                     .then(function (results) {
-                        var info = results.info,
-                            refs = [],
-                            i = 0;
+                        var info = results.info;
+                        var data = results.data;
+                        var items = results.data.items;
+                        $self.update_overview_info_from_ws_info(info);
 
-                        $self.obj_info = info;
-                        $self.link_ref = info[6] + '/' +
-                                         info[1] + '/' +
-                                         info[4];
-                        $self.group_info = results.data;
+                        $self.set_items = [];
+
+                        /* return null if not an int */
+                        var asInt = function(string_number) {
+                            if(string_number===null) return null;
+                            var value = string_number.toString().match(/^\d+$/);
+                            if(value) {
+                                value = parseInt(value[0]);
+                            }
+                            return value;
+                        }
+
+                        var total_reads = 0;
 
                         // pull all reads objects to calculate summary stats
                         // and individual browse row contents
-                        for (i = 0; i < $self.group_info.items.length; i++) {
-                            refs.push({'ref':$self.group_info.items[i].ref});
-                        }
+                        for (var i = 0; i < items.length; i++) {
+                            var lib = items[i];
 
-                        return refs;
-                    })
-                    .then(function (refs) {
-                        return Promise.resolve($self.wsClient.get_objects(refs));
-                    })
-                    .then(function (data) {
-                        var i = 0;
-                        $self.row_contents = data;
-                        $self.group_stats = {'read_count': 0, 'bp_count': 0};
-                        // calculate summary stats
-                        for (i = 0; i < data.length; i++) {
-                            if (data[i].data.hasOwnProperty('read_count')) {
-                                $self.group_stats.read_count += data[i].data.read_count;
-                                if (data[i].data.hasOwnProperty('read_size')) {
-                                    $self.group_stats.bp_count += data[i].data.read_count * data[i].data.read_size;
+                            var readLibData = {
+                                'ref': lib['ref'],
+                                'label': lib['label'],
+                                'n_reads': ''
+                            };
+                            readLibData['name'] = '<a href="/#dataview/' +lib['ref'] + '" target="_blank">' +
+                                                    lib['info'][1] + '</a>';
+                            var readMetadata = lib['info'][10];
+                            if(readMetadata['read_count']){
+                                if(asInt(readMetadata['read_count'])) {
+                                    readLibData['n_reads'] = readMetadata['read_count'];
+                                    if(asInt(total_reads)!==null) {
+                                        total_reads += asInt(readLibData['n_reads']);
+                                    } else {
+                                    }
+                                } else {
+                                    total_reads = '';
                                 }
                             }
+                            $self.set_items.push(readLibData);
                         }
+                        if(asInt(total_reads)) {
+                            $self.set_overview['total_reads'] = total_reads;
+                        }
+
                         $self.render();
                     })
-                    .catch(function (err) {
-                        console.error(err);
+                    .catch(function (error) {
+                        console.error("READSSET VIEWER Render Function Error : ", error);
+                        var errorMssg = '';
+                        if (error && typeof error === 'object'){
+                            if(error.error) {
+                                errorMssg = JSON.stringify(error.error);
+                                if(error.error.message){
+                                    errorMssg = error.error.message;
+                                    if(error.error.error){
+                                        errorMssg += '<br><b>Error Trace:</b>:' + error.error.error;
+                                    }
+                                } else {
+                                    errorMssg = JSON.stringify(error.error);
+                                }
+                            } else { errorMssg = error.message; }
+                        }
+                        else{ errorMssg = "Undefined error"; }
+                        $self.$elem.append($('<div>').addClass('alert alert-danger').append(errorMssg));
                     });
             },
+
+            /* the narrative provides info differently from WS, so we need two functions.
+            these could be combined for cleaner code */
+            update_overview_info_from_nar_info: function(info) {
+                var $self = this;
+                $self.set_overview.link_ref = info['ws_id'] + '/' + info['name'] + '/' + info['version'];
+                $self.set_overview.name = info['name'];
+
+                var metadata = info['meta'];
+                if(metadata) {
+                    if(metadata['description']) {
+                        $self.set_overview.description = metadata['description'];
+                    }
+                    if(metadata['item_count']) {
+                        $self.set_overview.n_read_libraries = metadata['item_count'];
+                    }
+                }
+            },
+
+            update_overview_info_from_ws_info: function(info) {
+                var $self = this;
+                $self.set_overview.link_ref = info[6] + '/' + info[1] + '/' + info[4];
+                $self.set_overview.name = info[1];
+
+                var metadata = info[10];
+                if(metadata) {
+                    if(metadata['description']) {
+                        $self.set_overview.description = metadata['description'];
+                    }
+                    if(metadata['item_count']) {
+                        $self.set_overview.n_read_libraries = metadata['item_count'];
+                    }
+                }
+            },
+
+
             render: function () {
                 var $self = this,
                     $container = this.$elem,
@@ -110,71 +191,82 @@ define (
                     },
                     $tabs = $('<ul class="nav nav-tabs">' +
                               '<li class="active"><a data-toggle="tab" href="#' + tab_ids.overview + '">Overview</a></li>' +
-                              '<li><a data-toggle="tab" href="#' + tab_ids.browse + '">Browse</a></li>' +
+                              '<li><a data-toggle="tab" href="#' + tab_ids.browse + '">Browse Read Libraries</a></li>' +
                               '</ul>'),
                     $divs = $('<div class="tab-content">'),
-                    $overviewTable = $('<table class="table table-striped table-bordered table-hover">'),
-                    $browseTable = $('<table class="table table-striped table-bordered table-hover">'),
                     row = {'read_count': null, 'read_size': null, 'insert_size_mean': null};
+
+                $container.empty();
+                var $overviewTable = $('<table>')
+                                            .addClass('table table-striped table-bordered table-hover')
+                                            .css({'margin-left':'auto', 'margin-right':'auto'})
+                                            .css({'word-wrap':'break-word', 'table-layout':'fixed'})
+                                            .append($('<colgroup>')
+                                                        .append($('<col span="1" style="width: 25%;">')));
 
                 $overviewTable.append($('<tbody>'));
                 $overviewTable.append('<tr>' +
-                                          '<th>KBase Object Name</th>' +
+                                          '<th><b>KBase Object Name</b></th>' +
                                           '<td><a href="/#dataview/' +
-                                          $self.link_ref +
+                                          $self.set_overview.link_ref +
                                           '" target="_blank">' +
-                                          $self.obj_info[1] +
+                                          $self.set_overview.name +
                                           '</a>' +
                                           '</tr>');
-                $overviewTable.append('<tr><th>Description</th><td>' +
-                                      $self.group_info.description +
+                $overviewTable.append('<tr><th><b>Description</b></th><td>' +
+                                      $self.set_overview.description +
                                       '</td></tr>');
-                $overviewTable.append('<tr><th>Read Libraries</th><td>' +
-                                      $self.obj_info[10].item_count +
+                $overviewTable.append('<tr><th><b>Read Libraries</b></th><td>' +
+                                      $self.set_overview.n_read_libraries +
                                       '</td></tr>');
                 $overviewTable.append(
-                    '<tr><th>Total reads</th><td>' +
-                    Numeral($self.group_stats.read_count).format('0,0') +
-                    '</td></tr>');
-                $overviewTable.append(
-                    '<tr><th>Total base pairs</th><td>' +
-                    Numeral($self.group_stats.bp_count).format('0,0') +
-                    '</td></tr>');
+                                      '<tr><th><b>Total reads</b></th><td>' +
+                                      $self.set_overview.total_reads +
+                                      '</td></tr>');
 
                 $divs.append($('<div id="' + tab_ids.overview + '" class="tab-pane active">')
-                             .append($overviewTable));
+                             .append($('<div>').css('margin-top','15px')
+                                .append($overviewTable)));
 
-                $browseTable.append('<thead><tr>' +
-                                    '<th>Name</th>' +
-                                    '<th># Reads</th>' +
-                                    '<th>Read Length</th>' +
-                                    '<th>Insert Size</th>' +
-                                    '</tr></thead>');
-                $browseTable.append($('<tbody>'));
+                var $browseTable = $('<table>')
+                                            .addClass('table table-striped table-bordered table-hover')
+                                            .css({'margin-left':'auto', 'margin-right':'auto', 'width':'100%', 'border': '1px solid #ddd'})
+                                            .css({'word-wrap':'break-word'});
 
-                for (var i = 0; i < $self.row_contents.length; i++) {
-                    row.read_count = $self.row_contents[i].data.read_count;
-                    row.read_size = $self.row_contents[i].data.read_size;
-                    row.insert_size_mean = $self.row_contents[i].data.insert_size_mean;
+                $divs.append($('<div id="' + tab_ids.browse + '" class="tab-pane">')
+                             .append($('<div>').css({'margin-top':'15px', 'margin-bottom':'20px'})
+                                .append($browseTable)));
 
-                    for (var k in row) {
-                        if (row[k] !== null && row[k] !== undefined) {
-                            row[k] = Numeral(row[k]).format('0,0');
-                        } else {
-                            row[k] = "Missing";
-                        }
-                    }
-
-                    $browseTable.append(
-                        '<tr>' +
-                        '<td>' + $self.row_contents[i].info[1] + '</td>' +
-                        '<td>' + row.read_count + '</td>' +
-                        '<td>' + row.read_size + '</td>' +
-                        '<td>' + row.insert_size_mean + '</td>' +
-                        '</tr>');
+                var libsPerPage = 10;
+                var sDom = 'lft<ip>';
+                if($self.set_items.length<libsPerPage) {
+                    sDom = 'fti';
                 }
 
-                $divs.append($('<div id="' + tab_ids.browse + '" class="tab-pane">').append($browseTable));
+                var browseTableSettings = {
+                        "bFilter": true,
+                        "sPaginationType": "full_numbers",
+                        "iDisplayLength": 10,
+                        "sDom": sDom,
+                        "aaSorting": [[ 0, "dsc" ]],
+                        "columns": [
+                            {sTitle: "<b>Label</b>", data: "label"},
+                            {sTitle: '<b>Library Data Name</b>', data: "name"},
+                            {sTitle: "<b>Number of Reads</b>", data: "n_reads"}
+                        ],
+                        "data": $self.set_items,
+                        "language": {
+                            "lengthMenu": "_MENU_ Read Libraries per page",
+                            "zeroRecords": "No Matching Read Libraries Found",
+                            "info": "Showing _START_ to _END_ of _TOTAL_ Read Libraries",
+                            "infoEmpty": "No Read Libraries in set.",
+                            "infoFiltered": "(filtered from _MAX_)",
+                            "search" : "Search"
+                        }
+                    };
+                $browseTable.DataTable(browseTableSettings);
+                $browseTable.find('th').css('cursor','pointer');
+
                 $container.append($tabs);
                 $container.append($divs);
             },


### PR DESCRIPTION
Switched the reads browser to data tables and turned off any calls to the WS, instead relying on metadata for each item returned from the SetAPI.  Also generally improved formatting to align with the assembly and genome viewers.