### PR TITLE
Fix error when metadata is none

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1036,7 +1036,7 @@ define([
                         window.open('/#people/' + object_info[5]);
                     });
             }
-            var metadata = object_info[10];
+            var metadata = object_info[10] || {};
             var metadataText = '';
             for (var key in metadata) {
                 if (metadata.hasOwnProperty(key)) {


### PR DESCRIPTION
This'll cause the data panel to fail to render data objects.
