### PR TITLE
Fixes to widget that shows up with importer jobs

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -243,12 +243,12 @@ define([
                             objRefs.push({ref: ref});
                         });
                         var newObjTmpl = Handlebars.compile(NewObjectsTemplate);
-                        this.tabController.addTab({tab: 'New Data Objects', showContentCallback: function() {
-                            var wsClient = new Workspace(Config.url('workspace'), {token: this.runtime.authToken()});
-                            var $div = $('<div>');
-                            Promise.resolve(wsClient.get_object_info_new({objects: objRefs}))
-                            .then(function(objInfo) {
+                        var wsClient = new Workspace(Config.url('workspace'), {token: this.runtime.authToken()});
+                        Promise.resolve(wsClient.get_object_info_new({objects: objRefs}))
+                        .then(function(objInfo) {
+                            this.tabController.addTab({tab: 'New Data Objects', showContentCallback: function() {
                                 var renderedInfo = [];
+                                var $div = $('<div>');
                                 objInfo.forEach(function(obj) {
                                     renderedInfo.push({
                                         'name': obj[1],
@@ -266,9 +266,12 @@ define([
                                     }.bind(this));
                                 }
                                 $div.append($objTable);
-                            }.bind(this));
-                            return $div;
-                        }.bind(this)});
+                                return $div;
+                            }.bind(this)});
+                        }.bind(this))
+                        .catch(function(error) {
+                            //die silently.
+                        });
                     }
                 }
                 this.showingNewObjects = true;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
@@ -223,7 +223,7 @@ define (
             );
             return this;
         },
-        
+
         getVersionTag: function() {
             var tag = Jupyter.narrative.sidePanel.$methodsWidget.currentTag;
             if (!tag) {
@@ -231,7 +231,7 @@ define (
             }
             return tag;
         },
-        
+
         getMethodSpecs: function(callback, errorCallback) {
             var self = this;
             var tag = self.getVersionTag();
@@ -247,13 +247,13 @@ define (
                     if (self.allMethodIds[tag][methodId]) {
                         methodIds.push(methodId);
                     } else {
-                        console.log("Importer method id=" + methodId + " is skipped for " + 
+                        console.log("Importer method id=" + methodId + " is skipped for " +
                                 "tag \"" + tag + "\"");
                     }
                 }
-                var prom1 = self.methClient.get_method_full_info({'ids': methodIds, 
+                var prom1 = self.methClient.get_method_full_info({'ids': methodIds,
                     'tag' : tag});
-                var prom2 = self.methClient.get_method_spec({'ids': methodIds, 
+                var prom2 = self.methClient.get_method_spec({'ids': methodIds,
                     'tag' : tag});
                 $.when(prom1, prom2).done(function(fullInfoList, specs) {
                     self.methodFullInfo[tag] = {};
@@ -272,7 +272,7 @@ define (
                 errorCallback(error);
             });
         },
-        
+
         showWidget: function(type, methodFullInfo, methods, tag) {
             var self = this;
             this.selectedType = type;
@@ -296,7 +296,7 @@ define (
             }
 
             for (var methodPos in importMethodIds) {
-                self.showTab(importMethodIds, methodPos, $header, $body, 
+                self.showTab(importMethodIds, methodPos, $header, $body,
                         numberOfTabs, methodFullInfo, methods);
             }
             var $importButton = $('<button>')
@@ -359,7 +359,7 @@ define (
             self.widgetPanelCard2.append($buttons);
         },
 
-        showTab: function(importMethodIds, methodPos, $header, $body, 
+        showTab: function(importMethodIds, methodPos, $header, $body,
                 numberOfTabs, methodFullInfo, methods) {
             var self = this;
             var methodId = importMethodIds[methodPos];
@@ -500,6 +500,7 @@ define (
         createImportStatusCell: function(methodName, jobId) {
             var cellIndex = Jupyter.notebook.get_selected_index();
             var cell = Jupyter.notebook.insert_cell_below('code', cellIndex);
+            $(cell.element).trigger('toggleCodeArea.cell');
             var title = 'Import job status for ' + methodName;
             var cellText = ['from biokbase.narrative.jobs.jobmanager import JobManager',
                             'JobManager().get_job(' + jobId + ')'].join('\n');

--- a/kbase-extension/static/kbase/templates/job_status/new_objects.html
+++ b/kbase-extension/static/kbase/templates/job_status/new_objects.html
@@ -1,0 +1,16 @@
+<table class="table table-striped table-bordered" style="margin-left: auto; margin-right: auto;">
+    <tr>
+        <th style="width:30%;color:#555">
+            <b>Created Object Name</b>
+        </th>
+        <th style="width:20%;color:#555">
+            <b>Type</b>
+        </th>
+    </tr>
+    {{#each this}}
+    <tr>
+        <td><a id="{{name}}">{{name}}</a></td>
+        <td>{{type}}</td>
+    </tr>
+    {{/each}}
+</table>


### PR DESCRIPTION
- Hides the code area on first appearance.
- Hides the "Report" and "New Objects" tabs until there's something to put there.
- Report only shows up if it can guess that there's a report object (looks for 'report_ref' in the results)
- "New Objects" will show up if there's a report (since that info is in there).
- "New Objects" also shows up if it looks like there's a workspace reference in the results. Scans through that object looking for any string that matches "XXX/YYY/ZZZ" where those can be anything (and the last part is optional). That might still be a bit brittle, since it just auto searches the workspace for that info.
