### PR TITLE
Staging "hotfix" to fix data panel / import tab, file upload breaking on Safari

### DIFF
--- a/kbase-extension/static/kbase/js/api/kbase-client-api.js
+++ b/kbase-extension/static/kbase/js/api/kbase-client-api.js
@@ -12805,10 +12805,20 @@ function ShockClient(params) {
 		return promise;
     };
     
+    self.getFileLastModificationTime = function (file) {
+        if (file.lastModifiedDate) {
+            return file.lastModifiedDate.getTime();
+        } else if (file.lastModified) {
+            return file.lastModified;
+        } else {
+            return 0;
+        }
+    };
+    
     self.check_file = function(file, ret, errorCallback) {
     	var promise = jQuery.Deferred();
 	    var fsize = file.size;
-	    var ftime = file.lastModifiedDate.getTime();
+	    var ftime = String(self.getFileLastModificationTime(file));
 	    var filters = {'file_size': fsize, 'file_time': ftime, 'file_name': file.name, 'limit': 1};
 	    self.get_nodes(filters, function (data) {
 	    	ret(data.length == 0 ? null : data[0]);
@@ -12846,7 +12856,7 @@ function ShockClient(params) {
 	    "incomplete": (lastChunk ? "0" : "1"), 
 	    "file_size": "" + file.size, 
 	    "file_name": file.name,
-	    "file_time": "" + file.lastModifiedDate.getTime(), 
+	    "file_time": String(self.getFileLastModificationTime(file)),
 	    "chunks": "" + (currentChunk+1),
 	    "chunk_size": "" + chunkSize};
 	var aFileParts = [ JSON.stringify(incomplete_attr) ];
@@ -12897,7 +12907,7 @@ function ShockClient(params) {
 		    		"incomplete": (lastChunk ? "0" : "1"), 
 		    		"file_size": "" + file.size, 
 		    		"file_name": file.name,
-		    		"file_time": "" + file.lastModifiedDate.getTime(), 
+		    		"file_time": String(self.getFileLastModificationTime(file)),
 		    		"chunks": "" + (currentChunk+1),
 		    		"chunk_size": "" + chunkSize};
 		    var aFileParts = [ JSON.stringify(incomplete_attr) ];
@@ -12994,7 +13004,7 @@ console.log(Date.now() + " chunk " + currentChunk);
     		var chunkSize = self.chunkSize;
     		var chunks = Math.ceil(file.size / chunkSize);
     		var incomplete_attr = { "incomplete": "1", "file_size": "" + file.size, "file_name": file.name,
-    					"file_time": "" + file.lastModifiedDate.getTime(), "chunk_size": "" + chunkSize};
+    					"file_time": String(self.getFileLastModificationTime(file)), "chunk_size": "" + chunkSize};
     		var aFileParts = [ JSON.stringify(incomplete_attr) ];
     		var oMyBlob = new Blob(aFileParts, { "type" : "text\/json" });
     		var fd = new FormData();
@@ -13040,7 +13050,7 @@ console.log(Date.now() + " chunk " + currentChunk);
 		if (data &&  data["attributes"] && 
 		    data["attributes"]["file_size"] === ("" + file.size) && 
 		    data["attributes"]["file_name"] === file.name &&
-    		    data["attributes"]["file_time"] === ("" + file.lastModifiedDate.getTime())) {
+    		    data["attributes"]["file_time"] === String(self.getFileLastModificationTime(file))) {
 		    processNode(data);
 		} else {
 		    searchForIncomplete();

--- a/kbase-extension/static/kbase/js/api/kbase-client-api.js
+++ b/kbase-extension/static/kbase/js/api/kbase-client-api.js
@@ -12818,7 +12818,7 @@ function ShockClient(params) {
     self.check_file = function(file, ret, errorCallback) {
     	var promise = jQuery.Deferred();
 	    var fsize = file.size;
-	    var ftime = String(self.getFileLastModificationTime(file));
+	    var ftime = self.getFileLastModificationTime(file);
 	    var filters = {'file_size': fsize, 'file_time': ftime, 'file_name': file.name, 'limit': 1};
 	    self.get_nodes(filters, function (data) {
 	    	ret(data.length == 0 ? null : data[0]);

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
@@ -177,6 +177,16 @@ define (
             this.fakeButton.innerHTML = inSelectFileMode ? "Select File" : "Cancel";
         },
         
+        getFileLastModificationTime: function (file) {
+            if (file.lastModifiedDate) {
+                return file.lastModifiedDate.getTime();
+            } else if (file.lastModified) {
+                return file.lastModified;
+            } else {
+                return 0;
+            }
+        },
+        
         fileSelected: function (nameText, prcText, realButton) {
             if (realButton.files.length != 1)
                 return;
@@ -193,7 +203,7 @@ define (
             self.onChange();
             console.log("kbaseNarrativeParameterFileInput.fileSelected: after self.onChange()");
             var curTime = new Date().getTime();
-            var ujsKey = "File:"+file.size+":"+file.lastModifiedDate.getTime()+":"+file.name+":"+self.getUser();
+            var ujsKey = "File:"+file.size+":"+String(this.getFileLastModificationTime(file))+":"+file.name+":"+self.getUser();
             var ujsClient = new UserAndJobState(self.options.ujsUrl, {'token': self.token});
             var shockClient = new ShockClient({url: self.options.shockUrl, token: self.token});
             ujsClient.get_has_state(self.options.serviceNameInUJS, ujsKey, 0, function(data) {


### PR DESCRIPTION
usage of lastModifiedDate was incompatible with Safari and non-standard.
tested on Mac Safari, FF, Chrome
could use additional testing on Windows
tested with a reads (single) file
1. from a narrative with a reads object
2. download FASTQ
3. attempt to import the fastq file
4. import it
5. repeat 3-4 for: same file, same file copied to another name, same file touched to give different timestamp, invalid fastq file (e.g. create a simple text file.)