### PR TITLE
Rerouted New Narrative button, changed UX for it.

### DIFF
--- a/kbase-extension/static/kbase/js/util/timeFormat.js
+++ b/kbase-extension/static/kbase/js/util/timeFormat.js
@@ -34,7 +34,7 @@ define([], function() {
 
     /**
      * VERY simple date parser.
-     * Returns a valid Date object if that time stamp's real. 
+     * Returns a valid Date object if that time stamp's real.
      * Returns null otherwise.
      * @param {String} time - the timestamp to convert to a Date
      * @returns {Object} - a Date object or null if the timestamp's invalid.
@@ -46,7 +46,7 @@ define([], function() {
          *
          * Try to make a new Date object.
          * If that fails, break it apart - This might be caused by some issues with the typical ISO
-         * timestamp style in certain browsers' implementations. From breaking it apart, build a 
+         * timestamp style in certain browsers' implementations. From breaking it apart, build a
          * new Date object directly.
          */
         var d = new Date(time);
@@ -83,15 +83,15 @@ define([], function() {
      * readable string in the UTC time.
      *
      * This assumes that the timestamp string is in the following format:
-     * 
+     *
      * YYYY-MM-DDThh:mm:ssZ, where Z is the difference
      * in time to UTC in the format +/-HHMM, eg:
      *   2012-12-17T23:24:06-0500 (EST time)
      *   2013-04-03T08:56:32+0000 (UTC time)
-     * 
+     *
      * If the string is not in that format, this method returns the unchanged
      * timestamp.
-     *        
+     *
      * @param {String} timestamp - the timestamp string returned by the service
      * @returns {String} a parsed timestamp in the format "YYYY-MM-DD HH:MM:SS" in the browser's local time.
      * @private
@@ -111,9 +111,9 @@ define([], function() {
      * YYYY-MM-DD HH:MM:SS
      * e.g.
      * 2016-01-05 13:26:02
-     * 
+     *
      * Adds leading zeros to each field if necessary.
-     * 
+     *
      * If it is not a dateObj, this just returns the input, unchanged.
      *
      * @param {Object} dateObj - the JavaScript Date object to format.
@@ -132,11 +132,11 @@ define([], function() {
             return value;
         };
 
-        return dateObj.getFullYear() + '-' + 
-               addLeadingZero(dateObj.getMonth() + 1) + '-' + 
-               addLeadingZero(dateObj.getDate()) + ' ' + 
-               addLeadingZero(dateObj.getHours()) + ':' + 
-               addLeadingZero(dateObj.getMinutes()) + ':' + 
+        return dateObj.getFullYear() + '-' +
+               addLeadingZero(dateObj.getMonth() + 1) + '-' +
+               addLeadingZero(dateObj.getDate()) + ' ' +
+               addLeadingZero(dateObj.getHours()) + ':' +
+               addLeadingZero(dateObj.getMinutes()) + ':' +
                addLeadingZero(dateObj.getSeconds());
     }
 
@@ -181,7 +181,7 @@ define([], function() {
      * into something human readable, e.g. "1.5 hrs"
      *
      * essentially does |d2-d1|, and makes it legible.
-     * 
+     *
      * @return {string} Time difference.
      */
     function calcTimeDifference (d1, d2) {
@@ -233,9 +233,13 @@ define([], function() {
      * Ported out from data list widget... needs updating.
      * edited from: http://stackoverflow.com/questions/3177836/how-to-format-time-since-xxx-e-g-4-minutes-ago-similar-to-stack-exchange-site
      */
-    function getTimeStampStr (objInfoTimeStamp) {
+    function getTimeStampStr (objInfoTimeStamp, alwaysExact) {
         var date = new Date(objInfoTimeStamp);
         var seconds = Math.floor((new Date() - date) / 1000);
+
+        var exactDate = function(date) {
+            return monthLookup[date.getMonth()] + " " + date.getDate() + ", " + date.getFullYear();
+        }
 
         // f-ing safari, need to add extra ':' delimiter to parse the timestamp
         if (isNaN(seconds)) {
@@ -246,21 +250,24 @@ define([], function() {
             if (isNaN(seconds)) {
                 // just in case that didn't work either, then parse without the timezone offset, but
                 // then just show the day and forget the fancy stuff...
-                date = new Date(tokens[0]);
-                return monthLookup[date.getMonth()] + " " + date.getDate() + ", " + date.getFullYear();
+                return exactDate(new Date(tokens[0]));
             }
+        }
+
+        if (alwaysExact) {
+            return exactDate(date);
         }
 
         var interval = Math.floor(seconds / 31536000);
         if (interval > 1) {
-            return monthLookup[date.getMonth()] + " " + date.getDate() + ", " + date.getFullYear();
+            return exactDate(date);
         }
         interval = Math.floor(seconds / 2592000);
         if (interval > 1) {
             if (interval < 4) {
                 return interval + " months ago";
             } else {
-                return monthLookup[date.getMonth()] + " " + date.getDate() + ", " + date.getFullYear();
+                return exactDate(date);
             }
         }
         interval = Math.floor(seconds / 86400);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -528,7 +528,8 @@ define([
             return Promise.resolve(
                 this.serviceClient.sync_call(
                     'NarrativeService.list_objects_with_sets',
-                    [{'ws_name': this.ws_name}]
+                    [{'ws_name': this.ws_name,
+                      'includeMetadata': 1}]
                 )
             )
             .then(function(result) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -57,7 +57,7 @@ define([
             // expects:
             // name, id, version for appInfo
             this.appInfo = this.options.info;
-            
+
             var cellNode = this.$elem.closest('.cell').get(0);
             function findCell() {
                 var cells = Jupyter.notebook.get_cell_elements().toArray().filter(function (element) {
@@ -70,11 +70,11 @@ define([
                     return $(cells[0]).data('cell');
                 }
                 throw new Error('Cannot find the cell node!', cellNode, cells);
-                
+
             }
-            
+
             this.cell = findCell();
-            
+
             // this.cell = Jupyter.narrative.getCellByKbaseId(this.$elem.attr('id'));
             //console.log('initializing with job id = ' + this.jobId);
             if (!this.jobId) {
@@ -106,7 +106,7 @@ define([
                     type: 'job-status'
                 },
                 handle: function (message) {
-                    console.log('Have job status', message);
+                    // console.log('Have job status', message);
                     this.handleJobStatus(message);
                 }.bind(this)
             });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -1127,7 +1127,7 @@ define([
                         .append(workingStr);
                     Promise.resolve(this.serviceClient.sync_call(
                         "NarrativeService.create_new_narrative",
-                        [{}]
+                        [{ includeIntroCell: 1 }]
                     ))
                     .then(function(results) {
                         $btn.empty().append(doneStr);


### PR DESCRIPTION
Now, when clicking the 'New Narrative' button in the Narratives panel, it does this flow:
1. Disable the button.
2. Call the NarrativeService create narrative function.
3. Build a link to the new narrative and put it in place under the button. This is the biggest shift - just popping open a window via JavaScript will get stopped by most browsers' pop-up blockers. And I think we still want it to come up in a new tab/window. So that's the feel for now.
4. Re-enable the New Narrative button when the link is clicked, and dismiss the link, while we're at it.
5. On error - show the error in a slide down alert (in the same spot) and continue to disable the create button while the error is being shown.

This also does a little bit of cleanup.