### PR TITLE
Optional grouped params pass 1

### DIFF
--- a/kbase-extension/static/kbase/js/common/monoBus.js
+++ b/kbase-extension/static/kbase/js/common/monoBus.js
@@ -20,9 +20,10 @@ define([
     'uuid',
     'bluebird',
     './unodep'
-], function (Uuid, Promise, utils) {
+], function(Uuid, Promise, utils) {
     'use strict';
     var instanceId = 0;
+
     function newInstance() {
         instanceId += 1;
         return instanceId;
@@ -73,7 +74,7 @@ define([
                 if (strictMode) {
                     throw new Error('Channel description is required');
                 } else {
-                    
+
                 }
                 warn('Channel created without description');
             }
@@ -93,7 +94,7 @@ define([
         function ensureChannel(name) {
             if (!channels[name]) {
                 warn('Channel implicitly created', name);
-                makeChannel({name: name});
+                makeChannel({ name: name });
             }
             return channels[name];
         }
@@ -128,7 +129,7 @@ define([
             if (!listeners) {
                 return;
             }
-            listeners.forEach(function (listener) {
+            listeners.forEach(function(listener) {
                 handled = true;
                 log('PROCESSING KEY LISTENER', channel, item);
                 letListenerHandle(item, listener.handle);
@@ -226,7 +227,7 @@ define([
             listenerRegistry[id] = listener;
             return id;
         }
-        
+
         function removeListener(id) {
             var listenerToRemove = listenerRegistry[id],
                 channel, listeners, newListeners;
@@ -242,7 +243,7 @@ define([
                 if (!listeners) {
                     return;
                 }
-                channel.keyListeners[listenerToRemove.key] = listeners.filter(function (listener) {
+                channel.keyListeners[listenerToRemove.key] = listeners.filter(function(listener) {
                     return (listener.id !== listenerToRemove.id);
                 });
             } else if (listenerToRemove.test) {
@@ -250,14 +251,14 @@ define([
                 if (!listeners) {
                     return;
                 }
-                channel.testListeners = listeners.filter(function (listener) {
+                channel.testListeners = listeners.filter(function(listener) {
                     return (listener.id !== listenerToRemove.id);
                 });
             }
         }
-        
+
         function removeListeners(ids) {
-            ids.forEach(function (id) {
+            ids.forEach(function(id) {
                 removeListener(id);
             });
         }
@@ -268,7 +269,7 @@ define([
 
         function processTestListeners(channel, item) {
             var handled = false;
-            channel.testListeners.forEach(function (listener) {
+            channel.testListeners.forEach(function(listener) {
                 log('PROCESSING TEST LISTENER?', channel, item);
                 if (testListener(item, listener.test)) {
                     handled = true;
@@ -283,7 +284,7 @@ define([
         function processQueueItem(item) {
             var channel = getChannel(item.envelope.channel),
                 handled;
-            
+
             if (!channel) {
                 return;
             }
@@ -305,7 +306,7 @@ define([
             var processingQueue = transientMessages;
             transientMessages = [];
 
-            processingQueue.forEach(function (item) {
+            processingQueue.forEach(function(item) {
                 try {
                     processQueueItem(item);
                 } catch (ex) {
@@ -322,7 +323,7 @@ define([
             if (timer) {
                 return;
             }
-            timer = window.setTimeout(function () {
+            timer = window.setTimeout(function() {
                 timer = null;
                 try {
                     processQueues();
@@ -334,7 +335,7 @@ define([
 
         // SENDING
 
-        
+
 
         function setPersistentMessage(message, envelope) {
             var channel = ensureChannel(envelope.channel),
@@ -372,6 +373,12 @@ define([
                 envelope: persistentMessage.envelope
             });
             run();
+        }
+
+        function deepCopy(d) {
+            if (d !== undefined) {
+                return JSON.parse(JSON.stringify(d));
+            }
         }
 
         /*
@@ -437,11 +444,12 @@ define([
          */
         function respond(spec) {
             var originalHandle = spec.handle;
+
             function newHandle(message, envelope) {
                 try {
                     var responseMessage = originalHandle(message);
                     send(responseMessage, {
-                        key: {requestId: envelope.address.requestId}
+                        key: { requestId: envelope.address.requestId }
                     });
                 } catch (ex) {
                     console.error('Error handling in respond', ex);
@@ -457,7 +465,7 @@ define([
          * pending requests - which is a map of all request messages.
          */
         function request(message, address) {
-            return new Promise(function (resolve, reject) {
+            return new Promise(function(resolve, reject) {
                 var requestId = new Uuid(4).format();
 
                 // when this listener with a key set to the request id
@@ -466,10 +474,10 @@ define([
                 // is run, as well as to invoke the error handler upon
                 // timeout. (TODO)
                 listen({
-                    key: {requestId: requestId},
+                    key: { requestId: requestId },
                     once: true,
                     timeout: address.timeout || 10000,
-                    handle: function (responseMessage) {
+                    handle: function(responseMessage) {
                         resolve(responseMessage);
                     }
                 });
@@ -493,7 +501,7 @@ define([
             // });
             return listen({
                 channel: channel,
-                key: JSON.stringify({type: type}),
+                key: JSON.stringify({ type: type }),
                 handle: handler
             });
         }
@@ -503,7 +511,7 @@ define([
                 message = {};
             }
             send(message, {
-                key: {type: type}
+                key: { type: type }
             });
         }
 
@@ -536,7 +544,7 @@ define([
             function on(type, handler) {
                 return listen({
                     channel: channelName,
-                    key: {type: type},
+                    key: { type: type },
                     handle: handler
                 });
             }
@@ -547,7 +555,7 @@ define([
                 }
                 return send(message, {
                     channel: channelName,
-                    key: {type: type}
+                    key: { type: type }
                 });
             }
 
@@ -606,7 +614,7 @@ define([
 
 
         // MAIN
-        makeChannel({name: 'default', description: 'The Default Channel'});
+        makeChannel({ name: 'default', description: 'The Default Channel' });
 
         // API
         api = {
@@ -629,7 +637,7 @@ define([
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };

--- a/nbextensions/appCell2/appCell.js
+++ b/nbextensions/appCell2/appCell.js
@@ -60,19 +60,20 @@ define([
          */
         // TODO: move to spec module
         // TODO: recursively initialize params.
-        function initializeParams(appSpec) {
-            var defaultParams = {};
-            appSpec.parameters.forEach(function(parameterSpec) {
-                var param = ParameterSpec.make({ parameterSpec: parameterSpec }),
-                    defaultValue = param.defaultValue();
+        // function initializeParams(appSpec) {
+        //     console.log('INIT PARAM', appSpec);
+        //     var defaultParams = {};
+        //     appSpec.parameters.forEach(function(parameterSpec) {
+        //         var param = ParameterSpec.make({ parameterSpec: parameterSpec }),
+        //             defaultValue = param.defaultValue();
 
-                // A default value may be undefined, e.g. if the parameter is required and there is no default value.
-                if (defaultValue !== undefined) {
-                    defaultParams[param.id()] = defaultValue;
-                }
-            });
-            utils.setCellMeta(cell, 'kbase.appCell.params', defaultParams);
-        }
+        //         // A default value may be undefined, e.g. if the parameter is required and there is no default value.
+        //         if (defaultValue !== undefined) {
+        //             defaultParams[param.id()] = defaultValue;
+        //         }
+        //     });
+        //     utils.setCellMeta(cell, 'kbase.appCell.params', defaultParams);
+        // }
 
         function specializeCell() {
             cell.minimize = function() {
@@ -245,7 +246,7 @@ define([
         }
 
         return Object.freeze({
-            initializeParams: initializeParams,
+            // initializeParams: initializeParams,
             setupCell: setupCell,
             upgradeToAppCell: upgradeToAppCell
         });

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -207,6 +207,22 @@ define([
                         });
                     });
 
+                    bus.on('set-param-state', function(message) {
+                        model.setItem('paramState', message.id, message.state);
+                    });
+
+                    bus.respond({
+                        key: {
+                            type: 'get-param-state'
+                        },
+                        handle: function(message) {
+                            return {
+                                state: model.getItem('paramState', message.id)
+                            };
+                        }
+                    });
+
+
                     bus.respond({
                         key: {
                             type: 'get-parameter'

--- a/nbextensions/appCell2/widgets/appParamsWidget.js
+++ b/nbextensions/appCell2/widgets/appParamsWidget.js
@@ -17,7 +17,7 @@ define([
     'common/runtime'
     // All the input widgets
 
-], function (
+], function(
     Promise,
     html,
     UI,
@@ -47,7 +47,6 @@ define([
             bus,
             places,
             model = Props.make(),
-            inputBusses = [],
             paramResolver = ParamResolver.make(),
             settings = {
                 showAdvanced: null
@@ -95,21 +94,27 @@ define([
 
         function makeFieldWidget(appSpec, parameterSpec, value) {
             return paramResolver.getInputWidgetFactory(parameterSpec)
-                .then(function (inputWidget) {
-
-                    var fieldBus = runtime.bus().makeChannelBus(null, 'A field widget');
-
-                    inputBusses.push(fieldBus);
+                .then(function(inputWidget) {
+                    var fieldWidget = FieldWidget.make({
+                        inputControlFactory: inputWidget,
+                        showHint: true,
+                        useRowHighight: true,
+                        initialValue: value,
+                        appSpec: appSpec,
+                        parameterSpec: parameterSpec,
+                        workspaceId: workspaceInfo.id,
+                        referenceType: 'name'
+                    });
 
                     // Forward all changed parameters to the controller. That is our main job!
-                    fieldBus.on('changed', function (message) {
+                    fieldWidget.bus.on('changed', function(message) {
                         parentBus.emit('parameter-changed', {
                             parameter: parameterSpec.id,
                             newValue: message.newValue
                         });
                     });
 
-                    fieldBus.on('touched', function () {
+                    fieldWidget.bus.on('touched', function() {
                         parentBus.emit('parameter-touched', {
                             parameter: parameterSpec.id
                         });
@@ -117,41 +122,62 @@ define([
 
 
                     // An input widget may ask for the current model value at any time.
-                    fieldBus.on('sync', function () {
+                    fieldWidget.bus.on('sync', function() {
                         parentBus.emit('parameter-sync', {
                             parameter: parameterSpec.id
                         });
                     });
 
-                    fieldBus.on('sync-params', function (message) {
+                    fieldWidget.bus.on('sync-params', function(message) {
                         parentBus.emit('sync-params', {
                             parameters: message.parameters,
-                            replyToChannel: fieldBus.channelName
+                            replyToChannel: fieldWidget.bus.channelName
                         });
+                    });
+
+                    fieldWidget.bus.on('set-param-state', function(message) {
+                        parentBus.emit('set-param-state', {
+                            id: parameterSpec.id,
+                            state: message.state
+                        });
+                    });
+
+                    fieldWidget.bus.respond({
+                        key: {
+                            type: 'get-param-state'
+                        },
+                        handle: function(message) {
+                            console.log('getting param state');
+                            return parentBus.request({ id: parameterSpec.id }, {
+                                key: {
+                                    type: 'get-param-state'
+                                }
+                            });
+                        }
                     });
 
 
                     /*
                      * Or in fact any parameter value at any time...
                      */
-                    fieldBus.on('get-parameter-value', function (message) {
+                    fieldWidget.bus.on('get-parameter-value', function(message) {
                         parentBus.request({
                                 parameter: message.parameter
                             }, {
                                 key: 'get-parameter-value'
                             })
-                            .then(function (message) {
+                            .then(function(message) {
                                 bus.emit('parameter-value', {
                                     parameter: message.parameter
                                 });
                             });
                     });
 
-                    fieldBus.respond({
+                    fieldWidget.bus.respond({
                         key: {
                             type: 'get-parameter'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             if (message.parameterName) {
                                 return parentBus.request(message, {
                                     key: {
@@ -170,131 +196,15 @@ define([
                             type: 'update',
                             parameter: parameterSpec.id
                         },
-                        handle: function (message) {
-                            fieldBus.emit('update', {
+                        handle: function(message) {
+                            fieldWidget.bus.emit('update', {
                                 value: message.value
                             });
                         }
                     });
 
-
-                    // just forward...
-                    //bus.on('newstate', function (message) {
-                    //    inputWidgetBus.send(message);
-                    //});
-                    return {
-                        bus: bus,
-                        widget: FieldWidget.make({
-                            inputControlFactory: inputWidget,
-                            showHint: true,
-                            useRowHighight: true,
-                            initialValue: value,
-                            appSpec: appSpec,
-                            parameterSpec: parameterSpec,
-                            bus: fieldBus,
-                            workspaceId: workspaceInfo.id,
-                            referenceType: 'name'
-                        })
-                    };
+                    return fieldWidget;
                 });
-        }
-
-        function makeFieldWidgetx(appSpec, parameterSpec, value) {
-            var fieldBus = runtime.bus().makeChannelBus(null, 'A field widget'),
-                inputWidget = paramResolver.getInputWidgetFactory(parameterSpec);
-
-            inputBusses.push(fieldBus);
-
-            // Forward all changed parameters to the controller. That is our main job!
-            fieldBus.on('changed', function (message) {
-                parentBus.emit('parameter-changed', {
-                    parameter: parameterSpec.id,
-                    newValue: message.newValue
-                });
-            });
-
-
-            // An input widget may ask for the current model value at any time.
-            fieldBus.on('sync', function () {
-                parentBus.emit('parameter-sync', {
-                    parameter: parameterSpec.id
-                });
-            });
-
-            fieldBus.on('sync-params', function (message) {
-                parentBus.emit('sync-params', {
-                    parameters: message.parameters
-                });
-            });
-
-            /*
-             * Or in fact any parameter value at any time...
-             */
-            fieldBus.on('get-parameter-value', function (message) {
-                parentBus.request({
-                        parameter: message.parameter
-                    }, {
-                        key: 'get-parameter-value'
-                    })
-                    .then(function (message) {
-                        bus.emit('parameter-value', {
-                            parameter: message.parameter
-                        });
-                    });
-            });
-
-            //bus.on('parameter-value', function (message) {
-            //    bus.emit('parameter-value', message);
-            //});
-
-            fieldBus.respond({
-                key: {
-                    type: 'get-parameter'
-                },
-                handle: function (message) {
-                    if (message.parameterName) {
-                        return parentBus.request(message, {
-                            key: {
-                                type: 'get-parameter'
-                            }
-                        });
-                    } else {
-                        return null;
-                    }
-                }
-            });
-
-            // Just pass the update along to the input widget.
-            parentBus.listen({
-                key: {
-                    type: 'update',
-                    parameter: parameterSpec.id
-                },
-                handle: function (message) {
-                    fieldBus.emit('update', {
-                        value: message.value
-                    });
-                }
-            });
-
-
-            // just forward...
-            //bus.on('newstate', function (message) {
-            //    inputWidgetBus.send(message);
-            //});
-            return {
-                bus: bus,
-                widget: FieldWidget.make({
-                    inputControlFactory: inputWidget,
-                    showHint: true,
-                    useRowHighight: true,
-                    initialValue: value,
-                    appSpec: appSpec,
-                    parameterSpec: parameterSpec,
-                    bus: fieldBus,
-                    workspaceId: workspaceInfo.id
-                })
-            };
         }
 
         function renderAdvanced(area) {
@@ -443,12 +353,12 @@ define([
         // EVENTS
 
         function attachEvents() {
-            bus.on('reset-to-defaults', function () {
-                inputBusses.forEach(function (inputBus) {
-                    inputBus.emit('reset-to-defaults');
+            bus.on('reset-to-defaults', function() {
+                widgets.forEach(function(widget) {
+                    widget.bus.emit('reset-to-defaults');
                 });
             });
-            bus.on('toggle-advanced', function () {
+            bus.on('toggle-advanced', function() {
                 // we can just do that here? Or defer to the inputs?
                 // I don't know ...
                 //inputBusses.forEach(function (bus) {
@@ -460,9 +370,9 @@ define([
                 renderAdvanced('input-objects');
                 renderAdvanced('parameters');
             });
-            runtime.bus().on('workspace-changed', function () {
+            runtime.bus().on('workspace-changed', function() {
                 // tell each input widget about this amazing event!
-                widgets.forEach(function (widget) {
+                widgets.forEach(function(widget) {
                     widget.bus.emit('workspace-changed');
                 });
             });
@@ -482,7 +392,7 @@ define([
         }
 
         function validateParameterSpecs(params) {
-            return params.map(function (spec) {
+            return params.map(function(spec) {
                 return validateParameterSpec(spec);
             });
         }
@@ -490,11 +400,11 @@ define([
         function makeParamsLayout(params) {
             var view = {};
             var paramMap = {};
-            var orderedParams = params.map(function (param) {
+            var orderedParams = params.map(function(param) {
                 paramMap[param.id] = param;
                 return param.id;
             });
-            var layout = orderedParams.map(function (parameterId) {
+            var layout = orderedParams.map(function(parameterId) {
                 var id = html.genId();
                 view[parameterId] = {
                     id: id
@@ -523,27 +433,27 @@ define([
             // Separate out the params into the primary groups.
             var appSpec = model.getItem('appSpec');
 
-            return Promise.try(function () {
+            return Promise.try(function() {
                 var params = model.getItem('parameters'),
                     inputParams = makeParamsLayout(
-                        params.layout.filter(function (id) {
+                        params.layout.filter(function(id) {
                             return (params.specs[id].ui.class === 'input');
                         })
-                        .map(function (id) {
+                        .map(function(id) {
                             return params.specs[id];
                         })),
                     outputParams = makeParamsLayout(
-                        params.layout.filter(function (id) {
+                        params.layout.filter(function(id) {
                             return (params.specs[id].ui.class === 'output');
                         })
-                        .map(function (id) {
+                        .map(function(id) {
                             return params.specs[id];
                         })),
                     parameterParams = makeParamsLayout(
-                        params.layout.filter(function (id) {
+                        params.layout.filter(function(id) {
                             return (params.specs[id].ui.class === 'parameter');
                         })
-                        .map(function (id) {
+                        .map(function(id) {
                             return params.specs[id];
                         }));
 
@@ -556,19 +466,19 @@ define([
 
 
                 return Promise.resolve()
-                    .then(function () {
+                    .then(function() {
                         if (inputParams.layout.length === 0) {
                             places.inputFields.innerHTML = span({ style: { fontStyle: 'italic' } }, 'This app does not have input objects');
                         } else {
                             places.inputFields.innerHTML = inputParams.content;
-                            return Promise.all(inputParams.layout.map(function (parameterId) {
+                            return Promise.all(inputParams.layout.map(function(parameterId) {
                                 var spec = inputParams.paramMap[parameterId];
                                 try {
                                     return makeFieldWidget(appSpec, spec, model.getItem(['params', spec.id]))
-                                        .then(function (result) {
-                                            widgets.push(result);
+                                        .then(function(widget) {
+                                            widgets.push(widget);
 
-                                            return result.widget.start({
+                                            return widget.start({
                                                 node: document.getElementById(inputParams.view[parameterId].id)
                                             });
                                         });
@@ -582,19 +492,19 @@ define([
                             }));
                         }
                     })
-                    .then(function () {
+                    .then(function() {
                         if (outputParams.layout.length === 0) {
                             places.outputFields.innerHTML = span({ style: { fontStyle: 'italic' } }, 'This app does not create any named output objects');
                         } else {
                             places.outputFields.innerHTML = outputParams.content;
-                            return Promise.all(outputParams.layout.map(function (parameterId) {
+                            return Promise.all(outputParams.layout.map(function(parameterId) {
                                 var spec = outputParams.paramMap[parameterId];
                                 try {
                                     return makeFieldWidget(appSpec, spec, model.getItem(['params', spec.id]))
-                                        .then(function (result) {
-                                            widgets.push(result);
+                                        .then(function(widget) {
+                                            widgets.push(widget);
 
-                                            return result.widget.start({
+                                            return widget.start({
                                                 node: document.getElementById(outputParams.view[parameterId].id)
                                             });
                                         });
@@ -608,20 +518,20 @@ define([
                             }));
                         }
                     })
-                    .then(function () {
+                    .then(function() {
                         if (parameterParams.layout.length === 0) {
                             // TODO: should be own node
                             places.parameterFields.innerHTML = span({ style: { fontStyle: 'italic' } }, 'No parameters for this app');
                         } else {
                             places.parameterFields.innerHTML = parameterParams.content;
-                            return Promise.all(parameterParams.layout.map(function (parameterId) {
+                            return Promise.all(parameterParams.layout.map(function(parameterId) {
                                 var spec = parameterParams.paramMap[parameterId];
                                 try {
                                     return makeFieldWidget(appSpec, spec, model.getItem(['params', spec.id]))
-                                        .then(function (result) {
-                                            widgets.push(result);
+                                        .then(function(widget) {
+                                            widgets.push(widget);
 
-                                            return result.widget.start({
+                                            return widget.start({
                                                 node: document.getElementById(parameterParams.view[spec.id].id)
                                             });
                                         });
@@ -651,7 +561,7 @@ define([
                     //         return widget.widget.run(params);
                     //     }));
                     // })
-                    .then(function () {
+                    .then(function() {
                         renderAdvanced('input-objects');
                         renderAdvanced('parameters');
                     });
@@ -659,12 +569,12 @@ define([
         }
 
         function start() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 // send parent the ready message
                 parentBus.emit('ready');
 
                 // parent will send us our initial parameters
-                parentBus.on('run', function (message) {
+                parentBus.on('run', function(message) {
                     doAttach(message.node);
 
                     model.setItem('appSpec', message.appSpec);
@@ -673,22 +583,22 @@ define([
 
                     // we then create our widgets
                     renderParameters()
-                        .then(function () {
+                        .then(function() {
                             // do something after success
                             attachEvents();
                         })
-                        .catch(function (err) {
+                        .catch(function(err) {
                             // do somethig with the error.
                             console.error('ERROR in start', err);
                         });
                 });
 
-                parentBus.on('parameter-changed', function (message) {
+                parentBus.on('parameter-changed', function(message) {
                     // Also, tell each of our inputs that a param has changed.
                     // TODO: use the new key address and subscription
                     // mechanism to make this more efficient.
-                    inputBusses.forEach(function (bus) {
-                        bus.send(message, {
+                    widgets.forEach(function(widget) {
+                        widget.bus.send(message, {
                             key: {
                                 type: 'parameter-changed',
                                 parameter: message.parameter
@@ -701,7 +611,7 @@ define([
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 // really unhook things here.
             });
         }
@@ -714,14 +624,14 @@ define([
         return {
             start: start,
             stop: stop,
-            bus: function () {
+            bus: function() {
                 return bus;
             }
         };
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };


### PR DESCRIPTION
Supports optional grouped parameters which by default are disabled with a null value and may be enabled, in which case  they are populated with default values.
Still working on improving lists of grouped parameters.

Note that the enable/disable control is still the checkbox, and that when disabled the grouped params are not displayed -- they don't exist. This is consistent at least with the mechanism and model that what you see is what is in the data model holding the params.

The value of a disabled optional grouped parameter (mouthful!) is null (None in the generated code) rather than being missing as we discussed. This is really just easier now given the way the parameters work in the app cell. I think we should treat missing parameter and null value as the same.

This required changes to lists of grouped parameters (no real examples yet, but the example app (search dev apps with "grouped" to see them) exercises them), which work but needs to to resolve internal errors.

Also a little more work is required in order to adjust the defaulting of values across parameter types, or at least in the special case of the grouped parameters for now. There is the concept of "default value", in which a given parameter has a value derived from its own specified default value, and in the case of a grouped parameter, the default values of sub fields. But for optional parameters, the initial default value is null (this is one reason to use the null value for a disabled parameter rather than just removing it), but when it is enabled it should have the normal default value.  

Also in progress is the propagation of the enabled/disable state in the app cell. At present it is not preserved  when the cell is saved and re-opened. In theory it IS preserved in that the parameter, if having a non-null value, signals that it is enabled, this just does not feed back to the enabled/disabled display of the control yet.
