### PR TITLE
Relaxed failures on widgetmanager, added to staging tour

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -241,7 +241,7 @@ define([
 
         startTour: function() {
             if (!this.tour) {
-                this.tour = new UploadTour.Tour(this);
+                this.tour = new UploadTour.Tour(this.$elem);
             }
             this.tour.start();
         }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/uploadTour.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/uploadTour.js
@@ -10,10 +10,10 @@ define([
 ], function($, Tour, Handlebars, TourTmpl) {
     "use strict";
 
-    var UploadTour = function (narrative, notebook, events) {
+    var UploadTour = function ($elem, notebook, events) {
         var that = this;
+        this.$elem = $elem;
         this.notebook = notebook;
-        this.narrative = narrative;
         this.step_duration = 0;
         this.events = events;
         this.template = Handlebars.compile(TourTmpl);
@@ -24,6 +24,12 @@ define([
                 orphan: true,
                 content: 'This tour will show how to use the Staging panel to upload and manage data files, as well as how to import those into your Narrative as KBase data objects.',
                 backdrop: true
+            },
+            {
+                title: "Upload area",
+                placement: "bottom",
+                element: that.$elem.find('.kb-dropzone'),
+                content: 'Upload area!'
             },
             // {
             //     element: "#notebook_name",

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -280,7 +280,7 @@ class WidgetManager(object):
                     constants[p] = params[p]["allowed_values"][0]
         return constants
 
-    def show_output_widget(self, widget_name, params, tag="release", title="", type="method", cell_id=None, check_widget=True, **kwargs):
+    def show_output_widget(self, widget_name, params, tag="release", title="", type="method", cell_id=None, check_widget=False, **kwargs):
         """
         Renders a widget using the generic kbaseNarrativeOutputWidget container.
 
@@ -355,7 +355,7 @@ class WidgetManager(object):
         input_data['info_tuple'] = info_tuple
 
         bare_type = info_tuple[2].split('-')[0]
-        
+
         type_spec = self._sm.get_type_spec(bare_type, raise_exception=False)
         if type_spec is None:
             input_data['error_message'] = "Type-spec wasn't found for '" + bare_type + "'"
@@ -367,7 +367,7 @@ class WidgetManager(object):
             method_id = type_spec['view_method_ids'][0]
             spec = self._sm.get_spec(method_id, tag=tag)
             input_data['app_spec'] = spec
-            
+
             # Let's build output according to mappings in method-spec
             spec_params = self._sm.app_params(spec)
             input_params = {}
@@ -379,12 +379,12 @@ class WidgetManager(object):
             for param in spec_params:
                 if any(t == bare_type for t in param['allowed_types']):
                     input_params[param['id']] = obj_param_value
-    
+
             (input_params, ws_refs) = validate_parameters(method_id, tag,
                                                           spec_params, input_params)
             (output_widget, output) = map_outputs_from_state([], input_params, spec)
             input_data['output'] = output
-        
+
         input_template = """
         element.html("<div id='{{input_id}}' class='kb-vis-area'></div>");
 


### PR DESCRIPTION
When instantiating a widget, by default, the widgetmanager will check to see if that widget is referenced in any of the method specs. This is done to guess that it exists and is spelled correctly, etc. It's a little hand-wavey, and put there in lieu of having an actual widget registry solution.

But it's causing problems. This PR changes the default behavior to NOT check for widget existence, and just let the output cell catch the failure and display an error instead of the code cell stacktrace.

Also has a few little additions to the tour for the staging area (still incomplete... but that panel's hidden anyway).