### PR TITLE
Taxonomy ref control

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
         "jquery.tipsy": "*",
         "kbase-common-js": "1.9.0",
         "kbase-service-clients-js": "3.0.0",
-        "kbase-sdk-clients-js": "0.4.1",
+        "kbase-sdk-clients-js": "0.5.0",
         "numeral": "~1.5.0",
         "plotly.js": "git://github.com/plotly/plotly.js/#1.5.1",
         "pure-uuid": "1.4.2",

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/taxonomyRefInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/taxonomyRefInput.js
@@ -1,0 +1,428 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'kb_common/html',
+    'kb_common/utils',
+    'kb_service/client/workspace',
+    'kb_service/utils',
+    'common/validation',
+    'common/events',
+    'common/runtime',
+    'common/ui',
+    'common/data',
+    'util/timeFormat',
+    'kb_sdk_clients/genericClient',
+
+    'select2',
+    'bootstrap',
+    'css!font-awesome'
+], function(
+    Promise,
+    $,
+    html,
+    utils,
+    Workspace,
+    serviceUtils,
+    Validation,
+    Events,
+    Runtime,
+    UI,
+    Data,
+    TimeFormat,
+    GenericClient) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'),
+        select = t('select'),
+        option = t('option');
+
+    function factory(config) {
+        var spec = config.parameterSpec,
+            parent,
+            container,
+            runtime = Runtime.make(),
+            bus = runtime.bus().connect(),
+            channel = bus.channel(config.channelName),
+            ui,
+            model = {
+                value: undefined
+            },
+            eventListeners = [];
+
+        function makeInputControl() {
+            var selectOptions;
+            var selectElem = select({
+                class: 'form-control',
+                dataElement: 'input'
+            }, [option({ value: '' }, '')].concat(selectOptions));
+
+            return selectElem;
+        }
+
+        // CONTROL
+
+        function getControlValue() {
+            var control = ui.getElement('input-container.input'),
+                selected = control.selectedOptions;
+            // if (selected.length === 0) {
+            //     return;
+            // }
+            // we are modeling a single string value, so we always just get the
+            // first selected element, which is all there should be!
+            // return selected.item(0).value;
+            return $(control).val();
+        }
+
+        function setControlValue(value) {
+            // console.log('setting control value', value);
+            var stringValue;
+            if (value === null) {
+                stringValue = '';
+            } else {
+                stringValue = value;
+            }
+
+            var control = ui.getElement('input-container.input');
+
+            // NB id used as String since we are comparing it below to the actual dom
+            // element id
+            // var currentSelectionId = String(model.availableValuesMap[stringValue]);
+
+            $(control).val(value).trigger('change.select2');
+        }
+
+        // MODEL
+
+        function setModelValue(value) {
+            if (model.value === undefined) {
+                return;
+            }
+            if (model.value !== value) {
+                model.value = value;
+            }
+        }
+
+        function resetModelValue() {
+            setModelValue(spec.data.defaultValue);
+        }
+
+        function getModelValue() {
+            return model.value;
+        }
+
+        // VALIDATION
+
+        function validate() {
+            return Promise.try(function() {
+                var value = getControlValue();
+
+                // console.log('value', value);
+
+                return {
+                    isValid: true,
+                    validated: true,
+                    diagnosis: 'valid',
+                    errorMessage: null,
+                    value: value,
+                    parsedValue: value
+                };
+            });
+        }
+
+        function doChange() {
+            validate()
+                .then(function(result) {
+                    // console.log('validated??', result);
+                    if (result.isValid) {
+                        model.value = result.parsedValue;
+                        channel.emit('changed', {
+                            newValue: result.parsedValue
+                        });
+                    } else if (result.diagnosis === 'required-missing') {
+                        model.value = spec.data.nullValue;
+                        channel.emit('changed', {
+                            newValue: spec.data.nullValue
+                        });
+                    }
+                    channel.emit('validation', {
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        function doTemplateResult(item) {
+            // console.log('template', item);
+            if (!item.id) {
+                return $(div({
+                    style: {
+                        display: 'block',
+                        height: '20px'
+                    }
+                }, item.label || ''));
+            }
+            return $(div({
+                style: {
+                    display: 'block'
+                }
+            }, item.label));
+        }
+
+        function doTemplateSelection(item) {
+            return $(div({
+                style: {
+                    display: 'block'
+                }
+            }, item.label));
+        }
+
+        var totalItems;
+        var currentPage;
+        var currentStartItem;
+        var pageSize = 10;
+
+        function doTaxonomySearch(data) {
+            var term = data.q;
+            var page = data.page;
+            var startItem;
+            if (page) {
+                startItem = pageSize * (page - 1);
+            } else {
+                startItem = 0;
+            }
+
+            // globals
+            currentPage = page;
+            currentStartItem = startItem;
+            var start = new Date().getTime();
+
+            var taxonClient = new GenericClient({
+                url: runtime.config('services.service_wizard.url'),
+                module: 'taxonomy_service',
+                // version: 'dev',
+                token: Runtime.make().authToken()
+            });
+            return taxonClient.callFunc('search_taxonomy', [{
+                    private: 0,
+                    public: 1,
+                    search: term,
+                    limit: pageSize,
+                    start: startItem
+                }])
+                .then(function(result) {
+                    var elapsed = new Date().getTime() - start;
+                    console.log('Loaded data ' + result[0].hits.length + ' items of ' + result[0].num_of_hits + ' in ' + elapsed + 'ms');
+                    totalItems = result[0].num_of_hits;
+                    return result[0];
+                })
+        }
+
+        function getTaxonomyItem(taxonObject) {
+            // console.log('get taxonomy', taxonObject);
+            var ref = taxonObject,
+                taxonClient = new GenericClient({
+                    url: runtime.config('services.service_wizard.url'),
+                    module: 'TaxonAPI',
+                    // version: 'dev',
+                    token: Runtime.make().authToken()
+                });
+            return taxonClient.callFunc('get_scientific_name', [ref])
+                .then(function(result) {
+                    if (result.length === 0) {
+                        throw new Error('Cannot find taxon: ' + ref);
+                    }
+                    if (result.length > 1) {
+                        throw new Error('Too many taxa found for ' + ref);
+                    }
+                    // simulate the result from the taxonomy service
+                    return [{
+                        id: taxonObject,
+                        label: result[0]
+                    }];
+                })
+        }
+
+        function render() {
+            return Promise.try(function() {
+                var events = Events.make(),
+                    inputControl = makeInputControl(events),
+                    content = div({ class: 'input-group', style: { width: '100%' } }, inputControl);
+
+                ui.setContent('input-container', content);
+
+                $(ui.getElement('input-container.input')).select2({
+                    templateResult: doTemplateResult,
+                    templateSelection: doTemplateSelection,
+                    minimumInputLength: 2,
+                    escapeMarkup: function(markup) {
+                        return markup;
+                    },
+                    initSelection: function(element, callback) {
+                        var currentValue = model.value;
+                        if (!currentValue) {
+                            return;
+                        }
+                        getTaxonomyItem(currentValue)
+                            .then(function(taxon) {
+                                // console.log('TAXON', taxon);
+                                callback(taxon);
+                            });
+                    },
+                    formatMoreResults: function(page) {
+                        return "more???";
+                    },
+                    language: {
+                        loadingMore: function(arg) {
+                            // console.log('ARG', arg);
+                            return html.loading('Loading more scientific names');
+                        }
+                    },
+                    ajax: {
+                        service: 'myservice',
+                        dataType: 'json',
+                        delay: 500,
+                        data: function(params) {
+                            return {
+                                q: params.term,
+                                page: params.page
+                            };
+                        },
+                        processResults: function(data, params) {
+                            // console.log('processing', data, params);
+                            params.page = params.page || 1;
+                            return {
+                                results: data.hits,
+                                pagination: {
+                                    more: (params.page * pageSize) < data.num_of_hits
+                                }
+                            }
+                        },
+                        transport: function(options, success, failure) {
+
+                            var status = null;
+
+                            doTaxonomySearch(options.data)
+                                .then(function(results) {
+                                    success(results);
+                                })
+                                .catch(function(err) {
+                                    status = 'error';
+                                    failure();
+                                });
+                            // console.log('transport got ', options);
+
+                            return {
+                                status: status
+                            };
+                        }
+                    }
+                }).on('change', function() {
+                    doChange();
+                });
+                events.attachEvents(container);
+
+            });
+        }
+
+        /*
+         * In the layout we set up an environment in which one or more parameter
+         * rows may be inserted.
+         * For the objectInput, there is only ever one control.
+         */
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({ dataElement: 'input-container' })
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        function autoValidate() {
+            return validate()
+                .then(function(result) {
+                    channel.emit('validation', {
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        // function syncModelToControl() {
+        //     if (!model.value) {
+        //         // set empty control...
+        //     }
+
+        // }
+
+        // LIFECYCLE API
+        function start(arg) {
+            return Promise.try(function() {
+                parent = arg.node;
+                container = parent.appendChild(document.createElement('div'));
+                ui = UI.make({ node: container });
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+
+                if (config.initialValue !== undefined) {
+                    model.value = config.initialValue;
+                }
+
+                render()
+                    .then(function() {
+
+                        channel.on('reset-to-defaults', function() {
+                            resetModelValue();
+                        });
+                        channel.on('update', function(message) {
+                            setModelValue(message.value);
+                        });
+                        // bus.channel().on('workspace-changed', function() {
+                        //     doWorkspaceChanged();
+                        // });
+                        // bus.emit('sync');
+
+                        setControlValue(getModelValue());
+                        autoValidate();
+                    });
+            });
+        }
+
+        function stop() {
+            return Promise.try(function() {
+                if (container) {
+                    parent.removeChild(container);
+                }
+                bus.stop();
+                eventListeners.forEach(function(id) {
+                    runtime.bus().removeListener(id);
+                });
+            });
+        }
+
+        // INIT
+
+
+        return {
+            start: start,
+            stop: stop
+        };
+    }
+
+    return {
+        make: function(config) {
+            return factory(config);
+        }
+    };
+});

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/taxonomyRefWithParentInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/taxonomyRefWithParentInput.js
@@ -1,0 +1,428 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+define([
+    'bluebird',
+    'jquery',
+    'kb_common/html',
+    'kb_common/utils',
+    'kb_service/client/workspace',
+    'kb_service/utils',
+    'common/validation',
+    'common/events',
+    'common/runtime',
+    'common/ui',
+    'common/data',
+    'util/timeFormat',
+    'kb_sdk_clients/genericClient',
+
+    'select2',
+    'bootstrap',
+    'css!font-awesome'
+], function(
+    Promise,
+    $,
+    html,
+    utils,
+    Workspace,
+    serviceUtils,
+    Validation,
+    Events,
+    Runtime,
+    UI,
+    Data,
+    TimeFormat,
+    GenericClient) {
+    'use strict';
+
+    // Constants
+    var t = html.tag,
+        div = t('div'),
+        select = t('select'),
+        option = t('option');
+
+    function factory(config) {
+        var spec = config.parameterSpec,
+            parent,
+            container,
+            runtime = Runtime.make(),
+            bus = runtime.bus().connect(),
+            channel = bus.channel(config.channelName),
+            ui,
+            model = {
+                value: undefined
+            },
+            eventListeners = [];
+
+        function makeInputControl() {
+            var selectOptions;
+            var selectElem = select({
+                class: 'form-control',
+                dataElement: 'input'
+            }, [option({ value: '' }, '')].concat(selectOptions));
+
+            return selectElem;
+        }
+
+        // CONTROL
+
+        function getControlValue() {
+            var control = ui.getElement('input-container.input'),
+                selected = control.selectedOptions;
+            // if (selected.length === 0) {
+            //     return;
+            // }
+            // we are modeling a single string value, so we always just get the
+            // first selected element, which is all there should be!
+            // return selected.item(0).value;
+            return $(control).val();
+        }
+
+        function setControlValue(value) {
+            // console.log('setting control value', value);
+            var stringValue;
+            if (value === null) {
+                stringValue = '';
+            } else {
+                stringValue = value;
+            }
+
+            var control = ui.getElement('input-container.input');
+
+            // NB id used as String since we are comparing it below to the actual dom
+            // element id
+            // var currentSelectionId = String(model.availableValuesMap[stringValue]);
+
+            $(control).val(value).trigger('change.select2');
+        }
+
+        // MODEL
+
+        function setModelValue(value) {
+            if (model.value === undefined) {
+                return;
+            }
+            if (model.value !== value) {
+                model.value = value;
+            }
+        }
+
+        function resetModelValue() {
+            setModelValue(spec.data.defaultValue);
+        }
+
+        function getModelValue() {
+            return model.value;
+        }
+
+        // VALIDATION
+
+        function validate() {
+            return Promise.try(function() {
+                var value = getControlValue();
+
+                // console.log('value', value);
+
+                return {
+                    isValid: true,
+                    validated: true,
+                    diagnosis: 'valid',
+                    errorMessage: null,
+                    value: value,
+                    parsedValue: value
+                };
+            });
+        }
+
+        function doChange() {
+            validate()
+                .then(function(result) {
+                    // console.log('validated??', result);
+                    if (result.isValid) {
+                        model.value = result.parsedValue;
+                        channel.emit('changed', {
+                            newValue: result.parsedValue
+                        });
+                    } else if (result.diagnosis === 'required-missing') {
+                        model.value = spec.data.nullValue;
+                        channel.emit('changed', {
+                            newValue: spec.data.nullValue
+                        });
+                    }
+                    channel.emit('validation', {
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        function doTemplateResult(item) {
+            // console.log('template', item);
+            if (!item.id) {
+                return $(div({
+                    style: {
+                        display: 'block',
+                        height: '20px'
+                    }
+                }, item.label || ''));
+            }
+            return $(div({
+                style: {
+                    display: 'block'
+                }
+            }, item.label));
+        }
+
+        function doTemplateSelection(item) {
+            return $(div({
+                style: {
+                    display: 'block'
+                }
+            }, item.label));
+        }
+
+        var totalItems;
+        var currentPage;
+        var currentStartItem;
+        var pageSize = 10;
+
+        function doTaxonomySearch(data) {
+            var term = data.q;
+            var page = data.page;
+            var startItem;
+            if (page) {
+                startItem = pageSize * (page - 1);
+            } else {
+                startItem = 0;
+            }
+
+            // globals
+            currentPage = page;
+            currentStartItem = startItem;
+            var start = new Date().getTime();
+
+            var taxonClient = new GenericClient({
+                url: runtime.config('services.service_wizard.url'),
+                module: 'taxonomy_service',
+                // version: 'dev',
+                token: Runtime.make().authToken()
+            });
+            return taxonClient.callFunc('search_taxonomy', [{
+                    private: 0,
+                    public: 1,
+                    search: term,
+                    limit: pageSize,
+                    start: startItem
+                }])
+                .then(function(result) {
+                    var elapsed = new Date().getTime() - start;
+                    console.log('Loaded data ' + result[0].hits.length + ' items of ' + result[0].num_of_hits + ' in ' + elapsed + 'ms');
+                    totalItems = result[0].num_of_hits;
+                    return result[0];
+                })
+        }
+
+        function getTaxonomyItem(taxonObject) {
+            // console.log('get taxonomy', taxonObject);
+            var ref = taxonObject,
+                taxonClient = new GenericClient({
+                    url: runtime.config('services.service_wizard.url'),
+                    module: 'TaxonAPI',
+                    // version: 'dev',
+                    token: Runtime.make().authToken()
+                });
+            return taxonClient.callFunc('get_scientific_name', [ref])
+                .then(function(result) {
+                    if (result.length === 0) {
+                        throw new Error('Cannot find taxon: ' + ref);
+                    }
+                    if (result.length > 1) {
+                        throw new Error('Too many taxa found for ' + ref);
+                    }
+                    // simulate the result from the taxonomy service
+                    return [{
+                        id: taxonObject,
+                        label: result[0]
+                    }];
+                });
+        }
+
+        function render() {
+            return Promise.try(function() {
+                var events = Events.make(),
+                    inputControl = makeInputControl(events),
+                    content = div({ class: 'input-group', style: { width: '100%' } }, inputControl);
+
+                ui.setContent('input-container', content);
+
+                $(ui.getElement('input-container.input')).select2({
+                    templateResult: doTemplateResult,
+                    templateSelection: doTemplateSelection,
+                    minimumInputLength: 2,
+                    escapeMarkup: function(markup) {
+                        return markup;
+                    },
+                    initSelection: function(element, callback) {
+                        var currentValue = model.value;
+                        if (!currentValue) {
+                            return;
+                        }
+                        getTaxonomyItem(currentValue)
+                            .then(function(taxon) {
+                                // console.log('TAXON', taxon);
+                                callback(taxon);
+                            });
+                    },
+                    formatMoreResults: function(page) {
+                        return "more???";
+                    },
+                    language: {
+                        loadingMore: function(arg) {
+                            // console.log('ARG', arg);
+                            return html.loading('Loading more scientific names');
+                        }
+                    },
+                    ajax: {
+                        service: 'myservice',
+                        dataType: 'json',
+                        delay: 500,
+                        data: function(params) {
+                            return {
+                                q: params.term,
+                                page: params.page
+                            };
+                        },
+                        processResults: function(data, params) {
+                            // console.log('processing', data, params);
+                            params.page = params.page || 1;
+                            return {
+                                results: data.hits,
+                                pagination: {
+                                    more: (params.page * pageSize) < data.num_of_hits
+                                }
+                            }
+                        },
+                        transport: function(options, success, failure) {
+
+                            var status = null;
+
+                            doTaxonomySearch(options.data)
+                                .then(function(results) {
+                                    success(results);
+                                })
+                                .catch(function(err) {
+                                    status = 'error';
+                                    failure();
+                                });
+                            // console.log('transport got ', options);
+
+                            return {
+                                status: status
+                            };
+                        }
+                    }
+                }).on('change', function() {
+                    doChange();
+                });
+                events.attachEvents(container);
+
+            });
+        }
+
+        /*
+         * In the layout we set up an environment in which one or more parameter
+         * rows may be inserted.
+         * For the objectInput, there is only ever one control.
+         */
+        function layout(events) {
+            var content = div({
+                dataElement: 'main-panel'
+            }, [
+                div({ dataElement: 'input-container' })
+            ]);
+            return {
+                content: content,
+                events: events
+            };
+        }
+
+        function autoValidate() {
+            return validate()
+                .then(function(result) {
+                    channel.emit('validation', {
+                        errorMessage: result.errorMessage,
+                        diagnosis: result.diagnosis
+                    });
+                });
+        }
+
+        // function syncModelToControl() {
+        //     if (!model.value) {
+        //         // set empty control...
+        //     }
+
+        // }
+
+        // LIFECYCLE API
+        function start(arg) {
+            return Promise.try(function() {
+                parent = arg.node;
+                container = parent.appendChild(document.createElement('div'));
+                ui = UI.make({ node: container });
+
+                var events = Events.make(),
+                    theLayout = layout(events);
+
+                container.innerHTML = theLayout.content;
+                events.attachEvents(container);
+
+                if (config.initialValue !== undefined) {
+                    model.value = config.initialValue;
+                }
+
+                render()
+                    .then(function() {
+
+                        channel.on('reset-to-defaults', function() {
+                            resetModelValue();
+                        });
+                        channel.on('update', function(message) {
+                            setModelValue(message.value);
+                        });
+                        // bus.channel().on('workspace-changed', function() {
+                        //     doWorkspaceChanged();
+                        // });
+                        // bus.emit('sync');
+
+                        setControlValue(getModelValue());
+                        autoValidate();
+                    });
+            });
+        }
+
+        function stop() {
+            return Promise.try(function() {
+                if (container) {
+                    parent.removeChild(container);
+                }
+                bus.stop();
+                eventListeners.forEach(function(id) {
+                    runtime.bus().removeListener(id);
+                });
+            });
+        }
+
+        // INIT
+
+
+        return {
+            start: start,
+            stop: stop
+        };
+    }
+
+    return {
+        make: function(config) {
+            return factory(config);
+        }
+    };
+});

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/paramResolver.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/paramResolver.js
@@ -38,17 +38,10 @@ define([
                             };
                         case 'autocomplete':
                             // TODO: refactor this from the sdk on up.
-                            if (spec.data.defaultValue === 'Klebsiella oxytoca janaka') {
-                                return {
-                                    input: 'taxonomyRefWithParentInput',
-                                    view: 'autocompleteView'
-                                };
-                            } else {
-                                return {
-                                    input: 'taxonomyRefInput',
-                                    view: 'autocompleteView'
-                                };
-                            }
+                            return {
+                                input: 'taxonomyRefInput',
+                                view: 'taxonomyRefView'
+                            };
                         case 'text':
                         default:
                             // A string type is normally entered as a 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/paramResolver.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/paramResolver.js
@@ -37,10 +37,18 @@ define([
                                 view: 'customSubdataView'
                             };
                         case 'autocomplete':
-                            return {
-                                input: 'autocompleteInput',
-                                view: 'autocompleteView'
-                            };
+                            // TODO: refactor this from the sdk on up.
+                            if (spec.data.defaultValue === 'Klebsiella oxytoca janaka') {
+                                return {
+                                    input: 'taxonomyRefWithParentInput',
+                                    view: 'autocompleteView'
+                                };
+                            } else {
+                                return {
+                                    input: 'taxonomyRefInput',
+                                    view: 'autocompleteView'
+                                };
+                            }
                         case 'text':
                         default:
                             // A string type is normally entered as a 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/taxonomyRefView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/taxonomyRefView.js
@@ -243,7 +243,7 @@ define([
                         id: taxonObject,
                         label: result[0]
                     }];
-                });
+                })
         }
 
         function render() {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -499,7 +499,7 @@ define([
                     case 'editor':
                         return 'editor';
                     default:
-                        throw new Error('This app does not specify spec.info.app_type');
+                        throw new Error('This app does not specify a valid spec.info.app_type: ' + spec.info.app_type);
                 }
             }
 

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -25,7 +25,7 @@ require.config({
         tipsy: 'ext_components/jquery.tipsy/js/jquery.tipsy',
         typeahead: 'ext_components/corejs-typeahead/dist/typeahead.jquery.min',
         underscore: 'ext_components/underscore/underscore-min',
-        select2: 'ext_components/select2/dist/js/select2.full.min', //kbase/js/patched-components/select2/select2',
+        select2: 'ext_components/select2/dist/js/select2.full', //kbase/js/patched-components/select2/select2',
         uuid: 'ext_components/pure-uuid/uuid',
         'font-awesome': 'ext_components/font-awesome/css/font-awesome',
 

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -25,7 +25,7 @@ require.config({
         tipsy: 'ext_components/jquery.tipsy/js/jquery.tipsy',
         typeahead: 'ext_components/corejs-typeahead/dist/typeahead.jquery.min',
         underscore: 'ext_components/underscore/underscore-min',
-        select2: 'ext_components/select2/dist/js/select2.full', //kbase/js/patched-components/select2/select2',
+        select2: 'ext_components/select2/dist/js/select2.full.min', //kbase/js/patched-components/select2/select2',
         uuid: 'ext_components/pure-uuid/uuid',
         'font-awesome': 'ext_components/font-awesome/css/font-awesome',
 


### PR DESCRIPTION
Changes to autocomplete input to make it work
But then abandoned that in order to use select2, since that is the current use case
That control is taxonomyRefInput
There still is a use-case for autocomplete for scientific name, so it is still in the code-base, but there isn't anything to use it now
More work is needed in the taxonomy_service module, e.g. the field_type should not be autocomplete, but taxonomyRef (at least that is my suggestion).
This should be considered unstable, experimental work, in that it currently works with the state of the taxonomy_service, which defines the only apps using it, but both taxonomy_service and the control implementation will need to change.