### PR TITLE
Fix checkboxes in sequence not deleting

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
@@ -182,11 +182,14 @@ define([
         }
 
         function stop() {
-            if (container) {
-                parent.removeChild(container);
-            }
-            busConnection.stop();
+            return Promise.try(function() {
+                if (container) {
+                    parent.removeChild(container);
+                }
+                busConnection.stop();
+            });
         }
+
 
         // INIT
 


### PR DESCRIPTION
The stop method was not returning a promise, so it broke when removing a checkbox control from a sequence.