### PR TITLE
Add metadata support for editor and view cells

### DIFF
--- a/src/biokbase/narrative/contents/narrativeio.py
+++ b/src/biokbase/narrative/contents/narrativeio.py
@@ -339,6 +339,18 @@ class KBaseWSManagerMixin(object):
                     commit_hash = app.get('gitCommitHash', 'unknown')
                     method_info[u'method.' + id + '/' + commit_hash] += 1
                     num_methods += 1
+                elif kbase_type == 'editor':
+                    app = meta['kbase'].get('editorCell', {}).get('app', {})
+                    id = app.get('id', 'UnknownApp')
+                    commit_hash = app.get('gitCommitHash', 'unknown')
+                    method_info[u'method.' + id + '/' + commit_hash] += 1
+                    num_methods += 1                    
+                elif kbase_type == 'view':
+                    app = meta['kbase'].get('viewCell', {}).get('app', {})
+                    id = app.get('id', 'UnknownApp')
+                    commit_hash = app.get('gitCommitHash', 'unknown')
+                    method_info[u'method.' + id + '/' + commit_hash] += 1
+                    num_methods += 1                    
             else:
                 cell_info['jupyter.' + cell.get('cell_type', 'code')] += 1
 


### PR DESCRIPTION
These cell types were not being added to the notebook metadata stats upon narrative save, this fix simply replicates the code to do this using the same "method." property prefix. This treats all app cell types as the same, which reflects the way they are treated in the narrative