### PR TITLE
Return a default type of "app" for missing app_type fields.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ __Changes__
 - Release of support for data palettes (currently disabled in the service)
 - Data now gets fetched from a Narrative Service to support data palettes.
 - Support for an FTP-based data file staging area (currently disabled until import apps catch up).
+- Fixed issue where an undefined app_type field would cause a crash while instantiating an app cell.
 
 ### Version 3.1.0-alpha-4
 __Changes__

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -483,26 +483,22 @@ define([
         */
         determineMethodCellType: function(spec) {
 
-            // TODO: remove this switch when merging in grouped paramters and
-            // legacy parameters.
-            //if (spec.parameter_groups && spec.parameter_groups.length > 0) {
-            //   return 'app2';
-            //}
-
             // An app will execute via the method described in the behavior. If
             // such a method is not described, it is by definition not an
             // executing app.
             if (spec.behavior.kb_service_name && spec.behavior.kb_service_method) {
                 switch (spec.info.app_type) {
-                    case 'app':
-                        return 'app';
                     case 'editor':
                         return 'editor';
+                    case 'app':
+                        return 'app';
                     default:
-                        throw new Error('This app does not specify a valid spec.info.app_type: ' + spec.info.app_type);
+                        console.warn('The app ' + spec.info.id + ' does not specifcy a valid spec.info.app_type - defaulting to "app"');
+                        return 'app';
                 }
             }
 
+            // No specified execution behavior = a viewer.
             return 'view';
         },
 


### PR DESCRIPTION
App specs should now have a field called "info.app_type", as maintained in the NMS. Those that don't should try to infer what the app type is based on the presence of a few keys.

**Long version** = there are 3 possible app types - editor, viewer, and app. "Viewers" don't have their execution behavior defined in the spec (that's all managed by their widget) and are easy to infer. "Editors" are expected to be explicitly called out by the app_type field, since the cell change is mainly one of usability and how the code is executed. "Apps" are, well, all the rest of the apps.

Currently, in production, there are no Editors (e.g. the Reads Set Editor in CI), so defaulting to App won't break anything. This just means that before registering Editor apps in prod/appdev, we need to update NMS and Narrative. Once NMS is updated to generate that key on app registration, it will all work itself out.

**Short version** = If no app_type key is found, and the spec defines how code is run, it's treated as an app cell.