### PR TITLE
[WIP] Some UI fixes and tweaks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,13 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.1.2
+__Changes__
+- Do an autosave after starting an import job.
+- Hide the code area for the 'Job Status' widget, whenever that widget gets instantiated.
+- Remove 'Object Details...' button from data viewers (it's just hidden for now).
+- In the App Cell Report tab, remove 'Summary' or 'Report' areas if either of those are missing.
+
 ### Version 3.1.1
 __Changes__
 - Optimized how job status polling works.

--- a/kbase-extension/static/kbase/config/feature-config.json
+++ b/kbase-extension/static/kbase/config/feature-config.json
@@ -1,5 +1,5 @@
 {
-    "stagingDataViewer": false,
+    "stagingDataViewer": true,
     "advanced": false,
     "developer": false
 }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
@@ -71,7 +71,7 @@ define (
             this.ip_cell = options.cell;
 
             this.metadataInit();
-            
+
             this.render(options.info);
 
             return this;
@@ -99,14 +99,14 @@ define (
             var type_spec = this.options.type_spec;
             var app_spec = this.options.app_spec;
             var output = this.options.output;
-            
+
             var onViewerCreated = function (widget) {
                 widgetTitleElem.empty()
                 .append(widget.title)
                 .append('&nbsp;<a href="' + self.shortMarkdownDesc(self.obj_info,
                     self.options.lp_url) + '" target="_blank">' + self.obj_info.name + '</a>');
 
-                self.metadataRender(self.$elem);
+                // self.metadataRender(self.$elem);
                 self.$elem.append(widget.widget);
                 self.$elem.closest('.cell').trigger('set-title', [self.obj_info.name]);
             };
@@ -134,14 +134,14 @@ define (
 //-------------------------------------------------------------------------------------
 
         /**
-         * Higher-level interface to relevant workspace functions for 
+         * Higher-level interface to relevant workspace functions for
          * a given single object.
          */
         WorkspaceObject: function(wsclient, obj_spec) {
             var ws = wsclient, spec = obj_spec, self = this, i=0;
             // Get info for every version of this object
             ws.list_objects({ids: [spec.wsid], minObjectID: spec.objid,
-                                    maxObjectID: spec.objid, showAllVersions: 1})                    
+                                    maxObjectID: spec.objid, showAllVersions: 1})
                 .then(function(objlist) {
                     var info = {};
                     for (i=0; i < objlist.length; i++) {
@@ -149,7 +149,7 @@ define (
                         info[o[4]] = {objid: o[0], name: o[1], type: o[2],
                             save_date: o[3], version: o[4], saved_by: o[5],
                             wsid: o[6], workspace: o[7], chsum: o[8],
-                            size: o[9], meta: o[10], 
+                            size: o[9], meta: o[10],
                             id: o[0], ws_id: o[6] /* aliases */ };
                     }
                     return info;
@@ -165,20 +165,20 @@ define (
                 object_versions: function() {
                     return _.keys(self.metadata_info);
                 },
-                
+
                 /**
                  * The 'object_info' thing for a single object.
                  */
                 info_for_version: function(ver) {
                     return self.metadata_info[ver];
                 },
-                
+
                 /**
                  * References from/to the object.
                  */
                 references: function(ver) {
                     var result = {from: [], to: []};
-                    
+
                     var references_to = function(result) {
                         var subset_spec = {objid: spec.objid, wsid: spec.wsid,
                                            included: ['/refs'], 'ver': ver};
@@ -188,7 +188,7 @@ define (
                             return result;
                         });
                     },
-                        
+
                     references_from = function(result) {
                         return ws.list_referencing_objects([spec]).then(function(rfrom) {
                             console.debug('@@ references-from, got data:', rfrom);
@@ -198,13 +198,13 @@ define (
                             return result;
                         });
                     };
-                    
+
                     // chain the promises
                     return references_to(result).then(references_from);
                 }
             }
         },
-        
+
         /**
          * Initialize instance vars for metadata display.
          */
@@ -221,8 +221,8 @@ define (
             this.node_class = 'kb-data-obj-panel-gnode';
             return this;
         },
-        
-        
+
+
         /**
          * Panel to show object metadata and versions.
          *
@@ -231,7 +231,7 @@ define (
          */
         metadataRender: function ($elem) {
             var self = this, fade_ms = 400;
-        
+
             console.info('@@ create metadata panel - start');
             try {
                 var $meta_button = $('<button>')
@@ -247,7 +247,7 @@ define (
                     .click(function(event) {
                         $(this).parent().fadeOut(fade_ms);
                         $meta_button.show();
-                    });                     
+                    });
                 var $meta_panel = $('<div>')
                         .addClass('row kb-data-obj-panel')
                         .append(
@@ -276,7 +276,7 @@ define (
             console.info('@@ create metadata panel - end:', $meta_panel);
             return this;
         },
-        
+
         showMetadata: function($elem) {
             var success = true;
             var self = this;
@@ -290,9 +290,9 @@ define (
                 $info.html("<dl>" +
                            "<dt>Version</dt><dd>" +
                               "<span class='" + this.verlist_class + "'></span></dd>" +
-                           "<dt>Name</dt><dd>" + this.obj_info.name + "</dd>" + 
+                           "<dt>Name</dt><dd>" + this.obj_info.name + "</dd>" +
                            "<dt>ID</dt><dd>" + objref + "</dd>" +
-                           "<dt>Type</dt><dd>" + this.obj_info.type + "</dd>" + 
+                           "<dt>Type</dt><dd>" + this.obj_info.type + "</dd>" +
                            "<dt>Saved</dt><dd>" + this.obj_info.save_date + "</dd>" +
                            "<dt>Saved by</dt><dd>" + this.obj_info.saved_by + "</dd>" +
                            "<dt>Size</dt><dd>" + this.humanSize(this.obj_info.size, false) + "</dd>" +
@@ -302,7 +302,7 @@ define (
                 var $version_list = $info.find('.' + this.verlist_class);
                 // Generate version list
                 var version_list = this.wsobj.object_versions();
-                self.obj_maxver = _.max(version_list); 
+                self.obj_maxver = _.max(version_list);
                 for(var i=1; i <= self.obj_maxver; i++) {
                     var $ver_span = $('<span>');
                     $ver_span.text(i);
@@ -312,7 +312,7 @@ define (
                         var v = self.metadata_ver_cur = 1 * $(event.target).text();
                         self.obj_info = self.metadata_info[v];
                         // Re-display
-                        self.showMetadata($elem);                      
+                        self.showMetadata($elem);
                     });
                 }
                 // Select currently viewed version in the list
@@ -326,7 +326,7 @@ define (
                 var $g_rto = $("<div class='kb-data-obj-graph-ref-to'>")
                     .append('<table><thead><tr><th>Objects Referenced</th></tr></thead><tbody>');
                 // fetch refs
-                this.wsobj.references().then(function(refs) { 
+                this.wsobj.references().then(function(refs) {
                     _.each(refs.from, function(r) {
                         $g_rfrom.find('tbody').append($('<tr>').append($('<td>').text(r)));
                     });
@@ -342,14 +342,14 @@ define (
             catch (ex) {
                 console.error('Failed to populate metadata:', ex);
                 success = false;
-            }            
+            }
             return success;
         },
 
         selectCurrentVersion: function($elem) {
             var ver_selector = '.' + this.verlist_class + ' :nth-child(' +
                 this.metadata_ver_cur + ')';
-            $elem.find('.' + this.verlist_class).removeClass('selected'); 
+            $elem.find('.' + this.verlist_class).removeClass('selected');
             $elem.find(ver_selector).addClass('selected');
             this.metadata_ver_shown = self.metadata_ver_cur;
         },
@@ -377,13 +377,13 @@ define (
             } while(bytes >= thresh && u < units.length - 1);
             return bytes.toFixed(1)+' '+units[u];
         },
-        
+
         createInfoObject: function (info) {
             return _.object(['id', 'name', 'type', 'save_date', 'version',
                 'saved_by', 'ws_id', 'ws_name', 'chsum', 'size',
                 'meta'], info);
         },
-        
+
         createViewer: function(error_message, type_spec, app_spec, output_params) {
             var o = this.obj_info;
             if (error_message) {
@@ -397,10 +397,10 @@ define (
                         mdDesc += '\n' + p[0] + ': ' + p[1];
                     });
                 }
-                return {widget: $('<div>').append($('<pre>').append(mdDesc)), 
+                return {widget: $('<div>').append($('<pre>').append(mdDesc)),
                     title: 'Unknown Data Type'};
             }
-            
+
             var output = $.extend({}, output_params);
             output._obj_info = o;
             output.widgetTitle = type_spec.name || 'Unknown Data Type';
@@ -430,6 +430,6 @@ define (
                 title: output.widgetTitle
             };
         }
-     
+
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -85,9 +85,7 @@ define([
             }
 
             this.cell = findCell();
-
-            // this.cell = Jupyter.narrative.getCellByKbaseId(this.$elem.attr('id'));
-            //console.log('initializing with job id = ' + this.jobId);
+            this.cell.element.trigger('hideCodeArea.cell');
             if (!this.jobId) {
                 this.showError("No Job id provided!");
                 return this;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeOutputCell.js
@@ -34,9 +34,14 @@ define([
             if (this.options.cellId) {
                 this.cell = Jupyter.narrative.getCellByKbaseId(this.options.cellId);
                 if (!this.cell) {
-                    this.cell = $('#' + this.options.cellId).parents('.cell').data().cell;
+                    var cellElem = $('#' + this.options.cellId).parents('.cell').data();
+                    if (cellElem) {
+                        this.cell = cellElem.cell;
+                    }
                 }
-                this.cell.element.trigger('hideCodeArea.cell');
+                if (this.cell) {
+                    this.cell.element.trigger('hideCodeArea.cell');
+                }
             }
             if (this.options.widget.toLowerCase() === "null") {
                 this.options.widget = 'kbaseDefaultNarrativeOutput';

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
@@ -517,6 +517,9 @@ define (
                     }
             };
             cell.metadata = meta;
+            cell.events.one('output_appended.OutputArea', function() {
+                Jupyter.narrative.saveNarrative();
+            });
             cell.execute();
             Jupyter.narrative.hideOverlay();
             this.showInfo(''); // clear the info message when we close the overlay

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager']
 
 from semantic_version import Version
-__version__ = Version("3.1.1")
+__version__ = Version("3.1.2")
 version = lambda: __version__
 
 # if run directly:

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -314,6 +314,9 @@ class WidgetManager(object):
         # Let the kwargs override constants
         input_data.update(params)
 
+        if cell_id is not None:
+            cell_id = "\"{}\"".format(cell_id)
+
         input_template = """
         element.html("<div id='{{input_id}}' class='kb-vis-area'></div>");
         require(['kbaseNarrativeOutputCell'], function(KBaseNarrativeOutputCell) {
@@ -321,7 +324,7 @@ class WidgetManager(object):
                 "data": {{input_data}},
                 "type":"{{output_type}}",
                 "widget":"{{widget_name}}",
-                "cellId":"{{cell_id}}",
+                "cellId":{{cell_id}},
                 "title":"{{cell_title}}",
                 "time":{{timestamp}}
             });
@@ -385,6 +388,9 @@ class WidgetManager(object):
             (output_widget, output) = map_outputs_from_state([], input_params, spec)
             input_data['output'] = output
 
+        if cell_id is not None:
+            cell_id = "\"{}\"".format(cell_id)
+
         input_template = """
         element.html("<div id='{{input_id}}' class='kb-vis-area'></div>");
 
@@ -393,7 +399,7 @@ class WidgetManager(object):
                 "data": {{input_data}},
                 "type":"viewer",
                 "widget":"{{widget_name}}",
-                "cellId":"{{cell_id}}",
+                "cellId":{{cell_id}},
                 "title":"{{cell_title}}",
                 "time":{{timestamp}}
             });

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
**DO NOT MERGE!**

Some tweaks, mainly to support demos for the Contractor's meeting. In no particular order.

- [x] Drag and drop upload reactivated (so far in CI)
- [x] Fix problem where refreshing page causes import widgets to show code
- [x] Autosave after import begins (from Import tab)
- [x] Hide "Object details..." button in viewers
- [ ] Integrate d&d with Tian's new uploader for reads
- [ ] Deal with multiple scrollbars in D&D panel
- [ ] Deal with "Summary" area in Report panel of app cell
- [ ] HTML report file has UUID name - should be more readable
- [ ] Too much whitespace in reports view. Should start small, grow to a maximum height