### PR TITLE
Fixed misspelling

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -225,7 +225,7 @@ define (
                         { sTitle: "Function", mData: "function"},
                         { sTitle: "Min", mData:"min" },
                         { sTitle: "Max", mData:"max" },
-                        { sTitle: "Avgerage", mData:"avg" },
+                        { sTitle: "Average", mData:"avg" },
                         { sTitle: "Std. Dev.", mData:"std"},
                         { sTitle: "Missing Values?", mData:"missing_values" }
                     ]


### PR DESCRIPTION
Average now spelled correctly