### PR TITLE
View-only fixes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,11 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.1.3
+__Changes__
+- Fixed bug where read-only Narratives were still interactive (apps had run and reset buttons)
+- Fixed bug where copying a read-only Narrative created a bad forwarding URL.
+
 ### Version 3.1.2
 __Changes__
 - Do an autosave after starting an import job.

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -1105,6 +1105,7 @@ define([
                 }]
             ))
             .then(function(result) {
+                result = result[0];
                 return {
                     status: 'success',
                     url: [window.location.origin,

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1005,7 +1005,11 @@ define([
         }
 
         function buildRunControlPanelRunButtons(events) {
-            return div({ class: 'btn-group' },
+            var style = {};
+            if (Jupyter.narrative.readonly) {
+                style.display = 'none';
+            }
+            var buttonDiv = div({ class: 'btn-group', style: style},
                 Object.keys(actionButtons.availableButtons).map(function(key) {
                     var button = actionButtons.availableButtons[key],
                         classes = ['kb-flat-btn', 'kb-btn-action'].concat(button.classes);
@@ -1029,6 +1033,7 @@ define([
                     });
                 })
             );
+            return buttonDiv;
         }
 
         function buildRunControlPanelDisplayButtons(events) {
@@ -1108,7 +1113,7 @@ define([
                                 right: '100px',
                                 top: '0',
                                 height: '100px',
-                                borderRight: '1px silver solid'
+                                borderRight: Jupyter.narrative.readonly ? 'none' : '1px silver solid'
                             }
                         }, [
                             div({

--- a/nbextensions/editorCell/widgets/editors/readsSet/editor.js
+++ b/nbextensions/editorCell/widgets/editors/readsSet/editor.js
@@ -5,6 +5,7 @@ define([
     'require',
     'bluebird',
     'uuid',
+    'base/js/namespace',
     'common/runtime',
     'common/events',
     'common/html',
@@ -30,6 +31,7 @@ define([
     require,
     Promise,
     Uuid,
+    Jupyter,
     Runtime,
     Events,
     html,
@@ -189,6 +191,10 @@ define([
         }
 
         function buildLayout(events) {
+            var readOnlyStyle = {};
+            if (Jupyter.narrative.readonly) {
+                readOnlyStyle.display = 'none';
+            }
             return div({ class: 'kbase-extension kb-editor-cell', style: { display: 'flex', alignItems: 'stretch' } }, [
                 div({ class: 'prompt', dataElement: 'prompt', style: { display: 'flex', alignItems: 'stretch', flexDirection: 'column' } }, [
                     div({ dataElement: 'status' })
@@ -287,7 +293,8 @@ define([
                                 body: div({ dataElement: 'widget' })
                             }),
                             div({
-                                dataElement: 'available-actions'
+                                dataElement: 'available-actions',
+                                style: readOnlyStyle
                             }, [
                                 div({ class: 'btn-toolbar kb-btn-toolbar-cell-widget' }, [
                                     div({ class: 'btn-group' }, [
@@ -355,7 +362,7 @@ define([
 
             var fixedApp = fixApp(app);
             var code = PythonInterop.buildEditorRunner(cellId, runId, fixedApp, params);
-            // TODO: do something with the runId 
+            // TODO: do something with the runId
 
             // setStatus('Successfully built code');
 
@@ -590,7 +597,7 @@ define([
             }];
         }
 
-        // TODO: this should be a the error area -- and we should switch the 
+        // TODO: this should be a the error area -- and we should switch the
         // editor into error mode.
         function loadErrorWidget(error) {
             console.error('ERROR', error);
@@ -651,7 +658,7 @@ define([
                     controller.desc = 'update editor widget';
                     widgets.editor = {
                         path: ['editor', 'widget'],
-                        // module: widgetModule,                        
+                        // module: widgetModule,
                         type: 'update',
                         bus: bus,
                         instance: widget
@@ -756,11 +763,11 @@ define([
         }
 
         /*
-         * Given an object ref, fetch the set object via the setApi, 
+         * Given an object ref, fetch the set object via the setApi,
          * then populate
          */
         function loadData(objectRef) {
-            // TODO: check if the editor has unsaved changed, and 
+            // TODO: check if the editor has unsaved changed, and
             // show an error message if so, and refuse to switch.
             var setApiClient = new GenericClient({
                     url: runtime.config('services.service_wizard.url'),
@@ -775,13 +782,13 @@ define([
 
             return setApiClient.callFunc('get_reads_set_v1', [params])
                 .spread(function(setObject) {
-                    // After getting the reads set object, we populate our 
+                    // After getting the reads set object, we populate our
                     // view model (data model-ish) with the results.
                     // The editor will sync up with the model, and pick up the
-                    // values.                    
+                    // values.
                     model.setItem('params', {});
 
-                    // TODO: move this into code or config specific to 
+                    // TODO: move this into code or config specific to
                     // the reads set editor.
                     // *** removed the .value
                     model.setItem('params.name', setObject.info[1]);
@@ -831,7 +838,7 @@ define([
                     output_object_name: name,
                     data: {
                         description: '',
-                        // set api has bug -- will throw exception if fetch a 
+                        // set api has bug -- will throw exception if fetch a
                         // set with no items.
                         // stuff a sample item in here to start with.
                         items: []
@@ -1059,7 +1066,7 @@ define([
                     };
                     // When the user selects a reads set to edit.
                     widget.channel.on('changed', function(message) {
-                        // Call this when we have a new object to edit. It will 
+                        // Call this when we have a new object to edit. It will
                         // take care of updating the cell state as well as
                         // rendering the object.
                         //editorState.setItem('current.set.ref', objectInfo.ref);
@@ -1166,7 +1173,7 @@ define([
 
                     return validateModel()
                         .then(function(result) {
-                            // we have a tree of validations, so we need to walk the tree to see if anything 
+                            // we have a tree of validations, so we need to walk the tree to see if anything
                             // does not validate.
                             var messages = gatherValidationMessages(result);
 

--- a/nbextensions/viewCell/widgets/viewCellWidget.js
+++ b/nbextensions/viewCell/widgets/viewCellWidget.js
@@ -5,6 +5,7 @@ define([
     'jquery',
     'bluebird',
     'uuid',
+    'base/js/namespace',
     'common/runtime',
     'common/events',
     'common/html',
@@ -25,6 +26,7 @@ define([
     $,
     Promise,
     Uuid,
+    JupyterNamespace,
     Runtime,
     Events,
     html,
@@ -514,6 +516,10 @@ define([
         }
 
         function renderLayout() {
+            var readOnlyStyle = {};
+            if (JupyterNamespace.narrative.readonly) {
+                readOnlyStyle.display = 'none';
+            }
             var events = Events.make(),
                 content = div({ class: 'kbase-extension kb-app-cell', style: { display: 'flex', alignItems: 'stretch' } }, [
                     div({ class: 'prompt', dataElement: 'prompt', style: { display: 'flex', alignItems: 'stretch', flexDirection: 'column' } }, [
@@ -605,7 +611,8 @@ define([
                                     body: div({ dataElement: 'widget' })
                                 }),
                                 div({
-                                    dataElement: 'availableActions'
+                                    dataElement: 'availableActions',
+                                    style: readOnlyStyle,
                                 }, [
                                     div({ class: 'btn-toolbar kb-btn-toolbar-cell-widget' }, [
                                         div({ class: 'btn-group' }, [
@@ -1431,7 +1438,7 @@ define([
         function evaluateAppState() {
             validateModel()
                 .then(function(result) {
-                    // we have a tree of validations, so we need to walk the tree to see if anything 
+                    // we have a tree of validations, so we need to walk the tree to see if anything
                     // does not validate.
                     var messages = gatherValidationMessages(result);
 

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager']
 
 from semantic_version import Version
-__version__ = Version("3.1.2")
+__version__ = Version("3.1.3")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
This fixes a couple problems I found.
1. Using the copy button in read only narratives (e.g. public ones) worked, but created a bad URL in it's "Open the new narrative" button.
2. Disabled the execution controls for apps, editors, and view cells. Clicking on a data object should still create a (temporary) viewer, but a user can no longer run or modify any cell using the main action button.

@eapearson - I just added 'display:none' to the main cell areas when they get created. There's still plenty of internal logic that expects those buttons to be there for binding things, but just hiding their containers from the user seems to be sufficient.

see also https://kbase-jira.atlassian.net/browse/TASK-312