### PR TITLE
Added an appdev stanza to data_source_config

### DIFF
--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -328,5 +328,107 @@
                 }
             ]
         }
+    },
+    "appdev": {
+        "publicData": {
+            "genomes": {
+                "name": "Genomes",
+                "type": "KBaseGenomes.Genome",
+                "ws": "KBasePublicGenomesV5",
+                "search": true
+            },
+            "media": {
+                "name": "Media",
+                "type": "KBaseBiochem.Media",
+                "ws": "KBaseMedia",
+                "search": false
+            },
+            "phytozome_genomes": {
+                "name": "Phytozome Genomes",
+                "type": "KBaseGenomes.Genome",
+                "ws": "Phytozome_Genomes",
+                "search": false
+            },
+            "se_reads": {
+                "name": "RNA-seq Reads (single-end)",
+                "type": "KBaseAssembly.SingleEndLibrary",
+                "ws": "PlantCSGenomes",
+                "search": false
+            },
+            "pe_reads": {
+                "name": "RNA-seq Reads (paired-end)",
+                "type": "KBaseAssembly.PairedEndLibrary",
+                "ws": "PlantCSGenomes",
+                "search": false
+            },
+            "plant_rnaseq_anno": {
+                "name": "Plant RNA-seq Annotations",
+                "type": "KBaseRNASeq.ReferenceAnnotation",
+                "ws": "PlantCSGenomes",
+                "search": false
+            },
+            "plant_bowtie2_idx": {
+                "name": "Plant Bowtie2 Indexes",
+                "type": "KBaseRNASeq.Bowtie2Indexes",
+                "ws": "PlantCSGenomes",
+                "search": false
+            }
+        },
+        "exampleData": {
+            "ws": "KBaseExampleData",
+            "data_types": [
+                {
+                    "name": [
+                        "SingleEndLibrary",
+                        "PairedEndLibrary",
+                        "ReferenceAssembly"
+                    ],
+                    "displayName": "Example Sequence Assembly Inputs",
+                    "header": "Various types of read data configured for sequence assembly."
+                },
+                {
+                    "name": [
+                        "ContigSet"
+                    ],
+                    "displayName": "Example Contig Sets",
+                    "header": "A set of DNA sequences"
+                },
+                {
+                    "name": [
+                        "Genome"
+                    ],
+                    "displayName": "Example Genomes",
+                    "header": "Genomic sequence generally with attached functional annotations"
+                },
+                {
+                    "name": [
+                        "FBAModel"
+                    ],
+                    "displayName": "Example FBAModels",
+                    "header": "A metabolic model of an organism"
+                },
+                {
+                    "name": [
+                        "Media"
+                    ],
+                    "displayName": "Example Media",
+                    "header": "Specification of an environmental condition"
+                },
+                {
+                    "name": [
+                        "ExpressionMatrix"
+                    ],
+                    "displayName": "Example ExpressionMatrix",
+                    "header": "Gene expression data in a gene vs. condition matrix"
+                },
+                {
+                    "name": [
+                        "TranscriptomeHack"
+                    ],
+                    "displayName": "Example Sorghum Transcriptomes",
+                    "header": "Sorghum bicolor transcriptome data in response to ABA and osmotic stress"
+                }
+            ]
+        }
     }
 }

--- a/scripts/install_narrative.sh
+++ b/scripts/install_narrative.sh
@@ -209,11 +209,12 @@ then
     /bin/mv $SCRIPT_TGT $d
     log "Done installing scripts"
 
-    log "oh, wait, one more thing...installing nbextensions"
+    log "Installing nbextensions"
     cd nbextensions
     sh install.sh
     cd ../..
-    log "now, done."
+    jupyter nbextension enable --py --sys-prefix widgetsnbextension
+    log "Done installing nbextensions"
 fi
 
 console "Done. Run the narrative from your virtual environment $VIRTUAL_ENV with the command: $SCRIPT_TGT"

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -344,7 +344,7 @@ class JobManager(object):
         for job_id in self._running_jobs.keys():
             if self._running_jobs[job_id]['refresh'] or ignore_refresh_flag:
                 jobs_to_lookup.append(job_id)
-        # Only bother with the message if there are 
+        # Only bother with the message if there are
         status_set = self._construct_job_status_set(jobs_to_lookup)
         self._send_comm_message('job_status_all', status_set)
 
@@ -360,10 +360,9 @@ class JobManager(object):
         Initialize a loop that will look up job info. This uses a Timer thread on a 10
         second loop to update things.
         """
-        
+
         refreshing_jobs = self._lookup_all_job_status()
         # Automatically stop when there are no more jobs requesting a refresh.
-        print('here')
         if refreshing_jobs == 0:
             self.cancel_job_lookup_loop()
         else:

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -344,7 +344,6 @@ class JobManager(object):
         for job_id in self._running_jobs.keys():
             if self._running_jobs[job_id]['refresh'] or ignore_refresh_flag:
                 jobs_to_lookup.append(job_id)
-        # Only bother with the message if there are
         status_set = self._construct_job_status_set(jobs_to_lookup)
         self._send_comm_message('job_status_all', status_set)
 
@@ -352,7 +351,7 @@ class JobManager(object):
 
     def _start_job_status_loop(self):
         kblogging.log_event(self._log, 'starting job status loop', {})
-        if self._lookup_timer == None:
+        if self._lookup_timer is None:
             self._lookup_job_status_loop()
 
     def _lookup_job_status_loop(self):

--- a/src/biokbase/narrative/tests/test.cfg
+++ b/src/biokbase/narrative/tests/test.cfg
@@ -33,3 +33,15 @@ job_info_file=data/job_test_data.json
 [specs]
 app_specs_file=data/app_specs.json
 type_specs_file=data/type_specs.json
+
+[app_tests]
+public_ws_name=wjriehl:1475006266615
+public_ws_id=11635
+good_app_id=NarrativeTest/test_input_params
+good_app_tag=dev
+bad_app_id=NotARealApp
+bad_app_tag=NotARealTag
+test_app_id=AssemblyRAST/run_arast
+test_app_tag=dev
+test_job_id=new_job_id
+test_input_ref=11635/19/4

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -5,6 +5,8 @@ from IPython.display import HTML
 import unittest
 import mock
 import os
+import ConfigParser
+
 """
 Tests for the app manager.
 """
@@ -13,12 +15,14 @@ Tests for the app manager.
 class AppManagerTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):
+        config = ConfigParser.ConfigParser()
+        config.read('test.cfg')
         self.am = AppManager()
-        self.good_app_id = 'NarrativeTest/test_input_params'
-        self.good_tag = 'dev'
-        self.bad_app_id = 'NotARealApp'
-        self.bad_tag = 'NotARealTag'
-        self.test_app_id = "AssemblyRAST/run_arast"
+        self.good_app_id = config.get('app_tests', 'good_app_id')
+        self.good_tag = config.get('app_tests', 'good_app_tag')
+        self.bad_app_id = config.get('app_tests', 'bad_app_id')
+        self.bad_tag = config.get('app_tests', 'bad_app_tag')
+        self.test_app_id = config.get('app_tests', 'test_app_id')
         self.test_app_params = {
             "read_library_names": ["rhodo.art.jgi.reads"],
             "output_contigset_name": "rhodo_contigs",
@@ -27,11 +31,11 @@ class AppManagerTestCase(unittest.TestCase):
             "pipeline": "",
             "min_contig_len": None
         }
-        self.test_job_id = "new_job_id"
-        self.test_tag = "dev"
-        self.public_ws = "wjriehl:1475006266615"
-        self.ws_id = 11635
-        self.app_input_ref = "11635/19/4"
+        self.test_job_id = config.get('app_tests', 'test_job_id')
+        self.test_tag = config.get('app_tests', 'test_app_tag')
+        self.public_ws = config.get('app_tests', 'public_ws_name')
+        self.ws_id = int(config.get('app_tests', 'public_ws_id'))
+        self.app_input_ref = config.get('app_tests', 'test_input_ref')
 
     def test_reload(self):
         self.am.reload()

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -171,7 +171,7 @@ class JobManagerTest(unittest.TestCase):
         job_data = msg.get('data', {}).get('content', {})
         job_ids = job_data.keys()
         # assert that each job info that's flagged for lookup gets returned
-        jobs_to_lookup = [j for j in self.jm._running_jobs.keys() if self.jm._running_jobs[j]['refresh']]
+        jobs_to_lookup = [j for j in self.jm._running_jobs.keys()]
         self.assertItemsEqual(job_ids, jobs_to_lookup)
         for job_id in job_ids:
             self.assertTrue(self.validate_status_message(job_data[job_id]))

--- a/src/biokbase/narrative/tests/test_logging.py
+++ b/src/biokbase/narrative/tests/test_logging.py
@@ -3,7 +3,8 @@ import os
 import time
 import unittest
 #
-from biokbase.narrative.common.tests import util
+#from biokbase.narrative.common.tests import util
+import util
 from biokbase.narrative.common import kblogging
 
 """


### PR DESCRIPTION
The Public and Example tabs weren't working.

I'm not exactly sure what's supposed to be there, so I just copied the sources from prod. This changes lets Public Phytozome Genomes and Media work (the rest don't work for some reason... not sure how they're supposed to be configured, or if there's a missing Search service in appdev). Also, in the Example workspace (KBaseExampleData), there's only a few data sets.

So that should probably be either reconfigured to point to valid workspaces, or have those workspaces filled up with appropriate testing data.

Either way, this is better than an error message.