### PR TITLE
reports impossible error

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseCummerbundPlot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseCummerbundPlot.js
@@ -160,7 +160,16 @@ define (
             }
 
             ws.get_objects([ws_params]).then(function (d) {
-                $plot.setDataset(d[0].data.cummerbundplotSet);
+
+                if (! d[0].data.cummerbundplotSet || !d[0].data.cummerbundplotSet.length) {
+                  $plot.$elem.empty();
+                  $plot.$elem
+                      .addClass('alert alert-danger')
+                      .html("No cummerbundplotSet for " + ws_params.workspace + ':' + ws_params.name + ', [' + ws_params.wsid + ']');
+                }
+                else {
+                  $plot.setDataset(d[0].data.cummerbundplotSet);
+                }
             }).fail(function(d) {
                 $plot.$elem.empty();
                 $plot.$elem


### PR DESCRIPTION
If the cummerbund service isn't working properly, it can generate an invalid object which contains an empty cummerbundplotSet array key.

This modification will report that error which should never occur.