### PR TITLE
"Search methods" -> "Search apps"

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeMethodPanel.js
@@ -102,7 +102,7 @@ define ([
 
             this.$searchInput = $('<input type="text">')
                                 .addClass('form-control')
-                                .attr('Placeholder', 'Search methods')
+                                .attr('Placeholder', 'Search apps')
                                 .on('input',
                                     $.proxy(function(e) {
                                         this.filterList();


### PR DESCRIPTION
This is the placeholder text that appears in the app name text search box before you enter anything.
I hope this is the right place and right branch to change this.