### PR TITLE
refactors buildObjectIdentity into super class

### DIFF
--- a/kbase-extension/static/kbase/js/kbwidget.js
+++ b/kbase-extension/static/kbase/js/kbwidget.js
@@ -923,6 +923,28 @@ define (
                 return 'uuid-' + result;
             },
 
+            buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
+                var obj = {};
+                if (wsRef) {
+                  obj['ref'] = wsRef;
+                } else {
+                  if (/^\d+$/.exec(workspaceID))
+                    obj['wsid'] = workspaceID;
+                  else
+                    obj['workspace'] = workspaceID;
+
+                  // same for the id
+                  if (/^\d+$/.exec(objectID))
+                    obj['objid'] = objectID;
+                  else
+                    obj['name'] = objectID;
+
+                  if (objectVer)
+                    obj['ver'] = objectVer;
+                }
+                return obj;
+            },
+
         }
     );
 

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseDomainAnnotation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseDomainAnnotation.js
@@ -461,28 +461,6 @@ define (
                 });
         },
 
-        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-                obj['ref'] = wsRef;
-            } else {
-                if (/^\d+$/.exec(workspaceID))
-                    obj['wsid'] = workspaceID;
-                else
-                    obj['workspace'] = workspaceID;
-
-                // same for the id
-                if (/^\d+$/.exec(objectID))
-                    obj['objid'] = objectID;
-                else
-                    obj['name'] = objectID;
-
-                if (objectVer)
-                    obj['ver'] = objectVer;
-            }
-            return obj;
-        },
-
         clientError: function(error){
             this.loading(false);
             this.showMessage(error.error.error);

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionConditionsetBaseWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionConditionsetBaseWidget.js
@@ -1,11 +1,11 @@
 /**
  * Base class for viewers visualizaing expression of a set of conditions from various aspects
- * 
+ *
  * The descendant classes should override:
  * 1. getSubmtrixParams - to set params for get_submatrix_stat method from the KBaseFeatureValues service
  * 2. buildWidget - to create a custom visuzualization
  *
- * 
+ *
  *
  *
  * Pavel Novichkov <psnovichkov@lbl.gov>
@@ -73,7 +73,7 @@ define([
 
             // Create a message pane
             this.$messagePane = $("<div/>").addClass("kbwidget-message-pane kbwidget-hide-message");
-            this.$elem.append(this.$messagePane);       
+            this.$elem.append(this.$messagePane);
 
             return this;
         },
@@ -86,12 +86,12 @@ define([
                     "service_wizard");
                 this.genericClient = new GenericClient(serviceWizardURL, auth);
             } else {
-                this.featureValueClient = new KBaseFeatureValues(this.options.featureValueURL, auth);   
+                this.featureValueClient = new KBaseFeatureValues(this.options.featureValueURL, auth);
             }
-            this.ws = new Workspace(this.options.wsURL, auth);         
+            this.ws = new Workspace(this.options.wsURL, auth);
 
             // Let's go...
-            this.loadAndRender();           
+            this.loadAndRender();
             return this;
         },
 
@@ -198,7 +198,7 @@ define([
 
             var $vizContainer = $("<div/>");
             this.$elem.append( $vizContainer );
-            this.buildWidget( $vizContainer );            
+            this.buildWidget( $vizContainer );
         },
 
         buildOverviewDiv: function($containerDiv){
@@ -229,22 +229,22 @@ define([
                         { sTitle: "Name", mData: "id"},
                         // { sTitle: "Function", mData: "function"},
                         { sTitle: "Min", mData:"min" },
-                        { sTitle: "Max", mData:"max" },  
-                        { sTitle: "Avg", mData:"avg" },                                                      
+                        { sTitle: "Max", mData:"max" },
+                        { sTitle: "Avg", mData:"avg" },
                         { sTitle: "Std", mData:"std"},
                         { sTitle: "Missing", mData:"missing_values" }
                     ],
                     "oLanguage": {
                                 "sEmptyTable": "No conditions found!",
                                 "sSearch": "Search: "
-                    }                    
+                    }
                 } );
 
             $overviewSwitch.click(function(){
                 $overvewContainer.toggle();
             });
         },
-      
+
         buildConditionsTableData: function(){
             var submatrixStat = this.submatrixStat;
             var tableData = [];
@@ -278,12 +278,12 @@ define([
                        .append($("<td />").append(value));
             return $row;
         },
-        
+
         loading: function(isLoading) {
             if (isLoading)
                 this.showMessage("<img src='" + this.options.loadingImage + "'/>");
             else
-                this.hideMessage();                
+                this.hideMessage();
         },
 
         showMessage: function(message) {
@@ -318,44 +318,22 @@ define([
                                  "and will be fixed shortly."
                 }
             }
-            
+
             var $errorDiv = $("<div>")
                             .addClass("alert alert-danger")
                             .append("<b>Error:</b>")
                             .append("<br>" + errString);
             this.$elem.empty();
             this.$elem.append($errorDiv);
-        },            
+        },
 
         uuid: function() {
-            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, 
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
                 function(c) {
                     var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
                     return v.toString(16);
                 });
         },
-
-        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-                obj['ref'] = wsRef;
-            } else {
-                if (/^\d+$/.exec(workspaceID))
-                    obj['wsid'] = workspaceID;
-                else
-                    obj['workspace'] = workspaceID;
-
-                // same for the id
-                if (/^\d+$/.exec(objectID))
-                    obj['objid'] = objectID;
-                else
-                    obj['name'] = objectID;
-                
-                if (objectVer)
-                    obj['ver'] = objectVer;
-            }
-            return obj;
-        }
 
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionEstimateK.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionEstimateK.js
@@ -240,28 +240,6 @@ define (
 				});
 		},
 
-		buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-			var obj = {};
-			if (wsRef) {
-				obj['ref'] = wsRef;
-			} else {
-				if (/^\d+$/.exec(workspaceID))
-					obj['wsid'] = workspaceID;
-				else
-					obj['workspace'] = workspaceID;
-
-				// same for the id
-				if (/^\d+$/.exec(objectID))
-					obj['objid'] = objectID;
-				else
-					obj['name'] = objectID;
-
-				if (objectVer)
-					obj['ver'] = objectVer;
-			}
-			return obj;
-		},
-
 		clientError: function(error){
 			this.loading(false);
 			this.showMessage(error.error.error);

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
@@ -504,28 +504,6 @@ define (
 			this.$messagePane.empty();
 		},
 
-		buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-			var obj = {};
-			if (wsRef) {
-				obj['ref'] = wsRef;
-			} else {
-				if (/^\d+$/.exec(workspaceID))
-					obj['wsid'] = workspaceID;
-				else
-					obj['workspace'] = workspaceID;
-
-				// same for the id
-				if (/^\d+$/.exec(objectID))
-					obj['objid'] = objectID;
-				else
-					obj['name'] = objectID;
-
-				if (objectVer)
-					obj['ver'] = objectVer;
-			}
-			return obj;
-		},
-
 		clientError: function(error){
 			this.loading(false);
 			this.showMessage(error.error.error);

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionGenesetBaseWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionGenesetBaseWidget.js
@@ -1,11 +1,11 @@
 /**
  * Base class for viewers visualizaing expression of a set of genes from various aspects
- * 
+ *
  * The descendant classes should override:
  * 1. getSubmtrixParams - to set params for get_submatrix_stat method from the KBaseFeatureValues service
  * 2. buildWidget - to create a custom visuzualization
  *
- * 
+ *
  *
  *
  * Pavel Novichkov <psnovichkov@lbl.gov>
@@ -315,27 +315,6 @@ define([
                     return v.toString(16);
                 });
         },
-        buildObjectIdentity: function (workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-                obj['ref'] = wsRef;
-            } else {
-                if (/^\d+$/.exec(workspaceID))
-                    obj['wsid'] = workspaceID;
-                else
-                    obj['workspace'] = workspaceID;
-
-                // same for the id
-                if (/^\d+$/.exec(objectID))
-                    obj['objid'] = objectID;
-                else
-                    obj['name'] = objectID;
-
-                if (objectVer)
-                    obj['ver'] = objectVer;
-            }
-            return obj;
-        }
 
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -323,27 +323,6 @@ define (
                 });
         },
 
-        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-                obj['ref'] = wsRef;
-            } else {
-                if (/^\d+$/.exec(workspaceID))
-                    obj['wsid'] = workspaceID;
-                else
-                    obj['workspace'] = workspaceID;
-
-                // same for the id
-                if (/^\d+$/.exec(objectID))
-                    obj['objid'] = objectID;
-                else
-                    obj['name'] = objectID;
-
-                if (objectVer)
-                    obj['ver'] = objectVer;
-            }
-            return obj;
-        },
 
         clientError: function(error){
             this.loading(false);

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseFeatureSet.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseFeatureSet.js
@@ -248,28 +248,6 @@ define (
             this.$elem.append($errorDiv);
         },
 
-        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-                obj['ref'] = wsRef;
-            } else {
-                if (/^\d+$/.exec(workspaceID))
-                    obj['wsid'] = workspaceID;
-                else
-                    obj['workspace'] = workspaceID;
-
-                // same for the id
-                if (/^\d+$/.exec(objectID))
-                    obj['objid'] = objectID;
-                else
-                    obj['name'] = objectID;
-
-                if (objectVer)
-                    obj['ver'] = objectVer;
-            }
-            return obj;
-        },
-
         loading: function(doneLoading) {
             if (doneLoading)
                 this.hideMessage();

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMSA.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMSA.js
@@ -207,28 +207,6 @@ define (
             };
         },
 
-        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-            	obj['ref'] = wsRef;
-            } else {
-            	if (/^\d+$/.exec(workspaceID))
-            		obj['wsid'] = workspaceID;
-            	else
-            		obj['workspace'] = workspaceID;
-
-            	// same for the id
-            	if (/^\d+$/.exec(objectID))
-            		obj['objid'] = objectID;
-            	else
-            		obj['name'] = objectID;
-
-            	if (objectVer)
-            		obj['ver'] = objectVer;
-            }
-            return obj;
-        },
-
         loading: function(doneLoading) {
             if (doneLoading)
                 this.hideMessage();

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseMatrix2DAbstract.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseMatrix2DAbstract.js
@@ -489,28 +489,6 @@ define (
                 });
         },
 
-        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-                obj['ref'] = wsRef;
-            } else {
-                if (/^\d+$/.exec(workspaceID))
-                    obj['wsid'] = workspaceID;
-                else
-                    obj['workspace'] = workspaceID;
-
-                // same for the id
-                if (/^\d+$/.exec(objectID))
-                    obj['objid'] = objectID;
-                else
-                    obj['name'] = objectID;
-
-                if (objectVer)
-                    obj['ver'] = objectVer;
-            }
-            return obj;
-        }
-
     });
 });
 

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -242,8 +242,8 @@ define([
             };
         },
 
-        // preserved for a minute. The approach below blocks off the report and presents a 
-        // translucent layer and link on top of the report area. The premise is that the 
+        // preserved for a minute. The approach below blocks off the report and presents a
+        // translucent layer and link on top of the report area. The premise is that the
         // content is nearly useless, so don't encourage users to try to use it.
 
         // openReportWindow: function (arg) {
@@ -473,7 +473,7 @@ define([
                         // We may receive this if a 'ready' was received
                         // from another cell. Perhaps there is a better
                         // way of filtering messages before getting here!
-                        // TODO: implement an address feature to allow a 
+                        // TODO: implement an address feature to allow a
                         //   message bus to ignore messages not sent to it.
                         //   we use the frame id for this, but it should actually
                         //   be a feature of the message bus itself.
@@ -712,7 +712,7 @@ define([
                 // REPORT SECTION
 
                 /*
-                The "inline" report can come from either the direct_html property or the direct_html_link_index. 
+                The "inline" report can come from either the direct_html property or the direct_html_link_index.
                 The direct_html_link_index will take precedence since it offers a better method for referencing
                 content within an iframe. Generally the app developer should use either method, not both
                  */
@@ -722,7 +722,7 @@ define([
                 if (report.direct_html && report.direct_html.length > 0) {
                     hasDirectHtml = true;
                 }
-                if (typeof report.direct_html_link_index === 'number' && 
+                if (typeof report.direct_html_link_index === 'number' &&
                     report.direct_html_link_index >= 0) {
                     hasDirectHtmlIndex = true;
                 }
@@ -761,7 +761,7 @@ define([
                                 };
                             }
                         } else {
-                            // If the direct_html is a full document we cannot (yet?) insert 
+                            // If the direct_html is a full document we cannot (yet?) insert
                             // the necessary code to gracefully handle resizing and click-passthrough.
                             if (/<html/.test(report.direct_html)) {
                                 console.warn('Html document inserted into iframe', report);
@@ -771,8 +771,8 @@ define([
                                     events: events
                                 });
                             } else {
-                                // note that for direct_html, we set the max height. this content is expected 
-                                // to be smaller than linked content, and we will want the container 
+                                // note that for direct_html, we set the max height. this content is expected
+                                // to be smaller than linked content, and we will want the container
                                 // to shrink, but if it is larger, we simply don't want it to be too tall.
                                 iframe = _this.makeIframe({
                                     content: report.direct_html,
@@ -991,26 +991,6 @@ define([
             this.$elem.empty();
             this.$elem.append($errorDiv);
         },
-        buildObjectIdentity: function (workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-                obj['ref'] = wsRef;
-            } else {
-                if (/^\d+$/.exec(workspaceID))
-                    obj['wsid'] = workspaceID;
-                else
-                    obj['workspace'] = workspaceID;
 
-                // same for the id
-                if (/^\d+$/.exec(objectID))
-                    obj['objid'] = objectID;
-                else
-                    obj['name'] = objectID;
-
-                if (objectVer)
-                    obj['ver'] = objectVer;
-            }
-            return obj;
-        }
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseTree.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseTree.js
@@ -122,11 +122,11 @@ define (
                 		console.log(err);
                 	});
                 }
-                
+
                 function EasyTreeForNarrative(canvasId, treeString, nodeIdToNameMap, leafClickListener, nodeColorFunc) {
-                    
+
                     var kn_g_tree = kn_parse(treeString);
-                    
+
                     if (nodeIdToNameMap) {
                         for (var nodePos in kn_g_tree.node) {
                             var nodeId = kn_g_tree.node[nodePos].name;
@@ -137,7 +137,7 @@ define (
                             }
                         }
                     }
-                    
+
                     if (nodeColorFunc) {
                         for (var nodePos in kn_g_tree.node) {
                             var node = kn_g_tree.node[nodePos];
@@ -147,10 +147,10 @@ define (
                             }
                         }
                     }
-                    
+
                     var kn_g_conf = new Object();
                     var canvas = document.getElementById(canvasId);
-                    
+
                     var conf = kn_g_conf;
                     conf.c_box = new Array();
                     conf.width = 1000; conf.height = 600;
@@ -179,7 +179,7 @@ define (
                     var changeLayoutY = 0;
                     var changeLayoutW = 0;
                     var changeLayoutH = 0;
-                    
+
                     function plot(canvas, kn_g_tree, kn_g_conf) {
                         kn_plot_core(canvas, kn_g_tree, kn_g_conf);
                         var text = "Change layout";
@@ -198,7 +198,7 @@ define (
                         changeLayoutW = w;
                         changeLayoutH = h;
                     }
-                    
+
                     function changeLayout(isCircular) {
                         kn_g_conf.is_circular = isCircular;
                         kn_g_conf.height = kn_g_conf.is_circular? kn_g_conf.width : kn_g_conf.ymargin * 2 + kn_g_tree.n_tips * kn_g_conf.yskip;
@@ -285,12 +285,12 @@ define (
                         canvas_parent.removeChild(canvas);
                         canvas_parent.appendChild(o);
                         o.appendChild(canvas);
-                        
+
                         if (canvas.addEventListener) canvas.addEventListener('click', ev_canvas, false);
                         else canvas.attachEvent('onclick', ev_canvas);
                     }
                 };
-                
+
                 new EasyTreeForNarrative(self.canvasId, tree.tree, tree.default_node_labels, function(node) {
                 	if ((!tree.ws_refs) || (!tree.ws_refs[node.id])) {
                 		var node_name = tree.default_node_labels[node.id];
@@ -339,28 +339,6 @@ define (
                 workspace: this.options.workspaceID,
                 title: 'Tree'
             };
-        },
-
-        buildObjectIdentity: function(workspaceID, objectID, objectVer, wsRef) {
-            var obj = {};
-            if (wsRef) {
-            	obj['ref'] = wsRef;
-            } else {
-            	if (/^\d+$/.exec(workspaceID))
-            		obj['wsid'] = workspaceID;
-            	else
-            		obj['workspace'] = workspaceID;
-
-            	// same for the id
-            	if (/^\d+$/.exec(objectID))
-            		obj['objid'] = objectID;
-            	else
-            		obj['name'] = objectID;
-
-            	if (objectVer)
-            		obj['ver'] = objectVer;
-            }
-            return obj;
         },
 
         loading: function(doneLoading) {


### PR DESCRIPTION
The sole purpose of this pull request is to cause merge pain for Bill. Well, okay, not sole purpose. Primary, probably.

Anyway, I noticed that we've had a proliferation of buildObjectIdentity methods in the system that are all identical. So this just refactors them and rips out the common method from the individual widgets and puts it up into the superclass in kbwidget. I know that we have other redundant methods, but this is the one that jumped out at me.

This has not been thoroughly tested - I made sure that a few narratives I had spun up, but I didn't actually have anything to test the actual affected widgets. See first comment about causing merge pain for Bill.

That said, it *shouldn't* cause any problems, since it's just refactoring a redundant method into a single definition in a common superclass. No functionality should change.

This is strictly a technical debt pull request, and can be integrated at leisure. No functionality changes (AFAIK), no new features are added. So I'll defer as to when is the most opportune time to include it, if at all.