### PR TITLE
sample_ids can now be names or refs

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
@@ -82,15 +82,26 @@ define (
                     analysis.sample_ids,
                     function (i, v) {
                         num_sample_ids++;
-                        all_promises.push(
-                            ws.get_object_info([
-                              //{ref : v}
-                              {
-                                workspace : $rna.options.workspace,
-                                name : v
-                              }
-                            ])
-                        )
+
+                        if (v.match(/\//)) {
+                          all_promises.push(
+                              ws.get_object_info([
+                                {ref : v}
+                              ])
+                          )
+                        }
+                        else {
+
+                          all_promises.push(
+                              ws.get_object_info([
+                                //{ref : v}
+                                {
+                                  workspace : $rna.options.workspace,
+                                  name : v
+                                }
+                              ])
+                          )
+                        }
                     }
                 );
             }


### PR DESCRIPTION
Should work, but I couldn't test due to workspace permission issues.

Just looks at a sample id to see if it has a / in it. If so, now assumes it's a ref. If not, assumes it was a name, as before.