### PR TITLE
Improved wording of copy message

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -369,7 +369,7 @@ define([
                 .append($jumpButton);
 
             this.copyModal = new BootstrapDialog({
-                title: 'Copy a narrative',
+                title: 'Copy this Narrative',
                 body: $copyModalBody,
                 closeButton: true,
                 buttons: [


### PR DESCRIPTION
"Copy a narrative" -> "Copy this Narrative"