### PR TITLE
Rna seq sampleset patch

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
@@ -204,12 +204,12 @@ define (
                 );
 
                 if (analysis.sample_ids) {
-
+console.log("REF MAP", ref_map_by_id);
                     var sample_id_data = [];
                     $.each(
                       analysis.sample_ids,
                       function (i, v) {
-
+console.log("ITERATE ON ", i, v);
                         sample_id_data.push(
                           [
                             ref_map_by_id[v].name,

--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
@@ -204,15 +204,15 @@ define (
                 );
 
                 if (analysis.sample_ids) {
-console.log("REF MAP", ref_map_by_id);
+
                     var sample_id_data = [];
                     $.each(
                       analysis.sample_ids,
                       function (i, v) {
-console.log("ITERATE ON ", i, v);
+
                         sample_id_data.push(
                           [
-                            ref_map_by_id[v].name,
+                            ref_map_by_id[v] ? ref_map_by_id[v].name : v,
                             analysis.condition[i]
                           ]
                         )

--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
@@ -416,7 +416,7 @@ define (
                 this.options.output.read_sample_ids,
                 function (i,v) {
 
-                  var label = '';
+                  var label = v;
                   $.each(
                     $rnaseq.options.output.mapped_rnaseq_alignments,
                     function (i, id) {

--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
@@ -324,6 +324,10 @@ define (
                     name : $pie.options[obj_key] || $pie.options.ws_alignment_sample_id,
                 };
 
+                if (this.options.ws_alignment_sample_id) {
+                  ws_params = { ref : this.options.ws_sample_id };
+                }
+
                 ws.get_objects([ws_params]).then(function (d) {
                   $pie.options.output = d[0].data;
 
@@ -344,7 +348,6 @@ define (
                   }
                 })
                 .fail(function(d) {
-
                     $pie.$elem.empty();
                     $pie.$elem
                         .addClass('alert alert-danger')
@@ -412,10 +415,22 @@ define (
               $.each(
                 this.options.output.read_sample_ids,
                 function (i,v) {
+
+                  var label = '';
+                  $.each(
+                    $rnaseq.options.output.mapped_rnaseq_alignments,
+                    function (i, id) {
+                      if (id[v]) {
+                        label = id[v];
+                        return;
+                      }
+                    }
+                  );
+
                   $selector.append(
                     $.jqElem('option')
                       .attr('value', $rnaseq.options.output.sample_alignments[i])
-                      .append(v)
+                      .append(label)
                   )
                 }
               );


### PR DESCRIPTION
more fiddling around with widgets to deal with the swap from name -> id.

kbaseRNASeqPieNew (which still doesn't have a pie chart) now assumes that the list of ids to select is actual a list of ids (instead of names, as previously).

kbaseRNASeqAnalysisNew now allows the sample_ids to contain IDs or names, and tries to guess.