### PR TITLE
Fix advanced sub controls rendering as blank spaces

### DIFF
--- a/kbase-extension/static/kbase/js/common/sdk.js
+++ b/kbase-extension/static/kbase/js/common/sdk.js
@@ -531,7 +531,9 @@ define([
                 class: spec.ui_class,
                 type: spec.field_type,
                 control: spec.field_type,
-                advanced: spec.advanced ? true : false
+                // If embedded in an advanced sequence control,
+                // the subcontrol does not need the advanced flag.
+                advanced: false
             },
             data: {
                 type: dataType,


### PR DESCRIPTION
Don't propagate advanced flag to subcontrols because doing so makes then un-renderable, or rather, the class added to advanced subcontrols won't be removed.
Fixes https://kbase-jira.atlassian.net/browse/TASK-439