### PR TITLE
Fix select2 control now rendering correctly as advanced parameter when un-hidden

### DIFF
--- a/kbase-extension/static/kbase/js/common/sdk.js
+++ b/kbase-extension/static/kbase/js/common/sdk.js
@@ -268,7 +268,11 @@ define([
             converted.ui.showSourceObject = spec.textsubdata_options.show_src_obj ? true : false;
             break;
         case 'customSubdata':
-            converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
+            if (spec.textsubdata) {
+                converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
+            } else {
+                converted.ui.multiSelection = false;
+            }
             // converted.ui.showSourceObject = spec.textsubdata_options.show_src_obj ? true : false;
             break;
         }

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
@@ -107,7 +107,8 @@ define([
             // CONTROL
             var selectElem = select({
                 class: 'form-control',
-                dataElement: 'input'
+                dataElement: 'input',
+                id: html.genId()
             }, [option({ value: '' }, '')].concat(selectOptions));
 
             return selectElem;
@@ -284,6 +285,8 @@ define([
                     }
                 }).on('change', function() {
                     doChange();
+                }).on('advanced-shown.kbase', function (e) {
+                    $(e.target).select2({width: 'resolve'});
                 });
                 events.attachEvents(container);
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/select2ObjectView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/select2ObjectView.js
@@ -104,6 +104,7 @@ define([
 
             // CONTROL
             var selectElem = select({
+                id: html.genId(),
                 class: 'form-control',
                 dataElement: 'input'
             }, [option({ value: '' }, '')].concat(selectOptions));
@@ -261,6 +262,9 @@ define([
                         }
                         return model.availableValues[object.id].name;
                     }
+                })
+                .on('advanced-shown.kbase', function (e) {
+                    $(e.target).select2({width: 'resolve'});
                 });
                 events.attachEvents(container);
 

--- a/nbextensions/appCell2/widgets/appParamsViewWidget.js
+++ b/nbextensions/appCell2/widgets/appParamsViewWidget.js
@@ -3,6 +3,7 @@
 
 define([
     'bluebird',
+    'jquery',
     // CDN
     'kb_common/html',
     // LOCAL
@@ -19,6 +20,7 @@ define([
 
 ], function(
     Promise,
+    $,
     html,
     UI,
     Events,
@@ -218,11 +220,8 @@ define([
 
             if (advancedInputs.length === 0) {
                 ui.setContent([areaElement, 'advanced-hidden-message'], '');
-                // ui.disableButton('toggle-advanced');
                 return;
             }
-
-            //            ui.enableButton('toggle-advanced');
 
             var removeClass = (settings.showAdvanced ? 'advanced-parameter-hidden' : 'advanced-parameter-showing'),
                 addClass = (settings.showAdvanced ? 'advanced-parameter-showing' : 'advanced-parameter-hidden');
@@ -230,6 +229,11 @@ define([
                 var input = advancedInputs[i];
                 input.classList.remove(removeClass);
                 input.classList.add(addClass);
+                 
+                var actualInput = input.querySelector('[data-element="input"]');
+                if (actualInput) {
+                    $(actualInput).trigger('advanced-shown.kbase');
+                }
             }
             //
             //            // How many advanaced?

--- a/nbextensions/appCell2/widgets/appParamsWidget.js
+++ b/nbextensions/appCell2/widgets/appParamsWidget.js
@@ -3,6 +3,7 @@
 
 define([
     'bluebird',
+    'jquery',
     // CDN
     'kb_common/html',
     // LOCAL
@@ -19,6 +20,7 @@ define([
 
 ], function (
     Promise,
+    $,
     html,
     UI,
     Events,
@@ -219,7 +221,6 @@ define([
         }
 
         function renderAdvanced(area) {
-
             // area is either "input" or "parameter"
 
             var areaElement = area + '-area',
@@ -228,11 +229,8 @@ define([
 
             if (advancedInputs.length === 0) {
                 ui.setContent([areaElement, 'advanced-hidden-message'], '');
-                // ui.disableButton('toggle-advanced');
                 return;
             }
-
-            //            ui.enableButton('toggle-advanced');
 
             var removeClass = (settings.showAdvanced ? 'advanced-parameter-hidden' : 'advanced-parameter-showing'),
                 addClass = (settings.showAdvanced ? 'advanced-parameter-showing' : 'advanced-parameter-hidden');
@@ -240,6 +238,11 @@ define([
                 var input = advancedInputs[i];
                 input.classList.remove(removeClass);
                 input.classList.add(addClass);
+                                
+                var actualInput = input.querySelector('[data-element="input"]');
+                if (actualInput) {
+                    $(actualInput).trigger('advanced-shown.kbase');
+                }
             }
             //
             //            // How many advanaced?

--- a/nbextensions/viewCell/widgets/appParamsViewWidget.js
+++ b/nbextensions/viewCell/widgets/appParamsViewWidget.js
@@ -3,6 +3,7 @@
 
 define([
     'bluebird',
+    'jquery',
     // CDN
     'kb_common/html',
     // LOCAL
@@ -19,6 +20,7 @@ define([
 
 ], function(
     Promise,
+    $,
     html,
     UI,
     Events,
@@ -229,6 +231,11 @@ define([
                 var input = advancedInputs[i];
                 input.classList.remove(removeClass);
                 input.classList.add(addClass);
+
+                var actualInput = input.querySelector('[data-element="input"]');
+                if (actualInput) {
+                    $(actualInput).trigger('advanced-shown.kbase');
+                }
             }
             //
             //            // How many advanaced?

--- a/nbextensions/viewCell/widgets/appParamsWidget.js
+++ b/nbextensions/viewCell/widgets/appParamsWidget.js
@@ -3,6 +3,7 @@
 
 define([
     'bluebird',
+    'jquery',
     // CDN
     'kb_common/html',
     // LOCAL
@@ -19,6 +20,7 @@ define([
 
 ], function (
     Promise,
+    $,
     html,
     UI,
     Events,
@@ -218,7 +220,6 @@ define([
         }
 
         function renderAdvanced(area) {
-
             // area is either "input" or "parameter"
 
             var areaElement = area + '-area',
@@ -239,6 +240,11 @@ define([
                 var input = advancedInputs[i];
                 input.classList.remove(removeClass);
                 input.classList.add(addClass);
+                
+                var actualInput = input.querySelector('[data-element="input"]');
+                if (actualInput) {
+                    $(actualInput).trigger('advanced-shown.kbase');
+                }
             }
             //
             //            // How many advanaced?


### PR DESCRIPTION
The root of the problem is that it calculates the wrong dimensions when hidden. Solution is to emit a jQuery event when advanced params are shown, and have the select2 listen for it and resize itself.
Fixes https://kbase-jira.atlassian.net/browse/TASK-440