### PR TITLE
Prevent app cell toolbar button area breaking

### DIFF
--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1079,7 +1079,6 @@ define([
                             dataElement: 'toolbar',
                             style: {
                                 position: 'absolute',
-                                left: '550px',
                                 right: '0',
                                 top: '0',
                                 height: '50px'
@@ -1087,11 +1086,12 @@ define([
                         }, [
                             div({
                                 style: {
+                                    display: 'inline-block',
+                                    right: '0',
                                     height: '50px',
                                     lineHeight: '50px',
                                     paddingRight: '15px',
-                                    verticalAlign: 'bottom',
-                                    textAlign: 'right'
+                                    verticalAlign: 'bottom'
                                 }
                             }, [
                                 div({


### PR DESCRIPTION
When the narrative window is made narrow, the toolbar area's "tab buttons" would break. This essentially right aligns the layout container and makes the button bar inline-block, thus acting as an unbreakable unit.