### PR TITLE
Fixed broken minified import tab. Some related fixes, too.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,13 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.2.1 (more notes will follow).
 
+### Version 3.1.10
+__Changes__
+- Fixed broken Import tab in the data slideout.
+- Adjusted text in staging area tour.
+- Fixed issue in App cells where the tab buttons could crowd each other out.
+- Adjusted behavior of slider buttons in volcano plot widget to be more performant.
+
 ### Version 3.1.9
 __Changes__
 - Expanded the reach of the front end code compiler.

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterDropdownInput.js
@@ -40,6 +40,11 @@ define (
         required: true,
         rowDivs: null,
 
+        init: function(options) {
+            this._super(options);
+            return this;
+        },
+
         render: function() {
             var self = this;
             var spec = self.spec;
@@ -212,7 +217,7 @@ define (
             if (!self.enabled) {
                 return { isValid: true, errormssgs:[]}; // do not validate if disabled
             }
-            var p= self.getParameterValue();
+            var p = self.getParameterValue();
             var errorDetected = false;
             var errorMessages = [];
             if(p instanceof Array) {
@@ -220,25 +225,25 @@ define (
             } else {
                 if (p) {
                     p = p.trim();
-                    // if it is a required selection and is empty, keep the required icon around but we have an error
-                    if (p==='' && self.required) {
-                        self.rowDivs[0].$row.removeClass("kb-method-parameter-row-error");
-                        self.rowDivs[0].$feedback.removeClass().addClass('kb-method-parameter-required-glyph glyphicon glyphicon-arrow-left').prop("title","required field");
-                        self.rowDivs[0].$feedback.show();
-                        self.rowDivs[0].$error.hide();
-                        errorDetected = true;
-                        errorMessages.push("required field "+self.spec.ui_name+" missing.");
-                    }
+                }
+                // if it is a required selection and is empty, keep the required icon around but we have an error
+                if (!p && self.required) {
+                    self.rowDivs[0].$row.removeClass("kb-method-parameter-row-error");
+                    self.rowDivs[0].$feedback.removeClass().addClass('kb-method-parameter-required-glyph glyphicon glyphicon-arrow-left').prop("title","required field");
+                    self.rowDivs[0].$feedback.show();
+                    self.rowDivs[0].$error.hide();
+                    errorDetected = true;
+                    errorMessages.push("required field "+self.spec.ui_name+" missing.");
+                }
 
-                    // no error, so we hide the error if any, and show the "accepted" icon if it is not empty
-                    if (!errorDetected) {
-                        if (self.rowDivs[0]) {
-                            self.rowDivs[0].$row.removeClass("kb-method-parameter-row-error");
-                            self.rowDivs[0].$error.hide();
-                            self.rowDivs[0].$feedback.removeClass();
-                            if (p!=='') {
-                                self.rowDivs[0].$feedback.removeClass().addClass('kb-method-parameter-accepted-glyph glyphicon glyphicon-ok');
-                            }
+                // no error, so we hide the error if any, and show the "accepted" icon if it is not empty
+                if (!errorDetected) {
+                    if (self.rowDivs[0]) {
+                        self.rowDivs[0].$row.removeClass("kb-method-parameter-row-error");
+                        self.rowDivs[0].$error.hide();
+                        self.rowDivs[0].$feedback.removeClass();
+                        if (p!=='') {
+                            self.rowDivs[0].$feedback.removeClass().addClass('kb-method-parameter-accepted-glyph glyphicon glyphicon-ok');
                         }
                     }
                 } else {

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterFileInput.js
@@ -4,14 +4,14 @@
  * KBase widget to upload file content into shock node.
  */
 define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
-		'narrativeConfig',
-		'kbaseNarrativeParameterInput',
+    [
+        'kbwidget',
+        'bootstrap',
+        'jquery',
+        'narrativeConfig',
+        'kbaseNarrativeParameterInput',
         'kb_service/client/shock'
-	], function(
+    ], function(
 		KBWidget,
 		bootstrap,
 		$,
@@ -49,6 +49,11 @@ define (
         cancelUpload: false,
         changeFuncs: [],
 
+        init: function(options) {
+            this._super(options);
+            return this;
+        },
+
         render: function() {
             if (!this.token) {
                 this.wrongToken = true;
@@ -64,63 +69,64 @@ define (
             }
 
             var pref = this.uuid();
-            
+
             var tbl = $('<table style="border: 0px; margin: 0px; cellpadding: 0px; cellspacing: 0px; width: 100%;"/>');
 
             var tr = $('<tr/>');
             var cellCss = { 'border' : 'none', 'vertical-align' : 'middle' };
             tr.css(cellCss);
             tbl.append(tr);
-            
+
             this.fileName = $('<input readonly>')
-            	.addClass('form-control')
-            	.css({'width' : '100%'})
-            	.attr('type', 'text');
+                .addClass('form-control')
+                .css({'width' : '100%'})
+                .attr('type', 'text');
             var percentTextWidth = '50px';
             if (self.options.isInSidePanel)
                 percentTextWidth = '100px';
             this.percentText = $('<input readonly>')
-            	.addClass('form-control')
-            	.css({'width' : percentTextWidth, 'padding': '0px', 'text-align': 'center'})
-            	.attr('type', 'text');
+                .addClass('form-control')
+                .css({'width' : percentTextWidth, 'padding': '0px', 'text-align': 'center'})
+                .attr('type', 'text');
 
             // create a file upload button and hide it and store it
             var realButton = document.createElement('input');
             realButton.setAttribute('type', 'file');
             realButton.setAttribute('style', 'display: none;');
-            realButton.addEventListener('change', function() { 
-            	var fileName = $(realButton).val();
-            	if (fileName && fileName.length > 0)
-            	    self.fileSelected(self.fileName, self.percentText, realButton);
+            realButton.addEventListener('change', function() {
+                var fileName = $(realButton).val();
+                if (fileName && fileName.length > 0)
+                    self.fileSelected(self.fileName, self.percentText, realButton);
             });
             realButton.uploader = this;
             //this.fileBrowse = realButton;
             this.$elem.append(realButton);
-            
+
             // create the visible upload button
             this.fakeButton = document.createElement('button');
             this.fakeButton.setAttribute('class', 'kb-primary-btn');
             this.selectFileMode(true);
             this.fakeButton.fb = realButton;
             this.fakeButton.addEventListener('click', function() {
-            	if (self.locked || !self.enabled)
-            	    return;
-            	if (self.inSelectFileMode) {
-            	    $(this.fb).val("");
-            	    this.fb.click();
-            	} else {
-            	    self.cancelUpload = true;
+                if (self.locked || !self.enabled) {
+                    return;
+                }
+                if (self.inSelectFileMode) {
+                    $(this.fb).val('');
+                    this.fb.click();
+                } else {
+                    self.cancelUpload = true;
                     self.selectFileMode(true);
                     self.uploadWasStarted = false;
-            	}
+                }
             });
             $(this.fakeButton);
             var td2 = $('<td/>');
             td2.css(cellCss);
             tr.append(td2);
             td2.append(this.fakeButton);
-	    
-	    	var td = $('<td/>');
+
+            var td = $('<td/>');
             td.css(cellCss);
             td.css({'width' : '70%', 'padding' : '0px', 'margin':'2px'});
             tr.append(td);
@@ -131,7 +137,7 @@ define (
             td3.css({'width' : percentTextWidth, 'padding' : '0px'});
             tr.append(td3);
             td3.append(this.percentText);
-            
+
             var $feedbackTip = $("<span>").css({"vertical-align":"middle"}).removeClass();
             if (self.required) {
                 $feedbackTip.addClass('kb-method-parameter-required-glyph glyphicon glyphicon-arrow-left').prop("title","required field");
@@ -141,7 +147,7 @@ define (
             var inputColClass = "col-md-5";
             var hintColClass  = "col-md-5";
             if (self.options.isInSidePanel) {
-            	nameColClass = "col-md-12";
+                nameColClass = "col-md-12";
                 inputColClass = "col-md-12";
                 hintColClass  = "col-md-12";
             }
@@ -173,12 +179,12 @@ define (
             self.rowDivs.push({$row:$row, $error:$errorPanel, $feedback:$feedbackTip});
             return this;
         },
-        
+
         selectFileMode: function(inSelectFileMode) {
             this.inSelectFileMode = inSelectFileMode;
             this.fakeButton.innerHTML = inSelectFileMode ? "Select File" : "Cancel";
         },
-        
+
         getFileLastModificationTime: function (file) {
             if (file.lastModifiedDate) {
                 return file.lastModifiedDate.getTime();
@@ -188,7 +194,7 @@ define (
                 return 0;
             }
         },
-        
+
         fileSelected: function (nameText, prcText, realButton) {
             if (realButton.files.length != 1)
                 return;
@@ -203,7 +209,7 @@ define (
             prcText.val("?..%");
             this.onChange();
             //console.log("kbaseNarrativeParameterFileInput.fileSelected: after this.onChange()");
-            var curTime = new Date().getTime();            
+            var curTime = new Date().getTime();
             var ujsKey = ["File", file.size, String(this.getFileLastModificationTime(file)), file.name, this.getUser()].join(':');
             var ujsClient = new UserAndJobState(this.options.ujsUrl, {'token': this.token});
             var shockClient = new Shock({url: this.options.shockUrl, token: this.token});
@@ -217,7 +223,7 @@ define (
                 console.error("kbaseNarrativeParameterFileInput.fileSelected, in ujsClient.get_has_state: ", error);
                 processAfterNodeCheck(prevShockNodeId);
             });
-            
+
             var self = this;
             function processAfterNodeCheck(storedShockNodeId) {
                 // console.log("kbaseNarrativeParameterFileInput.fileSelected, in processAfterNodeCheck: storedShockNodeId=", storedShockNodeId);
@@ -270,7 +276,7 @@ define (
                     return self.cancelUpload;
                 });
             }
-            
+
             function showShockInfo(shockNode) {
                 shockClient.get_node(shockNode, function(data) {
                     console.log("Info about node [" + shockNode + "]:");
@@ -280,32 +286,34 @@ define (
                 });
             }
         },
-        
+
         getShockNodeId: function() {
-        	return this.shockNodeId;
+            return this.shockNodeId;
         },
-        
+
         isUploadReady: function() {
-        	return this.uploadIsReady;
+            return this.uploadIsReady;
         },
-        
+
         isValid: function() {
             var self = this;
             var errorDetected = false;
             var errorMessages = [];
             var pVal = self.getParameterValue();
             if (self.enabled && (self.required || self.uploadWasStarted) && !pVal) {
-                self.rowDivs[0].$row.removeClass("kb-method-parameter-row-error");
-                self.rowDivs[0].$feedback.removeClass().addClass('kb-method-parameter-required-glyph glyphicon glyphicon-arrow-left').prop("title","required field");
-                self.rowDivs[0].$feedback.show();
-                self.rowDivs[0].$error.hide();
+                if (self.rowDivs) {
+                    self.rowDivs[0].$row.removeClass("kb-method-parameter-row-error");
+                    self.rowDivs[0].$feedback.removeClass().addClass('kb-method-parameter-required-glyph glyphicon glyphicon-arrow-left').prop("title","required field");
+                    self.rowDivs[0].$feedback.show();
+                    self.rowDivs[0].$error.hide();
+                }
                 if (self.uploadWasStarted) {
                     errorMessages.push("field "+self.spec.ui_name+" is not 100% ready.");
                 } else {
                     errorMessages.push("required field "+self.spec.ui_name+" missing.");
                 }
                 errorDetected = true;
-            } else {
+            } else if (self.rowDivs) {
                 self.rowDivs[0].$row.removeClass("kb-method-parameter-row-error");
                 self.rowDivs[0].$error.hide();
                 self.rowDivs[0].$feedback.removeClass();
@@ -314,7 +322,7 @@ define (
             }
             return {isValid: !errorDetected, errormssgs:errorMessages};
         },
-        
+
         cancelImport: function() {
         	// Do nothing
 		},
@@ -332,7 +340,7 @@ define (
 			});
 			return p;
 		},
-        
+
         getParameterValue: function() {
             var ret = this.uploadIsReady ? this.shockNodeId : null;
             return ret ? ret : "";
@@ -359,7 +367,7 @@ define (
             	shockClient.get_node(self.shockNodeId, function(info) {
             		if (!info)
                 		self.shockNodeId = null;
-                	self.isValid();                		
+                	self.isValid();
             	}, function(error) {
             		self.shockNodeId = null;
                 	self.isValid();
@@ -381,20 +389,20 @@ define (
             //this.render();
             return this;
         },
-        
+
         disableParameterEditing: function() {
             this.enabled = false;
             if (this.rowDivs) {
                 this.rowDivs[0].$feedback.removeClass();
             }
         },
-        
+
         enableParameterEditing: function() {
             // enable the input
             this.enabled = true;
             this.isValid();
         },
-        
+
         lockInputs: function() {
             if (this.enabled) {
             	this.locked = true;
@@ -403,7 +411,7 @@ define (
                 this.rowDivs[0].$feedback.removeClass();
             }
         },
-        
+
         unlockInputs: function() {
             if (this.enabled) {
             	this.locked = false;
@@ -414,7 +422,7 @@ define (
         addInputListener: function(onChangeFunc) {
             this.changeFuncs.push(onChangeFunc);
         },
-        
+
         onChange: function() {
             var value = "" + this.shockNodeId + ", " + this.fileName.val() + ", " + this.uploadIsReady + ", " + this.percentText.val();
             for (var i in this.changeFuncs) {
@@ -426,13 +434,13 @@ define (
         },
 
         uuid: function() {
-            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, 
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,
                 function(c) {
                     var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
                     return v.toString(16);
                 });
         },
-        
+
         getUser: function() {
             var ret = null;
             if (!this.token)

--- a/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
+++ b/kbase-extension/static/kbase/js/widgets/function_input/parameter_input/kbaseNarrativeParameterTextInput.js
@@ -454,7 +454,7 @@ define([
                 return {isValid: true, errormssgs: []}; // do not validate if disabled
             }
             var p = self.getParameterValue(true);
-            if (p === null) {
+            if (p === null && !self.required) {
                 return {isValid: true, errormssgs: []};
             }
             var errorDetected = false;
@@ -468,7 +468,7 @@ define([
                 if (p[i] === null) {
                     continue;
                 }
-                var pVal = p[i].trim();
+                var pVal = p ? p[i].trim() : '';
                 // if it is a required field and not empty, keep the required icon around but we have an error (only for the first element)
                 if (pVal === '' && self.required && i === 0) {
                     self.rowInfo[i].$row.removeClass("kb-method-parameter-row-error");

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
@@ -7,19 +7,19 @@
  * @public
  */
 define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
-		'narrativeConfig',
-		'kbaseAuthenticatedWidget',
-		'select2',
-		'util/string',
+    [
+        'kbwidget',
+        'bootstrap',
+        'jquery',
+        'narrativeConfig',
+        'kbaseAuthenticatedWidget',
+        'select2',
+        'util/string',
         'base/js/namespace',
         'common/pythonInterop',
         'util/kbaseApiUtil',
         'kbase-client-api'
-	], function(
+    ], function(
         KBWidget,
         bootstrap,
         $,
@@ -33,9 +33,9 @@ define (
 	) {
     'use strict';
     return KBWidget({
-        name: "kbaseNarrativeSideImportTab",
+        name: 'kbaseNarrativeSideImportTab',
         parent : kbaseAuthenticatedWidget,
-        version: "1.0.0",
+        version: '1.0.0',
         options: {
             ws_name: null
         },
@@ -372,7 +372,7 @@ define (
                 return;
             var inputWidgetName = methodSpec.widgets.input;
             if (!inputWidgetName || inputWidgetName === 'null')
-                inputWidgetName = "kbaseNarrativeMethodInput";
+                inputWidgetName = 'kbaseNarrativeMethodInput';
             var methodJson = JSON.stringify(methodSpec);
 
             var $inputDiv = $('<div>');
@@ -381,21 +381,21 @@ define (
             // var buttonLabel = 'details';
             var methodTitle = methodSpec.info.tooltip.trim();
             var methodDescr = methodFullInfo[methodId].description.trim();
-            var $overviewSwitch = $("<a/>").html('more...');
+            var $overviewSwitch = $('<a/>').html('more...');
             var $methodInfo = $('<div>')
                     .addClass('kb-func-desc')
                     .css({'margin' : '25px 0px 0px 15px'})
                     .append($('<h2>')
                     .attr('id', methodUuid)
                     .addClass('collapse in')
-                    .append(methodTitle).append("&nbsp;&nbsp&nbsp").append($overviewSwitch));
+                    .append(methodTitle).append('&nbsp;&nbsp&nbsp').append($overviewSwitch));
 
             var $methodDescrPanel = $('<div/>')
                     .addClass('kb-func-desc')
                     .css({'margin' : '20px 0px 0px 20px', 'display' : 'none'})
                     .append(methodDescr);
             if (methodDescr && methodDescr != '' && methodDescr != 'none' &&
-                    methodDescr != methodTitle && (methodDescr + ".") != methodTitle) {
+                    methodDescr != methodTitle && (methodDescr + '.') != methodTitle) {
                 $overviewSwitch.click(function(){
                     $methodDescrPanel.toggle();
                 });
@@ -407,7 +407,7 @@ define (
                     .append($('<div>')
                     .addClass('kb-func-panel kb-cell-run')
                     .append($methodInfo).append($methodDescrPanel))
-                    .append($('<div>').css({'margin' : '25px 0px 0px 15px'}).append("<hr>"))
+                    .append($('<div>').css({'margin' : '25px 0px 0px 15px'}).append('<hr>'))
                     .append($('<div>')
                     .append($inputDiv))
                     .append($('<div>')
@@ -429,7 +429,7 @@ define (
                 $header.append(tabHeader);
                 var tabContent = $('<div>')
                     .addClass('kb-side-tab3')
-                    .css("display", "none")
+                    .css('display', 'none')
                     .append(params.content);
                 $body.append(tabContent);
                 if (params.show) {
@@ -449,27 +449,32 @@ define (
                     }
                 }, this));
             }
-            var wig = $inputDiv[inputWidgetName]({ method: methodJson, isInSidePanel: true });
-            this.inputWidget[methodId] = wig;
+            require([inputWidgetName], function(InputWidget) {
+                // var wig = $inputDiv[inputWidgetName]({ method: methodJson, isInSidePanel: true });
+                var wig = new InputWidget($inputDiv, {method: methodJson, isInSidePanel: true});
+                self.inputWidget[methodId] = wig;
 
-            var onChange = function() {
-                var w = self.getInputWidget();
-                if (self.timer)
-                    return;
-                var v = w.isValid();
-                if (v.isValid) {
-                    self.showInfo('All parameters are valid and you can start "Import" now');
-                } else {
-                    self.showInfo('You can start "Import" when all parameters are ready (marked by green check)');
+                var onChange = function() {
+                    var w = self.getInputWidget();
+                    if (self.timer)
+                        return;
+                    var v = w.isValid();
+                    if (v.isValid) {
+                        self.showInfo('All parameters are valid and you can start "Import" now');
+                    } else {
+                        self.showInfo('You can start "Import" when all parameters are ready (marked by green check)');
+                    }
+                };
+                var paramValues = wig.getAllParameterValues();
+                for (var paramPos in paramValues) {
+                    var paramId = paramValues[paramPos].id;
+                    wig.addInputListener(paramId, onChange);
                 }
-            };
-            var paramValues = wig.getAllParameterValues();
-            for (var paramPos in paramValues) {
-                var paramId = paramValues[paramPos].id;
-                wig.addInputListener(paramId, onChange);
-            }
 
-            this.tabs[methodId] = tab;
+                self.tabs[methodId] = tab;
+            }, function(error) {
+                alert(error);
+            });
         },
 
         getSelectedTabId: function() {

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager']
 
 from semantic_version import Version
-__version__ = Version("3.1.9")
+__version__ = Version("3.1.10")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.1.9",
+    "version": "3.1.10",
     "dev_mode": true,
     "git_commit_hash": "60e2219",
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",


### PR DESCRIPTION
The parameter fields for the import tab were being set up in an unsupported way, and the minifier really exposed that.

There were other problems exposed by digging into this - a dropdown parameter was always treated as valid, even if it wasn't (e.g. the technology type dropdown for reads was allowed to be empty, even though it was marked required, which would cause the import to fail.)

There's still some interesting UX stuff going on if a text field is optional (it can be pre-filled, and still have a check mark when emptied), but those might be fixable with an improved docstring.