### PR TITLE
Hisat widget mod

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
@@ -406,39 +406,56 @@ define (
 
             if (this.options.output.read_sample_ids) {
 
-              var $selector = $.jqElem('select').css('width', '500px')
-                .on('change', function(e) {
-                  $rnaseq.loadAlignment( $selector.val() );
-                }
-              );
+              var promises = [];
+              var ws = new Workspace(window.kbconfig.urls.workspace, {token : $rnaseq.authToken()});
+              var hackedIDMap = {};
 
               $.each(
                 this.options.output.read_sample_ids,
                 function (i,v) {
-
-                  var label = v;
-                  $.each(
-                    $rnaseq.options.output.mapped_rnaseq_alignments,
-                    function (i, id) {
-                      if (id[v]) {
-                        label = id[v];
-                        return;
-                      }
-                    }
+                  promises.push(
+                    ws.get_object_info([{ref : v}])
                   );
-
-                  $selector.append(
-                    $.jqElem('option')
-                      .attr('value', $rnaseq.options.output.sample_alignments[i])
-                      .append(label)
-                  )
                 }
               );
 
-              this.$elem
-                .append("<br>Please select alignment: ")
-                .append($selector)
-                .append("<br><br>");
+              $.when.apply($, promises).then(function () {
+                var args = arguments;
+                $.each(
+                  arguments,
+                  function (i, v) {
+                    hackedIDMap[$rnaseq.options.output.read_sample_ids[i]] = v[0][1];
+                  }
+                );
+
+                var $selector = $.jqElem('select').css('width', '500px')
+                  .on('change', function(e) {
+                    $rnaseq.loadAlignment( $selector.val() );
+                  }
+                );
+
+                $.each(
+                  $rnaseq.options.output.read_sample_ids,
+                  function (i,v) {
+
+                    var label = hackedIDMap[v] || v;
+
+                    $selector.append(
+                      $.jqElem('option')
+                        .attr('value', $rnaseq.options.output.sample_alignments[i])
+                        .append(label)
+                    )
+                  }
+                );
+
+                var $block = $.jqElem('div').append("<br>Please select alignment: ")
+                  .append($selector)
+                  .append("<br><br>");
+
+                $rnaseq.$elem.prepend($block);
+
+              });
+
             }
 
 

--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
@@ -409,12 +409,25 @@ define (
               var promises = [];
               var ws = new Workspace(window.kbconfig.urls.workspace, {token : $rnaseq.authToken()});
               var hackedIDMap = {};
+              var sampleToAlignmentMap = {};
+
+              $.each(
+                $rnaseq.options.output.mapped_alignments_ids,
+                function (i,m) {
+                  $.each(
+                    m,
+                    function (k, v) {
+                      sampleToAlignmentMap[k] = v;
+                    }
+                  )
+                }
+              );
 
               $.each(
                 this.options.output.read_sample_ids,
                 function (i,v) {
                   promises.push(
-                    ws.get_object_info([{ref : v}])
+                    ws.get_object_info([{ref : sampleToAlignmentMap[v]}])
                   );
                 }
               );
@@ -424,6 +437,7 @@ define (
                 $.each(
                   arguments,
                   function (i, v) {
+
                     hackedIDMap[$rnaseq.options.output.read_sample_ids[i]] = v[0][1];
                   }
                 );
@@ -438,6 +452,7 @@ define (
                   $rnaseq.options.output.read_sample_ids,
                   function (i,v) {
 
+                    var objId = v;
                     var label = hackedIDMap[v] || v;
 
                     $selector.append(


### PR DESCRIPTION
The HISAT selector output *was* fixed, and even was fixed in production.

The problem was that it was looking at a table of mapping information provided by the given object, which contained a map from ID -> name. However, Shinjae informed me this morning that that mapping information is unreliable and should not be used.

So the rna_seq_alignments_mapping object which helpfully contained alignment ID -> alignment object mappings was instead sometimes populated with sample name -> alignment object mappings. And even those are not valid and not to be trusted.

Instead of using the provided mapping information, which is incorrect and should not be used. The widget should now map from sample -> alignment, get_object_info on all alignment objects, pull out the names of those objects, and use that to create a sample -> alignment object mapping. That's in here.

I'm not 100% convinced that the objects being produced on the backend are valid, but this hacks around it.

This widget has received minimal testing against a single object. It appears to work on that, but I don't know if there will be other structural inconsistencies in future objects.