### PR TITLE
Modified the CI  "publicData": {"GenomeFeatues_prod": {...}} to point…

### DIFF
--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -1,7 +1,7 @@
 {
     "ci": {
         "publicData": {
-            "GenomeFeatues_prod": {
+            "GenomeFeatues_ci": {
                 "name": "Reference Genomes",
                 "type": "KBaseGenomes.Genome",
                 "ws": "ReferenceDataManager",

--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -1,10 +1,10 @@
 {
     "ci": {
         "publicData": {
-            "genomes": {
-                "name": "Genomes",
+            "GenomeFeatues_prod": {
+                "name": "Reference Genomes",
                 "type": "KBaseGenomes.Genome",
-                "ws": "KBasePublicGenomesV5",
+                "ws": "ReferenceDataManager",
                 "search": true
             },
             "plant_genomes": {


### PR DESCRIPTION
There are by far 22k RefSeq genomes uploaded into the ReferenceDataManager workspace in production and 35k in CI.  I'd like to release them to the public users in the narrative, but I want to see if they work in CI first. So I only make the changes to the CI configuration.