### PR TITLE
not all sample ids were displaying

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
@@ -219,12 +219,14 @@ define (
                       }
                     )
 
-                    $rna.dataset().parsed_read_samples = $.jqElem('table').addClass('display').css('width', '100%').css('border', '1px solid gray');
-                    var $tt = $rna.dataset().parsed_read_samples.DataTable({
+                    $rna.dataset().parsed_read_samples = $.jqElem('div');
+                    var $sample_table = $.jqElem('table').addClass('display').css('width', '100%').css('border', '1px solid gray');
+                    $rna.dataset().parsed_read_samples.append($sample_table);
+                    var $tt = $sample_table.DataTable({
                         columns: [
                             {title: 'Reads'},
                             {title: 'Treatment Labels'}
-                        ]
+                        ],
                     });
 
                     $tt.rows.add(sample_id_data).draw();


### PR DESCRIPTION
 because the decorators around the datatables table to do searching and pagination weren't included. But now they are.