### PR TITLE
Fix narrbase image build

### DIFF
--- a/narrbase-image/Dockerfile
+++ b/narrbase-image/Dockerfile
@@ -11,10 +11,14 @@ ADD https://github.com/jupyter/notebook/archive/${JUPYTER_VERSION}.tar.gz /kb/in
 
 RUN \
     curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && \
-    apt-get install -y nodejs
+    apt-get install -y nodejs && \
+    pip install --upgrade pip && \
+    pip install setuptools==33.1.1  # https://github.com/pypa/setuptools/issues/942
 
 # Install Jupyter Notebook
 RUN cd /kb/installers/jupyter_notebook && tar -xvf notebook-${JUPYTER_VERSION}.tar.gz && cd notebook-${JUPYTER_VERSION} && pip install --pre -e .
 
 # Install IPywidgets
-RUN pip install --upgrade six && pip install ipywidgets==${IPYWIDGETS_VERSION} && jupyter nbextension enable --py widgetsnbextension
+RUN pip install --upgrade six
+RUN pip install ipywidgets==${IPYWIDGETS_VERSION}
+RUN jupyter nbextension enable --py widgetsnbextension


### PR DESCRIPTION
Installing IPywidgets brings in the latest setuptools (or some recent version) which is incompatible with other things, and effectively breaks our Python install.

This sticks to the last good version of setuptools (33.1.1) and should build.

See also this issue:
pypa/setuptools#942
