### PR TITLE
strip "." out of search query strings in public data search

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePublicTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePublicTab.js
@@ -258,6 +258,8 @@ define ([
 
         renderFromSearch: function(cat) {
             this.currentPage++;
+            // remove all periods from query since SOLR does those literally and returns unexpected things
+            this.currentQuery = this.currentQuery.replace(/\./g, '');
             this.search(this.currentCategory, this.currentQuery, this.itemsPerPage, this.currentPage, function(query, data) {
                 if (query !== this.currentQuery) {
                     return;


### PR DESCRIPTION
Leaving the "." character in search was returning some unexpected results. E.g. searching for "e. coli" would return nothing, but "e coli" would. This just removes periods before sending the search string to the service

Tagging @qzzhang who requested the change.