### PR TITLE
Updates widget ws loading

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
@@ -28,11 +28,7 @@ define (
 
         version: "1.0.0",
         options: {
-            //tableColumns : ['Experiment name', 'Title', 'Experiment Description', 'Experiment design', 'Platform', 'Library type',
-            //                'Genome name', 'Genome annotation', 'Number of samples', 'Reads Label', 'Number of replicates', 'Tissue', 'Condition',
-            //                'Domain', 'Source', 'Publication Details']
             tableColumns : [ 'RNA-seq Sample Set','Sampleset Description', 'Platform', 'Library type', 'Reads', 'Domain', 'Source', 'Publication Details']
-
         },
 
 
@@ -42,36 +38,12 @@ define (
         ],
 
 
-        /*setDataset : function setDataset(newDataset) {
-
-                var $table =  new kbaseTable($tableElem, {
-                        structure : {
-                            keys : keys,
-                            rows : overViewValues
-                        }
-
-                    }
-                );
-
-            this.data('loader').hide();
-            this.data('tableElem').show();
-
-            this.setValueForKey('dataset', newDataset);
-
-        },
-
-        setBarchartDataset : function setBarchartDataset(bars, xLabel, yLabel) {
-
-        },*/
 
         loadAnalysis : function(ws, analysis) {
 
             var $rna = this;
 
-            var all_promises = [
-//                ws.get_objects([{ ref : analysis.annotation_id}]),
-//                ws.get_objects([{ ref : analysis.genome_id}])
-            ];
+            var all_promises = [ ];
 
             var external_ids = {};
             var num_sample_ids = 0;
@@ -85,99 +57,26 @@ define (
 
                         if (v.match(/\//)) {
                           all_promises.push(
-                              ws.get_object_info([
+                              ws.get_object_info3({ objects : [
                                 {ref : v}
-                              ])
+                              ]})
                           )
                         }
                         else {
 
                           all_promises.push(
-                              ws.get_object_info([
+                              ws.get_object_info3({ objects : [
                                 //{ref : v}
                                 {
                                   workspace : $rna.options.workspace,
                                   name : v
                                 }
-                              ])
+                              ]})
                           )
                         }
                     }
                 );
             }
-
-
-            /*if (analysis.alignments) {
-
-                this.options.tableColumns.push('Alignments');
-                var alignment_ids = [];
-                $.each(
-                    analysis.alignments,
-                    function (k,v) {
-
-                        if (external_ids[k] == undefined) {
-
-                            alignment_ids.push(k);
-                            all_promises.push(
-                                ws.get_object_info([{ref : k}])
-                            )
-                            external_ids[k] = 1;
-                        }
-
-                        if (external_ids[v] == undefined) {
-
-                            alignment_ids.push(v);
-                            all_promises.push(
-                                ws.get_object_info([{ref : v}])
-                            )
-                            external_ids[v] = 1;
-                        }
-                    }
-                );
-
-
-            }
-
-            if (analysis.expression_values) {
-
-                this.options.tableColumns.push('Expression Values');
-                var ev_ids = [];
-                $.each(
-                    analysis.expression_values,
-                    function (k,v) {
-                        if (external_ids[k] == undefined) {
-                            ev_ids.push(k);
-                            all_promises.push(
-                                ws.get_object_info([{ref : k}])
-                            )
-                            external_ids[k] = 1;
-                        }
-
-                        if (external_ids[v] == undefined) {
-                            ev_ids.push(v);
-                            all_promises.push(
-                                ws.get_object_info([{ref : v}])
-                            )
-                            external_ids[v] = 1;
-                        }
-                    }
-                );
-
-            }
-
-            if (analysis.transcriptome_id) {
-                this.options.tableColumns.push('Cuffmerge Output');
-                all_promises.push(
-                    ws.get_object_info([{ref : analysis.transcriptome_id}])
-                );
-            }
-
-            if (analysis.cuffdiff_diff_exp_id) {
-                this.options.tableColumns.push('Cuffdiff Output');
-                all_promises.push(
-                    ws.get_object_info([{ref : analysis.cuffdiff_diff_exp_id}])
-                );
-            }*/
 
             $.when.apply($, all_promises).then(function () {
 
@@ -188,7 +87,7 @@ define (
                 var ref_map = {};
                 var ref_map_by_id = {};
                 $.each(
-                    extra_args,
+                    extra_args.infos,
                     function(i, v) {
 
                         var info_obj = {};
@@ -347,14 +246,16 @@ define (
                 this.loadAnalysis(ws, this.options.SetupRNASeqAnalysis);
             }
             else {
-                ws.get_objects(
-                    [{
+
+                ws.get_objects2(
+                    {objects : [{
                         workspace : this.options.workspace,
                         name : this.options.output
-                    }]
+                    }]}
                 ).then(function(d) {
 
-                    $rna.setDataset(d[0].data);
+
+                    $rna.setDataset(d.data[0].data);
                     if ($rna.dataset().tool_used) {
 
                       var promises = [];
@@ -364,7 +265,7 @@ define (
                         keys,
                         function (i,v) {
                           promises.push(
-                            ws.get_object_info([{ref : $rna.dataset()[v]}])
+                            ws.get_object_info3({ objects : [{ref : $rna.dataset()[v]}] })
                           );
                         }
                       );
@@ -386,7 +287,7 @@ define (
 
                     }
                     else {
-                      $rna.loadAnalysis(ws, d[0].data);
+                      $rna.loadAnalysis(ws, d.data[0].data);
                     }
                 })
                 .fail(function(d) {

--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqPieNew.js
@@ -328,11 +328,11 @@ define (
                   ws_params = { ref : this.options.ws_sample_id };
                 }
 
-                ws.get_objects([ws_params]).then(function (d) {
-                  $pie.options.output = d[0].data;
+                ws.get_objects2({objects : [ws_params]}).then(function (d) {
+                  $pie.options.output = d.data[0].data;
 
                   $pie.appendUI($pie.$elem);
-                  if (d[0].data.alignment_stats != undefined) {
+                  if (d.data[0].data.alignment_stats != undefined) {
                     $pie.data('container').removeTab('Overview');
                     //this.data('container').removeTab('Pie chart');
                           $pie.data('container').addTab(
@@ -341,10 +341,10 @@ define (
                                   content : 'Loading...',
                               }
                           );
-                    $pie.setDataset(d[0].data);
+                    $pie.setDataset(d.data[0].data);
                   }
                   else {
-                    $pie.loadAlignment(d[0].data.sample_alignments[0]);
+                    $pie.loadAlignment(d.data[0].data.sample_alignments[0]);
                   }
                 })
                 .fail(function(d) {
@@ -388,8 +388,8 @@ define (
                     ref : ref
                 };
 
-                ws.get_objects([ws_params]).then(function (d) {
-                    $pie.setDataset(d[0].data);
+                ws.get_objects2({objects : [ws_params]}).then(function (d) {
+                    $pie.setDataset(d.data[0].data);
                 })
                 .fail(function(d) {
 
@@ -427,18 +427,19 @@ define (
                 this.options.output.read_sample_ids,
                 function (i,v) {
                   promises.push(
-                    ws.get_object_info([{ref : sampleToAlignmentMap[v]}])
+                    ws.get_object_info3({objects : [{ref : sampleToAlignmentMap[v]}]})
                   );
                 }
               );
 
               $.when.apply($, promises).then(function () {
                 var args = arguments;
+
                 $.each(
                   arguments,
                   function (i, v) {
 
-                    hackedIDMap[$rnaseq.options.output.read_sample_ids[i]] = v[0][1];
+                    hackedIDMap[$rnaseq.options.output.read_sample_ids[i]] = v.infos[0][1];
                   }
                 );
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -15,7 +15,8 @@ define([
     'kbwidget',
     'kbaseNarrativeControlPanel',
     'kbaseNarrativeSharePanel',
-    'api/NewWorkspace',
+    //'api/NewWorkspace',
+    'kbase-client-api',
     'kbase-generic-client-api',
     'util/timeFormat'
 ], function (
@@ -28,7 +29,8 @@ define([
     KBWidget,
     ControlPanel,
     kbaseNarrativeSharePanel,
-    NewWorkspace,
+    //NewWorkspace,
+    KBaseClientAPI,
     GenericClient,
     TimeFormat
 ) {


### PR DESCRIPTION
I don't think a ticket was created for this, or if it was I couldn't find it.

Updated the rna-seq widgets on http://localhost:8888/narrative/ws.19113.obj.1 to use get_objects2 and get_object_info3 to load their data, and deal with /'s in the object refs. Also cleaned up some commented cruft in them.

PLEASE NOTE - *only* kbaseRNASeqPieNew.js and kbaseRNASeqAnalysisNew.js have been updated to use the new workspace methods, and I'm sure other rna-seq widget should be updated to use the newer methods, but without a narrative using those widgets to test against, I don't want to make the change since it's not quite a drop in replacement. It's almost a drop in, but I still want to actually look at something and test it before deploy.