### PR TITLE
Add download support to dynamic table

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "require-css": "0.1.8",
     "select2": "4.0.3",
     "select2-bootstrap-theme": "^0.1.0-beta.9",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "file-saver": "filesaver#^1.3.3"
   }
 }

--- a/kbase-extension/static/kbase/js/widgets/dynamicTable.js
+++ b/kbase-extension/static/kbase/js/widgets/dynamicTable.js
@@ -34,23 +34,30 @@
  *   style: 'css style to apply to outer container',
  *   rowFunction: function($row) {
  *      return $row; (after doing whatever to it)
- *   }
+ *   },
+ *   enableDownload: true/false,
+ *   downloadFileName: string,
  */
 define([
     'jquery',
     'bootstrap',
     'bluebird',
     'kbase-generic-client-api',
-    'util/display'
+    'util/display',
+    'util/string',
+    'fileSaver'
 ], function(
     $,
     Bootstrap,
     Promise,
     GenericClient,
-    DisplayUtil
+    Display,
+    StringUtil,
+    FileSaver  //enables the saveAs function.
 ) {
 
     var DynamicTable = function (elem, options) {
+        console.log(FileSaver);
         this.options = {
             class: '',
             style: {},
@@ -58,10 +65,13 @@ define([
             rowsPerPage: 10,
             headers: [],
             decoration: [],
-            data: []
+            data: [],
+            enableDownload: false,
+            downloadFileName: 'table_data.csv'
         };
         $.extend(true, this.options, options);
 
+        this.currentData = [];
         this.currentSort = {
             id: null,
             dir: null
@@ -114,10 +124,40 @@ define([
      * Just shows what rows are visible right now.
      */
     DynamicTable.prototype.makeWidgetFooter = function() {
+        // var dropdownId = 'dtable-' + StringUtil.uuid();
         this.$shownText = $('<span></span>');
         var $footer = $('<div class="row">')
-                      .append($('<div class="col-md-12">')
+                      .append($('<div class="col-md-6">')
                               .append(this.$shownText));
+
+        if (this.options.enableDownload) {
+            var self = this;
+            var csvRows = function(data) {
+                var headerNames = [];
+                self.headers.forEach(function(h) {
+                    headerNames.push(h.text);
+                });
+                data.unshift(headerNames);
+                return data.map(function(row) {
+                    return row.join(',') + '\n';
+                });
+            };
+            var $dlBtn = Display.simpleButton('btn-md btn-default dropdown-toggle', 'fa fa-download')
+                .click(function() {
+                    saveAs(new Blob(csvRows(self.currentData)), self.options.downloadFileName);
+                });
+            var $dlAllBtn = Display.simpleButton('btn-md btn-default dropdown-toggle', 'fa fa-cloud-download')
+                .click(function() {
+                    self.options.downloadAllDataFunction(self.currentSort.id, self.currentSort.sortState)
+                    .then(function(data) {
+                        saveAs(new Blob(csvRows(data)), self.options.downloadFileName);
+                    });
+                });
+            $footer.append($('<div class="col-md-6">')
+                           .append($('<div class="pull-right">')
+                                   .append($dlBtn)
+                                   .append($dlAllBtn)));
+        }
         return $footer;
     };
 
@@ -128,14 +168,14 @@ define([
      */
     DynamicTable.prototype.makeWidgetHeader = function() {
         var self = this;
-        var $leftBtn = DisplayUtil.simpleButton('btn-md', 'fa fa-caret-left')
+        var $leftBtn = Display.simpleButton('btn-md', 'fa fa-caret-left')
                        .click(function() {
                            var curP = self.currentPage;
                            if (self.getPrevPage() !== curP) {
                                self.getNewData();
                            }
                        });
-        var $rightBtn = DisplayUtil.simpleButton('btn-md', 'fa fa-caret-right')
+        var $rightBtn = Display.simpleButton('btn-md', 'fa fa-caret-right')
                         .click(function() {
                             var curP = self.currentPage;
                             if (self.getNextPage() !== curP) {
@@ -224,7 +264,7 @@ define([
         header.sortState = 0;
         if (header.isSortable) {
             // add sorting.
-            var $sortBtn = DisplayUtil.simpleButton('btn-xs', 'fa fa-sort text-muted').addClass('pull-right');
+            var $sortBtn = Display.simpleButton('btn-xs', 'fa fa-sort text-muted').addClass('pull-right');
             $sortBtn.click(function() {
                 // reset all other sort buttons
                 var curState = header.sortState;
@@ -258,6 +298,7 @@ define([
      */
     DynamicTable.prototype.setData = function(data) {
         // list of lists. Empty it out, then put it in place in the given order.
+        this.currentData = data;
         this.$tBody.empty();
         data.forEach(function(row) {
             // decorate each row element as necessary

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -4,6 +4,7 @@ require.config({
     // Jupyter does some magic where it merges its /static/ directory
     // with this one (kbase-profile/static)
     paths: {
+        fileSaver: 'ext_components/file-saver/FileSaver.min',
         bluebird: 'ext_components/bluebird/js/browser/bluebird.min',
         'bootstrap-slider': 'ext_components/bootstrap-slider/bootstrap-slider',
         'jquery-dataTables': 'ext_components/datatables/media/js/jquery.dataTables.min',


### PR DESCRIPTION
This is pretty heavy on the alpha-side of things, but this adds download support from the newer table widget that @msneddon and I put together. It's demonstrated with the binned contigs viewer. The buttons (pending redesign...) in the lower right of the table will download either the current data view (left button) or all of the data in that table (right button).

A problem is that it requires holding all data on the browser right now before funneling it to the file system. Doing it this way supports up to hundreds of MB of data (several GB for Chrome), so it *should* be fine, but could also be a problem for certain files. But this is an alpha. We can do things to alleviate problems, like just preventing download of all data for sets of certain sizes.