### PR TITLE
Removed dependency on 'dev' version of AssemblyAPI for assembly viewer

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotationAssembly.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotationAssembly.js
@@ -53,7 +53,7 @@ define ([
             // 1) get stats, and show the panel
             var basicInfoCalls = [];
             basicInfoCalls.push(
-                Promise.resolve(self.client.sync_call('AssemblyAPI.get_stats', [this.obj_ref], null, null, 'dev'))
+                Promise.resolve(self.client.sync_call('AssemblyAPI.get_stats', [this.obj_ref]))
                     .then(function(stats) {
                         self.assembly_stats = stats[0];
                     }));

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotationAssembly.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeAnnotationAssembly.js
@@ -174,7 +174,7 @@ define ([
                         query: query,
                         sort_by: sortBy,
                         start: pageNum * self.options.pageLimit
-                    }], null, null, 'dev'))
+                    }]))
                     .then(function(results) {
                         results = results[0];
                         var rows = [];


### PR DESCRIPTION
Minor fix that didn't get pushed in the last PR. Oops!
@msneddon - this means that the AssemblyAPI needs to be promoted to release in each environment so the `search_contigs` function is available.