### PR TITLE
bails out if no w [TASK-588]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
@@ -456,6 +456,8 @@ define (
 
                 var onChange = function() {
                     var w = self.getInputWidget();
+                    if (!w) { return };
+
                     if (self.timer)
                         return;
                     var v = w.isValid();


### PR DESCRIPTION
This patch is a hack that wallpapers over an actual issue, so it's submitted for informational purposes. It can be integrated, but it's may just be hiding another problem. Bill and Erik need to look into this more thoroughly, since it's getting into the guts which I am less familiar with.

There's a lot going on here, so please bear with me.

Right now, in CI, if you were to upload a gen bank file, the cell will add into the narrative and then immediately expand the cell while the job is still in the queue. If this happens, it'll fall into this issue where it claims that the job is still queued and not update the logs.

Conversely, in my local narrative, it will only show the title of the cell while it's in the queue. So the cell will be added to the narrative and only the title will be visible, e.g. - "Import Job status for UPLOAD GENBANK FILE", but no other info. After it has left the queue, it will pop open with status info. And if the job waits that long, then it will not manifest the problem and the logs will update as normal.

To confirm that the logs not updating is caused by the inputWidget not existing, I hacked into the source on ci via chrome. With this patch in place, the issue did not manifest. Without the patch, problems persisted.

So this definitely resolves it, but there's almost assuredly a better fix for it that should be investigated more thoroughly.