### PR TITLE
KBASE-5243 - Fix mapping from numerical month -> abbreviation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ __Changes__
 - Modified the Sharing dialog to make the actions more clear.
 - Modified the configuration for publicly available data sources.
 - Made global changes to support the new KBase authentication/authorization system.
+- KBASE-5243 - fix problem where Narratives (and probably data objects) were showing a change date one month into the future.
 
 ### Version 3.3.0
 __Changes__

--- a/kbase-extension/static/kbase/js/util/timeFormat.js
+++ b/kbase-extension/static/kbase/js/util/timeFormat.js
@@ -8,7 +8,7 @@
 define([], function() {
     'use strict';
 
-    var monthLookup = ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    var monthLookup = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
     /**
      * @method makePrettyTimestamp

--- a/test/unit/spec/Util/TimeFormatSpec.js
+++ b/test/unit/spec/Util/TimeFormatSpec.js
@@ -19,8 +19,21 @@ define (
     var testISOTime2 = '2016-01-06T00:48:43.196Z';
     var testOutputString = 'Wed Dec 09 2015';
     var reformattedString = '2015-12-09 13:58:22';
+    var testExactDayStr = 'Dec 9, 2015';
 
     describe('KBase Time Formatting Utility function module', function() {
+        it('getTimeStampStr should properly output an exact time string', function() {
+            var d = TF.getTimeStampStr(testISOTime, true);
+            expect(d).toBe(testExactDayStr);
+        });
+
+        it('getTimeStampStr should return a fuzzy relative time string', function() {
+            var prevDay = new Date();
+            prevDay.setDate(prevDay.getDate()-2);
+            var d = TF.getTimeStampStr(prevDay, false);
+            expect(d).toBe('2 days ago');
+        });
+
         it('parseDate should properly parse an ISO date string', function() {
             var d = TF.parseDate(testISOTime);
             expect(d).toEqual(jasmine.any(Object));


### PR DESCRIPTION
There was no mapping for May, oddly.