### PR TITLE
Bump version of base images and narrative

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # Made available under the KBase Open Source License
 #
 
-FROM kbase/narrbase:4.6
+FROM kbase/narrbase:4.7
 MAINTAINER Bill Riehl wjriehl@lbl.gov
 
 EXPOSE 8888

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,10 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 
+### Version 3.4.2
+- Update base Narrative image to include an Ubuntu kernel security update.
+- Add ETE3 to the environment.
+
 ### Version 3.4.1
 - Fixed job status widget spamming the kernel with constant update requests.
 - Fixed job status widget not starting its logs as expected.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "homepage": "https://kbase.us",
   "dependencies": {
     "bluebird": "3.4.7",

--- a/narrbase-image/Dockerfile
+++ b/narrbase-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM kbase/narrprereq:1.1
+FROM kbase/narrprereq:1.2
 MAINTAINER William Riehl wjriehl@lbl.gov
 
 ENV JUPYTER_VERSION 4.4.1

--- a/narrprereq-image/python-pip-list-narrative
+++ b/narrprereq-image/python-pip-list-narrative
@@ -4,6 +4,7 @@ biopython
 certifi==0.0.8
 chardet==1.0.1
 configobj
+ete3==3.0.0b35
 flup
 gitpython
 httplib2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbase-narrative-core",
   "description": "Core components for the KBase Narrative Interface",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {

--- a/scripts/build_narrative_container.sh
+++ b/scripts/build_narrative_container.sh
@@ -7,9 +7,9 @@ DS=$( date +%Y%m%d%H%M )
 NAR_NAME="kbase/narrative"
 HEADLESS_NAME="kbase/narrative_headless"
 NAR_BASE="kbase/narrbase"
-NAR_BASE_VER="4.6"
+NAR_BASE_VER="4.7"
 NAR_PREREQ="kbase/narrprereq"
-NAR_PREREQ_VER="1.1"
+NAR_PREREQ_VER="1.2"
 WEBROOT_DIR="/kb/deployment/services/kbase-ui"
 DOCKERFILE_HEADLESS="Dockerfile_headless"
 

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager']
 
 from semantic_version import Version
-__version__ = Version("3.4.1")
+__version__ = Version("3.4.2")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "dev_mode": true,
     "auth_cookie": "kbase_session",
     "git_commit_hash": "60e2219",


### PR DESCRIPTION
* bump narrprereq image to 1.2 (add distribution update, add ETE3 in environment)
* bump narrbase image to 4.7
* bump narrative to 3.4.2