### PR TITLE
Create define_env_vars.sh

### DIFF
--- a/scripts/define_env_vars.sh
+++ b/scripts/define_env_vars.sh
@@ -1,0 +1,10 @@
+# Source this file to define needed environment variables for image names and versions.
+
+# This is the name for now, as this is what the Lua provisioner looks for to fire up a Narrative.
+NAR_NAME="kbase/narrative"
+NAR_BASE="kbase/narrbase"
+NAR_BASE_VER="4.7"
+NAR_PREREQ="kbase/narrprereq"
+NAR_PREREQ_VER="1.2"
+
+export NAR_NAME NAR_BASE NAR_BASE_VER NAR_PREREQ NAR_PREREQ_VER


### PR DESCRIPTION
New (untested) file intended to be sourced inside shell scripts to define Docker image names and versions in the environment.