### PR TITLE
Removed the pubSEED_genomes section 

### DIFF
--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -109,6 +109,12 @@
     },
     "next": {
         "publicData": {
+            "genomes": {
+                "name": "Legacy Genomes",
+                "type": "KBaseGenomes.Genome",
+                "ws": "KBasePublicGenomesV5",
+                "search": true
+            },
             "plant_genomes": {
                 "name": "Plant Genomes",
                 "type": "KBaseGenomes.Genome",

--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -112,12 +112,6 @@
             "genomes": {
                 "name": "Legacy Genomes",
                 "type": "KBaseGenomes.Genome",
-                "ws": "ReferenceDataManager",
-                "search": true
-            },
-            "legacy_genomes": {
-                "name": "Legacy Genomes",
-                "type": "KBaseGenomes.Genome",
                 "ws": "KBasePublicGenomesV5",
                 "search": false
             },

--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -109,12 +109,6 @@
     },
     "next": {
         "publicData": {
-            "genomes": {
-                "name": "Legacy Genomes",
-                "type": "KBaseGenomes.Genome",
-                "ws": "KBasePublicGenomesV5",
-                "search": false
-            },
             "plant_genomes": {
                 "name": "Plant Genomes",
                 "type": "KBaseGenomes.Genome",
@@ -312,10 +306,10 @@
     },
     "appdev": {
         "publicData": {
-            "genomes": {
-                "name": "Legacy Genomes",
+            "reference_genomes": {
+                "name": "NCBI RefSeq Genomes",
                 "type": "KBaseGenomes.Genome",
-                "ws": "KBasePublicGenomesV5",
+                "ws": "ReferenceDataManager",
                 "search": true
             },
             "plant_genomes": {

--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -13,12 +13,6 @@
                 "ws": "Phytozome_Genomes",
                 "search": false
             },
-            "pubSEED_genomes": {		
-                "name": "Public SEED Genomes",		
-                "type": "KBaseGenomes.Genome",		
-                "ws": "pubSEEDGenomes",		
-                "search": false		
-            },
             "media": {
                 "name": "Media",
                 "type": "KBaseBiochem.Media",
@@ -133,12 +127,6 @@
                 "ws": "Phytozome_Genomes",
                 "search": false
             },
-            "pubSEED_genomes": {
-                "name": "Public SEED Genomes",
-                "type": "KBaseGenomes.Genome",
-                "ws": "pubSEEDGenomes",
-                "search": false
-            },
             "media": {
                 "name": "Media",
                 "type": "KBaseBiochem.Media",
@@ -251,12 +239,6 @@
                 "name": "Plant Genomes",
                 "type": "KBaseGenomes.Genome",
                 "ws": "Phytozome_Genomes",
-                "search": false
-            },
-            "pubSEED_genomes": {
-                "name": "Public SEED Genomes",
-                "type": "KBaseGenomes.Genome",
-                "ws": "pubSEEDGenomes",
                 "search": false
             },
             "media": {

--- a/kbase-extension/static/kbase/config/data_source_config.json
+++ b/kbase-extension/static/kbase/config/data_source_config.json
@@ -229,12 +229,6 @@
                 "ws": "KBaseMedia",
                 "search": false
             },
-            "legacy_genomes": {
-                "name": "Legacy Genomes",
-                "type": "KBaseGenomes.Genome",
-                "ws": "KBasePublicGenomesV5",
-                "search": false
-            },
             "plant_genomes": {
                 "name": "Plant Genomes",
                 "type": "KBaseGenomes.Genome",


### PR DESCRIPTION
Removed the pubSEED_genomes section from all 4 environments and replaced the legacy_genomes in appdev environment with reference_genomes as in prod.