### PR TITLE
TASK-877 new versions of apps with a new name caused errors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 
+### Version 3.4.3
+- TASK-877 - fix issue where mismatched App names between different versions caused the App Cell to fail to render.
+
 ### Version 3.4.2
 - Update base Narrative image to include an Ubuntu kernel security update.
 - Add ETE3 to the environment.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 
 ### Version 3.4.3
 - TASK-877 - fix issue where mismatched App names between different versions caused the App Cell to fail to render.
+- Update Expression Sample widget to better handle failures and only show a single widget tab.
 
 ### Version 3.4.2
 - Update base Narrative image to include an Ubuntu kernel security update.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "homepage": "https://kbase.us",
   "dependencies": {
     "bluebird": "3.4.7",

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1132,7 +1132,9 @@ define([
                                     role: 'alert'
                                 }, [
                                     span({ style: { 'font-weight': 'bold' } }, 'Warning'),
-                                    ': this app appears to be out of date. Running it may cause undesired results. Add a new "<b>' + model.getItem('app.spec.info.name') + '</b>" App for the most recent version.'
+                                    ': this app appears to be out of date. Running it may cause undesired results. Add a new "',
+                                    span({ style: { 'font-weight': 'bold' }, dataElement: 'new-app-name'}),
+                                    '" App for the most recent version.'
                                 ]),
                                 ui.buildPanel({
                                     title: 'App Cell Settings',
@@ -1450,6 +1452,7 @@ define([
             renderSettings();
             var state = fsm.getCurrentState();
             if (model.getItem('outdated')) {
+                ui.setContent('outdated.new-app-name', model.getItem('newAppName', model.getItem('app.spec.info.name')));
                 ui.showElement('outdated');
             }
 
@@ -2555,9 +2558,9 @@ define([
                 throw new Error('Mismatching app modules: ' + cellAppSpec.info.module + ' !== ' + appSpec.info.module);
             }
 
-            if (cellAppSpec.info.name !== appSpec.info.name) {
-                throw new Error('Mismatching app names: ' + cellAppSpec.info.name + ' !== ' + appSpec.info.name);
-            }
+            // if (cellAppSpec.info.name !== appSpec.info.name) {
+            //     throw new Error('Mismatching app names: ' + cellAppSpec.info.name + ' !== ' + appSpec.info.name);
+            // }
 
             if (cellAppSpec.info.git_commit_hash !== appSpec.info.git_commit_hash) {
                 return new ToErr.KBError({
@@ -2567,7 +2570,8 @@ define([
                     info: {
                         tag: model.getItem('app.tag'),
                         cellCommitHash: cellAppSpec.info.git_commit_hash,
-                        catalogCommitHash: appSpec.info.git_commit_hash
+                        catalogCommitHash: appSpec.info.git_commit_hash,
+                        newAppName: appSpec.info.name
                             //cellAppSpec: cellAppSpec,
                             //catalogAppSpec: appSpec
                     },
@@ -2600,6 +2604,7 @@ define([
                     if (warning && warning.severity === 'warning') {
                         if (warning.type === 'app-spec-mismatched-commit') {
                             model.setItem('outdated', true);
+                            model.setItem('newAppName', warning.info.newAppName);
                         }
                     }
 

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -2558,10 +2558,6 @@ define([
                 throw new Error('Mismatching app modules: ' + cellAppSpec.info.module + ' !== ' + appSpec.info.module);
             }
 
-            // if (cellAppSpec.info.name !== appSpec.info.name) {
-            //     throw new Error('Mismatching app names: ' + cellAppSpec.info.name + ' !== ' + appSpec.info.name);
-            // }
-
             if (cellAppSpec.info.git_commit_hash !== appSpec.info.git_commit_hash) {
                 return new ToErr.KBError({
                     severity: 'warning',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbase-narrative-core",
   "description": "Core components for the KBase Narrative Interface",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager']
 
 from semantic_version import Version
-__version__ = Version("3.4.2")
+__version__ = Version("3.4.3")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.4.2",
+    "version": "3.4.3",
     "dev_mode": true,
     "auth_cookie": "kbase_session",
     "git_commit_hash": "60e2219",


### PR DESCRIPTION
This case should just make a "version out of date" warning, but prompt with the newer name for the new app to click to update, instead of causing the app cell to crash all together.