### PR TITLE
another bug fix to ExpressionSampleTableNew

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseExpressionSampleTableNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseExpressionSampleTableNew.js
@@ -10,7 +10,7 @@ define (
 		'kbaseHistogram',
 		'kbase-client-api',
 		'kbaseTable',
-		'jquery-dataTables',
+		'jquery-dataTables-bootstrap',
 		'kbaseReportView'
 	], function(
 		KBWidget,
@@ -142,23 +142,26 @@ define (
               var $dt = this.data('$dt');
               if ($dt == undefined) {
 
-                var aoColumns = [
+                var columns = [
                     { title : 'Feature ID'},
                     { title : 'Feature Value : log2(FPKM + 1)'},
                 ];
                 if (newDataset.tpm_expression_levels != undefined) {
                   this.data('tableElem').find('th').css('display', '');
-                  aoColumns.push({ title : 'Feature Value : log2(TPM + 1)'});
+                  columns.push({ title : 'Feature Value : log2(TPM + 1)'});
                 }
 
-                $dt = this.data('tableElem').dataTable({
-                    aoColumns : aoColumns
+                $dt = this.data('tableElem').DataTable({
+                    columns : columns
                 });
 
                 this.data('$dt', $dt);
               }
+              else {
+                $dt.clear();
+              }
 
-              $dt.fnAddData(rows);
+              $dt.rows.add(rows).draw();
               this.data('loader').hide();
               this.data('containerElem').show();
             }

--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseExpressionSampleTableNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseExpressionSampleTableNew.js
@@ -11,7 +11,6 @@ define (
 		'kbase-client-api',
 		'kbaseTable',
 		'jquery-dataTables-bootstrap',
-		'kbaseReportView'
 	], function(
 		KBWidget,
 		bootstrap,
@@ -21,8 +20,7 @@ define (
 		kbaseHistogram,
 		kbase_client_api,
 		kbaseTable,
-		jquery_dataTables,
-		kbaseReportView
+		jquery_dataTables
 	) {
 
     'use strict';
@@ -202,16 +200,6 @@ define (
         init : function init(options) {
 
           this._super(options);
-
-          if (this.options.report_name != undefined) {
-
-            var $div = $.jqElem('div');
-            this.$elem.append($div);
-
-            $div.kbaseReportView( this.options);
-            return this;
-          }
-
 
 
             this._super(options);


### PR DESCRIPTION
Speaking poorly to our QA work, mostly mine, Arfath discovered yet another bug.

Choosing different expression levels would merely append more rows to the overview table, not redraw it.

Fixed. Also updated to the current data tables api in the process.