### PR TITLE
Stupid red bar fix [TASK-922]

### DIFF
--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -46,9 +46,9 @@
 }
 
 .kb-app-parameter-right-error-bar {
-    //height: 100%;
+    /* height: 100%; */
+    height:28px; /* firefox wants it explicitly wired */
     background: red;
-    height:28px;
 }
 
 

--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -46,8 +46,9 @@
 }
 
 .kb-app-parameter-right-error-bar {
-    height: 100%;
+    //height: 100%;
     background: red;
+    height:28px;
 }
 
 


### PR DESCRIPTION
This resolves TASK-922, aka TASK-448 regarding the red error bar in firefox.

The basic issue appears to be that Firefox won't render an empty element with a variable size height.

As is always the case with stupid cross-browser CSS issues, the fix is stupid - it just explicitly wires the height to 28px, which is the height of the line. I'm unhappy about having the magic number in there.

Alternatively, fieldWidgetCompact.js is the widget which is used to render it. Firefox doesn't want to render an empty element with a percentage height, so we could alter the indicator element to append a &nbsp; (or a clear gif? I suppose?) into that field. Doing that will also make firefox happily render it w/o issue.

Using the 28px magic number in the style sheet seemed like the lesser of the evils, but if we'd rather do it the other way I'm happy to change it to do it at the widget level instead. Alternative solutions are certainly welcome.