### PR TITLE
TASK-932 address token failure problems

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 
+### Version 3.4.4
+- TASK-932 - fix problem where authentication tokens appear to get lost when a Narrative has been asleep for a while.
+
 ### Version 3.4.3
 - TASK-877 - fix issue where mismatched App names between different versions caused the App Cell to fail to render.
 - Update Expression Sample widget to better handle failures and only show a single widget tab.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "homepage": "https://kbase.us",
   "dependencies": {
     "bluebird": "3.4.7",

--- a/kbase-extension/static/kbase/js/api/auth.js
+++ b/kbase-extension/static/kbase/js/api/auth.js
@@ -174,17 +174,20 @@ define([
                     return false;
                 }
                 else {
-                    return Promise.delay(1000)
-                    .then(function() {
-                        return validateToken(token, retries-0);
-                    })
-                    .then(function(info) {
-                        return info;
-                    })
-                    .catch(function(error) {
-                        return false;
-                    });
+                    throw error;
                 }
+                // else {
+                //     return Promise.delay(3000)
+                //     .then(function() {
+                //         return validateToken(token, retries-0);
+                //     })
+                //     .then(function(info) {
+                //         return info;
+                //     })
+                //     .catch(function(error) {
+                //         return false;
+                //     });
+                // }
             });
         }
 

--- a/kbase-extension/static/kbase/js/api/auth.js
+++ b/kbase-extension/static/kbase/js/api/auth.js
@@ -146,6 +146,48 @@ define([
             }));
         }
 
+        /**
+         * Validates a token with the following series of calls.
+         * 1. calls GET /token on the auth service.
+         * 2. If a 200 is returned (with valid JSON), returns true.
+         * 3. If a 401/403 is returned (also with valid JSON), returns false.
+         * 4. If anything is returned, it's a server error, and we wait a second before
+         *    trying again. This solves the case where a computer is reawakened and still
+         *    needs to connect to the internet before making a call.
+         */
+        function validateToken(token, retries) {
+            if (!token) {
+                token = getAuthToken();
+            }
+            if (retries === undefined || retries === null) {
+                retries = 3;
+            }
+            return getTokenInfo(token)
+            .then(function(info) {
+                if (info.expires && info.expires > new Date().getTime()) {
+                    return true;
+                }
+                return false;
+            })
+            .catch(function(error) {
+                if (error.status === 401 || error.status === 403 || retries < 0) {
+                    return false;
+                }
+                else {
+                    return Promise.delay(1000)
+                    .then(function() {
+                        return validateToken(token, retries-0);
+                    })
+                    .then(function(info) {
+                        return info;
+                    })
+                    .catch(function(error) {
+                        return false;
+                    });
+                }
+            });
+        }
+
         return {
             putCurrentProfile: putCurrentProfile,
             getCurrentProfile: getCurrentProfile,
@@ -156,7 +198,8 @@ define([
             revokeAuthToken: revokeAuthToken,
             getTokenInfo: getTokenInfo,
             getUserNames: getUserNames,
-            searchUserNames: searchUserNames
+            searchUserNames: searchUserNames,
+            validateToken: validateToken
         };
 
     }

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -460,6 +460,7 @@ define([
         }).catch(function (error) {
             console.error('Error while checking for a version update: ' + error.statusText);
             KBError('Narrative.checkVersion', 'Unable to check for a version update!');
+            console.error(error);
         });
     };
 

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -7,16 +7,14 @@ define(
         'bootstrap',
         'jquery',
         'narrativeConfig',
-        'common/runtime',
-        'kbaseNarrativeSharePanel'
+        'common/runtime'
     ],
     function(
         KBWidget,
         bootstrap,
         $,
         Config,
-        Runtime,
-        kbaseNarrativeSharePanel
+        Runtime
     ) {
         'use strict';
 

--- a/kbase-extension/static/kbase/js/narrativeConfig.js
+++ b/kbase-extension/static/kbase/js/narrativeConfig.js
@@ -63,10 +63,11 @@ define([
         uploaders: StagingUpload,
         data_panel: ConfigSet.data_panel,
         comm_wait_timeout: ConfigSet.comm_wait_timeout,
-        auth_cookie: ConfigSet.auth_cookie
+        auth_cookie: ConfigSet.auth_cookie,
+        auth_sleep_recheck_ms: ConfigSet.auth_sleep_recheck_ms
     };
 
-    debug = config.mode === "debug";
+    debug = config.mode === 'debug';
     config.debug = debug;
 
     // Add a remote UI-common to the Require.js config

--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -149,7 +149,7 @@ define ([
                 authClient.getTokenInfo(token)
                 .catch(function(error) {
                     console.error(error);
-                    tokenTimeout();
+                    tokenTimeout(true);
                 });
             }
             lastCheckTime = new Date().getTime();

--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -144,12 +144,20 @@ define ([
             if (!token) {
                 tokenTimeout();
             }
-            if (new Date().getTime() - lastCheckTime > browserSleepValidateTime) {
-                console.log('fetching token info');
-                authClient.getTokenInfo(token)
+            var lastCheckInterval = new Date().getTime() - lastCheckTime;
+            if (lastCheckInterval > browserSleepValidateTime) {
+                console.warn('Revalidating token after sleeping for ' + (lastCheckInterval/1000) + 's');
+                authClient.validateToken(token)
+                .then(function(info) {
+                    if (info === true) {
+                        console.warn('Auth is still valid. Carry on.');
+                    } else {
+                        console.warn('Auth is invalid! Logging out.');
+                    }
+                })
                 .catch(function(error) {
                     console.error(error);
-                    tokenTimeout(true);
+                    // tokenTimeout(true);
                 });
             }
             lastCheckTime = new Date().getTime();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbase-narrative-core",
   "description": "Core components for the KBase Narrative Interface",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {

--- a/src/biokbase/auth.py
+++ b/src/biokbase/auth.py
@@ -1,10 +1,6 @@
 """
-Kbase wrappers around Globus Online Nexus client libraries. We wrap the Nexus
-libraries to provide a similar API between the Perl Bio::KBase::Auth* libraries
-and the python version
-
-In this module, we follow standard Python idioms of raising exceptions for
-various failure states (Perl modules returned error states in error_msg field)
+Narrative authentication tools.
+This uses the KBase auth2 API to get and manage auth tokens.
 """
 
 import requests
@@ -16,6 +12,18 @@ tokenenv = 'KB_AUTH_TOKEN'
 token_api_url = URLS.auth + "/api/V2"
 endpt_token = "/token"
 endpt_token_revoke = "/tokens/revoke"
+
+
+def validate_token():
+    """
+    Validates the currently set auth token. Returns True if valid, False otherwise.
+    """
+    headers = {"Authorization": get_auth_token()}
+    r = requests.get(token_api_url + endpt_token, headers=headers)
+    if r.status_code == 200:
+        return True
+    else:
+        return False
 
 
 def set_environ_token(token):

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager']
 
 from semantic_version import Version
-__version__ = Version("3.4.3")
+__version__ = Version("3.4.4")
 version = lambda: __version__
 
 # if run directly:

--- a/src/biokbase/narrative/app_util.py
+++ b/src/biokbase/narrative/app_util.py
@@ -9,7 +9,6 @@ Some utility functions for running KBase Apps or Methods or whatever they are th
 __author__ = "Bill Riehl <wjriehl@lbl.gov>, Roman Sutormin <rsutormin@lbl.gov>"
 
 app_version_tags = ['release', 'beta', 'dev']
-_ws_client = clients.get('workspace')
 
 
 def check_tag(tag, raise_exception=False):
@@ -47,7 +46,7 @@ def system_variable(var):
         if ws_name is None:
             return None
         try:
-            ws_info = _ws_client.get_workspace_info({'workspace': ws_name})
+            ws_info = clients.get('workspace').get_workspace_info({'workspace': ws_name})
             return ws_info[0]
         except:
             return None
@@ -577,14 +576,14 @@ def validate_param_value(param, value, workspace):
                                          'have the right format - should be ' +
                                          'workspace/object/version(optional)'
                                          ).format(value))
-                info = _ws_client.get_object_info_new({
+                info = clients.get('workspace').get_object_info_new({
                     'objects': [{'ref': value}]
                 })[0]
                 path_items[len(path_items) - 1] = "{}/{}/{}".format(info[6], info[0], info[4])
                 ws_ref = ';'.join(path_items)
             # Otherwise, assume it's a name, not a reference.
             else:
-                info = _ws_client.get_object_info_new({
+                info = clients.get('workspace').get_object_info_new({
                     'objects': [{'workspace': workspace, 'name': value}]
                 })[0]
                 ws_ref = "{}/{}/{}".format(info[6], info[0], info[4])
@@ -637,7 +636,7 @@ def validate_param_value(param, value, workspace):
                     "Data object names can only include symbols: _ - . |")
 
     # Last, regex. not being used in any extant specs, but cover it anyway.
-    # Disabled for now - the regex string that works in javascript may not work 
+    # Disabled for now - the regex string that works in javascript may not work
     # in python and vice versa
     # if 'regex_constraint' in param:
     #     for regex in param['regex_constraint']:
@@ -659,12 +658,12 @@ def resolve_single_ref(workspace, value):
             if len(path_item.split('/')) > 3:
                 raise ValueError('Object reference {} has too many slashes  - should be workspace/object/version(optional)'.format(value))
             # return (ws_ref, 'Data reference named {} does not have the right format - should be workspace/object/version(optional)')
-        info = _ws_client.get_object_info_new({'objects': [{'ref': value}]})[0]
+        info = clients.get('workspace').get_object_info_new({'objects': [{'ref': value}]})[0]
         path_items[len(path_items) - 1] = "{}/{}/{}".format(info[6], info[0], info[4])
         ret = ';'.join(path_items)
     # Otherwise, assume it's a name, not a reference.
     else:
-        info = _ws_client.get_object_info_new({'objects': [{'workspace': workspace, 'name': value}]})[0]
+        info = clients.get('workspace').get_object_info_new({'objects': [{'workspace': workspace, 'name': value}]})[0]
         ret = "{}/{}/{}".format(info[6], info[0], info[4])
     return ret
 
@@ -673,7 +672,7 @@ def resolve_ref(workspace, value):
         return [resolve_single_ref(workspace, v) for v in value]
     else:
         return resolve_single_ref(workspace, value)
- 
+
 
 
 def resolve_ref_if_typed(value, spec_param):

--- a/src/biokbase/narrative/exception_util.py
+++ b/src/biokbase/narrative/exception_util.py
@@ -2,6 +2,7 @@ from requests.exceptions import HTTPError
 from biokbase.NarrativeJobService.baseclient import ServerError as NJSServerError
 from biokbase.userandjobstate.baseclient import ServerError as UJSServerError
 
+
 class NarrativeException(Exception):
     def __init__(self, code, message, name, source):
         self.code = code
@@ -11,6 +12,7 @@ class NarrativeException(Exception):
 
     def __str__(self):
         return self.message
+
 
 def transform_job_exception(e):
     """

--- a/src/biokbase/narrative/handlers/authhandlers.py
+++ b/src/biokbase/narrative/handlers/authhandlers.py
@@ -62,6 +62,7 @@ class KBaseLoginHandler(LoginHandler):
                 auth_info = get_user_info(token)
             except Exception as e:
                 app_log.error("Unable to get user information from authentication token!")
+                raise
 
             # re-enable if token logging info is needed.
             # if app_log.isEnabledFor(logging.DEBUG):

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -2,8 +2,6 @@
 A module for managing apps, specs, requirements, and for starting jobs.
 """
 import biokbase.auth as auth
-from biokbase.NarrativeJobService.Client import NarrativeJobService
-from biokbase.narrative.common.url_config import URLS
 from job import Job
 from jobmanager import JobManager
 from specmanager import SpecManager
@@ -53,9 +51,6 @@ class AppManager(object):
     """
     __instance = None
 
-    nms = clients.get('narrative_method_store')
-    ws_client = clients.get('workspace')
-    service_client = clients.get('service')
     __MAX_TOKEN_NAME_LEN = 30
 
     spec_manager = SpecManager()
@@ -310,8 +305,7 @@ class AppManager(object):
         kblogging.log_event(self._log, "run_app", log_info)
 
         try:
-            njs = NarrativeJobService(url=URLS.job_service, token=agent_token['token'])
-            job_id = njs.run_job(job_runner_inputs)
+            job_id = clients.get("job_service").run_job(job_runner_inputs)
         except Exception as e:
             log_info.update({'err': str(e)})
             kblogging.log_event(self._log, "run_app_error", log_info)
@@ -674,7 +668,7 @@ class AppManager(object):
         input_vals = params
         function_name = spec['behavior']['kb_service_name'] + '.' + spec['behavior']['kb_service_method']
         try:
-            result = self.service_client.sync_call(
+            result = clients.get("service").sync_call(
                 function_name,
                 input_vals,
                 service_version=tag

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -42,8 +42,6 @@ class Job(object):
         self.owner = owner
         self.token_id = token_id
 
-        self._njs = clients.get('job_service')
-
     @classmethod
     def from_state(Job, job_id, job_info, owner, app_id, tag='release',
                    cell_id=None, run_id=None, token_id=None):
@@ -110,7 +108,7 @@ class Job(object):
             return self.inputs
         else:
             try:
-                self.inputs = self._njs.get_job_params(self.job_id)[0]['params']
+                self.inputs = clients.get("job_service").get_job_params(self.job_id)[0]['params']
                 return self.inputs
             except Exception as e:
                 raise Exception("Unable to fetch parameters for job {} - {}".format(self.job_id, e))
@@ -123,7 +121,7 @@ class Job(object):
         if self._last_state is not None and self._last_state.get('finished', 0) == 1:
             return self._last_state
         try:
-            state = self._njs.check_job(self.job_id)
+            state = clients.get("job_service").check_job(self.job_id)
             if 'cancelled' in state:
                 state[u'canceled'] = state.get('cancelled', 0)
                 del state['cancelled']
@@ -204,8 +202,9 @@ class Job(object):
         return (num_available_lines, self._job_logs[first_line:first_line+num_lines])
 
     def _update_log(self):
-        log_update = self._njs.get_job_logs({'job_id': self.job_id,
-                                             'skip_lines': len(self._job_logs)})
+        log_update = clients.get("job_service").get_job_logs(
+            {'job_id': self.job_id,
+             'skip_lines': len(self._job_logs)})
         if log_update['lines']:
             self._job_logs = self._job_logs + log_update['lines']
 

--- a/src/biokbase/narrative/jobs/specmanager.py
+++ b/src/biokbase/narrative/jobs/specmanager.py
@@ -8,6 +8,7 @@ import json
 from jinja2 import Template
 from IPython.display import HTML
 
+
 class SpecManager(object):
     __instance = None
 
@@ -42,7 +43,7 @@ class SpecManager(object):
             for spec in specs:
                 spec_dict[spec['info']['id']] = spec
             self.app_specs[tag] = spec_dict
-        
+
         # And let's load all types from the beginning and cache them
         self.type_specs = client.list_categories({'load_types': 1})[3]
 

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -1,15 +1,4 @@
 from __future__ import print_function
-
-"""
-widgetmanager.py
-
-Implements the WidgetManager class that programmatically shows
-KBase JavaScript widgets.
-"""
-__author__ = 'Bill Riehl <wjriehl@lbl.gov>'
-
-from biokbase.narrative.common.url_config import URLS
-from biokbase.workspace.client import Workspace
 from biokbase.narrative.app_util import (
     check_tag,
     system_variable
@@ -27,6 +16,14 @@ from biokbase.narrative.jobs.specmanager import SpecManager
 import biokbase.narrative.clients as clients
 from biokbase.narrative.app_util import map_outputs_from_state
 from biokbase.narrative.app_util import validate_parameters
+"""
+widgetmanager.py
+
+Implements the WidgetManager class that programmatically shows
+KBase JavaScript widgets.
+"""
+__author__ = 'Bill Riehl <wjriehl@lbl.gov>'
+
 
 
 class WidgetManager(object):
@@ -400,7 +397,7 @@ class WidgetManager(object):
                                              cell_id=cell_id,
                                              timestamp=int(round(time.time()*1000)))
         return Javascript(data=js, lib=None, css=None)
-        
+
 
     def show_data_widget(self, ref, title="", cell_id=None, tag="release"):
         """

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
     "git_commit_time": "Thu Mar 3 15:44:21 2016 -0800",
     "release_notes": "https://github.com/kbase/narrative/blob/master/RELEASE_NOTES.md",
     "comm_wait_timeout": 60000,
+    "auth_sleep_recheck_ms": 60000,
     "data_panel": {
         "ws_chunk_size": 10000,
         "ws_max_objs_to_fetch": 30000,

--- a/src/config.json
+++ b/src/config.json
@@ -1,7 +1,7 @@
 {
     "config": "ci",
     "name": "KBase Narrative",
-    "version": "3.4.3",
+    "version": "3.4.4",
     "dev_mode": true,
     "auth_cookie": "kbase_session",
     "git_commit_hash": "60e2219",


### PR DESCRIPTION
There's a number of reasonably small changes in this PR: here's a summary.
1. If the browser stops checking whether it has an auth token for ~1 minute (mainly only happens if the computer goes to sleep), it will test if the token is still valid, regardless of the amount of time remaining in its lifespan.
2. Backend service clients are now always generated as needed. Previously, it was cached for essentially the lifetime of the server.
3. A teeny bit of code cleanup.

I have a nagging suspicion that this won't solve all the problems we've seen, but hopefully it will help.