### PR TITLE
TASK-959 Make the Narrative sharing panel refresh

### DIFF
--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -265,6 +265,9 @@ define([
                 });
                 return;
             }
+            if (shareWidget) {
+                shareWidget.refresh();
+            }
             shareDialog.show();
         }.bind(this));
     };


### PR DESCRIPTION
Whenever the sharing modal opens, it should show the current state of sharing; it shouldn't cache things from the previous time.