### PR TITLE
Read only mode task 938

### DIFF
--- a/docs/install/deployment_eap.md
+++ b/docs/install/deployment_eap.md
@@ -136,6 +136,12 @@ We'll have super powers for a while
 
     sudo su
 
+Install luasec first
+
+    apt-get install lua-sec
+
+Otherwise the lua deps won't install
+
 Run the Lua dependencies installer script:
 
     sh ./narrative/docker/lua-dependencies.txt
@@ -176,7 +182,8 @@ You'll need to make the the docker defaults sane to prevent your machine from th
 ```
 provision_count = 2
 container_max = 5
-server_name localhost localhost.kbase.us local-dev.kbase.us;
+# server_name localhost localhost.kbase.us local-dev.kbase.us;
+server_name ci.kbase.us;
 ```
 
 Add we really should operate in secure mode. (And part of the Narrative installation will attempt to contact the narrative server on a secure port, so we do need this.)

--- a/docs/notes/TASK-938-notes.md
+++ b/docs/notes/TASK-938-notes.md
@@ -1,0 +1,190 @@
+# Summary of Changes
+
+## Read Only Mode
+
+The original call-to-action was to ensure that app cell parameters were not editable in view-only or read-only Narrative mode. That occupied the first day of work, but it quickly became apparent during testing that there were many other issues.
+
+### Comments about and changes to the internal logic
+
+First, it was a little confusing to sort out the writable state of a Narrative from the view-only ui switching. This was partly due to the fact that there were several identifiers in the code with the term "read only", but used for different purposes.
+
+
+A Narratives writability, or read/write status (more fully, the permissions which is read/write/admin), is a reflection of the workspace permissions for the Narrative. The core functionality affected by this is the the ability to save a Narrative, but it an implication is that the Narrative _should_ not be editable. Therere a Narrative which is not writable also should not be editable.
+
+The editability is a reflection of whether, for whatever reason, the Narrative or some component may be modified. It is implemented as uiMode attribute of the Narrative (Jupyter.narrative.narrController as well as Jupyter.narrative), but is accessed via the "canEdit" method of Jupyter.narrative.narrController as well as an instance of utils/jupyter. 
+
+### Setting read-only and ui view mode
+
+The only time the writability of the Narrative is currently registered is during Narrative loading. There is existing code for reflecting changes in the writability of the Narrative but as far as I can tell, it was never utilized -- the event to trigger it was never emitted. In discussions with Bill, there is no appetite for adding yet-another-poller to monitor the Narrative workspace.
+
+On the other hand, the ui view mode in a writable narative can be enabled via the view-only pencil/eye button in the narrative header.
+
+The following situations lead to read-only and ui view mode in a Narrative
+
+- The narrative is not owned by the current user but shared with the current user with read-only permissions
+
+- The narrative is not owned by the current user and is shared publicly.
+
+- The narrative is owned by the current user, or shared with write or admin permission and the user has switched the ui into view mode via the view-mode button
+
+- In addition, the "Configure" panel of an app cell is switched to ui view mode when the app cell is running or has completed.
+
+### Ease of testing
+
+It is also notable that the view-mode toggle button made testing ui view mode much much easier than testing against a read-only narrative.
+
+### Paramters in app and related cells
+
+Parameter input controls come in pairs -- an input control and a view control. Improvements consisted generally in ensuring that view controls were displayed in view mode, and that view controls both honored the spirit of view mode by not allowing changes, and that their internal code also made changes in parameters impossible.
+
+There were several adjustments to view-mode parameters to make them more view-mode friendly. This involved ensuring that the view-mode widgets would not let the user change their state, yet continue to show the original information plus context (e.g. dropdowns still have the options available, but they are not selectable.)
+
+The sequence parameter view control was creating input controls not view controls.
+
+The view cells did not utilize view mode at all, so this was added to view cells.
+
+
+### Data Panel 
+
+
+#### Prevent inserting data objects
+
+I believe it was possible to attempt to add data objects to the narrative from the Data panel, and that the attempt was simply ignored. I may be wrong about that.
+
+In any case, the response now is a warning dialog.
+
+
+#### Prevent renaming or deleting data objects
+
+If the data panel options buttons are displayed in edit mode and then view mode is entered, the delete, rename, and histor buttons are buttons are still enabled.
+
+Conversely if they are first displayed in view mode, when returning to edit mode they are missing.
+
+This is because the logic of the data panel is to show/not-show these buttons depending on the read-only status of the narrative upon first rendering. If the ui mode changes due to using the toggle button (or in the future, when the write permissions of the narrative change), the data panel is not manipulated to reflect this state. 
+
+Since this functionality is only manifested via the view-mode toggle, it is something of a fringe issue. The utilty of the view-mode toggle is to allow a Narrative author to preview a narrative for view-only users, e.g. prior to sharing or makeing public. The worst problem would be for an author to inspect a data object in view-only mode, and then need to access those three edit buttons later, and find they are missing.
+
+Certainly a bug to fix, but not in this round.
+
+
+#### Apps Panel Enabled
+
+The disabling of the apps panel was not necessary, and made usage of the data panel confusing. For instance the input and output parameter filters served no obvious purpopse.
+
+After enabling the panel, the only change was to disable adding of apps to the narrative.
+
+This was accomplished at the lowest level, and generates an error if a user attempts it.
+
+It is perhaps debatable that the ability to attempt to add an app to a narrative should be disabled. However, other than being yet more work on an already-stretched-out task, it is arguable that allowing the user to attempt it and then informing that that it is not possible exposes the user to functionality that is available for editable narratives. 
+
+
+
+
+## Other UI Improvements
+
+### Title Editing Disabled
+
+Although there was code to prevent editing the narrative title, the id used for the element had apparently changed and was not longer effective. (Blame Jupyter upgrade?) In any case, since the title change also forced a narrative save, it generated a big error message. The change was simply to disable the click event on the title.
+
+### Remove "Narrative Settings"
+
+The cog in the main narrative menu was originally designed to enabling advanced and developer features in the Narrative, especially for the new app cell design. However, as those features were removed, the presence of this ui component is just confusing -- it did nothing but promised much!
+
+
+
+## Cell Toolbar Improvements
+
+### Cell Toolbar Layout
+
+The layout, especially padding between the collapse button and the top of the cell and the bottom of the title icon in the collapsed cell, were uneven. CHnages were required to 
+
+### Show Toolbar in View-only mode
+
+In view-only mode, the cell toolbar was hidden. This made it impossible to expand closed cells, or less importantly to collpase cells. (It does make navigation of large narratives easier when many cells are closed and just the ones of interest are open.)
+
+This implies that...
+
+### Cell Toolbar Buttons honor view-only mode
+
+The cell movement and cell deletion buttons are removed from view-only mode, making the toolbar save to use.
+
+
+### Cell Toolbar Buttons
+
+Moved the collapse button from inside the ellipse menu to the top level, right hand side.
+
+Changed style from orange to black when for expanded mode, orange when collapsed. This helps signal that the cell is collapsed - otherwise when looking at a narrative with little collapsed cells it may not be obvious. There are probably other better clues to add.
+
+### Optimize Ellipse Menu
+
+When there are no options above the delete item, the separator line is not displayed
+
+### Double clicking toolar expands/collapses cell
+
+I found myself constantly wanting to double click the title area of a cell to expand collapse it. This was implemented.
+
+### Message Area below buttons
+
+On the right hand side of the cell toolbar a new message area was added. It is enabled via metadata.kbase.cellState.message. This message area was added in response to the need to display to the user a reminder that double-clicking the markdown content will make it editable. Without a clue, it is not obvious to new users.
+
+
+## Markdown Cell Improvements
+
+The double clicking toolbar changes led to a change in markdown cell edit mode switching. The existing method detected double-clicking anywhere in the cell to enable edit mode. This always felt a little off, it was easy to accidentally trigger by selecting a cell and then clicking again.
+
+With double-click expand/collapse, there was a conflict anyway.
+
+The new behavior is double clicking on the markdown content itself. This is very natural, and in my experience with it, leads to more predictable behavior. It also makes closing edit mode symmetric, since clicking anywhere outside of the edit area would render the content and exit edit mode.
+
+There is more that can be done to improve this experience, such as a hover effect over editable content which might enable single click editing.
+
+The new message area of the toolbar also provides a message to user to remind then that double clicking the content will allow them to edit it.
+
+## Code Cell Improvements
+
+### Inoperative in view-only mode
+
+Code area editing is disabled in view-only mode. This required a trick in the readOnly setting for code mirror -- the boolean value did not appear to work, but the 'nocursor' value did.
+
+### Loading Spinner for title icon
+
+Since sometimes, and during the last few days of development particularly, high latency can cause long delays (on the order of several seconds) in cell rendering, the behavior of the cells can be quite confusing when a narrative first loads. Particularly, all code cells show the code cell "terminal" icon, which is then replaced with their own app cell when the app cell extension runs. This behavior is disconcerting. It is due to the fact that code cells initially utilize their default behavior (the terminal icon, showing code (addressed below)), which is then overriden, some time later, by the extension. 
+
+The solution is to show a spinner icon rather than the terminal icon, to indicate that the cell is loading (which it is.)
+
+This did not initially work for pure code cells, due to issues discussed below.
+
+### Code areas are not displayed initially
+
+After the migration to code cells for app cells, the code area would be displayed initially when an app cell was rendered, and then removed as the app cell extension was executed. During high latency with kbase service calls, the delay between narrative notebook startup and cell extension startup could be on the order of seconds, leaving the code cells sitting there. And generally, it led to thrashing of the user interface as the code cells popped in, and then out again.
+
+The fix was realatively simple -- hide the code area initially and add a -show class after the app cell (and all other code-cell based kbase cells) loads.
+
+However, in the case of raw code cells, the problem was not as simple. The core of the problem is that there is no reliable signal within Jupyter when a cell has finished loading and the metadata is available (after which the extensions load).
+
+So to solve this...
+
+### Added KBase code cell extension
+
+An extension was added to handle cells which are code cells but not kbase app cells. This allows the scheduling of code to run after the code cells are fully set up. This is the stage at which the code area is opened for pure code cells.
+
+The extension also allows the replacement of the spinner icon with the code cell terminal icon.
+
+## Code cell / Import cell improvements
+
+Although on its way out, there is still support in the narrative for the old style of importing data. This method spawns an import job, and then inserts a job-monitoring cell into the narrative. This poor cell has been the subject of much tweaking over the months. When making the code cell changes and testing, it was apparent that it needed some adjustements to play well with the new code cell extension. Specifically, the cell metadata was created in two different forms. First, it was populated in a way to simulate an output cell, but was not formed correctly and might actually trigger an error if left in that form (I had actually run across some of these and wondered where the funny cells came from.) However, as soon as the job monitoring widget begins operating, it would overwrite the existing metadata with a different structure, removing the title and other metadata structure.
+
+The improvement is to add code to the job manager widget to create a metadata structure which is compatible with the new code cell extension, and fixup code to both the new code cell extension and the job manager widget to detect old instances of these cells and convert them.
+
+
+## Future Work
+
+The Data Panel needs a fix to dynamically adjust to ui mode changes.
+
+Some functionality such as inserting data objects or apps into the narrative are left in place, but warning dialogs issued if the user attempts them. We may want to just disable the ability to attempt the action.
+
+Import cell accomodation should be removed once the data import situation is sorted out.
+
+Additional information needs to be added to all warning dialogs.
+
+We should generally integrate ui mode switching in a more methodical way. One of the reasons to change the ui mode to an arbitrary string from a boolean is to enable more than two ui modes (view and edit). For instance,  presentation modes could be useful, developer mode, design mode, etc. although this implies that they are mutually exclusive (which makes things simpler, but may exclude useful modes like editing in a presentation mode.)

--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -218,10 +218,10 @@
                       <div class="fa fa-share-alt"></div>
                       <div class="kb-nav-btn-txt">share</div>
                     </a>
-                    <a id="kb-settings-btn" tabindex="0" role="button" class="btn btn-default navbar-btn kb-nav-btn">
+                    <!-- <a id="kb-settings-btn" tabindex="0" role="button" class="btn btn-default navbar-btn kb-nav-btn">
                       <div class="fa fa-cog"></div>
                       <div class="kb-nav-btn-txt">settings</div>
-                    </a>
+		    </a> -->
                     <button id="kb-save-btn" class="btn btn-default navbar-btn kb-nav-btn">
                         <div class="fa fa-save"></div>
                         <div class="kb-nav-btn-txt">save</div>

--- a/kbase-extension/static/custom/custom.css
+++ b/kbase-extension/static/custom/custom.css
@@ -4,6 +4,7 @@ CSS should go in /kbase-extension/static/kbase/css/kbaseNarrative.css
 
 (or the specific css file if available)
 */
+
 .select2-container--default .select2-results__option--highlighted[aria-selected] {
     background-color: #337ab7;
     color: #FFF;
@@ -13,29 +14,27 @@ CSS should go in /kbase-extension/static/kbase/css/kbaseNarrative.css
     color: #FFF !important;
 }
 
-
 #site {
     overflow: visible;
 }
 
+
 /* disable the standard notebook, bottom spacer */
-#notebook > .end_space {
+
+#notebook>.end_space {
     min-height: 0;
     height: 0;
 }
 
-@media (min-width: 1200px)
-#notebook-container {
+@media (min-width: 1200px) #notebook-container {
     width: auto;
 }
 
-@media (min-width: 992px)
-#notebook-container {
+@media (min-width: 992px) #notebook-container {
     width: auto;
 }
 
-@media (min-width: 768px)
-#notebook-container {
+@media (min-width: 768px) #notebook-container {
     width: auto;
 }
 
@@ -44,6 +43,7 @@ CSS should go in /kbase-extension/static/kbase/css/kbaseNarrative.css
     background-color: #FFFFFF;
 }
 
+
 /* .btn * { color: black; } */
 
 .celltoolbar {
@@ -51,7 +51,8 @@ CSS should go in /kbase-extension/static/kbase/css/kbaseNarrative.css
     background: none;
     border: none;
     border-left: 1px solid transparent;
-    padding-top: 7px;
+    padding-top: 0;
+    padding-bottom: 2px;
 }
 
 div.input_area {
@@ -69,6 +70,7 @@ div.text_cell_input {
     border: 1px solid #CECECE;
     border-radius: 0px;
 }
+
 
 /*div.text_cell_render {
     margin-bottom: -10px;
@@ -112,6 +114,7 @@ div.cell.selected.kb-error {
     border: 1px solid #d9534f;
     border-left: 5px solid #d9534f;
 }
+
 input.raw_input {
     /*height:auto;*/
 }
@@ -138,7 +141,6 @@ span#notebook_name:hover {
     padding-top: 10px;
 }
 
-
 #notebook-container {
     box-shadow: none;
     -moz-box-shadow: none;
@@ -154,7 +156,9 @@ span#notebook_name:hover {
     padding-bottom: 100px;
 }
 
+
 /* margin left doesn't really seeem to play well */
+
 .btn-toolbar {
     margin-left: 0;
     padding-left: -5px;
@@ -169,9 +173,11 @@ span#notebook_name:hover {
     color: #888;
     margin: 0px
 }
+
 .btn-subtle .fa {
     color: #888;
 }
+
 .btn-subtle .fa::before {
     color: #888;
 }
@@ -180,23 +186,26 @@ span#notebook_name:hover {
     box-shadow: none;
 }
 
+
 /* Fooling around with the narrative cells */
 
 .notebook_app .inner_cell {
     overflow: visible;
     /*margin-right: 4px;*/
 }
+
+
 /*.notebook_app .cell.selected .inner_cell > div:nth-child(2),
 .notebook_app .cell.selected .inner_cell > div:nth-child(3) {
     background-color: #FFF;
 }
 */
 
-.notebook_app .celltoolbar > .button_container {
+.notebook_app .celltoolbar>.button_container {
     flex: 0 auto;
 }
 
-.notebook_app .celltoolbar > .button_container:nth-child(1) {
+.notebook_app .celltoolbar>.button_container:nth-child(1) {
     flex: auto;
 }
 
@@ -212,13 +221,16 @@ span#notebook_name:hover {
     width: 75px;
 }
 
+
 /*.notebook_app .code_cell {
     background-color: #FFF;
 }
 */
+
 .notebook_app .cell.unselected div.text_cell_render {
     border: 1px solid transparent;
 }
+
 .notebook_app .cell.selected div.text_cell_render {
     border: 1px solid transparent;
 }
@@ -226,7 +238,6 @@ span#notebook_name:hover {
 .notebook_app .buttons .dropdown-menu {
     height: auto !important;
     overflow: visible !important;
-
 }
 
 .notebook_app .btn.disabled .fa {
@@ -249,20 +260,26 @@ span#notebook_name:hover {
 .text_cell.opened.rendered.selected.kb-cell .rendered_html {
     border-left: 1px solid #4BB856;
 }
+
 .text_cell.opened.rendered.selected.kb-cell.kb-error .rendered_html {
     border-left: 1px solid #d9534f;
 }
+
 .text_cell.opened.rendered.kb-cell {
     padding-bottom: 0;
 }
+
+
 /* narrative cell icons */
 
 .cell.selected .prompt .method-icon {
     color: rgb(103, 58, 183);
 }
+
 .cell.selected .prompt .app-icon {
     color: rgb(0, 150, 136);
 }
+
 .cell.selected .prompt .markdown-icon {
     color: #000;
 }
@@ -291,7 +308,7 @@ span#notebook_name:hover {
     color: #D84315;
 }
 
-.cell > .inner_cell > .ctb_hideshow {
+.cell>.inner_cell>.ctb_hideshow {
     display: block;
 }
 
@@ -303,10 +320,11 @@ span#notebook_name:hover {
     color: #CCC;
 }
 
-.cell.unselected  .kb-cell-toolbar .title-container {
+.cell.unselected .kb-cell-toolbar .title-container {
     opacity: 0.5;
 }
-.cell.unselected  .kb-cell-toolbar .buttons-container {
+
+.cell.unselected .kb-cell-toolbar .buttons-container {
     opacity: 0.2;
 }
 
@@ -314,6 +332,7 @@ span#notebook_name:hover {
     display: inline-block;
     padding: 4px;
 }
+
 .kb-btn-icon .fa {
     opacity: 0.5
 }
@@ -327,6 +346,7 @@ span#notebook_name:hover {
   For some reason Jupyter removes the bottom margin. This causes problems with
    bootstrap, since bootstrap removes the top margin!
 */
+
 p {
     margin-bottom: 9px;
 }

--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -2,6 +2,7 @@
   All classes below may be wrapped in this class to avoid polluting
   the Narrative styles.
 */
+
 .kb-app-cell {
     font-family: 'Oxygen', sans-serif;
 }
@@ -11,58 +12,82 @@
     text-align: center;
 }
 
+
 /** new app parameter styling **/
-.kb-app-cell  .kb-app-parameter-panel {
+
+.kb-app-cell .kb-app-parameter-panel {
     border-left: 3px solid #fff;
 }
-.kb-app-cell  .kb-app-parameter-panel-hover {
+
+.kb-app-cell .kb-app-parameter-panel-hover {
     border-left: 3px solid #428bca;
 }
+
 .kb-app-cell .kb-app-parameter-row {
-    margin:0px;
-    padding:5px;
-    border-radius:5px;
-}
-.kb-app-cell .kb-app-parameter-row:hover {
-    background-color:rgba(0, 0, 0, 0.03);
+    margin: 0px;
+    padding: 5px;
+    border-radius: 5px;
 }
 
+.kb-app-cell .kb-app-parameter-row:hover {
+    background-color: rgba(0, 0, 0, 0.03);
+}
 
 .kb-app-row-close-btn-addon {
     background: transparent;
     border: 0;
-
 }
+
+.cell.selected .btn-default.kb-app-row-close-btn {
+    color: gray;
+}
+
+
+/* .cell.selected .btn-default.kb-app-row-close-btn:hover {
+    color: red;
+} */
+
 .kb-app-row-close-btn {
     height: 100%;
-    margin-left:1px;
-    border-left: 3px solid transparent;
+    margin-left: 1px;
+    /* border-left: 3px solid transparent; */
     border-right: 0;
     border-top: 0;
     border-bottom: 0;
+    border: none;
+    background-color: transparent;
+    color: gray;
 }
+
+
+/* let's just do this as a normal button hover effect */
+
 .kb-app-row-close-btn:hover {
-    border-left: 3px solid #337ab7; /* this is the bootstrap link color to match to close icon */
+    /* border-left: 3px solid #337ab7;  this is the bootstrap link color to match to close icon  */
+    /* color: red; */
+    /* background-color: rgba(234, 126, 126, 1); */
 }
 
 .kb-app-parameter-right-error-bar {
     /* height: 100%; */
-    height:28px; /* firefox wants it explicitly wired */
+    height: 28px;
+    /* firefox wants it explicitly wired */
     background: red;
 }
 
 
-
 /* for some reason, the css :hover doesn't work right on this div, so we use jquery to toggle this class */
+
 .kb-app-cell .kb-app-parameter-row-hover {
-    background:#F9F9F9;
+    background: #F9F9F9;
 }
 
-.kb-app-cell  .kb-app-parameter-row .message.-error {
+.kb-app-cell .kb-app-parameter-row .message.-error {
     background: #f2dede;
 }
-.kb-app-cell  .kb-app-parameter-row .message.-warning {
-}
+
+.kb-app-cell .kb-app-parameter-row .message.-warning {}
+
 .kb-app-cell .kb-app-parameter-row .message {
     text-align: center;
     font-family: 'Oxygen', sans-serif;
@@ -71,10 +96,12 @@
 .kb-app-cell .kb-app-parameter-row .message.-error {
     color: #F44336;
 }
-.kb-app-cell .kb-app-parameter-row .message.-warning {
-}
+
+.kb-app-cell .kb-app-parameter-row .message.-warning {}
+
 
 /* not sure how to get text in these divs to valign middle... */
+
 .kb-app-cell .kb-app-parameter-name {
     font-family: 'Oxygen', sans-serif;
     color: #777;
@@ -84,14 +111,14 @@
     padding-left: 0px;
     white-space: normal;
 }
+
 .kb-app-cell .kb-app-parameter-input {
-    vertical-align:middle;
+    vertical-align: middle;
 }
 
 .kb-app-cell .kb-app-parameter-input select.form-control {
     margin: 0;
 }
-
 
 .kb-app-field-feedback {
     background: transparent;
@@ -105,8 +132,6 @@
 }
 
 
-
-
 /*
 This set of styles is a to accomodate the required/satisfied icon which appears
 between the select input control and the help text to the right of it. The
@@ -118,20 +143,25 @@ to accomodate the the icon intruding into its space. This technique makes space
 in the column in which the icon lives, and does this by shrinking the select
 control with padding, and then scooting the icon back into its column.
 */
+
+
 /* .kb-app-cell .kb-app-parameter-input > div {
      allow space for the required (red arrow), satisfied (green checkbox) icon
     padding-right: 20px;
 }
 */
+
 .kb-app-cell .kb-app-parameter-input .kb-app-parameter-accepted-glyph,
 .kb-app-cell .kb-app-parameter-input .kb-app-parameter-required-glyph {
     /* This scoots the icon inside */
     font-size: 15px;
     margin-left: 0;
 }
+
 .kb-app-cell .kb-app-parameter-required-glyph {
     color: #F44336;
 }
+
 .kb-app-cell .kb-app-parameter-hint {
     padding-left: 7px;
 }
@@ -142,8 +172,8 @@ control with padding, and then scooting the icon back into its column.
 
 .kb-app-cell .kb-app-parameter-hint {
     color: #777;
-    text-align:left;
-    margin-top:3px;
+    text-align: left;
+    margin-top: 3px;
 }
 
 .kb-app-cell .kb-app-parameter-accepted-glyph {
@@ -157,10 +187,10 @@ control with padding, and then scooting the icon back into its column.
 .kb-app-cell .kb-parameter-data-row-remove {
     color: #777;
 }
+
 .kb-app-cell .kb-parameter-data-row-add {
     color: #777;
 }
-
 
 .kb-app-cell .kb-app-advanced-options-controller-inactive {
     font-family: 'Oxygen', sans-serif;
@@ -171,16 +201,18 @@ control with padding, and then scooting the icon back into its column.
     color: #777;
     text-align: center;
 }
+
 .kb-app-cell .kb-app-advanced-options-controller {
     font-family: 'Oxygen', sans-serif;
     font-weight: bold;
-    cursor:pointer;
+    cursor: pointer;
     font-style: italic;
     font-size: 10pt;
     line-height: 14px;
     color: #0088cc;
     text-align: center;
 }
+
 .kb-app-cell .kb-app-advanced-options-controller:hover {
     color: #2a6496;
 }
@@ -202,8 +234,7 @@ control with padding, and then scooting the icon back into its column.
     padding: 3px 5px;
 }
 
-
-.report-widget .panel-title > [data-toggle="collapse"]::before {
+.report-widget .panel-title>[data-toggle="collapse"]::before {
     display: inline-block;
     margin-left: 0px;
     margin-right: 4px;
@@ -217,12 +248,14 @@ control with padding, and then scooting the icon back into its column.
     vertical-align: baseline;
     content: "\f078 ";
 }
-.report-widget .panel-title > [data-toggle="collapse"].collapsed::before {
-    margin-left: 2px; margin-right: 2px;
+
+.report-widget .panel-title>[data-toggle="collapse"].collapsed::before {
+    margin-left: 2px;
+    margin-right: 2px;
     content: "\f054 ";
 }
 
-.kb-app-cell .panel-title > [data-toggle="collapse"]::before {
+.kb-app-cell .panel-title>[data-toggle="collapse"]::before {
     display: inline-block;
     margin-left: 0px;
     margin-right: 4px;
@@ -236,10 +269,13 @@ control with padding, and then scooting the icon back into its column.
     vertical-align: baseline;
     content: "\f078 ";
 }
-.kb-app-cell .panel-title > [data-toggle="collapse"].collapsed::before {
-    margin-left: 2px; margin-right: 2px;
+
+.kb-app-cell .panel-title>[data-toggle="collapse"].collapsed::before {
+    margin-left: 2px;
+    margin-right: 2px;
     content: "\f054 ";
 }
+
 
 /* tweaks to elemnts that should be dimmed when the cell is not selected */
 
@@ -250,6 +286,7 @@ control with padding, and then scooting the icon back into its column.
 .kb-app-cell .advanced-parameter-showing {
     display: block;
 }
+
 .kb-app-cell .advanced-parameter-hidden {
     display: none;
 }
@@ -257,6 +294,7 @@ control with padding, and then scooting the icon back into its column.
 .kb-elapsed-time {
     font-family: monospace;
 }
+
 .kb-elapsed-time.-active {
     color: lime;
 }
@@ -313,7 +351,6 @@ warning: orange
 
 */
 
-
 .btn.kb-app-cell-btn {
     color: rgb(33, 150, 243);
     background-color: #FFF;
@@ -323,23 +360,29 @@ warning: orange
 
 
 /* Primary Button Style */
+
 .btn.kb-app-cell-btn.btn-primary {
     color: rgb(33, 150, 243);
     border: 2px rgb(33, 150, 243) solid;
 }
+
 .btn.kb-app-cell-btn.btn-primary:hover {
     color: #FFF;
     background-color: rgb(33, 150, 243);
     border-bottom: 6px rgb(33, 150, 243) solid;
     margin-bottom: 0;
 }
+
 .btn.kb-app-cell-btn.btn-primary:active {
     color: #FFF;
     background-color: rgb(33, 150, 243);
 }
+
+
 /* Hovering over an active cell is different, it tries to make the tab look
    disassociated but using a gray background so it doesnt look like an inactive
    tab */
+
 .btn.kb-app-cell-btn.btn-primary.active {
     color: white;
     background-color: rgb(33, 150, 243);
@@ -347,6 +390,7 @@ warning: orange
     border-bottom: 6px rgb(33, 150, 243) solid;
     margin-bottom: 0;
 }
+
 .btn.kb-app-cell-btn.btn-primary.active:hover {
     color: rgb(33, 150, 243);
     background-color: #DDD;
@@ -354,38 +398,47 @@ warning: orange
     margin-bottom: 4px;
 }
 
+
 /* DANGER - for error */
+
 .btn.kb-app-cell-btn.btn-danger {
-    color: rgb(209,82,65);
-    border: 2px rgb(209,82,65) solid;
+    color: rgb(209, 82, 65);
+    border: 2px rgb(209, 82, 65) solid;
 }
+
 .btn.kb-app-cell-btn.btn-danger:hover {
-   color: #FFF;
-    background-color: rgb(209,82,65);
-    border-bottom: 6px rgb(209,82,65) solid;
+    color: #FFF;
+    background-color: rgb(209, 82, 65);
+    border-bottom: 6px rgb(209, 82, 65) solid;
     margin-bottom: 0;
 }
+
 .btn.kb-app-cell-btn.btn-danger.active:hover {
-    color:  rgb(209,82,65);
+    color: rgb(209, 82, 65);
     background-color: #DDD;
-    border-bottom: 2px  rgb(209,82,65) solid;
-    margin-bottom: 4px;
-}
-.btn.kb-app-cell-btn.btn-danger.active {
-    color: white;
-    background-color: rgb(209,82,65);
-    border: 2px rgb(209,82,65) solid;
-    border-bottom: 6px rgb(209,82,65) solid;
-    margin-bottom: 0;
-}
-.btn.kb-app-cell-btn.btn-danger.active:hover {
-    color: rgb(209,82,65);
-    background-color: #DDD;
-    border-bottom: 2px rgb(209,82,65) solid;
+    border-bottom: 2px rgb(209, 82, 65) solid;
     margin-bottom: 4px;
 }
 
+.btn.kb-app-cell-btn.btn-danger.active {
+    color: white;
+    background-color: rgb(209, 82, 65);
+    border: 2px rgb(209, 82, 65) solid;
+    border-bottom: 6px rgb(209, 82, 65) solid;
+    margin-bottom: 0;
+}
+
+.btn.kb-app-cell-btn.btn-danger.active:hover {
+    color: rgb(209, 82, 65);
+    background-color: #DDD;
+    border-bottom: 2px rgb(209, 82, 65) solid;
+    margin-bottom: 4px;
+}
+
+
 /* DISABLED is gray border and text */
+
+
 /*
 .btn.kb-app-cell-btn.btn-primary.disabled:hover {
     color: #888;
@@ -395,15 +448,14 @@ warning: orange
 }
 */
 
-.btn.kb-app-cell-btn.disabled, .btn.kb-app-cell-btn.disabled:hover, .btn.kb-app-cell-btn.disabled:active {
+.btn.kb-app-cell-btn.disabled,
+.btn.kb-app-cell-btn.disabled:hover,
+.btn.kb-app-cell-btn.disabled:active {
     color: #888;
     background-color: #FFF;
     border: 2px #888 solid;
     margin-bottom: 4px;
 }
-
-
-
 
 .kb-app-cell [data-element="run-control-panel"] {
     width: 100%;
@@ -413,28 +465,34 @@ warning: orange
     border-top: 2px rgb(33, 150, 243) solid;
 }
 
-.kb-app-cell [data-element="tab-pane"] > div:empty {
+.kb-app-cell [data-element="tab-pane"]>div:empty {
     padding: 0px;
 }
 
-.kb-app-cell [data-element="tab-pane"] > div {
+.kb-app-cell [data-element="tab-pane"]>div {
     padding: 4px;
 }
 
 .kb-app-status-ok {
-    color:  rgb(75,184,86);
-}
-.kb-app-status-warning {
-    color:  orange;
-}
-.kb-app-status-danger, .kb-app-status-error {
-    color:  rgb(209,82,65);
-}
-.kb-app-status-default {
-    color:  rgb(33, 150, 243);
+    color: rgb(75, 184, 86);
 }
 
+.kb-app-status-warning {
+    color: orange;
+}
+
+.kb-app-status-danger,
+.kb-app-status-error {
+    color: rgb(209, 82, 65);
+}
+
+.kb-app-status-default {
+    color: rgb(33, 150, 243);
+}
+
+
 /* app cell panels */
+
 
 /* TODO: higher level selector */
 
@@ -445,51 +503,52 @@ warning: orange
 
 .tt-input,
 .tt-query {
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  width : 100%
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    width: 100%
 }
 
 .tt-hint {
-  color: #999
+    color: #999
 }
 
-.tt-menu {    /* used to be tt-dropdown-menu in older versions */
-  margin-top: 4px;
-  padding: 4px 0;
-  background-color: #fff;
-  border: 1px solid #ccc;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  -webkit-border-radius: 4px;
-     -moz-border-radius: 4px;
-          border-radius: 4px;
-  -webkit-box-shadow: 0 5px 10px rgba(0,0,0,.2);
-     -moz-box-shadow: 0 5px 10px rgba(0,0,0,.2);
-          box-shadow: 0 5px 10px rgba(0,0,0,.2);
-  width : 100%
+.tt-menu {
+    /* used to be tt-dropdown-menu in older versions */
+    margin-top: 4px;
+    padding: 4px 0;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
+    -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+    -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+    box-shadow: 0 5px 10px rgba(0, 0, 0, .2);
+    width: 100%
 }
 
 .tt-suggestion {
-  padding: 3px 20px;
-  line-height: 24px;
+    padding: 3px 20px;
+    line-height: 24px;
 }
 
-.tt-suggestion.tt-cursor,.tt-suggestion:hover {
-  color: #fff;
-  background-color: #0097cf;
-
+.tt-suggestion.tt-cursor,
+.tt-suggestion:hover {
+    color: #fff;
+    background-color: #0097cf;
 }
 
 .tt-suggestion p {
-  margin: 0;
+    margin: 0;
 }
 
 .tt-header {
-  font-size : 75%;
-  /* this doesn't work, don't want to just turn it on, though:
+    font-size: 75%;
+    /* this doesn't work, don't want to just turn it on, though:
   font-color : gray;
   */
-  font-style : italic;
-  padding-left : 5px;
+    font-style: italic;
+    padding-left: 5px;
 }

--- a/kbase-extension/static/kbase/css/bootstrapHelper.css
+++ b/kbase-extension/static/kbase/css/bootstrapHelper.css
@@ -5,6 +5,7 @@
     Customize bootstrap styles
 */
 
+
 /*
   Bs recommends h4 for the modal title, but this is overridden by the general 
   purpose kbase h4 style. Generally, I (Erik) do not like using semantic tags
@@ -19,6 +20,17 @@
     color: #2e618d;
 }
 
+
+/*
+    Unset the global modal title color set above for alert modals, which 
+    may set the color style based on the alert type.
+*/
+
+.modal.kb-modal-alert .modal-title {
+    color: unset;
+}
+
+
 /*
     The BS checkbox appears too low, due to the top margin, when used with a label
     in the recommended manner. 
@@ -28,6 +40,7 @@
     accomodate this.) Anyway, we roll with it but try to patch up the styling
     as it breaks.
 */
+
 .modal input[type="checkbox"] {
     margin-top: 1px;
 }
@@ -36,22 +49,29 @@
     border: none;
     margin-bottom: 10px;
 }
+
+
 /* colors copied shamelessly from peeking at bootstrap
    http://getbootstrap.com/css/
 */
+
 .panel-danger.kb-panel-light .panel-title {
     color: #a94442;
 }
+
 .panel-success.kb-panel-light .panel-title {
     color: #3c763d;
 }
+
 .panel-warning.kb-panel-light .panel-title {
     color: #8a6d3b;
 }
+
 .panel-info.kb-panel-light .panel-title {
     color: blue;
 }
-.panel.kb-panel-light > .panel-heading {
+
+.panel.kb-panel-light>.panel-heading {
     background-color: transparent;
     font-weight: bold;
     color: #666;
@@ -59,6 +79,7 @@
     padding-bottom: 2px;
     border-bottom: 1px #CCC solid;
 }
+
 .panel.kb-panel-light .panel-body {
     padding-top: 0;
     padding: 0;
@@ -67,7 +88,8 @@
 .panel.kb-panel-container {
     border: none;
 }
-.panel.kb-panel-container > .panel-heading {
+
+.panel.kb-panel-container>.panel-heading {
     background-color: transparent;
     font-weight: bold;
     xcolor: #2e618d;
@@ -76,9 +98,11 @@
     border-bottom: 2px #CCC solid;
     margin-bottom: 10px;
 }
+
 .panel.kb-panel-container .panel-body {
     padding-top: 0;
 }
+
 
 /*
   The button bar in a cell widgetis located at the bottom of the inputs, but 
@@ -86,6 +110,7 @@
   These styles attempt to help the button toolbar, which represents the actions
   the user can take, be visually distinct from the other bits surrounding it.
 */
+
 .btn-toolbar.kb-btn-toolbar-cell-widget {
     margin-bottom: 20px;
     background-color: #EEE;

--- a/kbase-extension/static/kbase/css/methodCell.css
+++ b/kbase-extension/static/kbase/css/methodCell.css
@@ -5,3 +5,11 @@
 .twitter-typeahead {
     width: 100%;
 }
+
+.code_cell div.input_area {
+    display: none;
+}
+
+.code_cell div.input_area.-show {
+    display: block;
+}

--- a/kbase-extension/static/kbase/js/common/fsm.js
+++ b/kbase-extension/static/kbase/js/common/fsm.js
@@ -14,7 +14,7 @@ define([
 ], function(
     utils,
     Runtime
-    ) {
+) {
     'use strict';
 
 
@@ -61,15 +61,13 @@ define([
 
         function findState(stateToFind) {
             var foundStates = allStates.filter(function(stateDef) {
-                if (utils.isEqual(stateToFind, stateDef.state)) {
-                    return true;
-                }
+                return utils.isEqual(stateToFind, stateDef.state);
             });
             if (foundStates.length === 1) {
                 return foundStates[0];
             }
             if (foundStates.length > 1) {
-                console.error('state error: multiple states found:', stateToFind, foundStates)
+                console.error('state error: multiple states found:', stateToFind, foundStates);
                 throw new Error('state error: multiple states found');
             }
 

--- a/kbase-extension/static/kbase/js/common/jupyter.js
+++ b/kbase-extension/static/kbase/js/common/jupyter.js
@@ -5,12 +5,13 @@ define([
     'jquery',
     'base/js/namespace',
     'base/js/dialog'
-], function (
+], function(
     $,
     Jupyter,
     dialog
-    ) {
+) {
     'use strict';
+
     function deleteCell(cellOrIndex) {
         var cellIndex;
         if (typeof cellOrIndex === 'number') {
@@ -31,7 +32,7 @@ define([
     function editCellMetadata(cell) {
         dialog.edit_metadata({
             md: cell.metadata,
-            callback: function (md) {
+            callback: function(md) {
                 cell.metadata = md;
             },
             name: 'Cell',
@@ -39,21 +40,22 @@ define([
             keyboard_manager: Jupyter.keyboard_manager
         });
     }
-    
+
     function saveNotebook() {
         Jupyter.notebook.save_checkpoint();
     }
-    
+
     function findCellIndex(cell) {
         return Jupyter.notebook.find_cell_index(cell);
     }
-    
+
     function getCells() {
         return Jupyter.notebook.get_cells();
     }
 
     function getCell(kbaseId) {
-        var cells = getCells(), cell;
+        var cells = getCells(),
+            cell;
         for (var i = 0; i < cells.length; i += 1) {
             cell = cells[i];
             if (cell.metadata.kbase &&
@@ -65,7 +67,7 @@ define([
         }
         return null;
     }
-    
+
     /*
      * Disables the Jupyter keyboard manager for a given cell.
      * 
@@ -90,13 +92,13 @@ define([
      * specific cells or cell types, and within specific areas.
      */
     function disableKeyListenersForCell(cell) {
-        cell.element[0].addEventListener('focus', function () {
+        cell.element[0].addEventListener('focus', function() {
             Jupyter.keyboard_manager.disable();
         }, true);
     }
 
     function getWorkspaceRef() {
-        var workspaceName = Jupyter.notebook.metadata.ws_name, 
+        var workspaceName = Jupyter.notebook.metadata.ws_name,
             workspaceId;
 
         if (workspaceName) {
@@ -120,7 +122,15 @@ define([
             }
         });
     }
-    
+
+    function uiModeIs(modeTest) {
+        return Jupyter.narrative.narrController.uiModeIs(modeTest);
+    }
+
+    function canEdit() {
+        return Jupyter.narrative.narrController.uiModeIs('edit');
+    }
+
     return {
         deleteCell: deleteCell,
         editNotebookMetadata: editNotebookMetadata,
@@ -131,6 +141,8 @@ define([
         getCell: getCell,
         disableKeyListenersForCell: disableKeyListenersForCell,
         getWorkspaceRef: getWorkspaceRef,
-        onEvent: onEvent
+        onEvent: onEvent,
+        uiModeIs: uiModeIs,
+        canEdit: canEdit
     };
 });

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -142,12 +142,12 @@ define([
     // Wrappers for the Jupyter/Jupyter function so we only maintain it in one place.
     Narrative.prototype.patchKeyboardMapping = function () {
         var commonShortcuts = [
-            'a', 'm', 'f', 'y', 'r',
-            '1', '2', '3', '4', '5', '6',
-            'k', 'j', 'b', 'x', 'c', 'v',
-            'z', 'd,d', 's', 'l', 'o', 'h',
-            'i,i', '0,0', 'q', 'shift-j', 'shift-k',
-            'shift-m', 'shift-o', 'shift-v'
+                'a', 'm', 'f', 'y', 'r',
+                '1', '2', '3', '4', '5', '6',
+                'k', 'j', 'b', 'x', 'c', 'v',
+                'z', 'd,d', 's', 'l', 'o', 'h',
+                'i,i', '0,0', 'q', 'shift-j', 'shift-k',
+                'shift-m', 'shift-o', 'shift-v'
             ],
             commandShortcuts = [],
             editShortcuts = [
@@ -161,7 +161,7 @@ define([
             try {
                 Jupyter.keyboard_manager.command_shortcuts.remove_shortcut(shortcut);
             } catch (ex) {
-                console.warn('Error removing shortcut "'  + shortcut +'"', ex);
+                console.warn('Error removing shortcut "' + shortcut + '"', ex);
             }
             try {
                 Jupyter.notebook.keyboard_manager.edit_shortcuts.remove_shortcut(shortcut);
@@ -174,7 +174,7 @@ define([
             try {
                 Jupyter.keyboard_manager.command_shortcuts.remove_shortcut(shortcut);
             } catch (ex) {
-                console.warn('Error removing shortcut "'  + shortcut +'"', ex);
+                console.warn('Error removing shortcut "' + shortcut + '"', ex);
             }
         });
 
@@ -182,7 +182,7 @@ define([
             try {
                 Jupyter.notebook.keyboard_manager.edit_shortcuts.remove_shortcut(shortcut);
             } catch (ex) {
-                console.warn('Error removing shortcut "'  + shortcut +'"', ex);
+                console.warn('Error removing shortcut "' + shortcut + '"', ex);
             }
         });
     };
@@ -242,26 +242,26 @@ define([
      */
     Narrative.prototype.initSharePanel = function () {
         var sharePanel = $('<div style="text-align:center"><br><br><img src="' +
-            Config.get('loading_gif') +
-            '"></div>'),
+                Config.get('loading_gif') +
+                '"></div>'),
             shareWidget = null,
             shareDialog = new BootstrapDialog({
                 title: 'Change Share Settings',
                 body: sharePanel,
                 closeButton: true
             });
-        shareDialog.getElement().one('shown.bs.modal', function() {
+        shareDialog.getElement().one('shown.bs.modal', function () {
             shareWidget = new KBaseNarrativeSharePanel(sharePanel.empty(), {
                 ws_name_or_id: this.getWorkspaceName()
             });
         }.bind(this));
-        $('#kb-share-btn').click(function() {
+        $('#kb-share-btn').click(function () {
             var narrName = Jupyter.notebook.notebook_name;
             if (narrName.trim().toLowerCase() === 'untitled' || narrName.trim().length === 0) {
                 Jupyter.save_widget.rename_notebook({
                     notebook: Jupyter.notebook,
                     message: 'Please name your Narrative before sharing.',
-                    callback: function() { shareDialog.show(); }
+                    callback: function () { shareDialog.show(); }
                 });
                 return;
             }
@@ -271,52 +271,55 @@ define([
 
     /**
      */
-    function renderSettingsDialog(settings) {
-        var t = html.tag,
-            div = t('div'), input = t('input'), label = t('label'), p = t('p');
+    // function renderSettingsDialog(settings) {
+    //     var t = html.tag,
+    //         div = t('div'),
+    //         input = t('input'),
+    //         label = t('label'),
+    //         p = t('p');
 
-        return  div([
-            p({}, [
-                'These settings apply to and are saved with this Narrative. Changes ',
-                'made here will not affect existing Narratives or new Narratives that you ',
-                'may create.'
-            ]),
-            p({style: {fontStyle: 'italic'}}, [
-                'Please note that you will need to refresh the browser in order to ',
-                'enable any changes.'
-            ]),
-            div({class: 'form-horizontal settings-dialog'}, [
-                div({class: 'form-group'}, [
-                    div({class: 'col-md-8 checkbox'}, [
-                        label([
-                            input({
-                                type: 'checkbox',
-                                name: 'advanced',
-                                value: 'advanced',
-                                checked: settings.advanced
-                            }),
-                            'Use Advanced features'
-                        ])
-                    ]),
-                    div({class: 'col-md-4'})
-                ]),
-                div({class: 'form-group'}, [
-                    div({class: 'col-md-8 checkbox'}, [
-                        label([
-                            input({
-                                type: 'checkbox',
-                                name: 'developer',
-                                value: 'developer',
-                                checked: settings.developer
-                            }),
-                            'Use Developer features'
-                        ])
-                    ]),
-                    div({class: 'col-md-4'})
-                ])
-            ])
-        ]);
-    }
+    //     return div([
+    //         p({}, [
+    //             'These settings apply to and are saved with this Narrative. Changes ',
+    //             'made here will not affect existing Narratives or new Narratives that you ',
+    //             'may create.'
+    //         ]),
+    //         p({ style: { fontStyle: 'italic' } }, [
+    //             'Please note that you will need to refresh the browser in order to ',
+    //             'enable any changes.'
+    //         ]),
+    //         div({ class: 'form-horizontal settings-dialog' }, [
+    //             div({ class: 'form-group' }, [
+    //                 div({ class: 'col-md-8 checkbox' }, [
+    //                     label([
+    //                         input({
+    //                             type: 'checkbox',
+    //                             name: 'advanced',
+    //                             value: 'advanced',
+    //                             checked: settings.advanced
+    //                         }),
+    //                         'Use Advanced features'
+    //                     ])
+    //                 ]),
+    //                 div({ class: 'col-md-4' })
+    //             ]),
+    //             div({ class: 'form-group' }, [
+    //                 div({ class: 'col-md-8 checkbox' }, [
+    //                     label([
+    //                         input({
+    //                             type: 'checkbox',
+    //                             name: 'developer',
+    //                             value: 'developer',
+    //                             checked: settings.developer
+    //                         }),
+    //                         'Use Developer features'
+    //                     ])
+    //                 ]),
+    //                 div({ class: 'col-md-4' })
+    //             ])
+    //         ])
+    //     ]);
+    // }
 
     /*
      * Given an inner node, which is probably a button, inspect the contents
@@ -334,72 +337,71 @@ define([
         }
         return findParent(node.parentNode, selector);
     }
-    function doCheckSettings(innerNode) {
-        var dialogNode = findParent(innerNode, '.modal-dialog');
 
-        if (!dialogNode) {
-            console.error('COULD NOT FIND PARENT NODE');
-            throw new Error('Could not find the parent node!');
-        }
+    // function doCheckSettings(innerNode) {
+    //     var dialogNode = findParent(innerNode, '.modal-dialog');
 
-        var settings = {};
-        var advanced = dialogNode.querySelector('[name="advanced"]').checked;
-        settings.advanced = advanced;
+    //     if (!dialogNode) {
+    //         console.error('COULD NOT FIND PARENT NODE');
+    //         throw new Error('Could not find the parent node!');
+    //     }
 
-        var developer = dialogNode.querySelector('[name="developer"]').checked;
-        settings.developer = developer;
+    //     var settings = {};
+    //     var advanced = dialogNode.querySelector('[name="advanced"]').checked;
+    //     settings.advanced = advanced;
 
-        return settings;
-    }
+    //     var developer = dialogNode.querySelector('[name="developer"]').checked;
+    //     settings.developer = developer;
 
-    function doSaveSettings(settings) {
-        var existingSettings = Jupyter.notebook.metadata.kbase.userSettings;
-        Object.keys(settings).forEach(function (key) {
-            existingSettings[key] = settings[key];
-        });
-        Jupyter.notebook.metadata.kbase.userSettings = existingSettings;
-        Jupyter.notebook.save_checkpoint();
-    }
+    //     return settings;
+    // }
 
-    function showSettingsDialog() {
-        var ui = UI.make({node: document.body}),
-            existingSettings = Jupyter.notebook.metadata.kbase.userSettings;
+    // function doSaveSettings(settings) {
+    //     var existingSettings = Jupyter.notebook.metadata.kbase.userSettings;
+    //     Object.keys(settings).forEach(function(key) {
+    //         existingSettings[key] = settings[key];
+    //     });
+    //     Jupyter.notebook.metadata.kbase.userSettings = existingSettings;
+    //     Jupyter.notebook.save_checkpoint();
+    // }
 
-        if (!existingSettings) {
-            existingSettings = {};
-            Jupyter.notebook.metadata.kbase.userSettings = {};
-        }
-        ui.showDialog({
-            title: 'Narrative User Settings',
-            body: renderSettingsDialog(existingSettings),
-            buttons: [
-                {
-                    type: 'primary',
-                    label: 'Save Settings',
-                    action: 'save',
-                    handler: function (e) {
-                        return doCheckSettings(e.target);
-                    }
-                }
-            ]
-        })
-            .then(function (result) {
-                if (result.action === 'save') {
-                    doSaveSettings(result.result);
-                }
-            });
-    }
+    // function showSettingsDialog() {
+    //     var ui = UI.make({ node: document.body }),
+    //         existingSettings = Jupyter.notebook.metadata.kbase.userSettings;
 
-    Narrative.prototype.initSettingsDialog = function () {
-        var settingsButtonNode = document.getElementById('kb-settings-btn');
-        if (!settingsButtonNode) {
-            return;
-        }
+    //     if (!existingSettings) {
+    //         existingSettings = {};
+    //         Jupyter.notebook.metadata.kbase.userSettings = {};
+    //     }
+    //     ui.showDialog({
+    //             title: 'Narrative User Settings',
+    //             body: renderSettingsDialog(existingSettings),
+    //             buttons: [{
+    //                 type: 'primary',
+    //                 label: 'Save Settings',
+    //                 action: 'save',
+    //                 handler: function(e) {
+    //                     return doCheckSettings(e.target);
+    //                 }
+    //             }]
+    //         })
+    //         .then(function(result) {
+    //             if (result.action === 'save') {
+    //                 doSaveSettings(result.result);
+    //             }
+    //         });
+    // }
 
-        settingsButtonNode.addEventListener('click', function () {
-            showSettingsDialog();
-        });
-    };
+    // Narrative.prototype.initSettingsDialog = function() {
+    //     var settingsButtonNode = document.getElementById('kb-settings-btn');
+    //     if (!settingsButtonNode) {
+    //         return;
+    //     }
+
+    //     settingsButtonNode.addEventListener('click', function() {
+    //         showSettingsDialog();
+    //     });
+    // };
 
 
     /**
@@ -465,7 +467,7 @@ define([
 
     Narrative.prototype.createShutdownDialogButtons = function () {
         var $shutdownButton = $('<button>')
-            .attr({type: 'button', 'data-dismiss': 'modal'})
+            .attr({ type: 'button', 'data-dismiss': 'modal' })
             .addClass('btn btn-danger')
             .append('Okay. Shut it all down!')
             .click(function () {
@@ -478,7 +480,7 @@ define([
             .hide();
 
         var $firstShutdownBtn = $('<button>')
-            .attr({type: 'button'})
+            .attr({ type: 'button' })
             .addClass('btn btn-danger')
             .append('Shutdown')
             .click(function () {
@@ -531,9 +533,9 @@ define([
 
         new KBaseAccordion($verAccordionDiv, {
             elements: [{
-                    title: 'KBase Service URLs',
-                    body: $versionTable
-                }]
+                title: 'KBase Service URLs',
+                body: $versionTable
+            }]
         });
 
         var shutdownButtons = this.createShutdownDialogButtons();
@@ -696,53 +698,49 @@ define([
                 DisplayUtil.displayRealName(creatorId, $('#kb-narr-creator'));
 
                 // This puts the cell menu in the right place.
-                $([Jupyter.events]).trigger('select.Cell', {cell: Jupyter.notebook.get_selected_cell()});
+                $([Jupyter.events]).trigger('select.Cell', { cell: Jupyter.notebook.get_selected_cell() });
             }
-            if (this.getWorkspaceName() !== null) {
-                this.initSharePanel();
-
-                this.initSettingsDialog();
-
-                var wsInfo = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-                if (wsInfo && wsInfo.length === 3) {
-                    this.workspaceRef = wsInfo[1] + '/' + wsInfo[2];
-                    this.workspaceId = wsInfo[1];
-                }
-
-                this.sidePanel = new KBaseNarrativeSidePanel($('#kb-side-panel'), {autorender: false});
-                // init the controller
-                this.narrController = new KBaseNarrativeWorkspace($('#notebook_panel'), {
-                    ws_id: this.getWorkspaceName()
-                });
-                this.narrController.render()
-                    .finally(function () {
-                        this.sidePanel.render();
-                        $('#kb-wait-for-ws').remove();
-                    }.bind(this));
-
-                $([Jupyter.events]).on('kernel_ready.Kernel',
-                    function () {
-
-                        console.log('Kernel Ready! Initializing Job Channel...');
-
-                        // TODO: This should be an event "kernel-ready", perhaps broadcast
-                        // on the default bus channel.
-                        this.sidePanel.$jobsWidget.initCommChannel()
-                            .catch(function (err) {
-                                // TODO: put the narrative into a terminal state
-                                console.error('ERROR initializing kbase comm channel', err);
-                                KBFatal('Narrative.ini', 'KBase communication channel could not be initiated with the back end. TODO');
-                                $('#kb-wait-for-ws').remove();
-                                // alert('KBase communication channel could not be initiated with the back end. TODO: This should result in a terminal state for the Narrative.');
-                            });
-
-                        // this.initCommChannel();
-                    }.bind(this)
-                    );
-            } else {
+            if (this.getWorkspaceName() == null) {
                 KBFatal('Narrative.init', 'Unable to locate workspace name from the Narrative object!');
                 $('#kb-wait-for-ws').remove();
+                return;
             }
+
+            this.initSharePanel();
+            // this.initSettingsDialog();
+
+            var wsInfo = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
+            if (wsInfo && wsInfo.length === 3) {
+                this.workspaceRef = wsInfo[1] + '/' + wsInfo[2];
+                this.workspaceId = wsInfo[1];
+            }
+
+            this.sidePanel = new KBaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
+            // init the controller
+            this.narrController = new KBaseNarrativeWorkspace($('#notebook_panel'), {
+                ws_id: this.getWorkspaceName()
+            });
+            this.narrController.render()
+                .finally(function () {
+                    this.sidePanel.render();
+                    $('#kb-wait-for-ws').remove();
+                }.bind(this));
+
+            $([Jupyter.events]).on('kernel_ready.Kernel',
+                function () {
+                    console.log('Kernel Ready! Initializing Job Channel...');
+
+                    // TODO: This should be an event "kernel-ready", perhaps broadcast
+                    // on the default bus channel.
+                    this.sidePanel.$jobsWidget.initCommChannel()
+                        .catch(function (err) {
+                            // TODO: put the narrative into a terminal state
+                            console.error('ERROR initializing kbase comm channel', err);
+                            KBFatal('Narrative.ini', 'KBase communication channel could not be initiated with the back end. TODO');
+                            $('#kb-wait-for-ws').remove();
+                        });
+                }.bind(this)
+            );
         }.bind(this));
     };
 
@@ -755,11 +753,11 @@ define([
     Narrative.prototype.updateVersion = function () {
         var user = NarrativeLogin.sessionInfo.user; //.loginWidget($('#signin-button')).session('user_id');
         Promise.resolve($.ajax({
-            contentType: 'application/json',
-            url: '/narrative_shutdown/' + user,
-            type: 'DELETE',
-            crossDomain: true
-        }))
+                contentType: 'application/json',
+                url: '/narrative_shutdown/' + user,
+                type: 'DELETE',
+                crossDomain: true
+            }))
             .then(function () {
                 setTimeout(function () {
                     location.reload(true);
@@ -793,7 +791,7 @@ define([
     Narrative.prototype.createAndRunMethod = function (method_id, parameters) {
         //first make a request to get the method spec of a particular method
         //getFunctionSpecs.Narrative is implemented in kbaseNarrativeAppPanel
-        var request = {methods: [method_id]};
+        var request = { methods: [method_id] };
         var self = this;
         self.narrController.trigger('getFunctionSpecs.Narrative', [request,
             function (specs) {
@@ -904,7 +902,7 @@ define([
 
     Narrative.prototype.scrollToCell = function (cell, select) {
         var $elem = $('#notebook-container');
-        $elem.animate({scrollTop: cell.element.offset().top + $elem.scrollTop() - $elem.offset().top}, 400);
+        $elem.animate({ scrollTop: cell.element.offset().top + $elem.scrollTop() - $elem.offset().top }, 400);
         if (select) {
             Jupyter.notebook.focus_cell(cell);
             Jupyter.notebook.select(Jupyter.notebook.find_cell_index(cell));
@@ -932,20 +930,17 @@ define([
                 }
             }, delay);
             // Move content flush left-ish
-            $('#notebook-container').animate(
-                {left: 0},
-                {
-                    easing: 'swing',
-                    duration: delay
-                }
-            );
+            $('#notebook-container').animate({ left: 0 }, {
+                easing: 'swing',
+                duration: delay
+            });
         } else {
             $('#kb-side-toggle-in').hide(0, function () {
                 $('#left-column').show('slide', {
                     direction: 'left',
                     easing: 'swing'
                 }, delay);
-                $('#notebook-container').animate({left: 380}, {easing: 'swing', duration: delay});
+                $('#notebook-container').animate({ left: 380 }, { easing: 'swing', duration: delay });
             });
         }
     };

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -64,7 +64,15 @@ define(
             $('#kb-status-btn').attr('href', Config.url('status_page'));
 
             $('#kb-add-code-cell').click(function() {
-                    Jupyter.narrative.insertAndSelectCellBelow('code');
+                    var cell = Jupyter.narrative.insertAndSelectCellBelow('code');
+                    // Now we need to invent a way of triggering the cell to set itself up.
+                    $([Jupyter.events]).trigger('inserted.Cell', {
+                        cell: cell,
+                        kbase: {
+                            type: 'code',
+                            language: 'python'
+                        }
+                    });
                 })
                 .tooltip({
                     delay: {

--- a/kbase-extension/static/kbase/js/tour.js
+++ b/kbase-extension/static/kbase/js/tour.js
@@ -10,15 +10,14 @@ define([
 ], function($, Tour, Handlebars, TourTmpl) {
     "use strict";
 
-    var NarrativeTour = function (narrative, notebook, events) {
+    var NarrativeTour = function(narrative, notebook, events) {
         var that = this;
         this.notebook = notebook;
         this.narrative = narrative;
         this.step_duration = 0;
         this.events = events;
         this.template = Handlebars.compile(TourTmpl);
-        this.tour_steps = [
-            {
+        this.tour_steps = [{
                 title: "Welcome to the Narrative Tour", // add a grayed out background.
                 placement: 'bottom',
                 orphan: true,
@@ -183,12 +182,12 @@ define([
                 placement: 'bottom',
                 content: 'Access control options for the Jupyter kernel that powers the Narrative Interface. This is useful for restarting or reconnecting to KBase after your network connection has been disrupted.',
             },
-            {
-                element: '#kb-settings-btn',
-                title: 'Adjust Global Settings',
-                placement: 'bottom',
-                content: 'Enable advanced or developer features for your Narrative in the Settings Menu. These option are enabled for individual Narratives. Refresh your browser to enable these settings for your Narrative.'
-            },
+            // {
+            //     element: '#kb-settings-btn',
+            //     title: 'Adjust Global Settings',
+            //     placement: 'bottom',
+            //     content: 'Enable advanced or developer features for your Narrative in the Settings Menu. These option are enabled for individual Narratives. Refresh your browser to enable these settings for your Narrative.'
+            // },
             {
                 element: '#kb-add-code-cell',
                 title: 'Code Cells',
@@ -214,7 +213,7 @@ define([
             onResume: this.toggle_pause_play,
             steps: this.tour_steps,
             template: function(i, step) {
-                return that.template({step: (i+1), totalSteps: that.tour_steps.length});
+                return that.template({ step: (i + 1), totalSteps: that.tour_steps.length });
             },
             orphan: true
         });
@@ -231,14 +230,13 @@ define([
             // $('.kb-side-tab[kb-data-id="0"]').find('button > .fa-arrow-right')
             //                                  .first()
             //                                  .click();
-        }
-        else {
+        } else {
             this.narrative.hideOverlay();
             // $(document).trigger('hideSidePanelOverlay.Narrative');
         }
     };
 
-    NarrativeTour.prototype.start = function () {
+    NarrativeTour.prototype.start = function() {
         console.log("let's start the tour");
         this.tour.init();
         this.tour.start();
@@ -251,7 +249,7 @@ define([
         $('#modal_indicator').css('min-height', '18px');
     };
 
-    NarrativeTour.prototype.toggle_pause_play = function () {
+    NarrativeTour.prototype.toggle_pause_play = function() {
         $('#tour-pause').toggleClass('fa-pause fa-play');
     };
 
@@ -260,6 +258,6 @@ define([
         this.notebook.edit_mode();
     };
 
-    return {'Tour': NarrativeTour};
+    return { 'Tour': NarrativeTour };
 
 });

--- a/kbase-extension/static/kbase/js/util/bootstrapAlert.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapAlert.js
@@ -1,0 +1,91 @@
+/*global define*/
+/*jslint white: true*/
+define([
+    'bootstrap',
+    'jquery'
+], function(
+    bootstrap,
+    $
+) {
+    'use strict';
+
+    /**
+     * options:
+     * {
+     *     title: string,
+     *     body: jquery node
+     * }
+     */
+    var BootstrapAlert = function(options) {
+        this.$modal = $('<div class="modal kb-modal-alert fade" role="dialog">');
+        this.$dialog = $('<div class="modal-dialog">');
+        this.$dialogContent = $('<div class="modal-content">');
+        this.$header = $('<div class="modal-header">');
+
+        this.$title = $('<span>');
+
+        this.$headerTitle = $('<span class="modal-title">').append(this.$title);
+
+        this.$dialogBody = $('<div class="modal-body">');
+        this.$footer = $('<div class="modal-footer">');
+
+        this.$buttonList = $('<div>');
+
+        this.enterToTrigger = false;
+        if (options.enterToTrigger) {
+            this.enterToTrigger = options.enterToTrigger;
+        }
+
+        this.$modal.append(
+            this.$dialog.append(
+                this.$dialogContent.append(this.$header.append(this.$headerTitle))
+                .append(this.$dialogBody)
+                .append(this.$footer)));
+
+        this.initialize(options);
+    };
+
+    BootstrapAlert.prototype.initialize = function(options) {
+        if (!options) {
+            console.warn('BootstrapALert created with no arguments.');
+            return;
+        }
+        var $closeButton = $('<button type="button" class="close" data-dismiss="modal" aria-label="Close">')
+            .append($('<span aria-hidden="true">')
+                .append('&times;'));
+        this.$header.append($closeButton);
+        if (options.title) {
+            this.$title.html(options.title);
+        }
+        if (options.type) {
+            this.$title.addClass('text-' + options.type);
+        }
+        if (options.body) {
+            this.$dialogBody.html(options.body);
+        }
+        var $closeButton2 = $('<button type="button" class="btn btn-primary" data-dismiss="modal">')
+            .text('Close');
+        this.$footer.append($closeButton2);
+
+        this.$modal.modal('show');
+    };
+
+    BootstrapAlert.prototype.setBody = function($body) {
+        this.$dialogBody.empty().append($body);
+    };
+
+    BootstrapAlert.prototype.setTitle = function(title) {
+        this.$headerTitle.empty().append(title);
+    };
+
+    /**
+     * Removes this modal from the DOM and removes any associated content.
+     */
+    BootstrapAlert.prototype.destroy = function() {
+        this.$modal.remove();
+        this.$modal = null;
+        return null;
+    };
+
+    return BootstrapAlert;
+});

--- a/kbase-extension/static/kbase/js/widgets/appInfoPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/appInfoPanel.js
@@ -15,8 +15,7 @@ define([
     'kb_service/client/narrativeMethodStore',
     'handlebars',
     'text!kbase/templates/app_info_panel.html'
-],
-function(
+], function(
     Promise,
     Runtime,
     Catalog,
@@ -25,6 +24,7 @@ function(
     appInfoPanelTmpl
 ) {
     'use strict';
+
     function factory(config) {
         var container,
             runtime = Runtime.make(),
@@ -37,61 +37,55 @@ function(
             info = {};
 
         function start(arg) {
-            return Promise.try(function () {
-                container = arg.node;
+            return Promise.try(function() {
+                    container = arg.node;
 
-                var infoProms = [
-                    /* Get the method full info so we can populate the description */
-                    nms.get_method_full_info({'ids': [appId], 'tag': tag})
-                    .then(function(methodInfo) {
-                        methodInfo = methodInfo[0] || {};
-                        return Promise.try(function() {
-                            var desc = methodInfo.description || "";
+                    var infoProms = [
+                        /* Get the method full info so we can populate the description */
+                        nms.get_method_full_info({ 'ids': [appId], 'tag': tag })
+                        .then(function(methodInfo) {
+                            methodInfo = methodInfo[0] || {};
+                            var desc = methodInfo.description || '';
                             info.description = new Handlebars.SafeString(desc);
 
                             var authorList = methodInfo.authors || [];
                             info.authorList = authorList.join(', ');
                             info.multiAuthors = authorList.length > 1;
-                        });
-                    }),
+                        }),
 
-                    /* Get the method stats so we know how many times it was run. */
-                    catalog.get_exec_aggr_stats({'full_app_ids': [appId]})
-                    .then(function(appStats) {
-                        return Promise.try(function() {
+                        /* Get the method stats so we know how many times it was run. */
+                        catalog.get_exec_aggr_stats({ 'full_app_ids': [appId] })
+                        .then(function(appStats) {
+                            console.log('app stats', appStats);
                             appStats = appStats[0] || {};
                             info.runCount = appStats.number_of_calls || 'unknown';
-                        });
-                    }),
+                        }),
 
-                    /* Get the module info so we know when it was last updated. */
-                    catalog.get_module_info({'module_name': appModule})
-                    .then(function(moduleInfo) {
-                        return Promise.try(function() {
+                        /* Get the module info so we know when it was last updated. */
+                        catalog.get_module_info({ 'module_name': appModule })
+                        .then(function(moduleInfo) {
                             moduleInfo = moduleInfo[tag] || {};
                             var timestamp = moduleInfo.timestamp || 'unknown';
                             var dateString = 'unknown';
                             try {
                                 dateString = new Date(timestamp).toLocaleDateString();
-                            }
-                            catch (e) {
+                            } catch (e) {
                                 //pass
                             }
                             info.updateDate = dateString;
-                        });
-                    })
-                ];
-                return Promise.all(infoProms);
-            })
-            .then(function() {
-                return Promise.try(function() {
-                    container.html(infoPanel(info));
+                        })
+                    ];
+                    return Promise.all(infoProms);
+                })
+                .then(function() {
+                    return Promise.try(function() {
+                        container.html(infoPanel(info));
+                    });
                 });
-            });
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 container.html('');
             });
         }

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetCompact.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetCompact.js
@@ -17,7 +17,7 @@ define([
     'common/runtime',
     './errorControl',
     'css!google-code-prettify/prettify.css'
-], function (
+], function(
     Promise,
     PR,
     html,
@@ -75,6 +75,7 @@ define([
                 referenceType: config.referenceType
             });
         } catch (ex) {
+            console.error('Error creating input control', ex);
             inputControl = ErrorControlFactory.make({
                 message: ex.message
             }).make();
@@ -125,7 +126,7 @@ define([
                         class: 'btn btn-link alert-link',
                         id: events.addEvent({
                             type: 'click',
-                            handler: function () {
+                            handler: function() {
                                 showMessageDialog(messageDef.id);
                             }
                         })
@@ -214,12 +215,12 @@ define([
 
         function parameterInfoTypeRules(spec) {
             switch (spec.data.type) {
-            case 'float':
-            case 'int':
-                return [
-                    tr([th('Min'), td(spec.data.constraints.min)]),
-                    tr([th('Max'), td(spec.data.constraints.max)])
-                ];
+                case 'float':
+                case 'int':
+                    return [
+                        tr([th('Min'), td(spec.data.constraints.min)]),
+                        tr([th('Max'), td(spec.data.constraints.max)])
+                    ];
             }
         }
 
@@ -229,10 +230,10 @@ define([
                 tr([th('Data type'), td(spec.data.type)]),
                 // tr([th('Field type'), td(spec.spec.field_type)]),
                 tr([th('Multiple values?'), td(spec.multipleItems ? 'yes' : 'no')]),
-                (function () {
+                (function() {
                     return tr([th('Default value'), td(spec.data.defaultValue)]);
                 }()),
-                (function () {
+                (function() {
                     if (spec.data.constraints.types) {
                         return tr([th('Valid types'), td(spec.data.constraints.types.join('<br>'))]);
                     }
@@ -261,25 +262,25 @@ define([
                 div({ dataElement: 'big-tip', class: 'hidden' }, html.makeTabs({
                     alignRight: true,
                     tabs: [{
-                        label: 'Description',
-                        name: 'description',
-                        content: div({ style: { padding: '0px' } }, infoTipText)
-                    },
-                    {
-                        label: 'About',
-                        name: 'about',
-                        content: parameterInfoContent(spec)
-                    },
-                    {
-                        label: 'Rules',
-                        name: 'rules',
-                        content: parameterInfoRules(spec)
-                    },
-                    {
-                        label: 'Spec',
-                        name: 'spec',
-                        content: rawSpec(spec)
-                    }
+                            label: 'Description',
+                            name: 'description',
+                            content: div({ style: { padding: '0px' } }, infoTipText)
+                        },
+                        {
+                            label: 'About',
+                            name: 'about',
+                            content: parameterInfoContent(spec)
+                        },
+                        {
+                            label: 'Rules',
+                            name: 'rules',
+                            content: parameterInfoRules(spec)
+                        },
+                        {
+                            label: 'Spec',
+                            name: 'spec',
+                            content: rawSpec(spec)
+                        }
                     ]
                 }))
             ]);
@@ -342,21 +343,20 @@ define([
                         marginBottom: '0'
                     }
                 }, [
-                    div({class: 'col-md-3' }, [
-                            label({
-                                    class: 'xcontrol-label kb-app-parameter-name control-label',
-                                    title: infoTipText,
-                                    style: {cursor: 'help'},
-                                    id: events.addEvent({
-                                        type: 'click',
-                                            handler: function () {
-                                                places.infoPanel.querySelector('[data-element="big-tip"]').classList.toggle('hidden');
-                                            }
-                                        })
-                                },
-                                [
-                                    spec.ui.label || spec.ui.id
-                                ])
+                    div({ class: 'col-md-3' }, [
+                        label({
+                            class: 'xcontrol-label kb-app-parameter-name control-label',
+                            title: infoTipText,
+                            style: { cursor: 'help' },
+                            id: events.addEvent({
+                                type: 'click',
+                                handler: function() {
+                                    places.infoPanel.querySelector('[data-element="big-tip"]').classList.toggle('hidden');
+                                }
+                            })
+                        }, [
+                            spec.ui.label || spec.ui.id
+                        ])
                     ]),
                     div({ class: 'input-group col-md-9' }, [
                         div({
@@ -438,7 +438,7 @@ define([
         // LIFECYCLE
 
         function attach(node) {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 parent = node;
                 container = parent.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
@@ -471,37 +471,37 @@ define([
 
         function start(arg) {
             return attach(arg.node)
-                .then(function () {
-                    bus.on('validation', function (message) {
+                .then(function() {
+                    bus.on('validation', function(message) {
                         switch (message.diagnosis) {
-                        case 'valid':
-                            feedbackOk();
-                            clearError();
-                            break;
-                        case 'required-missing':
-                            feedbackRequired();
-                            clearError();
-                            break;
-                        case 'suspect':
-                            feedbackOk();
-                            clearError();
-                            setWarning({
-                                message: message.shortMessage,
-                                id: message.messageId
-                            });
-                            break;
-                        case 'invalid':
-                            feedbackError();
-                            clearError();
-                            setError({
-                                id: message.messageId,
-                                message: message.errorMessage
-                            });
-                            break;
-                        case 'optional-empty':
-                            feedbackNone();
-                            clearError();
-                            break;
+                            case 'valid':
+                                feedbackOk();
+                                clearError();
+                                break;
+                            case 'required-missing':
+                                feedbackRequired();
+                                clearError();
+                                break;
+                            case 'suspect':
+                                feedbackOk();
+                                clearError();
+                                setWarning({
+                                    message: message.shortMessage,
+                                    id: message.messageId
+                                });
+                                break;
+                            case 'invalid':
+                                feedbackError();
+                                clearError();
+                                setError({
+                                    id: message.messageId,
+                                    message: message.errorMessage
+                                });
+                                break;
+                            case 'optional-empty':
+                                feedbackNone();
+                                clearError();
+                                break;
                         }
                     });
                     // bus.on('touched', function (message) {
@@ -510,31 +510,31 @@ define([
                     // bus.on('changed', function () {
                     //     places.feedback.style.backgroundColor = '';
                     // });
-                    bus.on('enable', function (message) {
+                    bus.on('enable', function(message) {
                         doEnable();
                     });
-                    bus.on('disable', function (message) {
+                    bus.on('disable', function(message) {
                         doDisable();
                     });
 
                     if (inputControl.start) {
                         return inputControl.start({
-                            node: places.inputControl
-                        })
-                        .then(function () {
-                            // TODO: get rid of this pattern
-                            bus.emit('run', {
                                 node: places.inputControl
+                            })
+                            .then(function() {
+                                // TODO: get rid of this pattern
+                                bus.emit('run', {
+                                    node: places.inputControl
+                                });
                             });
-                        });
                     }
                 });
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 return inputControl.stop()
-                    .then(function () {
+                    .then(function() {
                         if (parent && container) {
                             parent.removeChild(container);
                         }
@@ -552,7 +552,7 @@ define([
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
@@ -108,6 +108,9 @@ define([
             var selectElem = select({
                 class: 'form-control',
                 dataElement: 'input',
+                style: {
+                    width: '100%'
+                },
                 id: html.genId()
             }, [option({ value: '' }, '')].concat(selectOptions));
 
@@ -184,22 +187,22 @@ define([
                 }
 
                 switch (objectRefType) {
-                case 'ref':
-                    return Validation.validateWorkspaceObjectRef(processedValue, validationOptions);
-                case 'name':
-                default:
-                    return Validation.validateWorkspaceObjectName(processedValue, validationOptions);
+                    case 'ref':
+                        return Validation.validateWorkspaceObjectRef(processedValue, validationOptions);
+                    case 'name':
+                    default:
+                        return Validation.validateWorkspaceObjectName(processedValue, validationOptions);
                 }
             });
         }
 
         function getObjectsByTypes_datalist(types) {
             return Data.getObjectsByTypes(types, bus, function(result) {
-                doWorkspaceUpdated(result.data);
-            })
-            .then(function(result) {
-                return result.data;
-            });
+                    doWorkspaceUpdated(result.data);
+                })
+                .then(function(result) {
+                    return result.data;
+                });
         }
 
 
@@ -285,8 +288,8 @@ define([
                     }
                 }).on('change', function() {
                     doChange();
-                }).on('advanced-shown.kbase', function (e) {
-                    $(e.target).select2({width: 'resolve'});
+                }).on('advanced-shown.kbase', function(e) {
+                    $(e.target).select2({ width: 'resolve' });
                 });
                 events.attachEvents(container);
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/sequenceInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/sequenceInput.js
@@ -71,33 +71,33 @@ define([
 
         function setModelValue(value, index) {
             return Promise.try(function() {
-                if (index !== undefined) {
-                    if (value) {
-                        model.value[index] = value;
+                    if (index !== undefined) {
+                        if (value) {
+                            model.value[index] = value;
+                        } else {
+                            model.value.splice(index, 1);
+                        }
                     } else {
-                        model.value.splice(index, 1);
+                        if (value) {
+                            model.value = value;
+                        } else {
+                            unsetModelValue();
+                        }
                     }
-                } else {
-                    if (value) {
-                        model.value = value;
-                    } else {
-                        unsetModelValue();
-                    }
-                }
-                normalizeModel();
-            })
-            .then(function() {
-                return render();
-            });
+                    normalizeModel();
+                })
+                .then(function() {
+                    return render();
+                });
         }
 
         function unsetModelValue() {
             return Promise.try(function() {
-                model.value = [];
-            })
-            .then(function() {
-                return render();
-            });
+                    model.value = [];
+                })
+                .then(function() {
+                    return render();
+                });
         }
 
         function resetModelValue() {
@@ -198,7 +198,7 @@ define([
                         key: {
                             type: 'get-parameter'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             if (message.parameterName) {
                                 return channel.request(message, {
                                     key: {
@@ -228,7 +228,7 @@ define([
                             height: '100%'
                         }
                     }, button({
-                        class: 'btn btn-link btn-xs kb-app-row-close-btn',
+                        class: 'btn btn-danger btn-xs kb-app-row-close-btn',
                         type: 'button',
                         dataIndex: String(control.index),
                         id: events.addEvent({
@@ -278,9 +278,9 @@ define([
                 type: 'click',
                 handler: function() {
                     addNewControl()
-                    .then(function() {
-                        return autoValidate();
-                    });
+                        .then(function() {
+                            return autoValidate();
+                        });
                 }
             };
         }
@@ -374,11 +374,11 @@ define([
                     return;
                 }
                 return Promise.all(initialValue.map(function(value) {
-                    return addNewControl(value);
-                }))
-                .then(function () {
-                    return autoValidate();
-                });
+                        return addNewControl(value);
+                    }))
+                    .then(function() {
+                        return autoValidate();
+                    });
             });
         }
 
@@ -429,11 +429,11 @@ define([
         function stop() {
             return Promise.try(function() {
                 return Promise.all(viewModel.getItem('items').map(function(item) {
-                    return item.inputControl.instance.stop();
-                }))
-                .then(function() {
-                    busConnection.stop();
-                });
+                        return item.inputControl.instance.stop();
+                    }))
+                    .then(function() {
+                        busConnection.stop();
+                    });
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
@@ -10,7 +10,7 @@ define([
 
     'bootstrap',
     'css!font-awesome'
-], function (
+], function(
     Promise,
     html,
     Validation,
@@ -45,8 +45,8 @@ define([
             fieldLayout = spec.ui.layout,
             struct = spec.parameters,
             places = {};
-        if (spec.data.constraints.required || 
-            config.initialValue || 
+        if (spec.data.constraints.required ||
+            config.initialValue ||
             spec.data.constraints.disableable === false) {
             viewModel.state.enabled = true;
         } else {
@@ -54,16 +54,16 @@ define([
         }
 
         function setModelValue(value) {
-            return Promise.try(function () {
-                viewModel.data = value;
-            })
-            .catch(function (err) {
-                console.error('Error setting model value', err);
-            });
+            return Promise.try(function() {
+                    viewModel.data = value;
+                })
+                .catch(function(err) {
+                    console.error('Error setting model value', err);
+                });
         }
 
         function unsetModelValue() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 viewModel.data = {};
             });
         }
@@ -77,7 +77,7 @@ define([
         }
 
         function validate(rawValue) {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 // var validationOptions = {
                 //     required: spec.data.constraints.required
                 // };
@@ -90,30 +90,30 @@ define([
             if (viewModel.state.enabled) {
                 // Note this spins off as an orphaned promise.
                 ui.showConfirmDialog({
-                    title: 'Disable parameter group "' + spec.ui.label + '"?',
-                    body: div([
-                        p('Disabling this parameter group will also remove any values you may have set.'),
-                        p('If enabled again, the values will be set to their defaults.'),
-                        p('Continue to disable this parameter group?')
-                    ]),
-                    yesLabel: 'Yes',
-                    noLabel: 'No'
-                })
-                .then(function (confirmed) {
-                    if (!confirmed) {
-                        return;
-                    }
-                    viewModel.state.enabled = false;
-                    button.innerHTML = 'Enable';
-                    viewModel.data = null;
-                    bus.emit('set-param-state', {
-                        state: viewModel.state
+                        title: 'Disable parameter group "' + spec.ui.label + '"?',
+                        body: div([
+                            p('Disabling this parameter group will also remove any values you may have set.'),
+                            p('If enabled again, the values will be set to their defaults.'),
+                            p('Continue to disable this parameter group?')
+                        ]),
+                        yesLabel: 'Yes',
+                        noLabel: 'No'
+                    })
+                    .then(function(confirmed) {
+                        if (!confirmed) {
+                            return;
+                        }
+                        viewModel.state.enabled = false;
+                        button.innerHTML = 'Enable';
+                        viewModel.data = null;
+                        bus.emit('set-param-state', {
+                            state: viewModel.state
+                        });
+                        bus.emit('changed', {
+                            newValue: lang.copy(viewModel.data)
+                        });
+                        renderSubcontrols();
                     });
-                    bus.emit('changed', {
-                        newValue: lang.copy(viewModel.data)
-                    });
-                    renderSubcontrols();
-                });
 
                 // Disable it
 
@@ -163,7 +163,7 @@ define([
         }
 
         function makeInputControl(events, bus) {
-            var promiseOfFields = fieldLayout.map(function (fieldName) {
+            var promiseOfFields = fieldLayout.map(function(fieldName) {
                 var fieldSpec = struct.specs[fieldName];
                 var fieldValue = viewModel.data[fieldName];
 
@@ -174,10 +174,10 @@ define([
             // one for now.
 
             return Promise.all(promiseOfFields)
-                .then(function (fields) {
+                .then(function(fields) {
                     var layout = div({
                         class: 'row'
-                    }, fields.map(function (field) {
+                    }, fields.map(function(field) {
                         return div({ id: field.id, style: { border: '0px orange dashed', padding: '0px' } });
                     }).join('\n'));
                     return {
@@ -200,7 +200,7 @@ define([
             // (at present) to have yet another one...
 
             validate(viewModel.data)
-                .then(function (result) {
+                .then(function(result) {
                     bus.emit('validation', result);
                 });
         }
@@ -211,7 +211,7 @@ define([
          */
         function makeSingleInputControl(value, fieldSpec, events) {
             return resolver.loadInputControl(fieldSpec)
-                .then(function (widgetFactory) {
+                .then(function(widgetFactory) {
                     var id = html.genId(),
                         fieldWidget = FieldWidget.make({
                             inputControlFactory: widgetFactory,
@@ -225,7 +225,7 @@ define([
 
 
                     // set up listeners for the input
-                    fieldWidget.bus.on('sync', function () {
+                    fieldWidget.bus.on('sync', function() {
                         var value = viewModel.data[fieldSpec.id];
                         if (value) {
                             fieldWidget.bus.emit('update', {
@@ -233,18 +233,18 @@ define([
                             });
                         }
                     });
-                    fieldWidget.bus.on('validation', function (message) {
+                    fieldWidget.bus.on('validation', function(message) {
                         if (message.diagnosis === 'optional-empty') {
                             bus.emit('changed', {
                                 newValue: lang.copy(viewModel.data)
                             });
                         }
                     });
-                    fieldWidget.bus.on('changed', function (message) {
+                    fieldWidget.bus.on('changed', function(message) {
                         doChanged(fieldSpec.id, message.newValue);
                     });
 
-                    fieldWidget.bus.on('touched', function () {
+                    fieldWidget.bus.on('touched', function() {
                         bus.emit('touched', {
                             parameter: fieldSpec.id
                         });
@@ -268,17 +268,17 @@ define([
                     node: container
                 });
                 return makeInputControl(events)
-                    .then(function (result) {
+                    .then(function(result) {
                         ui.setContent('input-container.subcontrols', result.content);
                         events.attachEvents();
                         structFields = {};
-                        result.fields.forEach(function (field) {
+                        result.fields.forEach(function(field) {
                             structFields[field.fieldName] = field;
                         });
                         // Start up all the widgets
 
                         return Promise.all(
-                            result.fields.map(function (field) {
+                            result.fields.map(function(field) {
                                 return field.instance.start({
                                     node: document.getElementById(field.id)
                                 });
@@ -286,10 +286,10 @@ define([
                     });
             } else {
                 return Promise.all(
-                        Object.keys(structFields).map(function (fieldName) {
+                        Object.keys(structFields).map(function(fieldName) {
                             return structFields[fieldName].instance.stop();
                         }))
-                    .then(function () {
+                    .then(function() {
                         ui.setContent('input-container.subcontrols', '');
                         structFields = {};
                     });
@@ -304,7 +304,7 @@ define([
                     margin: '6px'
                 }
             }, [
-                (function () {
+                (function() {
                     if (spec.data.constraints.disableable === false) {
                         return;
                     }
@@ -332,7 +332,7 @@ define([
 
         function autoValidate() {
             validate(viewModel.data)
-                .then(function (results) {
+                .then(function(results) {
                     bus.emit('validation', results);
 
                 });
@@ -342,7 +342,7 @@ define([
 
         function start(arg) {
             var events;
-            var init = Promise.try(function () {
+            var init = Promise.try(function() {
                 hostNode = arg.node;
                 container = hostNode.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
@@ -350,27 +350,27 @@ define([
                 viewModel.data = lang.copy(config.initialValue);
             });
             return init
-                .then(function () {
+                .then(function() {
                     return render(events);
                 })
-                .then(function () {
+                .then(function() {
                     return renderSubcontrols();
                 })
-                .then(function () {
+                .then(function() {
                     events.attachEvents(container);
 
-                    bus.on('reset-to-defaults', function () {
+                    bus.on('reset-to-defaults', function() {
                         resetModelValue();
                     });
 
-                    bus.on('update', function (message) {
+                    bus.on('update', function(message) {
                         // Update the model, and since we have sub widgets,
                         // we should send the individual data to them.
                         // TODO: container environment should know about enable/disabled state?
                         // FORNOW: just ignore
                         if (viewModel.state.enabled) {
                             viewModel.data = lang.copy(message.value);
-                            Object.keys(message.value).forEach(function (id) {
+                            Object.keys(message.value).forEach(function(id) {
                                 structFields[id].instance.bus.emit('update', {
                                     value: message.value[id]
                                 });
@@ -379,7 +379,7 @@ define([
 
                     });
 
-                    bus.on('submit', function () {
+                    bus.on('submit', function() {
                         bus.emit('submitted', {
                             value: lang.copy(viewModel.data)
                         });
@@ -387,25 +387,25 @@ define([
 
                     return autoValidate();
                 })
-                .catch(function (err) {
+                .catch(function(err) {
                     console.error('ERROR', err);
                     container.innerHTML = err.message;
                 });
         }
 
         function stop() {
-            return Promise.try(function () {
-                if (structFields) {
-                    return Promise.all(Object.keys(structFields).map(function (id) {
-                        return structFields[id].instance.stop();
-                    }));
-                }
-            })
-            .then(function () {
-                if (hostNode && container) {
-                    hostNode.removeChild(container);
-                }
-            });
+            return Promise.try(function() {
+                    if (structFields) {
+                        return Promise.all(Object.keys(structFields).map(function(id) {
+                            return structFields[id].instance.stop();
+                        }));
+                    }
+                })
+                .then(function() {
+                    if (hostNode && container) {
+                        hostNode.removeChild(container);
+                    }
+                });
         }
 
         return {
@@ -415,7 +415,7 @@ define([
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/subdataInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/subdataInput.js
@@ -62,6 +62,7 @@ define([
             container,
             model,
             subdataMethods,
+            isAvailableValuesInitialized = false,
             options = {
                 objectSelectionPageSize: 20
             },
@@ -191,7 +192,9 @@ define([
                 events = Events.make({ node: container }),
                 content;
 
-            if (itemsToShow.length === 0) {
+            if (!isAvailableValuesInitialized) {
+                content = div({ style: { textAlign: 'center' } }, html.loading('Loading data...'));
+            } else if (itemsToShow.length === 0) {
                 content = div({ style: { textAlign: 'center' } }, 'no available values');
             } else {
                 content = itemsToShow.map(function(item, index) {
@@ -417,8 +420,11 @@ define([
             var availableItems = model.getItem('availableValues', []),
                 filteredItems = model.getItem('filteredAvailableItems', []),
                 content;
-
-            if (availableItems.length === 0) {
+            if (!isAvailableValuesInitialized) {
+                content = span({ style: { fontStyle: 'italic' } }, [
+                    ' - ' + html.loading('Loading data...')
+                ]);
+            } else if (availableItems.length === 0) {
                 content = span({ style: { fontStyle: 'italic' } }, [
                     ' - no available items'
                 ]);
@@ -713,8 +719,9 @@ define([
                     return fetchData();
                 })
                 .then(function(data) {
+                    isAvailableValuesInitialized = true;
                     if (!data) {
-                        return " no data? ";
+                        return ' no data? ';
                     }
 
                     // If default values have been provided, prepend them to the data.
@@ -835,15 +842,7 @@ define([
                 model.setItem('availableValues', []);
                 model.setItem('referenceObjectName', null);
                 doFilterItems();
-
                 renderSearchBox();
-                renderStats();
-                renderToolbar();
-                renderAvailableItems();
-                renderSelectedItems();
-
-                // updateInputControl('availableValues');
-                // updateInputControl('value');
             });
 
             /*
@@ -866,7 +865,7 @@ define([
                         type: 'parameter-changed',
                         parameter: spec.data.constraints.subdataSelection.constant_ref
                     },
-                    handle: function(message) { 
+                    handle: function(message) {
                         var newValue = message.newValue;
                         if (message.newValue === '') {
                             newValue = null;
@@ -1036,7 +1035,7 @@ define([
                         //     model.setItem('selectedItems', selectedItems);
                         // }
                         // updateInputControl('value');
-                         if (!config.initialValue) {
+                        if (!config.initialValue) {
                             model.setItem('selectedItems', []);
                         } else {
                             var selectedItems = config.initialValue;

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/paramResolver.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/paramResolver.js
@@ -1,7 +1,7 @@
 define([
     'bluebird',
     'require'
-], function (
+], function(
     Promise,
     require
 ) {
@@ -14,138 +14,138 @@ define([
                 controlType = spec.ui.control;
 
             switch (dataType) {
-            case 'string':
-                switch (controlType) {
-                case 'dropdown':
+                case 'string':
+                    switch (controlType) {
+                        case 'dropdown':
+                            return {
+                                input: 'selectInput',
+                                view: 'selectView'
+                            };
+                        case 'textarea':
+                            return {
+                                input: 'textareaInput',
+                                view: 'textareaView'
+                            };
+                        case 'file':
+                            return {
+                                input: 'fileInput',
+                                view: 'fileView'
+                            };
+                        case 'custom_textsubdata':
+                            return {
+                                input: 'customSubdataInput',
+                                view: 'customSubdataView'
+                            };
+                        case 'autocomplete':
+                            // TODO: refactor this from the sdk on up.
+                            return {
+                                input: 'taxonomyRefInput',
+                                view: 'taxonomyRefView'
+                            };
+                        case 'text':
+                        default:
+                            // A string type is normally entered as a 
+                            // simple text input.
+                            return {
+                                input: 'textInput',
+                                view: 'textView'
+                            };
+                    }
+                case 'sequence':
                     return {
-                        input: 'selectInput',
-                        view: 'selectView'
+                        input: 'sequenceInput',
+                        view: 'sequenceView'
                     };
-                case 'textarea':
+                case 'int':
+                    switch (controlType) {
+                        case 'checkbox':
+                            return {
+                                input: 'checkboxInput',
+                                view: 'checkboxView'
+                            };
+                        case 'text':
+                        default:
+                            return {
+                                input: 'intInput',
+                                view: 'intView'
+                            };
+                    }
+                case 'float':
                     return {
-                        input: 'textareaInput',
-                        view: 'textareaView'
+                        input: 'floatInput',
+                        view: 'floatView'
                     };
-                case 'file':
+                case 'workspaceObjectRef':
+                    switch (spec.ui.class) {
+                        case 'input':
+                            //return 'singleObjectInput';                            
+                            return {
+                                input: 'select2ObjectInput',
+                                view: 'select2ObjectView'
+                            };
+                        case 'parameter':
+                            // return 'singleObjectInput';
+                            return {
+                                input: 'select2ObjectInput',
+                                view: 'select2ObjectView'
+                            };
+                        default:
+                            return {
+                                input: 'undefinedInput',
+                                view: 'undefinedView'
+                            };
+                    }
+                    // IS THIS used anywhere other than in output areas?? 
+                case 'workspaceObjectName':
+                    switch (spec.ui.class) {
+                        case 'parameter':
+                        case 'output':
+                            return {
+                                input: 'newObjectInput',
+                                view: 'newObjectView'
+                            };
+                        default:
+                            return {
+                                input: 'undefinedInput',
+                                view: 'undefinedView'
+                            };
+                    }
+                case 'subdata':
                     return {
-                        input: 'fileInput',
-                        view: 'fileView'
+                        input: 'subdataInput',
+                        view: 'subdataView'
                     };
-                case 'custom_textsubdata':
+                case 'customSubdata':
                     return {
                         input: 'customSubdataInput',
                         view: 'customSubdataView'
                     };
-                case 'autocomplete':
-                    // TODO: refactor this from the sdk on up.
+                case 'boolean':
                     return {
-                        input: 'taxonomyRefInput',
-                        view: 'taxonomyRefView'
+                        input: 'toggleButtonInput',
+                        view: 'toggleButtonView'
                     };
-                case 'text':
-                default:
-                    // A string type is normally entered as a 
-                    // simple text input.
+                case 'struct':
                     return {
-                        input: 'textInput',
-                        view: 'textView'
-                    }
-                }
-            case 'sequence':
-                return {
-                    input: 'sequenceInput',
-                    view: 'sequenceView'
-                };
-            case 'int':
-                switch (controlType) {
-                case 'checkbox':
-                    return {
-                        input: 'checkboxInput',
-                        view: 'checkboxView'
+                        input: 'structInput',
+                        view: 'structView'
                     };
-                case 'text':
-                default:
+                case 'custom':
                     return {
-                        input: 'intInput',
-                        view: 'intView'
-                    };
-                }
-            case 'float':
-                return {
-                    input: 'floatInput',
-                    view: 'floatView'
-                };
-            case 'workspaceObjectRef':
-                switch (spec.ui.class) {
-                case 'input':
-                    //return 'singleObjectInput';                            
-                    return {
-                        input: 'select2ObjectInput',
-                        view: 'select2ObjectView'
-                    };
-                case 'parameter':
-                    // return 'singleObjectInput';
-                    return {
-                        input: 'select2ObjectInput',
-                        view: 'select2ObjectView'
+                        input: 'customInput',
+                        view: 'customView'
                     };
                 default:
-                    return {
-                        input: 'undefinedInput',
-                        view: 'undefinedView'
-                    };
-                }
-                // IS THIS used anywhere other than in output areas?? 
-            case 'workspaceObjectName':
-                switch (spec.ui.class) {
-                case 'parameter':
-                case 'output':
-                    return {
-                        input: 'newObjectInput',
-                        view: 'newObjectView'
-                    };
-                default:
-                    return {
-                        input: 'undefinedInput',
-                        view: 'undefinedView'
-                    };
-                }
-            case 'subdata':
-                return {
-                    input: 'subdataInput',
-                    view: 'subdataView'
-                };
-            case 'customSubdata':
-                return {
-                    input: 'customSubdataInput',
-                    view: 'customSubdataView'
-                };
-            case 'boolean':
-                return {
-                    input: 'toggleButtonInput',
-                    view: 'toggleButtonView'
-                };
-            case 'struct':
-                return {
-                    input: 'structInput',
-                    view: 'structView'
-                };
-            case 'custom':
-                return {
-                    input: 'customInput',
-                    view: 'customView'
-                };
-            default:
-                console.error('ERROR could not detremine control modules for this spec', spec);
-                throw new Error('Could not determine control modules for this spec');
+                    console.error('ERROR could not detremine control modules for this spec', spec);
+                    throw new Error('Could not determine control modules for this spec');
             }
         }
 
         function loadModule(type, name) {
-            return new Promise(function (resolve, reject) {
-                require(['./' + type + '/' + name], function (Module) {
+            return new Promise(function(resolve, reject) {
+                require(['./' + type + '/' + name], function(Module) {
                     resolve(Module);
-                }, function (err) {
+                }, function(err) {
                     reject(err);
                 });
             });
@@ -167,7 +167,7 @@ define([
         };
     }
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/subdataMethods/manager.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/subdataMethods/manager.js
@@ -13,7 +13,7 @@ define([
     './samplePropertyHistogram',
     './growthCondition'
 
-], function(
+], function (
     Handlebars,
     Runtime,
     Props,
@@ -55,7 +55,7 @@ define([
             return div({ style: { wordWrap: 'break-word' } }, [
                 div({ style: { fontWeight: 'bold' } }, item.id),
                 item.desc,
-                (function() {
+                (function () {
                     if (showSourceObjectName && item.objectName) {
                         return div({ style: { padding: '0px', fontStyle: 'italic' } }, item.objectName);
                     }
@@ -77,7 +77,7 @@ define([
                 dataCall = workspaceCall(subObjectIdentity);
             }
             return dataCall
-                .then(function(results) {
+                .then(function (results) {
                     var values = [],
                         selectionId = subdataSelection.selection_id,
                         descriptionFields = subdataSelection.selection_description || [],
@@ -85,13 +85,13 @@ define([
                         descriptionTemplate;
 
                     if (!descriptionTemplateText) {
-                        descriptionTemplateText = descriptionFields.map(function(field) {
+                        descriptionTemplateText = descriptionFields.map(function (field) {
                             return '{{' + field + '}}';
                         }).join(' - ');
                     }
 
                     descriptionTemplate = Handlebars.compile(descriptionTemplateText);
-                    results.forEach(function(result) {
+                    results.forEach(function (result) {
                         if (!result) {
                             return;
                         }
@@ -128,7 +128,7 @@ define([
                         if (subdata instanceof Array) {
                             // For arrays we pluck off the "selectionId" property from
                             // each item.
-                            subdata.forEach(function(datum) {
+                            subdata.forEach(function (datum) {
                                 var id = datum;
                                 if (selectionId && typeof id === 'object') {
                                     id = datum[selectionId];
@@ -141,25 +141,25 @@ define([
                                 });
                             });
                         } else {
-                            Object.keys(subdata).forEach(function(key) {
+                            Object.keys(subdata).forEach(function (key) {
                                 var datum = subdata[key],
                                     id;
 
                                 if (selectionId) {
                                     switch (typeof datum) {
-                                        case 'object':
-                                            id = datum[selectionId];
-                                            break;
-                                        case 'string':
-                                        case 'number':
-                                            if (selectionId === 'value') {
-                                                id = datum;
-                                            } else {
-                                                id = key;
-                                            }
-                                            break;
-                                        default:
+                                    case 'object':
+                                        id = datum[selectionId];
+                                        break;
+                                    case 'string':
+                                    case 'number':
+                                        if (selectionId === 'value') {
+                                            id = datum;
+                                        } else {
                                             id = key;
+                                        }
+                                        break;
+                                    default:
+                                        id = key;
                                     }
                                 } else {
                                     id = key;
@@ -175,14 +175,14 @@ define([
                             });
                         }
                     });
-                    return values.map(function(item) {
+                    return values.map(function (item) {
                         item.text = makeLabel(item, arg.spec.ui.showSourceObject);
                         return item;
                     });
                 })
-                .then(function(data) {
+                .then(function (data) {
                     // sort by id now.
-                    data.sort(function(a, b) {
+                    data.sort(function (a, b) {
                         if (a.id > b.id) {
                             return 1;
                         }
@@ -197,32 +197,32 @@ define([
 
         function getSubdataInfo(appSpec, paramSpec) {
             switch (appSpec.widgets.input) {
-                case 'kbaseSamplePropertyHistogramInput':
-                    switch (paramSpec.id) {
-                        case 'input_samples':
-                            return SamplePropertyHistogram.make().getMethod();
-                        default:
-                            throw new Error('Unknown custom parameter id for ' + appSpec.widgets.input);
-                    }
-                case 'kbaseSampleProperty2DPlotInput':
-                    switch (paramSpec.id) {
-                        case 'input_property_x':
-                        case 'input_property_y':
-                            return SampleProperty.make().getMethod();
-                        default:
-                            throw new Error('Unknown custom parameter id for ' + appSpec.widgets.input);
-                    }
-                case 'kbaseGrowthParamsPlotInput':
-                    switch (paramSpec.id) {
-                        case 'input_condition_param':
-                            return GrowthCondition.make().getMethod();
-                        default:
-                            throw new Error('Unknown custom parameter id for ' + appSpec.widgets.input);
-                    }
-                case 'kbaseGrowthCurvesInput':
-                    return GrowthCurves.make().getMethod();
+            case 'kbaseSamplePropertyHistogramInput':
+                switch (paramSpec.id) {
+                case 'input_samples':
+                    return SamplePropertyHistogram.make().getMethod();
                 default:
-                    throw new Error('Sorry, input widget ' + appSpec.widgets.input + ' is not recognized');
+                    throw new Error('Unknown custom parameter id for ' + appSpec.widgets.input);
+                }
+            case 'kbaseSampleProperty2DPlotInput':
+                switch (paramSpec.id) {
+                case 'input_property_x':
+                case 'input_property_y':
+                    return SampleProperty.make().getMethod();
+                default:
+                    throw new Error('Unknown custom parameter id for ' + appSpec.widgets.input);
+                }
+            case 'kbaseGrowthParamsPlotInput':
+                switch (paramSpec.id) {
+                case 'input_condition_param':
+                    return GrowthCondition.make().getMethod();
+                default:
+                    throw new Error('Unknown custom parameter id for ' + appSpec.widgets.input);
+                }
+            case 'kbaseGrowthCurvesInput':
+                return GrowthCurves.make().getMethod();
+            default:
+                throw new Error('Sorry, input widget ' + appSpec.widgets.input + ' is not recognized');
             }
         }
 
@@ -235,7 +235,7 @@ define([
                     included: arg.included
                 }];
             return workspace.get_object_subset(query)
-                .then(function(result) {
+                .then(function (result) {
                     return arg.extractItems(result, arg.params);
                 });
         }
@@ -246,7 +246,7 @@ define([
                     token: runtime.authToken()
                 });
             return workspace.get_objects([{ ref: referenceObjectRef }])
-                .then(function(data) {
+                .then(function (data) {
                     var nextRef = arg.getRef(data),
                         query = [{
                             ref: nextRef,
@@ -254,7 +254,7 @@ define([
                         }];
                     return workspace.get_object_subset(query);
                 })
-                .then(function(result) {
+                .then(function (result) {
                     return arg.extractItems(result, arg.params);
                 });
         }
@@ -275,7 +275,7 @@ define([
     }
 
     return {
-        make: function(config) {
+        make: function (config) {
             return factory(config);
         }
     };

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/checkboxView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/checkboxView.js
@@ -100,11 +100,12 @@ define([
                 checked = true;
             }
             return label([
-                input({                   
+                input({
                     type: 'checkbox',
                     dataElement: 'input',
                     checked: checked,
                     value: 1,
+                    disabled: true,
                     readonly: true
                 })
             ]);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/floatView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/floatView.js
@@ -4,14 +4,19 @@ define([
     'bluebird',
     'base/js/namespace',
     'kb_common/html',
-    '../validators/float',
     'common/events',
     'common/ui',
     'common/props',
 
     'bootstrap',
     'css!font-awesome'
-], function(Promise, Jupyter, html, Validation, Events, UI, Props) {
+], function(
+    Promise,
+    Jupyter,
+    html,
+    Events,
+    UI,
+    Props) {
     'use strict';
 
     // Constants
@@ -45,14 +50,6 @@ define([
             setModelValue(spec.data.constraints.defaultValue);
         }
 
-        // VALIDATION
-
-        function validate(value) {
-            return Promise.try(function() {
-                return Validation.validate(value, spec);
-            });
-        }
-
         /*
          * Creates the markup
          * Places it into the dom node
@@ -71,7 +68,7 @@ define([
             return div({ style: { width: '100%' }, dataElement: 'input-wrapper' }, [
                 div({ class: 'input-group', style: { width: '100%' } }, [
                     (typeof min === 'number' ? div({ class: 'input-group-addon kb-input-group-addon', fontFamily: 'monospace' }, String(min) + ' &#8804; ') : ''),
-                    input({                        
+                    input({
                         class: 'form-control',
                         dataElement: 'input',
                         dataType: 'float',
@@ -89,31 +86,20 @@ define([
 
         function render() {
             return Promise.try(function() {
-                var events = Events.make(),
-                    inputControl = makeViewControl(model.getItem('value'), events, bus);
-
+                var inputControl = makeViewControl(model.getItem('value'));
                 ui.setContent('input-container', inputControl);
-                events.attachEvents(container);
             });
         }
 
-        function layout(events) {
+        function layout() {
             var content = div({
                 dataElement: 'main-panel'
             }, [
                 div({ dataElement: 'input-container' })
             ]);
             return {
-                content: content,
-                events: events
+                content: content
             };
-        }
-
-        function autoValidate() {
-            return validate(model.getItem('value'))
-                .then(function(result) {
-                    bus.emit('validation', result);
-                });
         }
 
         // LIFECYCLE API
@@ -124,12 +110,9 @@ define([
                 container = parent.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
 
-                var events = Events.make(),
-                    theLayout = layout(events);
+                var theLayout = layout();
 
                 container.innerHTML = theLayout.content;
-                events.attachEvents(container);
-                // model.setItem('value', arg.value);
 
                 bus.on('reset-to-defaults', function() {
                     resetModelValue();
@@ -137,12 +120,8 @@ define([
                 bus.on('update', function(message) {
                     model.setItem('value', message.value);
                 });
-                // bus.emit('sync');
 
-                return render()
-                    .then(function() {
-                        return autoValidate();
-                    });
+                return render();
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/intView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/intView.js
@@ -31,23 +31,6 @@ define([
             model,
             ui;
 
-        // CONTROL
-
-        function getControlValue() {
-            return ui.getElement('input-container.input').value;
-        }
-
-        function setControlValue(value) {
-            var stringValue;
-            if (value === null) {
-                stringValue = '';
-            } else {
-                stringValue = String(value);
-            }
-
-            ui.getElement('input-container.input').value = stringValue;
-        }
-
         // MODEL
 
         function setModelValue(value) {
@@ -64,21 +47,6 @@ define([
 
         function resetModelValue() {
             setModelValue(spec.data.constraints.defaultValue);
-        }
-
-        // VALIDATION
-
-        function validate(value) {
-            return Promise.try(function() {
-                return Validation.validate(value, spec);
-            });
-        }
-
-        function autoValidate() {
-            return validate(model.getItem('value'))
-                .then(function(result) {
-                    bus.emit('validation', result);
-                });
         }
 
         function makeViewControl(currentValue) {
@@ -118,19 +86,16 @@ define([
             });
         }
 
-        function layout(events) {
+        function layout() {
             var content = div({
                 dataElement: 'main-panel'
             }, [
                 div({ dataElement: 'input-container' })
             ]);
             return {
-                content: content,
-                events: events
+                content: content
             };
         }
-
-
 
         // LIFECYCLE API
 
@@ -140,12 +105,9 @@ define([
                 container = parent.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
 
-                var events = Events.make(),
-                    theLayout = layout(events);
+                var theLayout = layout();
 
                 container.innerHTML = theLayout.content;
-                events.attachEvents(container);
-                // model.setItem('value', message.value);
 
                 bus.on('reset-to-defaults', function() {
                     resetModelValue();
@@ -153,22 +115,8 @@ define([
                 bus.on('update', function(message) {
                     model.setItem('value', message.value);
                 });
-                bus.on('enable', function() {
-                    doEnable();
-                });
-                bus.on('disable', function() {
-                    doDisable();
-                });
 
-                // TODO: since we now rely on initialValue -- perhaps 
-                // we can omit the 'sync' event or at least in cases
-                // in which the initial value is known to be available.
-                // bus.emit('sync');
-
-                return render()
-                    .then(function() {
-                        return autoValidate();
-                    });
+                return render();
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/objectRefView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/objectRefView.js
@@ -75,7 +75,8 @@ define([
                         }
                         return option({
                             value: ref,
-                            selected: selected
+                            selected: selected,
+                            disabled: true
                         }, objectInfo.name);
                     });
             }

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/objectView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/objectView.js
@@ -78,7 +78,8 @@ define([
                         }
                         return option({
                             value: ref,
-                            selected: selected
+                            selected: selected,
+                            disabled: true
                         }, objectInfo.name);
                     });
             }

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/select2ObjectView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/select2ObjectView.js
@@ -97,16 +97,22 @@ define([
                         }
                         return option({
                             value: ref,
-                            selected: selected
+                            selected: selected,
+                            disabled: true
                         }, objectInfo.name);
                     });
             }
 
             // CONTROL
+
             var selectElem = select({
                 id: html.genId(),
                 class: 'form-control',
-                dataElement: 'input'
+                style: {
+                    width: '100%'
+                },
+                dataElement: 'input',
+                disabled: true
             }, [option({ value: '' }, '')].concat(selectOptions));
 
             return selectElem;
@@ -183,22 +189,22 @@ define([
                 }
 
                 switch (objectRefType) {
-                case 'ref':
-                    return Validation.validateWorkspaceObjectRef(processedValue, validationOptions);
-                case 'name':
-                default:
-                    return Validation.validateWorkspaceObjectName(processedValue, validationOptions);
+                    case 'ref':
+                        return Validation.validateWorkspaceObjectRef(processedValue, validationOptions);
+                    case 'name':
+                    default:
+                        return Validation.validateWorkspaceObjectName(processedValue, validationOptions);
                 }
             });
         }
 
         function getObjectsByTypes_datalist(types) {
             return Data.getObjectsByTypes(types, bus, function(result) {
-                doWorkspaceUpdated(result.data);
-            })
-            .then(function(result) {
-                return result.data;
-            });
+                    doWorkspaceUpdated(result.data);
+                })
+                .then(function(result) {
+                    return result.data;
+                });
         }
 
 
@@ -254,18 +260,18 @@ define([
                 ui.setContent('input-container', content);
 
                 $(ui.getElement('input-container.input')).select2({
-                    readonly: true,
-                    templateResult: formatObjectDisplay,
-                    templateSelection: function(object) {
-                        if (!object.id) {
-                            return object.text;
+                        readonly: true,
+                        templateResult: formatObjectDisplay,
+                        templateSelection: function(object) {
+                            if (!object.id) {
+                                return object.text;
+                            }
+                            return model.availableValues[object.id].name;
                         }
-                        return model.availableValues[object.id].name;
-                    }
-                })
-                .on('advanced-shown.kbase', function (e) {
-                    $(e.target).select2({width: 'resolve'});
-                });
+                    })
+                    .on('advanced-shown.kbase', function(e) {
+                        $(e.target).select2({ width: 'resolve' });
+                    });
                 events.attachEvents(container);
 
             });
@@ -347,7 +353,7 @@ define([
                     });
             }
         }
-     
+
         // LIFECYCLE API
         function start(arg) {
             return Promise.try(function() {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/selectView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/selectView.js
@@ -35,9 +35,6 @@ define([
                 value: null
             };
 
-        // Validate configuration.
-        // Nothing to do...
-
         options.enabled = true;
 
         model.availableValues = spec.data.constraints.options;
@@ -47,34 +44,6 @@ define([
             item.index = index;
             model.availableValuesMap[item.value] = item;
         });
-
-        function getControlValue() {
-            var control = ui.getElement('input-container.input'),
-                selected = control.selectedOptions;
-
-            if (selected.length === 0) {
-                return spec.data.nullValue;
-            }
-
-            // we are modeling a single string value, so we always just get the 
-            // first selected element, which is all there should be!
-            return selected.item(0).value;
-        }
-
-        // VALIDATION
-
-        function validate(value) {
-            return Promise.try(function() {
-                return Validation.validate(value, spec);
-            });
-        }
-
-        function autoValidate() {
-            return validate(model.value)
-                .then(function(result) {
-                    bus.emit('validation', result);
-                });
-        }
 
         function makeViewControl(events) {
             var selected,
@@ -86,7 +55,8 @@ define([
 
                     return option({
                         value: item.value,
-                        selected: selected
+                        selected: selected,
+                        disabled: true
                     }, item.display);
                 });
 
@@ -160,7 +130,6 @@ define([
                 // bus.emit('sync');
 
                 setModelValue(config.initialValue);
-                autoValidate();
                 syncModelToControl();
             });
         }

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
@@ -87,37 +87,6 @@ define([
             }
         }
 
-        /*
-         * If the parameter is optional, and is empty, return null.
-         * If it allows multiple values, wrap single results in an array
-         * There is a weird twist where if it ...
-         * well, hmm, the only consumer of this, isValid, expects the values
-         * to mirror the input rows, so we shouldn't really filter out any
-         * values.
-         */
-
-        function getInputValue() {
-            return ui.getElement('input-container.input').value;
-        }
-
-        /*
-         *
-         * Text fields can occur in multiples.
-         * We have a choice, treat single-text fields as a own widget
-         * or as a special case of multiple-entry -- 
-         * with a min-items of 1 and max-items of 1.
-         * 
-         *
-         */
-
-        function copyProps(from, props) {
-            var newObj = {};
-            props.forEach(function(prop) {
-                newObj[prop] = from[prop];
-            });
-            return newObj;
-        }
-
         function validate(rawValue) {
             return Promise.try(function() {
                 // var validationOptions = {
@@ -125,81 +94,6 @@ define([
                 // };
                 return Validation.validate(rawValue, spec);
             });
-        }
-
-        function updateValue() {}
-
-        function doToggleEnableControl() {
-            var label = document.querySelector('#' + places.enableControl + ' [data-element="label"]');
-            if (viewModel.state.enabled) {
-                // Disable it
-                viewModel.state.enabled = false;
-                label.innerHTML = 'Enable';
-                viewModel.data = null;
-            } else {
-                // Enable it
-                viewModel.state.enabled = true;
-                label.innerHTML = 'Disable';
-                viewModel.data = lang.copy(spec.data.defaultValue);
-            }
-            bus.emit('set-param-state', {
-                state: viewModel.state
-            });
-            bus.emit('changed', {
-                newValue: lang.copy(viewModel.data)
-            });
-            renderSubcontrols();
-        }
-
-        function enableControl(events) {
-            var required = spec.data.constraints.required;
-
-            places.enableControl = html.genId();
-
-            // If the group is required, there is no choice, it is always enabled.
-            if (required) {
-                return '';
-                // return div({
-                //     id: places.enableControl
-                // }, [
-                //     input({
-                //         type: 'checkbox',
-                //         checked: true,
-                //         readonly: true,
-                //         disabled: true
-                //     }),
-                //     ' This group is required'
-                // ]);
-            }
-
-            var label, checked;
-            if (viewModel.state.enabled) {
-                label = 'Disable';
-                checked = true;
-            } else {
-                label = 'Enable'
-                checked = false;
-            }
-            return div({
-                id: places.enableControl
-            }, [
-                input({
-                    id: events.addEvent({
-                        type: 'click',
-                        handler: function(e) {
-                            doToggleEnableControl(e);
-                        }
-                    }),
-                    type: 'checkbox',
-                    checked: checked
-                }),
-                span({
-                    dataElement: 'label',
-                    style: {
-                        marginLeft: '4px'
-                    }
-                }, label)
-            ]);
         }
 
         function makeInputControl(events, bus) {
@@ -345,11 +239,6 @@ define([
                     margin: '6px'
                 }
             }, [
-                div({
-                    class: 'row'
-                }, [
-                    enableControl(events)
-                ]),
                 div({ dataElement: 'subcontrols' })
             ]);
             ui.setContent('input-container', layout);
@@ -365,38 +254,6 @@ define([
             renderStruct(events);
 
         }
-
-        // function autoValidate() {
-        //     return Promise.all(viewModel.data.map(function (value, index) {
-        //             // could get from DOM, but the model is the same.
-        //             var rawValue = container.querySelector('[data-index="' + index + '"]').value;
-        //             return validate(rawValue);
-        //         }))
-        //         .then(function (results) {
-        //             // a bit of a hack -- we need to handle the 
-        //             // validation here, and update the individual rows
-        //             // for now -- just create one mega message.
-        //             var errorMessages = [],
-        //                 validationMessage;
-        //             results.forEach(function (result, index) {
-        //                 if (result.errorMessage) {
-        //                     errorMessages.push(result.errorMessage + ' in item ' + index);
-        //                 }
-        //             });
-        //             if (errorMessages.length) {
-        //                 validationMessage = {
-        //                     diagnosis: 'invalid',
-        //                     errorMessage: errorMessages.join('<br/>')
-        //                 };
-        //             } else {
-        //                 validationMessage = {
-        //                     diagnosis: 'valid'
-        //                 };
-        //             }
-        //             bus.emit('validation', validationMessage);
-
-        //         });
-        // }
 
         // LIFECYCLE API
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/textView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/textView.js
@@ -36,10 +36,6 @@ define([
 
         // CONTROL
 
-        function getControlValue() {
-            return ui.getElement('input-container.input').value;
-        }
-
         function setControlValue(newValue) {
             ui.getElement('input-container.input').value = newValue;
         }
@@ -64,30 +60,6 @@ define([
         function syncModelToControl() {
             setControlValue(model.getItem('value', null));
         }
-
-
-
-        // VALIDATION
-
-        function importControlValue() {
-            return Promise.try(function() {
-                return Validation.importString(getControlValue());
-            });
-        }
-
-        function validate(value) {
-            return Promise.try(function() {
-                return Validation.validate(value, spec);
-            });
-        }
-
-        function autoValidate() {
-            return validate(model.getItem('value'))
-                .then(function(result) {
-                    bus.emit('validation', result);
-                });
-        }
-
 
         // DOM & RENDERING
 
@@ -119,7 +91,6 @@ define([
             }
         }
 
-
         // LIFECYCLE API
 
         function start(arg) {
@@ -134,15 +105,9 @@ define([
                 events.attachEvents(container);
                 // model.setItem('value', config.initialValue);
                 syncModelToControl();
-                autoValidate();
 
                 bus.on('reset-to-defaults', function() {
                     resetModelValue();
-                });
-                bus.on('update', function(message) {
-                    setModelValue(message.value);
-                    syncModelToControl();
-                    autoValidate();
                 });
                 bus.on('focus', function() {
                     doFocus();
@@ -165,10 +130,7 @@ define([
             data: {
                 value: null
             },
-            onUpdate: function() {
-                //syncModelToControl();
-                //autoValidate();
-            }
+            onUpdate: function() {}
         });
 
         setModelValue(config.initialValue);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/textareaView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/textareaView.js
@@ -5,7 +5,6 @@ define([
     'common/events',
     'common/ui',
     'common/props',
-    '../inputUtils',
     'bootstrap',
     'css!font-awesome'
 ], function(
@@ -14,8 +13,7 @@ define([
     Validation,
     Events,
     UI,
-    Props,
-    inputUtils) {
+    Props) {
     'use strict';
 
     // Constants
@@ -37,10 +35,6 @@ define([
             };
 
         // CONTROL
-
-        function getControlValue() {
-            return ui.getElement('input-container.input').value;
-        }
 
         function setControlValue(newValue) {
             if (newValue === null) {
@@ -73,34 +67,12 @@ define([
             setControlValue(model.getItem('value', null));
         }
 
-
-        // VALIDATION
-
-        function importControlValue() {
-            return Promise.try(function() {
-                return Validation.importString(getControlValue());
-            });
-        }
-
-        function validate(value) {
-            return Promise.try(function() {
-                return Validation.validate(value, spec);
-            });
-        }
-
-        function autoValidate() {
-            return validate(model.getItem('value'))
-                .then(function(result) {
-                    bus.emit('validation', result);
-                });
-        }
-
         /*
          * Creates the markup
          * Places it into the dom node
          * Hooks up event listeners
          */
-        function makeViewControl(events) {
+        function makeViewControl() {
             return textarea({
                 class: 'form-control',
                 dataElement: 'input',
@@ -109,17 +81,16 @@ define([
             });
         }
 
-        function render(events) {
+        function render() {
             var content = div({
                 dataElement: 'main-panel'
             }, [
                 div({ dataElement: 'input-container' }, [
-                    makeViewControl(events)
+                    makeViewControl()
                 ])
             ]);
             return {
-                content: content,
-                events: events
+                content: content
             };
         }
 
@@ -130,13 +101,11 @@ define([
                 container = parent.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
 
-                var events = Events.make(),
-                    theLayout = render(events);
+                var theLayout = render();
 
                 setModelValue(config.initialValue);
 
                 container.innerHTML = theLayout.content;
-                events.attachEvents(container);
 
                 bus.on('reset-to-defaults', function() {
                     resetModelValue();
@@ -144,9 +113,7 @@ define([
                 bus.on('update', function(message) {
                     setModelValue(message.value);
                 });
-                // bus.emit('sync');
                 syncModelToControl();
-                autoValidate();
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/ipythonCellMenu.js
@@ -10,20 +10,22 @@ define([
     'kb_common/html',
     'kbaseNarrativeCellMenu',
     'kbaseCellToolbarMenu'
-], function ($, celltoolbar, Jupyter, html, KBaseNarrativeCellMenu, KBaseMenu) {
-    "use strict";
+], function (
+    $,
+    celltoolbar,
+    Jupyter,
+    html,
+    KBaseNarrativeCellMenu,
+    KBaseMenu
+) {
+    'use strict';
 
     var t = html.tag,
-        span = html.tag('span');
+        span = t('span');
 
     /*
      * Dealing with metadata
      */
-    function createMeta(cell, initial) {
-        var meta = cell.metadata;
-        meta.kbase = initial;
-        cell.metadata = meta;
-    }
     function getMeta(cell, group, name) {
         if (!cell.metadata.kbase) {
             return;
@@ -33,67 +35,29 @@ define([
         }
         return cell.metadata.kbase[group][name];
     }
-    function setMeta(cell, group, name, value) {
-        /*
-         * This funny business is because the trigger on setting the metadata
-         * property (via setter and getter in core Cell object) is only invoked
-         * when the metadata preoperty is actually set -- doesn't count if
-         * properties of it are.
-         */
-        var temp = cell.metadata;
-        if (!temp.kbase) {
-            temp.kbase = {};
-        }
-        if (!temp.kbase[group]) {
-            temp.kbase[group] = {};
-        }
-        temp.kbase[group][name] = value;
-        cell.metadata = temp;
-    }
 
     function makeKBaseMenux(div, cell) {
-        new KBaseNarrativeCellMenu(div, {cell: cell});
+        new KBaseNarrativeCellMenu(div, { cell: cell });
     }
+
     function makeKBaseMenu($toolbarNode, cell) {
         var kbaseMenu = KBaseMenu.make();
         kbaseMenu.register_callback($toolbarNode, cell);
     }
-    function toggleInput(toolbarDiv, cell) {
-        if (!cell.metadata.kbase) {
-            return;
-        }
-        if (cell.metadata.kbase.type !== 'method') {
-            return;
-        }
-        var button = html.tag('button'),
-            inputAreaShowing = getMeta(cell, 'user-settings', 'showCodeInputArea'),
-            label = inputAreaShowing ? 'Hide code' : 'Show code',
-            toggleButton = button({
-                type: 'button',
-                class: 'btn btn-default btn-xs',
-                dataElement: 'kbase-method-cell-hideshow'}, [
-                label
-            ]);
-        toolbarDiv.append(toggleButton);
-        toolbarDiv.find('[data-element="kbase-method-cell-hideshow"]').on('click', function (e) {
-            toggleCodeInputArea(cell);
-        });
-    }
 
     function status(toolbarDiv, cell) {
         var status = getMeta(cell, 'attributes', 'status'),
-            content = span({style: {fontWeight: 'bold'}}, status);
-        toolbarDiv.append(span({style: {padding: '4px'}}, content));
+            content = span({ style: { fontWeight: 'bold' } }, status);
+        toolbarDiv.append(span({ style: { padding: '4px' } }, content));
     }
 
     function jobStatus(toolbarDiv, cell) {
         var jobStatus = getMeta(cell, 'attributes', 'jobStatus'),
-            content = span({style: {fontWeight: 'bold'}}, jobStatus);
-        $(toolbarDiv).append(span({style: {padding: '4px'}}, content));
+            content = span({ style: { fontWeight: 'bold' } }, jobStatus);
+        $(toolbarDiv).append(span({ style: { padding: '4px' } }, content));
     }
 
     var register = function (notebook) {
-
         celltoolbar.CellToolbar.register_callback('kbase.menu', makeKBaseMenux);
         celltoolbar.CellToolbar.register_callback('kbase-status', status);
         celltoolbar.CellToolbar.register_callback('kbase-job-status', jobStatus);
@@ -102,5 +66,5 @@ define([
         // default.rawedit for the metadata editor
         celltoolbar.CellToolbar.register_preset('KBase', ['kbase-menu']);
     };
-    return {register: register};
+    return { register: register };
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -25,9 +25,11 @@ define([
     'handlebars',
     'text!kbase/templates/data_list/object_row.html',
     'kb_service/utils',
+    'util/bootstrapAlert',
+
     'bootstrap',
     'jquery-nearest'
-], function(
+], function (
     KBWidget,
     $,
     _,
@@ -45,7 +47,8 @@ define([
     Runtime,
     Handlebars,
     ObjectRowHtml,
-    serviceUtils
+    serviceUtils,
+    BootstrapAlert
 ) {
     'use strict';
     return KBWidget({
@@ -116,7 +119,7 @@ define([
          * @param obj Info tuple from ws_list_objects
          * @return Identifier (string)
          */
-        itemId: function(obj) {
+        itemId: function (obj) {
             return obj[6] + '/' + obj[0];
         },
 
@@ -127,7 +130,7 @@ define([
          * @param obj_info Object info tuple, as returned by ws.list_objects()
          * @return true if in a set, false otherwise
          */
-        isASet: function(objInfo) {
+        isASet: function (objInfo) {
             return this.setInfo[this.itemId(objInfo)] ? true : false;
             // return _.has(this.setInfo, this.itemId(obj_info));
         },
@@ -135,7 +138,7 @@ define([
         /**
          * Returns true if in set view mode AND the object is a set.
          */
-        isAViewedSet: function(objInfo) {
+        isAViewedSet: function (objInfo) {
             if (this.setViewMode) {
                 return this.isASet(objInfo);
             } else {
@@ -150,7 +153,7 @@ define([
          *                  workspace API for list_objects()
          * @return true or false
          */
-        inAnySet: function(item_info) {
+        inAnySet: function (item_info) {
             if (this.setViewMode) {
                 var item_id = this.itemId(item_info);
                 return _.has(this.setItems, item_id);
@@ -159,7 +162,7 @@ define([
             }
         },
 
-        getSetInfo: function(obj_info) {
+        getSetInfo: function (obj_info) {
             return this.setInfo[this.itemId(obj_info)];
         },
 
@@ -171,7 +174,7 @@ define([
          * @return All parents, expanded or not, as a mapping with
          *         the keys: (item_id, expanded, div).
          */
-        getItemParents: function(item_info) {
+        getItemParents: function (item_info) {
             var item_id = this.itemId(item_info);
             // empty if not in ANY set
             if (!_.has(this.setItems, item_id)) {
@@ -182,7 +185,7 @@ define([
             // map for each of the Sets.
             return _.map(
                 _.keys(this.setItems[item_id]),
-                function(key) {
+                function (key) {
                     return {
                         item_id: key,
                         expanded: self.setInfo[key].expanded,
@@ -196,12 +199,12 @@ define([
          * Clear data structures tracking the workspace sets.
          * This will cause the next refresh to fetch new data.
          */
-        clearSets: function() {
+        clearSets: function () {
             this.setItems = {};
             this.setInfo = {};
         },
 
-        itemIdsInSet: function(set_id) {
+        itemIdsInSet: function (set_id) {
             if (this.setViewMode) {
                 return this.setInfo[set_id].item_ids;
             } else {
@@ -219,7 +222,7 @@ define([
          * @returns {Object} this shiny new widget.
          * @private
          */
-        init: function(options) {
+        init: function (options) {
             this._super(options);
             var self = this;
 
@@ -257,7 +260,7 @@ define([
             this.mainListId = StringUtil.uuid();
             this.$mainListDiv = $('<div id=' + this.mainListId + '>')
                 .css({ 'overflow-x': 'hidden', 'overflow-y': 'auto', 'height': this.mainListPanelHeight })
-                .on('scroll', function() {
+                .on('scroll', function () {
                     if ($(this).scrollTop() + $(this).innerHeight() >= this.scrollHeight) {
                         self.renderMore();
                     }
@@ -265,7 +268,7 @@ define([
 
             this.$addDataButton = $('<span>').addClass('kb-data-list-add-data-button fa fa-plus fa-2x')
                 .css({ 'position': 'absolute', bottom: '15px', right: '25px', 'z-index': '5' })
-                .click(function() {
+                .click(function () {
                     self.trigger('hideGalleryPanelOverlay.Narrative');
                     self.trigger('toggleSidePanelOverlay.Narrative', self.options.parentControlPanel.$overlayPanel);
                 });
@@ -280,7 +283,7 @@ define([
             }
 
             // listener for refresh
-            $(document).on('updateDataList.Narrative', function() {
+            $(document).on('updateDataList.Narrative', function () {
                 self.refresh();
             })
 
@@ -295,7 +298,7 @@ define([
             return this;
         },
 
-        setListHeight: function(height, animate) {
+        setListHeight: function (height, animate) {
             if (this.$mainListDiv) {
                 if (animate) {
                     this.$mainListDiv.animate({ 'height': height }, this.options.slideTime);
@@ -312,7 +315,7 @@ define([
          * It associates the new auth token with this widget and refreshes the data panel.
          * @private
          */
-        loggedInCallback: function(event, auth) {
+        loggedInCallback: function (event, auth) {
             this.ws = new Workspace(this.options.ws_url, auth);
             this.serviceClient = new GenericClient(Config.url('service_wizard'), auth);
             this.my_user_id = auth.user_id;
@@ -327,29 +330,29 @@ define([
          * It throws away the auth token and workspace client, and refreshes the widget
          * @private
          */
-        loggedOutCallback: function() {
+        loggedOutCallback: function () {
             this.ws = null;
             this.isLoggedIn = false;
             this.my_user_id = null;
             return this;
         },
 
-        showLoading: function(caption) {
+        showLoading: function (caption) {
             this.$mainListDiv.hide();
             this.loadingDiv.setText(caption || '');
             this.loadingDiv.div.show();
         },
 
-        hideLoading: function() {
+        hideLoading: function () {
             this.loadingDiv.div.hide();
             this.$mainListDiv.show();
         },
 
-        refresh: function(showError) {
+        refresh: function (showError) {
             // Set the refresh timer on the first refresh. From  here, it'll refresh itself
             // every this.options.refresh_interval (30000) ms
             if (this.refreshTimer === null) {
-                this.refreshTimer = setInterval(function() {
+                this.refreshTimer = setInterval(function () {
                     this.refresh();
                 }.bind(this), this.options.refresh_interval); // check if there is new data every X ms
             }
@@ -364,7 +367,7 @@ define([
             Promise.resolve(this.ws.get_workspace_info({
                     workspace: this.ws_name
                 }))
-                .then(function(wsInfo) {
+                .then(function (wsInfo) {
                     if (this.wsLastUpdateTimestamp !== wsInfo[3]) {
                         this.wsLastUpdateTimestamp = wsInfo[3];
                         this.maxWsObjId = wsInfo[4];
@@ -375,7 +378,7 @@ define([
                         // this.hideLoading();
                     }
                 }.bind(this))
-                .catch(function(error) {
+                .catch(function (error) {
                     console.error('DataList: when checking for updates:', error);
                     if (showError) {
                         this.showBlockingError('Sorry, an error occurred while fetching your data.', { 'error': 'Unable to connect to KBase database.' });
@@ -383,8 +386,8 @@ define([
                 }.bind(this));
         },
 
-        refreshTimeStrings: function() {
-            Object.keys(this.dataObjects).forEach(function(i) {
+        refreshTimeStrings: function () {
+            Object.keys(this.dataObjects).forEach(function (i) {
                 if (this.dataObjects[i].$div) {
                     var newTime = TimeFormat.getTimeStampStr(this.dataObjects[i].info[3]);
                     this.dataObjects[i].$div.find('.kb-data-list-date').text(newTime);
@@ -392,7 +395,7 @@ define([
             }.bind(this));
         },
 
-        reloadWsData: function() {
+        reloadWsData: function () {
             // empty the existing object list first
             this.objData = {};
             this.availableTypes = {};
@@ -403,15 +406,15 @@ define([
             this.clearSets();
 
             this.fetchWorkspaceData()
-                .then(function() {
+                .then(function () {
                     // Signal all data channel listeners that we have new data.
                     // TODO: only signal if there are actual changes
                     // TODO: data fetch and sychronization should live as a ui
                     // service, not in a widget.
-                    var justInfo = Object.keys(this.dataObjects).map(function(objId) {
+                    var justInfo = Object.keys(this.dataObjects).map(function (objId) {
                         return this.dataObjects[objId].info;
                     }.bind(this));
-                    var objectInfoPlus = Object.keys(this.dataObjects).map(function(objId) {
+                    var objectInfoPlus = Object.keys(this.dataObjects).map(function (objId) {
                         // see code below this function for the format of
                         // items in the dataObjects collection
                         var dataObject = this.dataObjects[objId];
@@ -432,7 +435,7 @@ define([
                         }
                     });
                 }.bind(this))
-                .then(function() {
+                .then(function () {
                     this.showLoading('Rendering data...');
                     var numObj = Object.keys(this.dataObjects).length;
                     if (numObj > this.options.maxObjsToPreventFilterAsYouTypeInSearch) {
@@ -440,7 +443,7 @@ define([
                     }
 
                     if (numObj <= this.options.max_objs_to_prevent_initial_sort) {
-                        this.viewOrder.sort(function(a, b) {
+                        this.viewOrder.sort(function (a, b) {
                             var idA = a.objId,
                                 idB = b.objId;
                             if (this.dataObjects[idA].info[3] > this.dataObjects[idB].info[3]) {
@@ -469,7 +472,7 @@ define([
          * This empties out the main data div and injects an error into it.
          * Used mainly when lookups fail.
          */
-        showBlockingError: function(title, error) {
+        showBlockingError: function (title, error) {
             this.$mainListDiv.empty();
             this.$mainListDiv.append(
                 DisplayUtil.createError(title, error)
@@ -478,8 +481,8 @@ define([
             this.$mainListDiv.show();
         },
 
-        fetchWorkspaceData: function() {
-            var addObjectInfo = function(objInfo, dpInfo) {
+        fetchWorkspaceData: function () {
+            var addObjectInfo = function (objInfo, dpInfo) {
                 // Get the object info
                 var objId = this.itemId(objInfo); //objInfo[6] + '/' + objInfo[0]; // + '/' + objInfo[2]
                 var fullDpReference = null;
@@ -523,9 +526,9 @@ define([
                 this.availableTypes[typeName].count++;
             }.bind(this);
 
-            var updateSetInfo = function(obj) {
+            var updateSetInfo = function (obj) {
                 var setId = this.itemId(obj.object_info); //obj.object_info[6] + '/' + obj.object_info[0];
-                obj.set_items.set_items_info.forEach(function(setItem) {
+                obj.set_items.set_items_info.forEach(function (setItem) {
                     var itemId = this.itemId(setItem); //setItem[6] + '/' + setItem[0];
                     if (!this.setInfo[setId]) {
                         this.setInfo[setId] = {
@@ -553,7 +556,7 @@ define([
                         }]
                     )
                 )
-                .then(function(result) {
+                .then(function (result) {
                     result = result[0]['data'];
 
                     for (var i = 0; i < result.length; i++) {
@@ -571,10 +574,10 @@ define([
                         }
                     }
                 }.bind(this))
-                .catch(function(error) {
-                    this.showBlockingError("Sorry, an error occurred while fetching your data.", error);
+                .catch(function (error) {
+                    this.showBlockingError('Sorry, an error occurred while fetching your data.', error);
                     console.error(error);
-                    KBError("kbaseNarrativeDataList.fetchWorkspaceData", error.error.message);
+                    KBError('kbaseNarrativeDataList.fetchWorkspaceData', error.error.message);
                     throw error;
                 }.bind(this));
 
@@ -584,7 +587,7 @@ define([
          * Returns the available object data for a type.
          * If no type is specified (type is falsy), returns all object data
          */
-        getObjData: function(type) {
+        getObjData: function (type) {
             if (type) {
                 var dataSet = {};
                 if (typeof type === 'string') {
@@ -600,7 +603,7 @@ define([
             return this.objData;
         },
 
-        getDataObjectByRef: function(ref) {
+        getDataObjectByRef: function (ref) {
             if (!ref) {
                 return null;
             }
@@ -621,10 +624,10 @@ define([
             return null;
         },
 
-        getDataObjectByName: function(name, wsId) {
+        getDataObjectByName: function (name, wsId) {
             // means we gotta search. Oof.
             var objInfo = null;
-            Object.keys(this.dataObjects).forEach(function(id) {
+            Object.keys(this.dataObjects).forEach(function (id) {
                 var obj = this.dataObjects[id];
                 if (obj.info[1] === name) {
                     if (wsId) {
@@ -642,7 +645,7 @@ define([
         $currentSelectedRow: null,
         selectedObject: null,
 
-        setSelected: function($selectedRow, object_info) {
+        setSelected: function ($selectedRow, object_info) {
             var self = this;
             if (self.$currentSelectedRow) {
                 self.$currentSelectedRow.removeClass('kb-data-list-obj-row-selected');
@@ -654,12 +657,12 @@ define([
             }
         },
 
-        addDataControls: function(object_info, $alertContainer, fromPalette, ref_path) {
+        addDataControls: function (object_info, $alertContainer, fromPalette, ref_path) {
             var self = this;
             var $btnToolbar = $('<span>')
                 .addClass('btn-group');
 
-            var btnClasses = "btn btn-xs btn-default";
+            var btnClasses = 'btn btn-xs btn-default';
             var css = { 'color': '#888' };
 
             var $filterMethodInput = $('<span>')
@@ -673,7 +676,7 @@ define([
                 })
                 .addClass(btnClasses)
                 .append($('<span>').addClass('fa fa-sign-in').css(css))
-                .click(function() {
+                .click(function () {
                     this.trigger('filterMethods.Narrative', 'in_type:' + object_info[2].split('-')[0].split('.')[1]);
                 }.bind(this));
 
@@ -688,7 +691,7 @@ define([
                 })
                 .addClass(btnClasses)
                 .append($('<span>').addClass('fa fa-sign-out').css(css))
-                .click(function() {
+                .click(function () {
                     this.trigger('filterMethods.Narrative', 'out_type:' + object_info[2].split('-')[0].split('.')[1]);
                 }.bind(this));
 
@@ -703,7 +706,7 @@ define([
                 })
                 .addClass(btnClasses)
                 .append($('<span>').addClass('fa fa-binoculars').css(css))
-                .click(function(e) {
+                .click(function (e) {
                     e.stopPropagation();
                     $alertContainer.empty();
                     // var typeTokens = object_info[2].split('-')[0].split('.');
@@ -722,17 +725,17 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-history').css(css))
-                .click(function(e) {
+                .click(function (e) {
                     e.stopPropagation();
                     $alertContainer.empty();
 
                     if (self.ws_name && self.ws) {
-                        self.ws.get_object_history({ ref: object_info[6] + "/" + object_info[0] },
-                            function(history) {
+                        self.ws.get_object_history({ ref: object_info[6] + '/' + object_info[0] },
+                            function (history) {
                                 $alertContainer.append($('<div>')
                                     .append($('<button>').addClass('kb-data-list-cancel-btn')
                                         .append('Hide History')
-                                        .click(function() {
+                                        .click(function () {
                                             $alertContainer.empty();
                                         })));
                                 history.reverse();
@@ -751,7 +754,7 @@ define([
                                         });
                                     } else {
                                         var revertRef = { wsid: history[k][6], objid: history[k][0], ver: history[k][4] };
-                                        (function(revertRefLocal) {
+                                        (function (revertRefLocal) {
                                             $revertBtn.tooltip({
                                                     title: 'Revert to this version?',
                                                     container: 'body',
@@ -761,15 +764,15 @@ define([
                                                         hide: Config.get('tooltip').hideDelay
                                                     }
                                                 })
-                                                .click(function() {
+                                                .click(function () {
                                                     self.ws.revert_object(revertRefLocal,
-                                                        function(reverted_obj_info) {
+                                                        function (reverted_obj_info) {
                                                             self.refresh();
                                                         },
-                                                        function(error) {
+                                                        function (error) {
                                                             console.error(error);
                                                             $alertContainer.empty();
-                                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append("Error! " + error.error.message));
+                                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
                                                         });
                                                 });
                                         })(revertRef);
@@ -792,10 +795,10 @@ define([
                                 }
                                 $alertContainer.append($tbl);
                             },
-                            function(error) {
+                            function (error) {
                                 console.error(error);
                                 $alertContainer.empty();
-                                $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append("Error! " + error.error.message));
+                                $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
                             });
                     }
 
@@ -813,7 +816,7 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-sitemap fa-rotate-90').css(css))
-                .click(function(e) {
+                .click(function (e) {
                     e.stopPropagation();
                     $alertContainer.empty();
                     window.open('/#objgraphview/' + object_info[7] + '/' + object_info[1]);
@@ -829,7 +832,7 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-download').css(css))
-                .click(function(e) {
+                .click(function (e) {
                     e.stopPropagation();
                     $alertContainer.empty();
                     var type = object_info[2].split('-')[0];
@@ -858,46 +861,54 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-font').css(css))
-                .click(function(e) {
+                .click(function (e) {
                     e.stopPropagation();
                     $alertContainer.empty();
+                    if (Jupyter.narrative.readonly) {
+                        $alertContainer
+                            .append($('<div>')
+                                .append($('<span>')
+                                    .append('Read-only Narrative - Cannot rename data object')
+                                    .addClass('text-warning')));
+                        return;
+                    }
                     var $newNameInput = $('<input type="text">')
                         .addClass('form-control')
                         .val(object_info[1])
-                        .on('focus', function() {
+                        .on('focus', function () {
                             if (Jupyter && Jupyter.narrative) {
                                 Jupyter.narrative.disableKeyboardManager();
                             }
                         })
-                        .on('blur', function() {
+                        .on('blur', function () {
                             if (Jupyter && Jupyter.narrative) {
                                 Jupyter.narrative.enableKeyboardManager();
                             }
                         });
                     $alertContainer.append($('<div>')
-                        .append($('<div>').append("Warning: Apps using the old name may break."))
+                        .append($('<div>').append('Warning: Apps using the old name may break.'))
                         .append($('<div>').append($newNameInput))
                         .append($('<button>').addClass('kb-data-list-btn')
                             .append('Rename')
-                            .click(function() {
+                            .click(function () {
                                 if (self.ws_name && self.ws) {
                                     self.ws.rename_object({
-                                            obj: { ref: object_info[6] + "/" + object_info[0] },
+                                            obj: { ref: object_info[6] + '/' + object_info[0] },
                                             new_name: $newNameInput.val()
                                         },
-                                        function(renamed_info) {
+                                        function (renamed_info) {
                                             self.refresh();
                                         },
-                                        function(error) {
+                                        function (error) {
                                             console.error(error);
                                             $alertContainer.empty();
-                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append("Error! " + error.error.message));
+                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
                                         });
                                 }
                             }))
                         .append($('<button>').addClass('kb-data-list-cancel-btn')
                             .append('Cancel')
-                            .click(function() {
+                            .click(function () {
                                 $alertContainer.empty();
                             })));
                 });
@@ -912,54 +923,65 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-trash-o').css(css))
-                .click(function(e) {
+                .click(function (e) {
                     e.stopPropagation();
                     $alertContainer.empty();
+                    // TODO: The control should actually be disabled. This should be via a listener
+                    // for the view-only event...
+                    if (Jupyter.narrative.readonly) {
+                        $alertContainer
+                            .append($('<div>')
+                                .append($('<span>')
+                                    .append('Read-only Narrative - Cannot delete data object')
+                                    .addClass('text-warning')));
+                        return;
+                    }
                     $alertContainer.append($('<div>')
                         .append($('<span>').append('Are you sure?'))
                         .append($('<button>').addClass('kb-data-list-btn')
                             .append('Delete')
-                            .click(function() {
+                            .click(function () {
                                 if (self.ws_name && self.ws) {
                                     self.ws.rename_object({
-                                            obj: { ref: object_info[6] + "/" + object_info[0] },
-                                            new_name: object_info[1].split('-deleted-')[0] + "-deleted-" + (new Date()).getTime()
+                                            obj: { ref: object_info[6] + '/' + object_info[0] },
+                                            new_name: object_info[1].split('-deleted-')[0] + '-deleted-' + (new Date()).getTime()
                                         },
-                                        function(renamed_info) {
-                                            self.ws.delete_objects([{ ref: object_info[6] + "/" + object_info[0] }],
-                                                function() {
+                                        function (renamed_info) {
+                                            self.ws.delete_objects([{ ref: object_info[6] + '/' + object_info[0] }],
+                                                function () {
                                                     self.refresh();
                                                 },
-                                                function(error) {
+                                                function (error) {
                                                     console.error(error);
                                                     $alertContainer.empty();
-                                                    $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append("Error! " + error.error.message));
+                                                    $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
                                                 });
                                         },
-                                        function(error) {
+                                        function (error) {
                                             console.error(error);
                                             $alertContainer.empty();
-                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append("Error! " + error.error.message));
+                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
                                         });
                                 }
                             }))
                         .append($('<button>').addClass('kb-data-list-cancel-btn')
                             .append('Cancel')
-                            .click(function() {
+                            .click(function () {
                                 $alertContainer.empty();
                             })));
                 });
 
-            if (!Jupyter.narrative.readonly) {
-                $btnToolbar.append($filterMethodInput)
-                    .append($filterMethodOutput);
-            }
+            // if (!Jupyter.narrative.readonly) {
+            $btnToolbar.append($filterMethodInput)
+                .append($filterMethodOutput);
+            // }
             $btnToolbar.append($openLandingPage);
             if (!Jupyter.narrative.readonly && !fromPalette) {
                 $btnToolbar.append($openHistory);
             }
             $btnToolbar.append($openProvenance)
                 .append($download);
+
             if (!Jupyter.narrative.readonly && !fromPalette) {
                 $btnToolbar.append($rename)
                     .append($delete);
@@ -968,7 +990,7 @@ define([
             return $btnToolbar;
         },
 
-        toggleSetExpansion: function(objId, $setDiv) {
+        toggleSetExpansion: function (objId, $setDiv) {
             var setInfo = this.setInfo[objId];
             if (!setInfo) {
                 return;
@@ -997,7 +1019,7 @@ define([
          * This is the main function for rendering a data object
          * in the data list.
          */
-        renderObjectRowDiv: function(objId, indent) {
+        renderObjectRowDiv: function (objId, indent) {
             var self = this;
             var objData = this.dataObjects[objId];
             var object_info = objData.info;
@@ -1034,7 +1056,7 @@ define([
             this.dataIconParam[this.itemId(object_info)] = data_icon_param;
             // add behavior
 
-            $logo.click(function(e) {
+            $logo.click(function (e) {
                 e.stopPropagation();
                 self.insertViewer(object_key);
             });
@@ -1045,9 +1067,9 @@ define([
                 shortName = shortName.substring(0, this.options.max_name_length - 3) + '...';
                 isShortened = true;
             }
-            var $name = $('<span>').addClass("kb-data-list-name").append('<a>' + shortName + '</a>')
+            var $name = $('<span>').addClass('kb-data-list-name').append('<a>' + shortName + '</a>')
                 .css({ 'cursor': 'pointer' })
-                .click(function(e) {
+                .click(function (e) {
                     e.stopPropagation();
                     self.insertViewer(object_key);
                 });
@@ -1062,8 +1084,8 @@ define([
                 });
             }
 
-            var $version = $('<span>').addClass("kb-data-list-version").append('v' + object_info[4]);
-            var $type = $('<div>').addClass("kb-data-list-type").append(type);
+            var $version = $('<span>').addClass('kb-data-list-version').append('v' + object_info[4]);
+            var $type = $('<div>').addClass('kb-data-list-type').append(type);
             var $paletteIcon = '';
             if (objData.fromPalette) {
                 $paletteIcon = $('<span>')
@@ -1082,11 +1104,11 @@ define([
                     });
             }
 
-            var $date = $('<span>').addClass("kb-data-list-date").append(TimeFormat.getTimeStampStr(object_info[3]));
-            var $byUser = $('<span>').addClass("kb-data-list-edit-by");
+            var $date = $('<span>').addClass('kb-data-list-date').append(TimeFormat.getTimeStampStr(object_info[3]));
+            var $byUser = $('<span>').addClass('kb-data-list-edit-by');
             if (object_info[5] !== self.my_user_id) {
                 $byUser.append(' by ' + object_info[5])
-                    .click(function(e) {
+                    .click(function (e) {
                         e.stopPropagation();
                         window.open('/#people/' + object_info[5]);
                     });
@@ -1108,23 +1130,23 @@ define([
             DisplayUtil.displayRealName(object_info[5], $savedByUserSpan);
 
             var $alertDiv = $('<div>').css({ 'text-align': 'center', 'margin': '10px 0px' });
-            var typeLink = '<a href="/#spec/module/' + type_module + '" target="_blank">' + type_module + "</a>.<wbr>" +
+            var typeLink = '<a href="/#spec/module/' + type_module + '" target="_blank">' + type_module + '</a>.<wbr>' +
                 '<a href="/#spec/type/' + object_info[2] + '" target="_blank">' + (type_tokens[1].replace('-', '&#8209;')) + '.' + type_tokens[2] + '</a>';
-            var $moreRow = $('<div>').addClass("kb-data-list-more-div").hide()
+            var $moreRow = $('<div>').addClass('kb-data-list-more-div').hide()
                 .append($('<div>').css({ 'text-align': 'center', 'margin': '5pt' })
                     .append(self.addDataControls(object_info, $alertDiv, objData.fromPalette, ref_path)).append($alertDiv))
                 .append(
                     $('<table style="width:100%;">')
-                    .append("<tr><th>Permament Id</th><td>" + object_info[6] + "/" + object_info[0] + "/" + object_info[4] + '</td></tr>')
-                    .append("<tr><th>Full Type</th><td>" + typeLink + '</td></tr>')
+                    .append('<tr><th>Permament Id</th><td>' + object_info[6] + '/' + object_info[0] + '/' + object_info[4] + '</td></tr>')
+                    .append('<tr><th>Full Type</th><td>' + typeLink + '</td></tr>')
                     .append($('<tr>').append('<th>Saved by</th>').append($savedByUserSpan))
                     .append(metadataText));
 
             var $toggleAdvancedViewBtn =
-                $('<span>').addClass("kb-data-list-more") //.addClass('btn btn-default btn-xs kb-data-list-more-btn')
+                $('<span>').addClass('kb-data-list-more') //.addClass('btn btn-default btn-xs kb-data-list-more-btn')
                 .hide()
                 .html($('<button class="btn btn-xs btn-default pull-right" aria-hidden="true">').append('<span class="fa fa-ellipsis-h" style="color:#888" />'));
-            var toggleAdvanced = function() {
+            var toggleAdvanced = function () {
                 if (self.selectedObject === object_info[0] && $moreRow.is(':visible')) {
                     // assume selection handling occurs before this is called
                     // so if we are now selected and the moreRow is visible, leave it...
@@ -1149,7 +1171,7 @@ define([
                         .append($('<td>')
                             .append($toggleAdvancedViewBtn))))
                 .click(
-                    function() {
+                    function () {
                         self.setSelected($(this).closest('.kb-data-list-obj-row'), object_info);
                         toggleAdvanced();
                     });
@@ -1159,7 +1181,7 @@ define([
                 $toggleIcon = $('<span>')
                     .addClass('fa fa-lg fa-' + (objData.expanded ? 'chevron-down' : 'chevron-right'))
                     .css({ color: '#888', cursor: 'pointer', 'font-size': '1.2em' })
-                    .click(function(e) {
+                    .click(function (e) {
                         e.stopPropagation();
                         objData.expanded = !objData.expanded;
                         $toggleIcon.removeClass().addClass('fa fa-lg fa-' + (objData.expanded ? 'chevron-down' : 'chevron-right'));
@@ -1188,10 +1210,10 @@ define([
                     .append($topTable))
                 .append($moreRow)
                 // show/hide ellipses on hover, show extra info on click
-                .mouseenter(function() {
+                .mouseenter(function () {
                     $toggleAdvancedViewBtn.show();
                 })
-                .mouseleave(function() {
+                .mouseleave(function () {
                     $toggleAdvancedViewBtn.hide();
                 });
 
@@ -1212,26 +1234,34 @@ define([
 
         // ============= DnD ==================
 
-        addDropZone: function(container, targetCell, isBelow) {
+        addDropZone: function (container, targetCell, isBelow) {
             var targetDiv = document.createElement('div'),
                 self = this;
 
             targetDiv.classList.add('kb-data-list-drag-target');
             targetDiv.innerHTML = '<i>drop data object here</i>';
-            targetDiv.addEventListener('dragover', function(e) {
+            targetDiv.addEventListener('dragover', function (e) {
                 e.target.classList.add('-drag-active');
                 e.preventDefault();
             });
-            targetDiv.addEventListener('dragenter', function(e) {
+            targetDiv.addEventListener('dragenter', function (e) {
                 e.target.classList.add('-drag-hover');
                 e.preventDefault();
             });
-            targetDiv.addEventListener('dragleave', function(e) {
+            targetDiv.addEventListener('dragleave', function (e) {
                 e.target.classList.remove('-drag-hover');
                 e.target.classList.remove('-drag-active');
                 e.preventDefault();
             });
-            targetDiv.addEventListener('drop', function(e) {
+            targetDiv.addEventListener('drop', function (e) {
+                if (Jupyter.narrative.readonly) {
+                    new BootstrapAlert({
+                        type: 'warning',
+                        title: 'Warning',
+                        body: 'Read-only Narrative -- may not insert a data viewer into this Narrative'
+                    });
+                    return;
+                }
                 var data = JSON.parse(e.dataTransfer.getData('info')),
                     obj = self.dataObjects[self.keyToObjId[data.key]],
                     info = self.createInfoObject(obj.info, obj.refPath),
@@ -1262,7 +1292,7 @@ define([
             }
         },
 
-        addDragAndDrop: function($row) {
+        addDragAndDrop: function ($row) {
             var node = $row.parent().get(0),
                 key = $row.attr('kb-oid'),
                 obj = this.dataObjects[this.keyToObjId[key]], //_.findWhere(this.objectList, {key: key}),
@@ -1277,7 +1307,7 @@ define([
 
             node.setAttribute('draggable', true);
 
-            node.addEventListener('dragstart', function(e) {
+            node.addEventListener('dragstart', function (e) {
                 e.dataTransfer.dropEffect = 'copy';
                 e.dataTransfer.setData('info', dataString);
 
@@ -1292,7 +1322,7 @@ define([
                 }
             });
 
-            node.addEventListener('dragend', function() {
+            node.addEventListener('dragend', function () {
                 var container = document.querySelector('#notebook-container'),
                     targetCells = document.querySelectorAll('#notebook-container .kb-data-list-drag-target');
                 for (var i = 0; i < targetCells.length; i += 1) {
@@ -1326,7 +1356,7 @@ define([
          * Helper function to create named object attrs from
          * list of fields returned from Workspace service.
          */
-        createInfoObject: function(info, refPath) {
+        createInfoObject: function (info, refPath) {
             var ret = _.object(['id', 'name', 'type', 'save_date', 'version',
                 'saved_by', 'ws_id', 'ws_name', 'chsum', 'size',
                 'meta'
@@ -1338,7 +1368,15 @@ define([
         },
         // ============= end DnD ================
 
-        insertViewer: function(key) {
+        insertViewer: function (key) {
+            if (Jupyter.narrative.readonly) {
+                new BootstrapAlert({
+                    type: 'warning',
+                    title: 'Warning',
+                    body: 'Read-only Narrative -- may not add a data viewer to this Narrative'
+                });
+                return;
+            }
             var cell = Jupyter.notebook.get_selected_cell(),
                 near_idx = 0;
             if (cell) {
@@ -1357,7 +1395,7 @@ define([
             });
         },
 
-        renderMore: function() {
+        renderMore: function () {
             var start = this.lastObjectRendered;
             var limit = this.n_objs_rendered + this.options.objs_to_render_on_scroll;
             for (var i = start + 1;
@@ -1370,13 +1408,13 @@ define([
             }
         },
 
-        detachAllRows: function() {
+        detachAllRows: function () {
             this.$mainListDiv.children().detach();
             this.n_objs_rendered = 0;
             this.renderedAll = false;
         },
 
-        shouldRenderObject: function(viewInfo) {
+        shouldRenderObject: function (viewInfo) {
             var render = viewInfo.inFilter;
             if (render) {
                 if (this.setViewMode && this.inAnySet(this.dataObjects[viewInfo.objId].info)) {
@@ -1386,7 +1424,7 @@ define([
             return render;
         },
 
-        renderList: function() {
+        renderList: function () {
             this.detachAllRows();
             this.n_objs_rendered = 0;
 
@@ -1410,11 +1448,11 @@ define([
                     .css({ 'text-align': 'center', 'margin': '20pt' })
                     .append('This Narrative has no data yet.<br><br>');
                 if (Jupyter && Jupyter.narrative && !Jupyter.narrative.readonly) {
-                    $noDataDiv.append($("<button>")
+                    $noDataDiv.append($('<button>')
                         .append('Add Data')
                         .addClass('kb-data-list-add-data-text-button')
                         .css({ 'margin': '20px' })
-                        .click(function() {
+                        .click(function () {
                             this.trigger('hideGalleryPanelOverlay.Narrative');
                             this.trigger('toggleSidePanelOverlay.Narrative', this.options.parentControlPanel.$overlayPanel);
                         }.bind(this)));
@@ -1425,7 +1463,7 @@ define([
             }
         },
 
-        renderObject: function(objId) {
+        renderObject: function (objId) {
             var $renderedDiv = this.renderObjectRowDiv(objId);
             this.dataObjects[objId].$div = $renderedDiv;
             this.$mainListDiv.append($renderedDiv);
@@ -1434,14 +1472,14 @@ define([
             }
         },
 
-        renderController: function() {
+        renderController: function () {
             var self = this;
 
             var $byDate = $('<label id="nar-data-list-default-sort-label" class="btn btn-default">').addClass('btn btn-default')
                 .append($('<input type="radio" name="options" id="nar-data-list-default-sort-option" autocomplete="off">'))
-                .append("date")
-                .on('click', function() {
-                    self.sortData(function(a, b) {
+                .append('date')
+                .on('click', function () {
+                    self.sortData(function (a, b) {
                         if (self.dataObjects[a.objId].info[3] > self.dataObjects[b.objId].info[3])
                             return -1; // sort by date
                         if (self.dataObjects[a.objId].info[3] < self.dataObjects[b.objId].info[3])
@@ -1452,9 +1490,9 @@ define([
 
             var $byName = $('<label class="btn btn-default">')
                 .append($('<input type="radio" name="options" id="option2" autocomplete="off">'))
-                .append("name")
-                .on('click', function() {
-                    self.sortData(function(a, b) {
+                .append('name')
+                .on('click', function () {
+                    self.sortData(function (a, b) {
                         if (self.dataObjects[a.objId].info[1].toUpperCase() < self.dataObjects[b.objId].info[1].toUpperCase())
                             return -1; // sort by name
                         if (self.dataObjects[a.objId].info[1].toUpperCase() > self.dataObjects[b.objId].info[1].toUpperCase())
@@ -1465,9 +1503,9 @@ define([
 
             var $byType = $('<label class="btn btn-default">')
                 .append($('<input type="radio" name="options" id="option3" autocomplete="off">'))
-                .append("type")
-                .on('click', function() {
-                    self.sortData(function(a, b) {
+                .append('type')
+                .on('click', function () {
+                    self.sortData(function (a, b) {
                         if (self.dataObjects[a].info[2].toUpperCase() > self.dataObjects[b].info[2].toUpperCase())
                             return -1; // sort by type
                         if (self.dataObjects[a].info[2].toUpperCase() < self.dataObjects[b].info[2].toUpperCase())
@@ -1477,13 +1515,13 @@ define([
                 });
             var $upOrDown = $('<button class="btn btn-default btn-sm" type="button">').css({ 'margin-left': '5px' })
                 .append('<span class="glyphicon glyphicon-sort" style="color:#777" aria-hidden="true" />')
-                .on('click', function() {
+                .on('click', function () {
                     self.reverseData();
                 });
 
             var $sortByGroup = $('<div data-toggle="buttons">')
-                .addClass("btn-group btn-group-sm")
-                .css({ "margin": "2px" })
+                .addClass('btn-group btn-group-sm')
+                .css({ 'margin': '2px' })
                 .append($byDate)
                 .append($byName)
                 .append($byType);
@@ -1503,7 +1541,7 @@ define([
                     }
                 })
                 .append('<span class="fa fa-copy"></span>')
-                .on('click', function() {
+                .on('click', function () {
                     self.setViewMode = !self.setViewMode;
                     if (self.setViewMode) {
                         $('#kb-data-list-hierctl').attr('enabled', '1');
@@ -1514,7 +1552,7 @@ define([
                 });
 
             // Search control
-            self.controlClickHnd.search = function() {
+            self.controlClickHnd.search = function () {
                 if (!self.$searchDiv.is(':visible')) {
                     self.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
                     self.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
@@ -1539,7 +1577,7 @@ define([
                 .on('click', self.controlClickHnd.search);
 
             // Sort control
-            self.controlClickHnd.sort = function() {
+            self.controlClickHnd.sort = function () {
                 if (!self.$sortByDiv.is(':visible')) {
                     self.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
                     self.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
@@ -1563,7 +1601,7 @@ define([
                 .on('click', self.controlClickHnd.sort);
 
             // Filter control
-            self.controlClickHnd.filter = function() {
+            self.controlClickHnd.filter = function () {
                 if (!self.$filterTypeDiv.is(':visible')) {
                     self.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
                     self.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
@@ -1598,38 +1636,38 @@ define([
                     }
                 })
                 .append('<span class="glyphicon glyphicon-refresh"></span>')
-                .on('click', function() {
+                .on('click', function () {
                     self.refresh();
                 });
             self.$searchInput = $('<input type="text">')
                 .attr('Placeholder', 'Search in your data')
                 .addClass('form-control')
-                .on('focus', function() {
+                .on('focus', function () {
                     if (Jupyter && Jupyter.narrative) {
                         Jupyter.narrative.disableKeyboardManager();
                     }
                 })
-                .on('blur', function() {
+                .on('blur', function () {
                     if (Jupyter && Jupyter.narrative) {
                         Jupyter.narrative.enableKeyboardManager();
                     }
                 })
-                .on('input change blur', function() {
+                .on('input change blur', function () {
                     this.search();
                 }.bind(this))
-                .on('keyup', function(e) {
+                .on('keyup', function (e) {
                     if (e.keyCode === 27) {
                         this.search();
                     }
                 }.bind(this));
 
-            self.$searchDiv = $('<div>').addClass("input-group").css({ 'margin-bottom': '10px' })
+            self.$searchDiv = $('<div>').addClass('input-group').css({ 'margin-bottom': '10px' })
                 .append(self.$searchInput)
-                .append($("<span>").addClass("input-group-addon")
-                    .append($("<span>")
-                        .addClass("glyphicon glyphicon-search")
+                .append($('<span>').addClass('input-group-addon')
+                    .append($('<span>')
+                        .addClass('glyphicon glyphicon-search')
                         .css({ 'cursor': 'pointer' })
-                        .on('click', function() {
+                        .on('click', function () {
                             self.search();
                         })));
 
@@ -1638,11 +1676,11 @@ define([
                 .append($sortByGroup)
                 .append($upOrDown);
 
-            self.$filterTypeSelect = $('<select>').addClass("form-control")
+            self.$filterTypeSelect = $('<select>').addClass('form-control')
                 .css('margin', 'inherit')
                 .append($('<option value="">'))
-                .change(function() {
-                    var optionSelected = $(this).find("option:selected");
+                .change(function () {
+                    var optionSelected = $(this).find('option:selected');
                     var typeSelected = optionSelected.val();
 
                     // whenever we change the type filter, we need to clear the current match
@@ -1686,34 +1724,34 @@ define([
         /**
          * Populates the filter set of available types.
          */
-        populateAvailableTypes: function() {
+        populateAvailableTypes: function () {
             if (this.availableTypes && this.$filterTypeSelect) {
                 this.$filterTypeSelect.empty();
                 var runningCount = 0;
-                Object.keys(this.availableTypes).sort().forEach(function(type) {
+                Object.keys(this.availableTypes).sort().forEach(function (type) {
                     var typeInfo = this.availableTypes[type];
                     var suf = typeInfo.count > 0 ? 's' : '';
                     this.$filterTypeSelect.append(
                         $('<option value="' + typeInfo.type + '">')
-                        .append([typeInfo.type, ' (', typeInfo.count, " object", suf, ")"].join(''))
+                        .append([typeInfo.type, ' (', typeInfo.count, ' object', suf, ')'].join(''))
                     );
                     runningCount += typeInfo.count;
                 }.bind(this));
                 var suf = runningCount > 0 ? 's' : '';
                 this.$filterTypeSelect
                     .prepend($('<option value="">')
-                        .append("Show All Types (" + runningCount + " object" + suf + ")"))
-                    .val("");
+                        .append('Show All Types (' + runningCount + ' object' + suf + ')'))
+                    .val('');
             }
         },
 
-        reverseData: function() {
+        reverseData: function () {
             this.viewOrder.reverse();
             this.renderList();
             this.search();
         },
 
-        sortData: function(sortfunction) {
+        sortData: function (sortfunction) {
             this.viewOrder.sort(sortfunction);
             this.renderList();
             this.search(); // always refilter on the search term search if there is something there
@@ -1724,7 +1762,7 @@ define([
             }, 300); // fast = 200, slow = 600
         },
 
-        search: function(term, type) {
+        search: function (term, type) {
             if (!this.dataObjects) {
                 return;
             }
@@ -1735,7 +1773,7 @@ define([
 
             // if type wasn't selected, then we try to get something that was set
             if (!type && this.$filterTypeSelect) {
-                type = this.$filterTypeSelect.find("option:selected").val();
+                type = this.$filterTypeSelect.find('option:selected').val();
             }
 
             term = term.trim();
@@ -1780,7 +1818,7 @@ define([
                                 if (regex.test(info[10][metaKey])) {
                                     match = true;
                                     break;
-                                } else if (regex.test(metaKey + "::" + info[10][metaKey])) {
+                                } else if (regex.test(metaKey + '::' + info[10][metaKey])) {
                                     match = true;
                                     break;
                                 }
@@ -1797,7 +1835,7 @@ define([
                 }
             } else {
                 // no new search, so show all and render the list
-                this.viewOrder.forEach(function(viewInfo) {
+                this.viewOrder.forEach(function (viewInfo) {
                     viewInfo.inFilter = true;
                 });
             }
@@ -1805,12 +1843,12 @@ define([
             this.currentTerm = term;
         },
 
-        filterByType: function(type) {
+        filterByType: function (type) {
             this.search(null, type);
         },
 
-        getRichData: function(object_info, $moreRow) {
-            var $usernameTd = $moreRow.find(".kb-data-list-username-td");
+        getRichData: function (object_info, $moreRow) {
+            var $usernameTd = $moreRow.find('.kb-data-list-username-td');
             DisplayUtil.displayRealName(object_info[5], $usernameTd);
         }
     })

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -18,11 +18,14 @@ define([
     'kbaseReportView',
     'common/runtime',
     'common/semaphore',
+    'common/utils',
     'text!kbase/templates/job_status/status_table.html',
     'text!kbase/templates/job_status/header.html',
     'text!kbase/templates/job_status/log_panel.html',
     'text!kbase/templates/job_status/log_line.html',
     'text!kbase/templates/job_status/new_objects.html',
+    'util/bootstrapAlert',
+
     'css!kbase/css/kbaseJobLog.css',
     'bootstrap'
 ], function (
@@ -42,16 +45,18 @@ define([
     KBaseReportView,
     Runtime,
     Semaphore,
+    utils,
     JobStatusTableTemplate,
     HeaderTemplate,
     LogPanelTemplate,
     LogLineTemplate,
-    NewObjectsTemplate
+    NewObjectsTemplate,
+    Alert
 ) {
     'use strict';
 
     function VirtualSlice(config) {
-        var maxSize = config.max  || 100;
+        var maxSize = config.max || 100;
         var startPos;
         var theSlice;
         var trimEnd = config.trimEnd || 'auto';
@@ -85,6 +90,7 @@ define([
                 startPos = startPos + chop;
             }
         }
+
         function grow(log) {
             // handle cases in which the new entires are discontiguous.
             if (log.start + log.lines.length < startPos) {
@@ -95,7 +101,8 @@ define([
                 replace(log);
                 return;
             }
-            var growLength, growLines, growAtBegin = false, growAtEnd = false;
+            var growLength, growLines, growAtBegin = false,
+                growAtEnd = false;
             if (log.first < startPos) {
                 growLength = log.first + log.lines.length - startPos;
                 growLines = log.lines.slice(0, log.lines.length - growLength);
@@ -127,6 +134,7 @@ define([
             theSlice = log.lines;
             trim();
         }
+
         function update(log) {
             if (log.first === null || log.first === undefined || !log.lines) {
                 return;
@@ -151,12 +159,15 @@ define([
         function getStart() {
             return startPos;
         }
+
         function getEnd() {
             return startPos + theSlice.length;
         }
+
         function getLength() {
             return theSlice.length;
         }
+
         function trimAt(newEnd) {
             trimEnd = newEnd;
         }
@@ -235,14 +246,21 @@ define([
              * 3. Initialize layout, set up bus.
              */
             var cellMeta = this.getCellState();
-            if (cellMeta && cellMeta.state.jobId === this.jobId) {
-                // use this and not the state input.
-                this.state = cellMeta.state;
+
+            // When this is initially inserted into the Narrative, the cell metadata will not be fully populated.
+            // In this case, the job state that is passed to the widget will be used, otherwise the job state
+            // stored in the metadata will be used.
+            if (utils.getCellMeta(this.cell, 'kbase.codeCell.jobInfo.state.jobId') === this.jobId) {
+                this.state = utils.getCellMeta(this.cell, 'kbase.codeCell.jobInfo.state');
             }
+
+            // if (cellMeta && cellMeta.codeCell && cellMeta.codeCell && cellMeta.codeCell.jobInfo.state.jobId === this.jobId) {
+            //     // use this and not the state input.
+            //     this.state = cellMeta.codeCell.jobInfo.state;
+            // }
             if (cellMeta && cellMeta.attributes && cellMeta.attributes.id) {
                 this.cellId = cellMeta.attributes.id;
-            }
-            else {
+            } else {
                 this.cellId = StringUtil.uuid();
             }
 
@@ -299,6 +317,19 @@ define([
                         }.bind(this)
                     });
 
+                    this.busConnection.listen({
+                        channel: {
+                            jobId: this.jobId
+                        },
+                        key: {
+                            type: 'job-does-not-exist'
+                        },
+                        handle: function (message) {
+                            // this.handleJobStatus(message);
+                            console.warn('job does not exist? ', message);
+                        }.bind(this)
+                    });
+
                     this.channel.emit('request-job-status', {
                         jobId: this.jobId
                     });
@@ -333,15 +364,16 @@ define([
             var $tabDiv = $('<div>');
             this.tabController = new KBaseTabs($tabDiv, {
                 tabs: [{
-                    tab: 'Status',
-                    canDelete: false,
-                    content: body,
-                },
-                {
-                    tab: 'Log',
-                    canDelete: false,
-                    showContentCallback: this.initLogView.bind(this)
-                }]
+                        tab: 'Status',
+                        canDelete: false,
+                        content: body,
+                    },
+                    {
+                        tab: 'Log',
+                        canDelete: false,
+                        showContentCallback: this.initLogView.bind(this)
+                    }
+                ]
             });
             this.$elem.append($tabDiv);
         },
@@ -371,7 +403,6 @@ define([
                     this.showNewObjects();
                 }
             }
-
         },
 
         showNewObjects: function () {
@@ -421,7 +452,17 @@ define([
                                         var $objTable = $(newObjTmpl(renderedInfo));
                                         for (var i = 0; i < objInfo.length; i++) {
                                             var info = objInfo[0];
-                                            $objTable.find('#' + objInfo[i][1]).click(function () {
+                                            $objTable.find('[data-object-name="' + objInfo[i][1] + '"]').click(function (e) {
+                                                e.stopPropagation();
+                                                e.preventDefault();
+                                                if (Jupyter.narrative.readonly) {
+                                                    new Alert({
+                                                        type: 'warning',
+                                                        title: 'Warning: Read-only Narrative',
+                                                        body: 'You cannot insert a data viewer cell into this Narrative because it is read-only'
+                                                    });
+                                                    return;
+                                                }
                                                 this.openViewerCell(this.createInfoObject(info));
                                             }.bind(this));
                                         }
@@ -544,9 +585,46 @@ define([
             return $(tmpl(this.appInfo));
         },
 
+
+
         getCellState: function () {
             var metadata = this.cell.metadata;
-            if (metadata.kbase && metadata.kbase.state) {
+            // This is altogether the wrong place to do this sort of
+            // cell repair...
+            if (metadata.kbase) {
+                if (metadata.kbase.state) {
+                    // Copied from the codeCell extension
+                    var newKbaseMeta = {
+                        type: 'code',
+                        attributes: {
+                            id: StringUtil.uuid(),
+                            status: 'new',
+                            created: new Date().toGMTString(),
+                            lastLoaded: new Date().toGMTString(),
+                            icon: 'code',
+                            title: 'Import Job Cell',
+                            subtitle: ''
+                        },
+                        codeCell: {
+                            userSettings: {
+                                showCodeInputArea: true
+                            },
+                            jobInfo: {
+                                jobId: metadata.kbase.jobId,
+                                state: metadata.kbase.state
+                            }
+                        }
+                    };
+                    // fix up the metadata.
+                    // The old metadata just wrote over the kbase property
+                    // kbase.jobId
+                    // kbase.state
+                    // Originally it was set up as an output cell, but
+                    // did not match an output cell metadata, so would fail
+                    // we need to fix that here...
+                    this.cell.metadata.kbase = newKbaseMeta;
+                    this.cell.metadata = this.cell.metadata;
+                }
                 return metadata.kbase;
             } else {
                 return null;
@@ -555,7 +633,7 @@ define([
 
         setCellState: function () {
             var metadata = this.cell.metadata;
-            metadata['kbase'] = {
+            metadata.kbase.codeCell.jobInfo = {
                 jobId: this.jobId,
                 state: this.state
             };
@@ -729,7 +807,8 @@ define([
                 .children()
                 .tooltip()
                 .on('click', function (e) {
-                    $(e.currentTarget).tooltip('hide'); });
+                    $(e.currentTarget).tooltip('hide');
+                });
             return $logPanel;
         },
 
@@ -759,7 +838,7 @@ define([
             this.logView.find('#kblog-msg').html(message);
         },
 
-        logButton: function(name) {
+        logButton: function (name) {
             return this.logView.find('#kblog-' + name);
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSideImportTab.js
@@ -6,7 +6,7 @@
  * @author Roman Sutormin <rsutormin@lbl.gov>
  * @public
  */
-define (
+define(
     [
         'kbwidget',
         'bootstrap',
@@ -19,7 +19,8 @@ define (
         'common/pythonInterop',
         'util/kbaseApiUtil',
         'kbase-client-api'
-    ], function(
+    ],
+    function(
         KBWidget,
         bootstrap,
         $,
@@ -30,528 +31,541 @@ define (
         Jupyter,
         PythonInterop,
         APIUtil
-	) {
-    'use strict';
-    return KBWidget({
-        name: 'kbaseNarrativeSideImportTab',
-        parent : kbaseAuthenticatedWidget,
-        version: '1.0.0',
-        options: {
-            ws_name: null
-        },
-        token: null,
-        wsName: null,
-        loadingImage: Config.get('loading_gif'),
-        wsUrl: Config.url('workspace'),
-        methodStoreURL: Config.url('narrative_method_store'),
-        methodStoreTypesURL: Config.url('narrative_method_store_types'),
-        methClient: null,
-        uploaderURL: Config.url('transform'),
-        ujsURL: Config.url('user_and_job_state'),
-        shockURL: Config.url('shock'),
-        methodIds: null,        // [method_id] that are involved in type importers
-        allMethodIds: {},       // {tag -> {method_id -> method_name}}
-        methods: {},            // {tag -> {method_id -> method_spec}}
-        methodFullInfo: {},     // {tag -> {method_id -> method_full_info}}
-        types: null,            // {type_name -> type_spec}
-        selectedType: null,     // selected type name
-        widgetPanel: null,      // div for selected type
-        widgetPanelCard1: null, // first page with importer type combobox (this page will be put on widgetPanel)
-        widgetPanelCard2: null, // second page with import widget (this page will be put on widgetPanel)
-        infoPanel: null,
-        inputWidget: null,      // {methodId -> widget for selected type}
-        tabs: null,             // mapping {methodId -> div}
-        fileUploadInProgress: false,
+    ) {
+        'use strict';
+        return KBWidget({
+            name: 'kbaseNarrativeSideImportTab',
+            parent: kbaseAuthenticatedWidget,
+            version: '1.0.0',
+            options: {
+                ws_name: null
+            },
+            token: null,
+            wsName: null,
+            loadingImage: Config.get('loading_gif'),
+            wsUrl: Config.url('workspace'),
+            methodStoreURL: Config.url('narrative_method_store'),
+            methodStoreTypesURL: Config.url('narrative_method_store_types'),
+            methClient: null,
+            uploaderURL: Config.url('transform'),
+            ujsURL: Config.url('user_and_job_state'),
+            shockURL: Config.url('shock'),
+            methodIds: null, // [method_id] that are involved in type importers
+            allMethodIds: {}, // {tag -> {method_id -> method_name}}
+            methods: {}, // {tag -> {method_id -> method_spec}}
+            methodFullInfo: {}, // {tag -> {method_id -> method_full_info}}
+            types: null, // {type_name -> type_spec}
+            selectedType: null, // selected type name
+            widgetPanel: null, // div for selected type
+            widgetPanelCard1: null, // first page with importer type combobox (this page will be put on widgetPanel)
+            widgetPanelCard2: null, // second page with import widget (this page will be put on widgetPanel)
+            infoPanel: null,
+            inputWidget: null, // {methodId -> widget for selected type}
+            tabs: null, // mapping {methodId -> div}
+            fileUploadInProgress: false,
 
-        init: function(options) {
-            this._super(options);
-            this.wsName = Jupyter.narrative.getWorkspaceName();
+            init: function(options) {
+                this._super(options);
+                this.wsName = Jupyter.narrative.getWorkspaceName();
 
-            return this;
-        },
+                return this;
+            },
 
-        render: function() {
-            var self = this;
-            this.inputWidget = {};
-            this.tabs = {};
-            var errorModalId = "app-error-modal-" + StringUtil.uuid();
-            var modalLabel = "app-error-modal-lablel-" + StringUtil.uuid();
+            render: function() {
+                var self = this;
+                this.inputWidget = {};
+                this.tabs = {};
+                var errorModalId = 'app-error-modal-' + StringUtil.uuid();
+                var modalLabel = 'app-error-modal-lablel-' + StringUtil.uuid();
 
-            // Build error modal
-            self.$errorModalContent = $('<div>');
-            self.$errorModal = $('<div id="'+errorModalId+'" tabindex="-1" role="dialog" aria-labelledby="'+modalLabel+'" aria-hidden="true" style="position:auto">')
-                               .addClass("modal fade");
-            self.$errorModal.append(
-                $('<div>').addClass('modal-dialog').append(
-                    $('<div>').addClass('modal-content').append(
-                        $('<div>').addClass('modal-header kb-app-step-error-main-heading').append('<h4 class="modal-title" id="'+modalLabel+'">Problems exist in your parameter settings.</h4>')
-                    ).append(
-                       $('<div>').addClass('modal-body').append(self.$errorModalContent)
-                    ).append(
-                        $('<div>').addClass('modal-footer').append(
-                            $('<button type="button" data-dismiss="modal">').addClass("kb-default-btn").append("Dismiss"))
-                    )
-                ));
-            $('body').append(self.$errorModal);
+                // Build error modal
+                self.$errorModalContent = $('<div>');
+                self.$errorModal = $('<div id="' + errorModalId + '" tabindex="-1" role="dialog" aria-labelledby="' + modalLabel + '" aria-hidden="true" style="position:auto">')
+                    .addClass('modal fade');
+                self.$errorModal.append(
+                    $('<div>').addClass('modal-dialog').append(
+                        $('<div>').addClass('modal-content').append(
+                            $('<div>').addClass('modal-header kb-app-step-error-main-heading').append('<h4 class="modal-title" id="' + modalLabel + '">Problems exist in your parameter settings.</h4>')
+                        ).append(
+                            $('<div>').addClass('modal-body').append(self.$errorModalContent)
+                        ).append(
+                            $('<div>').addClass('modal-footer').append(
+                                $('<button type="button" data-dismiss="modal">').addClass('kb-default-btn').append('Dismiss'))
+                        )
+                    ));
+                $('body').append(self.$errorModal);
 
-            // Build warning modal
-            self.$warningModalContent = $('<div>');
-            self.$warningModal =  $('<div tabindex="-1" role="dialog" aria-labelledby="'+modalLabel+'" aria-hidden="true" style="position:auto">').addClass("modal fade");
-            var confirmButton = $('<button type="button" data-dismiss="modal">')
-                                .addClass("btn")
-                                .append("Confirm")
-                                .click(function() {
-                                    self.stopTimer();
-                                    self.back();
-								}.bind(this));
+                // Build warning modal
+                self.$warningModalContent = $('<div>');
+                self.$warningModal = $('<div tabindex="-1" role="dialog" aria-labelledby="' + modalLabel + '" aria-hidden="true" style="position:auto">').addClass('modal fade');
+                var confirmButton = $('<button type="button" data-dismiss="modal">')
+                    .addClass('btn')
+                    .append('Confirm')
+                    .click(function() {
+                        self.stopTimer();
+                        self.back();
+                    }.bind(this));
 
-            self.$warningModal.append(
-                $('<div>').addClass('modal-dialog').append(
-                    $('<div>').addClass('modal-content').append(
-                        $('<div>').addClass('modal-header kb-app-step-error-main-heading').append('<h4 class="modal-title" id="'+modalLabel+'">User confirmation required.</h4>')
-                    ).append(
-                       $('<div>').addClass('modal-body').append(self.$warningModalContent)
-                    ).append(
-                        $('<div>').addClass('modal-footer').append(confirmButton).append(
-                            $('<button type="button" data-dismiss="modal">').addClass("kb-default-btn").append("Cancel"))
-                    )
-                ));
-            $('body').append(self.$warningModal);
+                self.$warningModal.append(
+                    $('<div>').addClass('modal-dialog').append(
+                        $('<div>').addClass('modal-content').append(
+                            $('<div>').addClass('modal-header kb-app-step-error-main-heading').append('<h4 class="modal-title" id="' + modalLabel + '">User confirmation required.</h4>')
+                        ).append(
+                            $('<div>').addClass('modal-body').append(self.$warningModalContent)
+                        ).append(
+                            $('<div>').addClass('modal-footer').append(confirmButton).append(
+                                $('<button type="button" data-dismiss="modal">').addClass('kb-default-btn').append('Cancel'))
+                        )
+                    ));
+                $('body').append(self.$warningModal);
 
-            // Build widget container panel that holds importer inputs
-            this.widgetPanel = $('<div>');
-            this.widgetPanelCard1 = $('<div style="margin: 30px 30px 0px 30px;">');
-            this.widgetPanel.append(this.widgetPanelCard1);
-            this.widgetPanelCard1.append("<div class='kb-cell-run'><h2 class='collapse in'>" +
-                    "Import data from your local computer or another data source. First, select the type of data you wish to import." +
-                    "</h2></div><hr>");
+                // Build widget container panel that holds importer inputs
+                this.widgetPanel = $('<div>');
+                this.widgetPanelCard1 = $('<div style="margin: 30px 30px 0px 30px;">');
+                this.widgetPanel.append(this.widgetPanelCard1);
+                this.widgetPanelCard1.append('<div class=\'kb-cell-run\'><h2 class=\'collapse in\'>' +
+                    'Import data from your local computer or another data source. First, select the type of data you wish to import.' +
+                    '</h2></div><hr>');
 
-            var $nameDiv = $('<div>')
-                           .addClass("kb-method-parameter-name")
-                           .css("text-align", "left")
-                           .append("DATA TYPE");
+                var $nameDiv = $('<div>')
+                    .addClass('kb-method-parameter-name')
+                    .css('text-align', 'left')
+                    .append('DATA TYPE');
 
-            var $dropdown = $('<select>').css({width:"400px"});
-            var $nextButton = $('<button>')
-                              .attr('id', this.cellId + '-next')
-                              .attr('type', 'button')
-                              .attr('value', 'Next')
-                              .addClass('kb-primary-btn')
-                              .css({'border' : '4px'})
-                              .append('Next');
-            var $hintDiv = $('<div>')
-                           .addClass("kb-method-parameter-hint")
-                           .append("Use the pulldown menu of data types above " +
-                                   "to select the type of data you wish to " +
-                                   "import; then click the Next button.");
+                var $dropdown = $('<select>').css({ width: '400px' });
+                var $nextButton = $('<button>')
+                    .attr('id', this.cellId + '-next')
+                    .attr('type', 'button')
+                    .attr('value', 'Next')
+                    .addClass('kb-primary-btn')
+                    .css({ 'border': '4px' })
+                    .append('Next');
+                var $hintDiv = $('<div>')
+                    .addClass('kb-method-parameter-hint')
+                    .append('Use the pulldown menu of data types above ' +
+                        'to select the type of data you wish to ' +
+                        'import; then click the Next button.');
 
-            $nextButton.click(
-                $.proxy(function(event) {
-                    event.preventDefault();
-                    var selectedType = $dropdown.val();
-                    self.getMethodSpecs(function(methodFullInfo, methods, tag) {
-                        self.showWidget(selectedType, methodFullInfo, methods, tag);
-                    }, function(error) {
-                        self.showError(error);
-                    });
-                }, this)
-            );
-            this.widgetPanelCard1
-                .append('<div style="height: 30px">')
-                .append($nameDiv)
-                .append($('<div>').append($dropdown))
-                .append($hintDiv)
-                .append('<div style="height: 30px">')
-                .append($('<div>').append($nextButton));
+                $nextButton.click(
+                    $.proxy(function(event) {
+                        event.preventDefault();
+                        var selectedType = $dropdown.val();
+                        self.getMethodSpecs(function(methodFullInfo, methods, tag) {
+                            self.showWidget(selectedType, methodFullInfo, methods, tag);
+                        }, function(error) {
+                            self.showError(error);
+                        });
+                    }, this)
+                );
+                this.widgetPanelCard1
+                    .append('<div style="height: 30px">')
+                    .append($nameDiv)
+                    .append($('<div>').append($dropdown))
+                    .append($hintDiv)
+                    .append('<div style="height: 30px">')
+                    .append($('<div>').append($nextButton));
 
-            this.widgetPanelCard2 = $('<div style="display: none; margin: 0px;">');
-            this.widgetPanel.append(this.widgetPanelCard2);
+                this.widgetPanelCard2 = $('<div style="display: none; margin: 0px;">');
+                this.widgetPanel.append(this.widgetPanelCard2);
 
-            this.infoPanel = $('<div style="margin: 20px 30px 0px 30px;">');
+                this.infoPanel = $('<div style="margin: 20px 30px 0px 30px;">');
 
-            this.$mainPanel = $('<div>').css({'overflow-y':'auto','height':'604px'});
-            this.$elem.append(this.$mainPanel);
-            this.$mainPanel.append(this.widgetPanel);
-            this.$mainPanel.append(this.infoPanel);
+                this.$mainPanel = $('<div>').css({ 'overflow-y': 'auto', 'height': '604px' });
+                this.$elem.append(this.$mainPanel);
+                this.$mainPanel.append(this.widgetPanel);
+                this.$mainPanel.append(this.infoPanel);
 
-            this.methClient = new NarrativeMethodStore(this.methodStoreURL);
-            if (!this.methodStoreTypesURL) {
-                this.methodStoreTypesURL = this.methodStoreURL;
-            }
-            var typesClient = new NarrativeMethodStore(this.methodStoreTypesURL);
-            typesClient.list_categories({'load_methods': 0, 'load_apps' : 0, 'load_types' : 1},
-                $.proxy(function(data) {
-                    var aTypes = data[3];
-                    self.methodIds = [];
-                    self.types = {};
-                    for (var key in aTypes) {
-                        if (aTypes[key]["loading_error"]) {
-                            console.log("Error loading type [" + key + "]: " + aTypes[key]["loading_error"]);
-                            continue;
-                        }
-                        if (aTypes[key]["import_method_ids"].length > 0) {
-                            self.types[key] = aTypes[key];
-                            for (var methodPos in aTypes[key]["import_method_ids"]) {
-                                var methodId = aTypes[key]["import_method_ids"][methodPos];
-                                if (methodId.indexOf('/') > 0)
-                                    self.methodIds.push(methodId);
+                this.methClient = new NarrativeMethodStore(this.methodStoreURL);
+                if (!this.methodStoreTypesURL) {
+                    this.methodStoreTypesURL = this.methodStoreURL;
+                }
+                var typesClient = new NarrativeMethodStore(this.methodStoreTypesURL);
+                typesClient.list_categories({ 'load_methods': 0, 'load_apps': 0, 'load_types': 1 },
+                    $.proxy(function(data) {
+                        var aTypes = data[3];
+                        self.methodIds = [];
+                        self.types = {};
+                        for (var key in aTypes) {
+                            if (aTypes[key]['loading_error']) {
+                                console.log('Error loading type [' + key + ']: ' + aTypes[key]['loading_error']);
+                                continue;
+                            }
+                            if (aTypes[key]['import_method_ids'].length > 0) {
+                                self.types[key] = aTypes[key];
+                                for (var methodPos in aTypes[key]['import_method_ids']) {
+                                    var methodId = aTypes[key]['import_method_ids'][methodPos];
+                                    if (methodId.indexOf('/') > 0)
+                                        self.methodIds.push(methodId);
+                                }
                             }
                         }
-                    }
-                    var keys = [];
-                    for (key in self.types) {
-                        keys.push(key);
-                    }
-                    keys.sort(function(a,b) {return self.types[a]["name"].localeCompare(self.types[b]["name"])});
-                    for (var keyPos in keys) {
-                        addItem(keys[keyPos]);
-                    }
-                    $dropdown.select2({
-                        minimumResultsForSearch: -1,
-                        formatSelection: function(object) {
-                            var display = '<span class="kb-parameter-data-selection">'+object.text+'</span>';
-                            return display;
+                        var keys = [];
+                        for (key in self.types) {
+                            keys.push(key);
                         }
-                    });
+                        keys.sort(function(a, b) { return self.types[a]['name'].localeCompare(self.types[b]['name']) });
+                        for (var keyPos in keys) {
+                            addItem(keys[keyPos]);
+                        }
+                        $dropdown.select2({
+                            minimumResultsForSearch: -1,
+                            formatSelection: function(object) {
+                                var display = '<span class="kb-parameter-data-selection">' + object.text + '</span>';
+                                return display;
+                            }
+                        });
 
-                    function addItem(key) {
-                        var name = self.types[key]["name"];
-                        $dropdown.append($('<option value="'+key+'">').append(name));
-                    }
-                }, this),
-                $.proxy(function(error) {
-                    self.showError(error);
-                }, this)
-            );
-            return this;
-        },
+                        function addItem(key) {
+                            var name = self.types[key]['name'];
+                            $dropdown.append($('<option value="' + key + '">').append(name));
+                        }
+                    }, this),
+                    $.proxy(function(error) {
+                        self.showError(error);
+                    }, this)
+                );
+                return this;
+            },
 
-        // getVersionTag: function() {
-        //     var tag = Jupyter.narrative.sidePanel.$methodsWidget.currentTag;
-        //     if (!tag) {
-        //         tag = "release";
-        //     }
-        //     return tag;
-        // },
+            // getVersionTag: function() {
+            //     var tag = Jupyter.narrative.sidePanel.$methodsWidget.currentTag;
+            //     if (!tag) {
+            //         tag = "release";
+            //     }
+            //     return tag;
+            // },
 
-        getMethodSpecs: function(callback, errorCallback) {
-            var self = this;
-            var tag = APIUtil.getAppVersionTag();
-            if (self.allMethodIds[tag] && self.methodFullInfo[tag] && self.methods[tag]) {
-                callback(self.methodFullInfo[tag], self.methods[tag], tag);
-                return;
-            }
-            self.methClient.list_method_ids_and_names({tag: tag}, function(methodIdToName) {
-                self.allMethodIds[tag] = methodIdToName;
-                var methodIds = [];
-                for (var i in self.methodIds) {
-                    var methodId = self.methodIds[i];
-                    if (self.allMethodIds[tag][methodId]) {
-                        methodIds.push(methodId);
-                    } else {
-                        console.log("Importer method id=" + methodId + " is skipped for " +
-                                "tag \"" + tag + "\"");
-                    }
-                }
-                var prom1 = self.methClient.get_method_full_info({'ids': methodIds,
-                    'tag' : tag});
-                var prom2 = self.methClient.get_method_spec({'ids': methodIds,
-                    'tag' : tag});
-                $.when(prom1, prom2).done(function(fullInfoList, specs) {
-                    self.methodFullInfo[tag] = {};
-                    for (var i in fullInfoList) {
-                        self.methodFullInfo[tag][fullInfoList[i].id] = fullInfoList[i];
-                    }
-                    self.methods[tag] = {};
-                    for (i in specs) {
-                        self.methods[tag][specs[i].info.id] = specs[i];
-                    }
+            getMethodSpecs: function(callback, errorCallback) {
+                var self = this;
+                var tag = APIUtil.getAppVersionTag();
+                if (self.allMethodIds[tag] && self.methodFullInfo[tag] && self.methods[tag]) {
                     callback(self.methodFullInfo[tag], self.methods[tag], tag);
-                }).fail(function(error) {
+                    return;
+                }
+                self.methClient.list_method_ids_and_names({ tag: tag }, function(methodIdToName) {
+                    self.allMethodIds[tag] = methodIdToName;
+                    var methodIds = [];
+                    for (var i in self.methodIds) {
+                        var methodId = self.methodIds[i];
+                        if (self.allMethodIds[tag][methodId]) {
+                            methodIds.push(methodId);
+                        } else {
+                            console.log('Importer method id=' + methodId + ' is skipped for ' +
+                                'tag "' + tag + '"');
+                        }
+                    }
+                    var prom1 = self.methClient.get_method_full_info({
+                        'ids': methodIds,
+                        'tag': tag
+                    });
+                    var prom2 = self.methClient.get_method_spec({
+                        'ids': methodIds,
+                        'tag': tag
+                    });
+                    $.when(prom1, prom2).done(function(fullInfoList, specs) {
+                        self.methodFullInfo[tag] = {};
+                        for (var i in fullInfoList) {
+                            self.methodFullInfo[tag][fullInfoList[i].id] = fullInfoList[i];
+                        }
+                        self.methods[tag] = {};
+                        for (i in specs) {
+                            self.methods[tag][specs[i].info.id] = specs[i];
+                        }
+                        callback(self.methodFullInfo[tag], self.methods[tag], tag);
+                    }).fail(function(error) {
+                        alert(error);
+                        errorCallback(error);
+                    });
+                }, function(error) {
                     alert(error);
                     errorCallback(error);
                 });
-            }, function(error) {
-                alert(error);
-                errorCallback(error);
-            });
-        },
+            },
 
-        showWidget: function(type, methodFullInfo, methods, tag) {
-            var self = this;
-            this.selectedType = type;
-            this.widgetPanelCard1.css('display', 'none');
-            this.widgetPanelCard2.css('display', '');
-            this.widgetPanelCard2.empty();
-            var $header = null;
-            var $body = null;
-            var importMethodIds = [];
-            for (var methodPos in self.types[type]["import_method_ids"]) {
-                var methodId = this.types[type]["import_method_ids"][methodPos];
-                if (methods[methodId]) {
-                    importMethodIds.push(methodId);
+            showWidget: function(type, methodFullInfo, methods, tag) {
+                var self = this;
+                this.selectedType = type;
+                this.widgetPanelCard1.css('display', 'none');
+                this.widgetPanelCard2.css('display', '');
+                this.widgetPanelCard2.empty();
+                var $header = null;
+                var $body = null;
+                var importMethodIds = [];
+                for (var methodPos in self.types[type]['import_method_ids']) {
+                    var methodId = this.types[type]['import_method_ids'][methodPos];
+                    if (methods[methodId]) {
+                        importMethodIds.push(methodId);
+                    }
                 }
-            }
-            var numberOfTabs = importMethodIds.length;
-            if (numberOfTabs > 1) {
-                $header = $('<div>');
-                $body = $('<div>');
-                this.widgetPanelCard2.append($header).append($body);
-            }
+                var numberOfTabs = importMethodIds.length;
+                if (numberOfTabs > 1) {
+                    $header = $('<div>');
+                    $body = $('<div>');
+                    this.widgetPanelCard2.append($header).append($body);
+                }
 
-            for (var methodPos in importMethodIds) {
-                self.showTab(importMethodIds, methodPos, $header, $body,
+                for (var methodPos in importMethodIds) {
+                    self.showTab(importMethodIds, methodPos, $header, $body,
                         numberOfTabs, methodFullInfo, methods);
-            }
-            var $importButton = $('<button>')
-                             .attr('id', this.cellId + '-run')
-                             .attr('type', 'button')
-                             .attr('value', 'Import')
-                             .addClass('kb-primary-btn')
-                             .append('Import');
+                }
+                var $importButton = $('<button>')
+                    .attr('id', this.cellId + '-run')
+                    .attr('type', 'button')
+                    .attr('value', 'Import')
+                    .addClass('kb-primary-btn')
+                    .append('Import');
 
-            $importButton.click(
-                $.proxy(function(event) {
-                    event.preventDefault();
-                    var v = self.getInputWidget().isValid();
-                    if (v.isValid) {
-                        $importButton.prop('disabled', true);
-                        self.runImport(methods, tag);
-                    } else {
-                        var errorCount = 1;
-                        self.$errorModalContent.empty();
-                        var $errorStep = $('<div>');
-                        for (var e=0; e<v.errormssgs.length; e++) {
-                            $errorStep.append($('<div>')
-                                    .addClass("kb-app-step-error-mssg")
-                                    .append('['+errorCount+']: ' + v.errormssgs[e]));
-                            errorCount = errorCount+1;
+                $importButton.click(
+                    $.proxy(function(event) {
+                        event.preventDefault();
+                        var v = self.getInputWidget().isValid();
+                        if (v.isValid) {
+                            $importButton.prop('disabled', true);
+                            self.runImport(methods, tag);
+                        } else {
+                            var errorCount = 1;
+                            self.$errorModalContent.empty();
+                            var $errorStep = $('<div>');
+                            for (var e = 0; e < v.errormssgs.length; e++) {
+                                $errorStep.append($('<div>')
+                                    .addClass('kb-app-step-error-mssg')
+                                    .append('[' + errorCount + ']: ' + v.errormssgs[e]));
+                                errorCount = errorCount + 1;
+                            }
+                            self.$errorModalContent.append($errorStep);
+                            self.$errorModal.modal('show');
                         }
-                        self.$errorModalContent.append($errorStep);
-                        self.$errorModal.modal('show');
-                    }
-                }, this)
-            );
-            if (numberOfTabs == 0) {
-                $importButton.hide();
-                self.widgetPanelCard2.append(
-                        "<div class='kb-cell-run' style='margin: 30px 30px 0px 33px;'>" +
-                        "<h2 class='collapse in'>" +
-                        "No import methods available for \"" + tag + "\" tag.</h2><hr></div>");
-            }
+                    }, this)
+                );
+                if (numberOfTabs == 0) {
+                    $importButton.hide();
+                    self.widgetPanelCard2.append(
+                        '<div class=\'kb-cell-run\' style=\'margin: 30px 30px 0px 33px;\'>' +
+                        '<h2 class=\'collapse in\'>' +
+                        'No import methods available for "' + tag + '" tag.</h2><hr></div>');
+                }
 
-            var $backButton = $('<button>')
-                             .attr('id', this.cellId + '-back')
-                             .attr('type', 'button')
-                             .attr('value', 'Back')
-                             .addClass('kb-primary-btn')
-                             .append('Back');
-            $backButton.click(
-                $.proxy(function(event) {
-                    event.preventDefault();
-                    self.back();
-                }, this)
-            );
+                var $backButton = $('<button>')
+                    .attr('id', this.cellId + '-back')
+                    .attr('type', 'button')
+                    .attr('value', 'Back')
+                    .addClass('kb-primary-btn')
+                    .append('Back');
+                $backButton.click(
+                    $.proxy(function(event) {
+                        event.preventDefault();
+                        self.back();
+                    }, this)
+                );
 
-            var $buttons = $('<div style="margin: 0px 30px 0px 33px;">')
-                           .addClass('buttons')
-                           .append($backButton)
-                           .append('&nbsp;')
-                           .append('&nbsp;')
-                           .append($importButton);
+                var $buttons = $('<div style="margin: 0px 30px 0px 33px;">')
+                    .addClass('buttons')
+                    .append($backButton)
+                    .append('&nbsp;')
+                    .append('&nbsp;')
+                    .append($importButton);
 
-            self.widgetPanelCard2.append($buttons);
-        },
+                self.widgetPanelCard2.append($buttons);
+            },
 
-        showTab: function(importMethodIds, methodPos, $header, $body,
+            showTab: function(importMethodIds, methodPos, $header, $body,
                 numberOfTabs, methodFullInfo, methods) {
-            var self = this;
-            var methodId = importMethodIds[methodPos];
-            var methodSpec = methods[methodId];
-            if (!methodSpec)
-                return;
-            var inputWidgetName = methodSpec.widgets.input;
-            if (!inputWidgetName || inputWidgetName === 'null')
-                inputWidgetName = 'kbaseNarrativeMethodInput';
-            var methodJson = JSON.stringify(methodSpec);
+                var self = this;
+                var methodId = importMethodIds[methodPos];
+                var methodSpec = methods[methodId];
+                if (!methodSpec)
+                    return;
+                var inputWidgetName = methodSpec.widgets.input;
+                if (!inputWidgetName || inputWidgetName === 'null')
+                    inputWidgetName = 'kbaseNarrativeMethodInput';
+                var methodJson = JSON.stringify(methodSpec);
 
-            var $inputDiv = $('<div>');
+                var $inputDiv = $('<div>');
 
-            var methodUuid = 'import-method-details-'+StringUtil.uuid();
-            // var buttonLabel = 'details';
-            var methodTitle = methodSpec.info.tooltip.trim();
-            var methodDescr = methodFullInfo[methodId].description.trim();
-            var $overviewSwitch = $('<a/>').html('more...');
-            var $methodInfo = $('<div>')
+                var methodUuid = 'import-method-details-' + StringUtil.uuid();
+                // var buttonLabel = 'details';
+                var methodTitle = methodSpec.info.tooltip.trim();
+                var methodDescr = methodFullInfo[methodId].description.trim();
+                var $overviewSwitch = $('<a/>').html('more...');
+                var $methodInfo = $('<div>')
                     .addClass('kb-func-desc')
-                    .css({'margin' : '25px 0px 0px 15px'})
+                    .css({ 'margin': '25px 0px 0px 15px' })
                     .append($('<h2>')
-                    .attr('id', methodUuid)
-                    .addClass('collapse in')
-                    .append(methodTitle).append('&nbsp;&nbsp&nbsp').append($overviewSwitch));
+                        .attr('id', methodUuid)
+                        .addClass('collapse in')
+                        .append(methodTitle).append('&nbsp;&nbsp&nbsp').append($overviewSwitch));
 
-            var $methodDescrPanel = $('<div/>')
+                var $methodDescrPanel = $('<div/>')
                     .addClass('kb-func-desc')
-                    .css({'margin' : '20px 0px 0px 20px', 'display' : 'none'})
+                    .css({ 'margin': '20px 0px 0px 20px', 'display': 'none' })
                     .append(methodDescr);
-            if (methodDescr && methodDescr != '' && methodDescr != 'none' &&
+                if (methodDescr && methodDescr != '' && methodDescr != 'none' &&
                     methodDescr != methodTitle && (methodDescr + '.') != methodTitle) {
-                $overviewSwitch.click(function(){
-                    $methodDescrPanel.toggle();
-                });
-            } else {
-                $overviewSwitch.css({'display' : 'none'});
-            }
-
-            var tab = $('<div style="margin: 0px 30px 0px 15px;">')
-                    .append($('<div>')
-                    .addClass('kb-func-panel kb-cell-run')
-                    .append($methodInfo).append($methodDescrPanel))
-                    .append($('<div>').css({'margin' : '25px 0px 0px 15px'}).append('<hr>'))
-                    .append($('<div>')
-                    .append($inputDiv))
-                    .append($('<div>')
-                    .css({'overflow' : 'hidden', 'margin' : '0px 0px 0px 18px'}));
-
-            var isShown = methodPos == 0;
-            var tabName = methodSpec.info.name;
-            var params = {tab: tabName,
-                          content: tab,
-                          canDelete : false,
-                          show: isShown};
-            if (numberOfTabs == 1) {
-                this.widgetPanelCard2.append(tab);
-            } else {
-                var tabHeader = $('<div>')
-                                .addClass('kb-side-header');
-                tabHeader.css('width', (100/numberOfTabs)+'%');
-                tabHeader.append($('<small>').append(params.tab));
-                $header.append(tabHeader);
-                var tabContent = $('<div>')
-                    .addClass('kb-side-tab3')
-                    .css('display', 'none')
-                    .append(params.content);
-                $body.append(tabContent);
-                if (params.show) {
-                    tabHeader.addClass('active');
-                    tabContent.css('display', '');
+                    $overviewSwitch.click(function() {
+                        $methodDescrPanel.toggle();
+                    });
+                } else {
+                    $overviewSwitch.css({ 'display': 'none' });
                 }
-                tabHeader.click($.proxy(function(event) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    var $headerDiv = $(event.currentTarget);
-                    if (!$headerDiv.hasClass('active')) {
-                        var idx = $headerDiv.index();
-                        $header.find('div').removeClass('active');
-                        $headerDiv.addClass('active');
-                        $body.find('div.kb-side-tab3').css('display', 'none');
-                        $body.find('div:nth-child(' + (idx+1) + ').kb-side-tab3').css('display', '');
-                    }
-                }, this));
-            }
-            require([inputWidgetName], function(InputWidget) {
-                // var wig = $inputDiv[inputWidgetName]({ method: methodJson, isInSidePanel: true });
-                var wig = new InputWidget($inputDiv, {method: methodJson, isInSidePanel: true});
-                self.inputWidget[methodId] = wig;
 
-                var onChange = function() {
-                    var w = self.getInputWidget();
-                    if (!w) { return };
+                var tab = $('<div style="margin: 0px 30px 0px 15px;">')
+                    .append($('<div>')
+                        .addClass('kb-func-panel kb-cell-run')
+                        .append($methodInfo).append($methodDescrPanel))
+                    .append($('<div>').css({ 'margin': '25px 0px 0px 15px' }).append('<hr>'))
+                    .append($('<div>')
+                        .append($inputDiv))
+                    .append($('<div>')
+                        .css({ 'overflow': 'hidden', 'margin': '0px 0px 0px 18px' }));
 
-                    if (self.timer)
-                        return;
-                    var v = w.isValid();
-                    if (v.isValid) {
-                        self.showInfo('All parameters are valid and you can start "Import" now');
-                    } else {
-                        self.showInfo('You can start "Import" when all parameters are ready (marked by green check)');
-                    }
+                var isShown = methodPos == 0;
+                var tabName = methodSpec.info.name;
+                var params = {
+                    tab: tabName,
+                    content: tab,
+                    canDelete: false,
+                    show: isShown
                 };
-                var paramValues = wig.getAllParameterValues();
-                for (var paramPos in paramValues) {
-                    var paramId = paramValues[paramPos].id;
-                    wig.addInputListener(paramId, onChange);
-                }
-
-                self.tabs[methodId] = tab;
-            }, function(error) {
-                alert(error);
-            });
-        },
-
-        getSelectedTabId: function() {
-            var ret = null;
-            for (var tabId in this.tabs) {
-                var tab = this.tabs[tabId];
-                if (tab.is(':visible'))
-                    ret = tabId;
-            }
-            return ret;
-        },
-
-        getInputWidget: function() {
-            return this.inputWidget[this.getSelectedTabId()];
-        },
-
-        back: function() {
-            var self = this;
-            if (self.timer != null) {
-                self.$warningModalContent.empty();
-                self.$warningModalContent.append(
-                    $('<div>').addClass("kb-app-step-error-mssg")
-                              .append('Import process is not finished yet. Are you sure you want to stop watching it?'));
-                self.$warningModal.modal('show');
-                return;
-            }
-            this.infoPanel.empty();
-            this.widgetPanelCard2.css('display', 'none');
-            this.widgetPanelCard1.css('display', '');
-        },
-
-        createImportStatusCell: function(methodName, jobId) {
-            var cellIndex = Jupyter.notebook.get_selected_index();
-            var cell = Jupyter.notebook.insert_cell_below('code', cellIndex);
-            $(cell.element).trigger('toggleCodeArea.cell');
-            var title = 'Import job status for ' + methodName;
-            var cellText = ['from biokbase.narrative.jobs.jobmanager import JobManager',
-                            'JobManager().get_job(' + jobId + ')'].join('\n');
-            cell.set_text(cellText);
-            var meta = {
-                    'kbase': {
-                        'attributes': {
-                            'status': 'new',
-                            'title': title
-                        },
-                        'type': 'output'
+                if (numberOfTabs == 1) {
+                    this.widgetPanelCard2.append(tab);
+                } else {
+                    var tabHeader = $('<div>')
+                        .addClass('kb-side-header');
+                    tabHeader.css('width', (100 / numberOfTabs) + '%');
+                    tabHeader.append($('<small>').append(params.tab));
+                    $header.append(tabHeader);
+                    var tabContent = $('<div>')
+                        .addClass('kb-side-tab3')
+                        .css('display', 'none')
+                        .append(params.content);
+                    $body.append(tabContent);
+                    if (params.show) {
+                        tabHeader.addClass('active');
+                        tabContent.css('display', '');
                     }
-            };
-            cell.metadata = meta;
-            cell.events.one('output_appended.OutputArea', function() {
-                Jupyter.narrative.saveNarrative();
-            });
-            cell.execute();
-            Jupyter.narrative.hideOverlay();
-            this.showInfo(''); // clear the info message when we close the overlay
-            Jupyter.narrative.scrollToCell(cell, true);
-            this.back();
-        },
+                    tabHeader.click($.proxy(function(event) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        var $headerDiv = $(event.currentTarget);
+                        if (!$headerDiv.hasClass('active')) {
+                            var idx = $headerDiv.index();
+                            $header.find('div').removeClass('active');
+                            $headerDiv.addClass('active');
+                            $body.find('div.kb-side-tab3').css('display', 'none');
+                            $body.find('div:nth-child(' + (idx + 1) + ').kb-side-tab3').css('display', '');
+                        }
+                    }, this));
+                }
+                require([inputWidgetName], function(InputWidget) {
+                    // var wig = $inputDiv[inputWidgetName]({ method: methodJson, isInSidePanel: true });
+                    var wig = new InputWidget($inputDiv, { method: methodJson, isInSidePanel: true });
+                    self.inputWidget[methodId] = wig;
 
-        runImport: function(methods, tag) {
-            var self = this;
-            var methodId = self.getSelectedTabId();
-            var methodSpec = methods[methodId];
+                    var onChange = function() {
+                        var w = self.getInputWidget();
+                        if (!w) { return };
 
-            var paramValueArray = self.getInputWidget().getParameters();
-            var params = {};
-            for (var i in methodSpec.parameters) {
-                var paramId = methodSpec.parameters[i].id;
-                var paramValue = paramValueArray[i];
-                params[paramId] = paramValue;
-            }
-            var pythonCode = PythonInterop.buildAppRunner(null, null,
-                    {tag: tag, version: null, id: methodId}, params);
-            pythonCode += ".job_id.encode('ascii','ignore')";
-            var callbacks = {
+                        if (self.timer)
+                            return;
+                        var v = w.isValid();
+                        if (v.isValid) {
+                            self.showInfo('All parameters are valid and you can start "Import" now');
+                        } else {
+                            self.showInfo('You can start "Import" when all parameters are ready (marked by green check)');
+                        }
+                    };
+                    var paramValues = wig.getAllParameterValues();
+                    for (var paramPos in paramValues) {
+                        var paramId = paramValues[paramPos].id;
+                        wig.addInputListener(paramId, onChange);
+                    }
+
+                    self.tabs[methodId] = tab;
+                }, function(error) {
+                    alert(error);
+                });
+            },
+
+            getSelectedTabId: function() {
+                var ret = null;
+                for (var tabId in this.tabs) {
+                    var tab = this.tabs[tabId];
+                    if (tab.is(':visible'))
+                        ret = tabId;
+                }
+                return ret;
+            },
+
+            getInputWidget: function() {
+                return this.inputWidget[this.getSelectedTabId()];
+            },
+
+            back: function() {
+                var self = this;
+                if (self.timer != null) {
+                    self.$warningModalContent.empty();
+                    self.$warningModalContent.append(
+                        $('<div>').addClass('kb-app-step-error-mssg')
+                        .append('Import process is not finished yet. Are you sure you want to stop watching it?'));
+                    self.$warningModal.modal('show');
+                    return;
+                }
+                this.infoPanel.empty();
+                this.widgetPanelCard2.css('display', 'none');
+                this.widgetPanelCard1.css('display', '');
+            },
+
+            createImportStatusCell: function(methodName, jobId) {
+                var cellIndex = Jupyter.notebook.get_selected_index();
+                var cell = Jupyter.notebook.insert_cell_below('code', cellIndex);
+                $(cell.element).trigger('toggleCodeArea.cell');
+                var title = 'Import job status for ' + methodName;
+                var cellText = ['from biokbase.narrative.jobs.jobmanager import JobManager',
+                    'JobManager().get_job(' + jobId + ')'
+                ].join('\n');
+                cell.set_text(cellText);
+                $([Jupyter.events]).trigger('inserted.Cell', {
+                    cell: cell,
+                    kbase: {
+                        type: 'code',
+                        language: 'python',
+                        title: title
+                    }
+                });
+                // var meta = {
+                //     'kbase': {
+                //         'attributes': {
+                //             'title': title
+                //         },
+                //         'type': 'code'
+                //     }
+                // };
+                // cell.metadata = meta;
+                cell.events.one('output_appended.OutputArea', function() {
+                    Jupyter.narrative.saveNarrative();
+                });
+                cell.execute();
+                Jupyter.narrative.hideOverlay();
+                this.showInfo(''); // clear the info message when we close the overlay
+                Jupyter.narrative.scrollToCell(cell, true);
+                this.back();
+            },
+
+            runImport: function(methods, tag) {
+                var self = this;
+                var methodId = self.getSelectedTabId();
+                var methodSpec = methods[methodId];
+
+                var paramValueArray = self.getInputWidget().getParameters();
+                var params = {};
+                for (var i in methodSpec.parameters) {
+                    var paramId = methodSpec.parameters[i].id;
+                    var paramValue = paramValueArray[i];
+                    params[paramId] = paramValue;
+                }
+                var pythonCode = PythonInterop.buildAppRunner(null, null, { tag: tag, version: null, id: methodId }, params);
+                pythonCode += '.job_id.encode(\'ascii\',\'ignore\')';
+                var callbacks = {
                     shell: {
                         reply: function(content) {},
                         payload: { set_next_input: function(content) {} }
@@ -569,67 +583,67 @@ define (
                         clear_output: function(content) {}
                     },
                     input: function(content) {}
-            };
-            var executeOptions = {
+                };
+                var executeOptions = {
                     silent: false,
                     user_expressions: {},
                     allow_stdin: false,
                     store_history: false
-            };
-            Jupyter.notebook.kernel.execute(pythonCode, callbacks, executeOptions);
-            self.showInfo("Your import job is being submitted and you will be directed to it shortly.");
-        },
+                };
+                Jupyter.notebook.kernel.execute(pythonCode, callbacks, executeOptions);
+                self.showInfo('Your import job is being submitted and you will be directed to it shortly.');
+            },
 
-        asBool: function(val) {
-            if (!val)
-                return false;
-            return (val == 1 || val === "1");
-        },
+            asBool: function(val) {
+                if (!val)
+                    return false;
+                return (val == 1 || val === '1');
+            },
 
-        asInt: function(val) {
-            if (!val)
+            asInt: function(val) {
+                if (!val)
+                    return 0;
+                if (val == 1 || val === '1')
+                    return 1;
                 return 0;
-            if (val == 1 || val === "1")
-                return 1;
-            return 0;
-        },
+            },
 
-        stopTimer: function() {
-            var self = this;
-            if (self.timer != null) {
-                clearInterval(self.timer);
-                self.timer = null;
+            stopTimer: function() {
+                var self = this;
+                if (self.timer != null) {
+                    clearInterval(self.timer);
+                    self.timer = null;
+                }
+            },
+
+            showError: function(error) {
+                console.log(error);
+                if (typeof error === 'object' && error.error) {
+                    error = error.error;
+                    if (typeof error === 'object' && error.message)
+                        error = error.message;
+                }
+                this.infoPanel.empty();
+                this.infoPanel.append('<pre style="text-align: left; background-color: #ffe0e0;">Error:\n' + error + '</pre>');
+            },
+
+            showInfo: function(message, spinner) {
+                if (spinner)
+                    message = '<img src="' + this.loadingImage + '"/> ' + message;
+                this.infoPanel.empty();
+                this.infoPanel.append(message);
+            },
+
+            loggedInCallback: function(event, auth) {
+                this.token = auth.token;
+                this.render();
+                return this;
+            },
+
+            loggedOutCallback: function(event) {
+                this.token = null;
+                this.render();
+                return this;
             }
-        },
-
-        showError: function(error) {
-            console.log(error);
-            if (typeof error === 'object' && error.error) {
-                error = error.error;
-                if (typeof error === 'object' && error.message)
-                    error = error.message;
-            }
-            this.infoPanel.empty();
-            this.infoPanel.append('<pre style="text-align: left; background-color: #ffe0e0;">Error:\n'+error+'</pre>');
-        },
-
-        showInfo: function(message, spinner) {
-            if (spinner)
-                message = '<img src="'+this.loadingImage+'"/> ' + message;
-            this.infoPanel.empty();
-            this.infoPanel.append(message);
-        },
-
-        loggedInCallback: function(event, auth) {
-            this.token = auth.token;
-            this.render();
-            return this;
-        },
-
-        loggedOutCallback: function(event) {
-            this.token = null;
-            this.render();
-            return this;
-        }
+        });
     });
-});

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -1,423 +1,414 @@
 /*global define*/
 /*jslint white: true*/
-define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
-		'narrativeConfig',
-		'jqueryui',
-		'kbaseNarrativeDataPanel',
-		'kbaseNarrativeAppPanel',
-		'kbaseNarrativeManagePanel',
-		'kbaseNarrativeJobsPanel',
-		'kbaseNarrative'
-	], function(
-		KBWidget,
-		bootstrap,
-		$,
-		Config,
-		jqueryui,
-		kbaseNarrativeDataPanel,
-		kbaseNarrativeAppPanel,
-		kbaseNarrativeManagePanel,
-		kbaseNarrativeJobsPanel,
-		kbaseNarrative
-	) {
-    'use strict';
-    return KBWidget({
-        name: 'kbaseNarrativeSidePanel',
+define(
+    [
+        'kbwidget',
+        'bootstrap',
+        'jquery',
+        'narrativeConfig',
+        'jqueryui',
+        'kbaseNarrativeDataPanel',
+        'kbaseNarrativeAppPanel',
+        'kbaseNarrativeManagePanel',
+        'kbaseNarrativeJobsPanel',
+        'kbaseNarrative'
+    ],
+    function(
+        KBWidget,
+        bootstrap,
+        $,
+        Config,
+        jqueryui,
+        kbaseNarrativeDataPanel,
+        kbaseNarrativeAppPanel,
+        kbaseNarrativeManagePanel,
+        kbaseNarrativeJobsPanel,
+        kbaseNarrative
+    ) {
+        'use strict';
+        return KBWidget({
+            name: 'kbaseNarrativeSidePanel',
 
-        options: {
-            loadingImage: Config.get('loading_gif'),
-            autorender: true,
-            workspaceURL: Config.url('workspace'),
-        },
-        $dataWidget: null,
-        dataWidgetListHeight: [340, 680], // [height with methods showing, max height], overwritten on window size change
-        $methodsWidget: null,
-        methodsWidgetListHeight: [300, 600], // [height with data showing, max height]
+            options: {
+                loadingImage: Config.get('loading_gif'),
+                autorender: true,
+                workspaceURL: Config.url('workspace'),
+            },
+            $dataWidget: null,
+            dataWidgetListHeight: [340, 680], // [height with methods showing, max height], overwritten on window size change
+            $methodsWidget: null,
+            methodsWidgetListHeight: [300, 600], // [height with data showing, max height]
 
-        heightListOffset: 220,  // in px, space taken up by titles, header bar, etc.  The rest of the real estate is divided
-                                // by half for for the method and data lists
-        heightPanelOffset: 110, // in px, space taken by just the header, the rest is for the full panel size, which is the
-                                // case for the narratives/jobs panels
-        $narrativesWidget: null,
-        $jobsWidget: null,
-        $overlay: null,
+            heightListOffset: 220, // in px, space taken up by titles, header bar, etc.  The rest of the real estate is divided
+            // by half for for the method and data lists
+            heightPanelOffset: 110, // in px, space taken by just the header, the rest is for the full panel size, which is the
+            // case for the narratives/jobs panels
+            $narrativesWidget: null,
+            $jobsWidget: null,
+            $overlay: null,
 
-        hideButtonSize: 4, //percent width
+            hideButtonSize: 4, //percent width
 
-        /**
-         * Does the initial panel layout - tabs and spots for each widget
-         * It then instantiates them, but not until told to render (unless autorender = true)
-         */
-        init: function(options) {
-            this._super(options);
-            var analysisWidgets = this.buildPanelSet([
-                {
-                    name : 'kbaseNarrativeDataPanel',
-                    params : {
-                        collapseCallback: $.proxy(function(isMinimized) {
+            /**
+             * Does the initial panel layout - tabs and spots for each widget
+             * It then instantiates them, but not until told to render (unless autorender = true)
+             */
+            init: function(options) {
+                this._super(options);
+                var analysisWidgets = this.buildPanelSet([{
+                        name: 'kbaseNarrativeDataPanel',
+                        params: {
+                            collapseCallback: $.proxy(function(isMinimized) {
                                 this.handleMinimizedDataPanel(isMinimized);
-                            }
-                            ,this)
-                    }
-                },
-                {
-                    name : 'kbaseNarrativeAppPanel',
-                    params : {
-                        autopopulate: false ,
-                        collapseCallback: $.proxy(function(isMinimized) {
+                            }, this)
+                        }
+                    },
+                    {
+                        name: 'kbaseNarrativeAppPanel',
+                        params: {
+                            autopopulate: false,
+                            collapseCallback: $.proxy(function(isMinimized) {
                                 this.handleMinimizedMethodPanel(isMinimized);
-                            }
-                            ,this)
+                            }, this)
+                        }
                     }
-                }
-            ]);
-            this.$dataWidget = analysisWidgets['kbaseNarrativeDataPanel'];
-            this.$methodsWidget = analysisWidgets['kbaseNarrativeAppPanel'];
+                ]);
+                this.$dataWidget = analysisWidgets['kbaseNarrativeDataPanel'];
+                this.$methodsWidget = analysisWidgets['kbaseNarrativeAppPanel'];
 
-            var $analysisPanel = analysisWidgets['panelSet'];
+                var $analysisPanel = analysisWidgets['panelSet'];
 
-            var manageWidgets = this.buildPanelSet([
-                {
-                    name : 'kbaseNarrativeManagePanel',
-                    params : { autopopulate: true, showTitle: false }
-                },
-            ]);
+                var manageWidgets = this.buildPanelSet([{
+                    name: 'kbaseNarrativeManagePanel',
+                    params: { autopopulate: true, showTitle: false }
+                }, ]);
 
-            this.$narrativesWidget = manageWidgets['kbaseNarrativeManagePanel'];
-            var $managePanel = manageWidgets['panelSet'];
+                this.$narrativesWidget = manageWidgets['kbaseNarrativeManagePanel'];
+                var $managePanel = manageWidgets['panelSet'];
 
-            var jobsWidget = this.buildPanelSet([
-                {
-                    name : 'kbaseNarrativeJobsPanel',
-                    params : { autopopulate: true, showTitle: false }
-                }
-            ]);
-            this.$jobsWidget = jobsWidget['kbaseNarrativeJobsPanel'];
-            var $jobsPanel = jobsWidget['panelSet'];
+                var jobsWidget = this.buildPanelSet([{
+                    name: 'kbaseNarrativeJobsPanel',
+                    params: { autopopulate: true, showTitle: false }
+                }]);
+                this.$jobsWidget = jobsWidget['kbaseNarrativeJobsPanel'];
+                var $jobsPanel = jobsWidget['panelSet'];
 
-            this.$tabs = this.buildTabs([
-                {
-                    tabName : 'Analyze',
-                    content : $analysisPanel
-                },
-                {
-                    tabName : 'Narratives',
-                    content: $managePanel
-                },
-                // {
-                //     tabName : this.$jobsWidget.title,
-                //     content: $jobsPanel
-                // }
-            ], true);
+                this.$tabs = this.buildTabs([{
+                        tabName: 'Analyze',
+                        content: $analysisPanel
+                    },
+                    {
+                        tabName: 'Narratives',
+                        content: $managePanel
+                    },
+                    // {
+                    //     tabName : this.$jobsWidget.title,
+                    //     content: $jobsPanel
+                    // }
+                ], true);
 
-            this.$elem.addClass('kb-side-panel');
-            this.$elem.append(this.$tabs.header)
-                      .append(this.$tabs.body);
+                this.$elem.addClass('kb-side-panel');
+                this.$elem.append(this.$tabs.header)
+                    .append(this.$tabs.body);
 
-            $(document).on('showSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
-                this.showOverlay(panel);
-            }, this));
-
-            $(document).on('hideSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
-                this.hideOverlay(panel);
-            }, this));
-
-            $(document).on('toggleSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
-                this.toggleOverlay(panel);
-            }, this));
-
-            // handle window size change in left panel, and call it once to set the correct size now
-            $(window).on('resize',$.proxy(function() { this.windowSizeChange(); }, this));
-            this.windowSizeChange();
-
-            if (this.autorender) {
-                this.render();
-            }
-            else {
-
-            }
-
-
-            return this;
-        },
-
-        /**
-         * @method
-         * @public
-         * A bit of a hack. Set a specific read-only mode where we don't see the jobs or methods panel,
-         * only the data panel and narratives panel.
-         * So we need to remove the 'Jobs' header all together, then hide the methods panel,
-         * and expand the data panel to fill the screen
-         */
-        setReadOnlyMode: function(readOnly) {
-            // toggle off the methods and jobs panels
-            this.$methodsWidget.$elem.toggle(!readOnly);
-            // this.$jobsWidget.$elem.toggle(!readOnly);
-
-            // toggle off the jobs header
-            // this.$tabs.header.find('div:nth-child(4).kb-side-header').toggle(!readOnly); // hide the jobs header
-            // this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? ((100-this.hideButtonSize)/2)+'%' : ((100-this.hideButtonSize)/3)+'%')});
-
-            this.$dataWidget.setReadOnlyMode(readOnly);
-            this.handleMinimizedMethodPanel(readOnly);
-        },
-
-        /**
-         * @method
-         * @private
-         * Builds a very simple set of tabs.
-         * @param {Array} tabs - a list of objects where each has a 'tabName' and 'content' property.
-         * As you might expect, 'tabName' is the name of the tab that goes into the styled header,
-         * and 'content' is the tab content, expected to be something that can be attached via .append()
-         * @param isOuter - if true, treat these tabs as though they belong to the outer side panel,
-         * not to an inner set of tabs. That is, when any new tab is selected, it hides the overlay,
-         * if it's open.
-         */
-        buildTabs: function(tabs, isOuter) {
-            var $header = $('<div>');
-            var $body = $('<div>');
-
-            $header.append($('<div>')
-                           .addClass('kb-side-toggle')
-                           .css('width', this.hideButtonSize + '%')
-                           .append($('<span>')
-                                   .addClass('fa fa-caret-left'))
-                           .click(function() {
-                               Jupyter.narrative.toggleSidePanel();
-                           }));
-            for (var i=0; i<tabs.length; i++) {
-                var tab = tabs[i];
-                $header.append($('<div>')
-                               .addClass('kb-side-header')
-                               .css('width', ((100-this.hideButtonSize)/tabs.length)+'%')
-                               .append(tab.tabName)
-                               .attr('kb-data-id', i));
-                $body.append($('<div>')
-                             .addClass('kb-side-tab')
-                             .append(tab.content)
-                             .attr('kb-data-id', i));
-            }
-
-            $header.find('div[kb-data-id]').click($.proxy(function(event) {
-                var $headerDiv = $(event.currentTarget);
-
-                if (!$headerDiv.hasClass('active')) {
-                    var idx = $headerDiv.attr('kb-data-id');
-                    $header.find('div').removeClass('active');
-                    $headerDiv.addClass('active');
-                    $body.find('div.kb-side-tab').removeClass('active');
-                    // $body.find('div:nth-child(' + (idx+1) + ').kb-side-tab').addClass('active');
-                    $body.find('[kb-data-id=' + idx + ']').addClass('active');
-                    if (isOuter)
-                        this.hideOverlay();
-                }
-            }, this));
-
-            $header.find('div:nth-child(2)').addClass('active');
-            $body.find('div:first-child.kb-side-tab').addClass('active');
-
-            return {
-                header: $header,
-                body: $body
-            };
-        },
-
-        initOverlay: function() {
-            var self = this;
-
-            this.$overlayBody = $('<div class="kb-overlay-body">');
-            this.$overlayFooter  = $('<div class="kb-overlay-footer">');
-            this.$overlay = $('<div>')
-                            .addClass('kb-side-overlay-container');
-                            //.append(this.$overlayBody)
-                            //.append(this.$overlayFooter);
-
-            $('body').append(this.$overlay);
-            this.$overlay.hide();
-
-            this.$narrativeDimmer = $('<div>')
-                                    .addClass('kb-overlay-dimmer');
-
-            $('body').append(this.$narrativeDimmer);
-            this.$narrativeDimmer.hide();
-            this.updateOverlayPosition();
-
-            // hide panel when clicking outside
-            this.$narrativeDimmer.unbind('click');
-            this.$narrativeDimmer.click(function() {
-                self.hideOverlay();
-            });
-        },
-
-        updateOverlayPosition: function() {
-            this.$overlay.position({my: 'left top', at: 'right top', of: this.$elem});
-            this.$narrativeDimmer.position({my: 'left top', at: 'right top', of: this.$elem});
-        },
-
-        /**
-         * @method
-         * @public
-         * Also available through a trigger - 'toggleSidePanelOverlay.Narrative'
-         * The behavior here is done in three cases.
-         * 1. If the overlay is currently visible, it gets hidden.
-         * 1a. If there is a panel given, and it is different from the currently attached panel, then
-         *     the new panel is attached and the overlay is redisplayed.
-         * 2. If the overlay is currently hidden, it is shown with the given panel.
-         */
-        toggleOverlay: function(panel) {
-            if (this.$overlay.is(':visible')) {
-                this.hideOverlay();
-                if (panel && panel !== this.currentPanel) {
+                $(document).on('showSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
                     this.showOverlay(panel);
-                }
-            }
-            else
-                this.showOverlay(panel);
-        },
-
-        showOverlay: function(panel) {
-            if (this.$overlay) {
-                if (panel) {
-                    if (this.currentPanel)
-                        $(this.currentPanel).detach();
-                    this.$overlay.append(panel);
-                    this.currentPanel = panel;
-                }
-                Jupyter.narrative.disableKeyboardManager();
-                this.$narrativeDimmer.show();
-                this.$elem.find('.kb-side-header, .kb-side-toggle').addClass('kb-overlay-active');
-                this.$overlay.show('slide', 'fast', $.proxy(function() {
-                    this.trigger('sidePanelOverlayShown.Narrative');
                 }, this));
-            }
-        },
 
-        hideOverlay: function() {
-            if (this.$overlay) {
-                Jupyter.narrative.enableKeyboardManager();
-                this.$narrativeDimmer.hide();
-                this.$elem.find('.kb-side-header, .kb-side-toggle').removeClass('kb-overlay-active');
-                this.$overlay.hide('slide', 'fast', $.proxy(function() {
-                    this.trigger('sidePanelOverlayHidden.Narrative');
+                $(document).on('hideSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
+                    this.hideOverlay(panel);
                 }, this));
-            }
-        },
 
-        /**
-         * Builds the general structure for a panel set.
-         * These are intended to start with 2 panels, but we can move from there if needed.
-         *
-         * (I'll jsdoc this up in a bit)
-         * widgets = [
-         *     {
-         *         name: kbaseNarrativeDataPanel (for instance)
-         *         params: {}
-         *     }
-         * ]
-         * @param {object} widgets
-         *
-         */
-        buildPanelSet: function(widgets) {
-            var $panelSet = $('<div>')
-                            .addClass('kb-narr-side-panel-set');
-            if (!widgets || Object.prototype.toString.call(widgets) !== '[object Array]' || widgets.length === 0)
-                return $panelSet;
+                $(document).on('toggleSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
+                    this.toggleOverlay(panel);
+                }, this));
 
-            var height = 100 / widgets.length;
-            var minHeight = 200;
+                // handle window size change in left panel, and call it once to set the correct size now
+                $(window).on('resize', $.proxy(function() { this.windowSizeChange(); }, this));
+                this.windowSizeChange();
 
-            var retObj = {};
-            for (var i=0; i<widgets.length; i++) {
-                var widgetInfo = widgets[i];
-                var $widgetDiv = $('<div>')
-                                 .addClass('kb-side-separator')
-                                 .css({'height' : height + '%'});
+                if (this.autorender) {
+                    this.render();
+                } else {
 
-                var constructor_mapping = {
-                    'kbaseNarrativeDataPanel' : kbaseNarrativeDataPanel,
-                    'kbaseNarrativeAppPanel' : kbaseNarrativeAppPanel,
-                    'kbaseNarrativeManagePanel' : kbaseNarrativeManagePanel,
-                    'kbaseNarrativeJobsPanel' : kbaseNarrativeJobsPanel,
+                }
+
+
+                return this;
+            },
+
+            /**
+             * @method
+             * @public
+             * A bit of a hack. Set a specific read-only mode where we don't see the jobs or methods panel,
+             * only the data panel and narratives panel.
+             * So we need to remove the 'Jobs' header all together, then hide the methods panel,
+             * and expand the data panel to fill the screen
+             */
+            setReadOnlyMode: function(readOnly) {
+                // toggle off the methods and jobs panels
+                // this.$methodsWidget.$elem.toggle(!readOnly);
+                // this.$jobsWidget.$elem.toggle(!readOnly);
+
+                // toggle off the jobs header
+                // this.$tabs.header.find('div:nth-child(4).kb-side-header').toggle(!readOnly); // hide the jobs header
+                // this.$tabs.header.find('div.kb-side-header').css({'width': (readOnly ? ((100-this.hideButtonSize)/2)+'%' : ((100-this.hideButtonSize)/3)+'%')});
+
+                this.$dataWidget.setReadOnlyMode(readOnly);
+                // this.handleMinimizedMethodPanel(readOnly);
+            },
+
+            /**
+             * @method
+             * @private
+             * Builds a very simple set of tabs.
+             * @param {Array} tabs - a list of objects where each has a 'tabName' and 'content' property.
+             * As you might expect, 'tabName' is the name of the tab that goes into the styled header,
+             * and 'content' is the tab content, expected to be something that can be attached via .append()
+             * @param isOuter - if true, treat these tabs as though they belong to the outer side panel,
+             * not to an inner set of tabs. That is, when any new tab is selected, it hides the overlay,
+             * if it's open.
+             */
+            buildTabs: function(tabs, isOuter) {
+                var $header = $('<div>');
+                var $body = $('<div>');
+
+                $header.append($('<div>')
+                    .addClass('kb-side-toggle')
+                    .css('width', this.hideButtonSize + '%')
+                    .append($('<span>')
+                        .addClass('fa fa-caret-left'))
+                    .click(function() {
+                        Jupyter.narrative.toggleSidePanel();
+                    }));
+                for (var i = 0; i < tabs.length; i++) {
+                    var tab = tabs[i];
+                    $header.append($('<div>')
+                        .addClass('kb-side-header')
+                        .css('width', ((100 - this.hideButtonSize) / tabs.length) + '%')
+                        .append(tab.tabName)
+                        .attr('kb-data-id', i));
+                    $body.append($('<div>')
+                        .addClass('kb-side-tab')
+                        .append(tab.content)
+                        .attr('kb-data-id', i));
+                }
+
+                $header.find('div[kb-data-id]').click($.proxy(function(event) {
+                    var $headerDiv = $(event.currentTarget);
+
+                    if (!$headerDiv.hasClass('active')) {
+                        var idx = $headerDiv.attr('kb-data-id');
+                        $header.find('div').removeClass('active');
+                        $headerDiv.addClass('active');
+                        $body.find('div.kb-side-tab').removeClass('active');
+                        // $body.find('div:nth-child(' + (idx+1) + ').kb-side-tab').addClass('active');
+                        $body.find('[kb-data-id=' + idx + ']').addClass('active');
+                        if (isOuter)
+                            this.hideOverlay();
+                    }
+                }, this));
+
+                $header.find('div:nth-child(2)').addClass('active');
+                $body.find('div:first-child.kb-side-tab').addClass('active');
+
+                return {
+                    header: $header,
+                    body: $body
                 };
-                retObj[widgetInfo.name] = new constructor_mapping[widgetInfo.name]($widgetDiv, widgetInfo.params);
-                $panelSet.append($widgetDiv);
+            },
+
+            initOverlay: function() {
+                var self = this;
+
+                this.$overlayBody = $('<div class="kb-overlay-body">');
+                this.$overlayFooter = $('<div class="kb-overlay-footer">');
+                this.$overlay = $('<div>')
+                    .addClass('kb-side-overlay-container');
+                //.append(this.$overlayBody)
+                //.append(this.$overlayFooter);
+
+                $('body').append(this.$overlay);
+                this.$overlay.hide();
+
+                this.$narrativeDimmer = $('<div>')
+                    .addClass('kb-overlay-dimmer');
+
+                $('body').append(this.$narrativeDimmer);
+                this.$narrativeDimmer.hide();
+                this.updateOverlayPosition();
+
+                // hide panel when clicking outside
+                this.$narrativeDimmer.unbind('click');
+                this.$narrativeDimmer.click(function() {
+                    self.hideOverlay();
+                });
+            },
+
+            updateOverlayPosition: function() {
+                this.$overlay.position({ my: 'left top', at: 'right top', of: this.$elem });
+                this.$narrativeDimmer.position({ my: 'left top', at: 'right top', of: this.$elem });
+            },
+
+            /**
+             * @method
+             * @public
+             * Also available through a trigger - 'toggleSidePanelOverlay.Narrative'
+             * The behavior here is done in three cases.
+             * 1. If the overlay is currently visible, it gets hidden.
+             * 1a. If there is a panel given, and it is different from the currently attached panel, then
+             *     the new panel is attached and the overlay is redisplayed.
+             * 2. If the overlay is currently hidden, it is shown with the given panel.
+             */
+            toggleOverlay: function(panel) {
+                if (this.$overlay.is(':visible')) {
+                    this.hideOverlay();
+                    if (panel && panel !== this.currentPanel) {
+                        this.showOverlay(panel);
+                    }
+                } else
+                    this.showOverlay(panel);
+            },
+
+            showOverlay: function(panel) {
+                if (this.$overlay) {
+                    if (panel) {
+                        if (this.currentPanel)
+                            $(this.currentPanel).detach();
+                        this.$overlay.append(panel);
+                        this.currentPanel = panel;
+                    }
+                    Jupyter.narrative.disableKeyboardManager();
+                    this.$narrativeDimmer.show();
+                    this.$elem.find('.kb-side-header, .kb-side-toggle').addClass('kb-overlay-active');
+                    this.$overlay.show('slide', 'fast', $.proxy(function() {
+                        this.trigger('sidePanelOverlayShown.Narrative');
+                    }, this));
+                }
+            },
+
+            hideOverlay: function() {
+                if (this.$overlay) {
+                    Jupyter.narrative.enableKeyboardManager();
+                    this.$narrativeDimmer.hide();
+                    this.$elem.find('.kb-side-header, .kb-side-toggle').removeClass('kb-overlay-active');
+                    this.$overlay.hide('slide', 'fast', $.proxy(function() {
+                        this.trigger('sidePanelOverlayHidden.Narrative');
+                    }, this));
+                }
+            },
+
+            /**
+             * Builds the general structure for a panel set.
+             * These are intended to start with 2 panels, but we can move from there if needed.
+             *
+             * (I'll jsdoc this up in a bit)
+             * widgets = [
+             *     {
+             *         name: kbaseNarrativeDataPanel (for instance)
+             *         params: {}
+             *     }
+             * ]
+             * @param {object} widgets
+             *
+             */
+            buildPanelSet: function(widgets) {
+                var $panelSet = $('<div>')
+                    .addClass('kb-narr-side-panel-set');
+                if (!widgets || Object.prototype.toString.call(widgets) !== '[object Array]' || widgets.length === 0)
+                    return $panelSet;
+
+                var height = 100 / widgets.length;
+                var minHeight = 200;
+
+                var retObj = {};
+                for (var i = 0; i < widgets.length; i++) {
+                    var widgetInfo = widgets[i];
+                    var $widgetDiv = $('<div>')
+                        .addClass('kb-side-separator')
+                        .css({ 'height': height + '%' });
+
+                    var constructor_mapping = {
+                        'kbaseNarrativeDataPanel': kbaseNarrativeDataPanel,
+                        'kbaseNarrativeAppPanel': kbaseNarrativeAppPanel,
+                        'kbaseNarrativeManagePanel': kbaseNarrativeManagePanel,
+                        'kbaseNarrativeJobsPanel': kbaseNarrativeJobsPanel,
+                    };
+                    retObj[widgetInfo.name] = new constructor_mapping[widgetInfo.name]($widgetDiv, widgetInfo.params);
+                    $panelSet.append($widgetDiv);
+                }
+                retObj['panelSet'] = $panelSet;
+                return retObj;
+            },
+
+
+            /**
+             * Specialized callback controlling heights of panels when data panel is minimized.
+             * Assumes data and method panel are on the same tab.
+             */
+            handleMinimizedDataPanel: function(isMinimized) {
+                if (isMinimized) {
+                    // data panel was minimized
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1], true);
+                } else {
+                    // data panel was maximized
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0], true);
+                }
+            },
+
+            /**
+             * Specialized callback controlling heights of panels when method panel is minimized.
+             * Assumes data and method panel are on the same tab.
+             */
+            handleMinimizedMethodPanel: function(isMinimized) {
+                if (isMinimized) {
+                    // data panel was minimized
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[1], true);
+                } else {
+                    // data panel was maximized
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[0], true);
+                }
+            },
+
+
+            windowSizeChange: function() {
+
+                // determine height of panels, and set the bounds
+                var $window = $(window);
+                var h = $window.height();
+
+                if (h < 300) { // below a height of 300px, don't trim anymore, just let the rest be clipped
+                    h = 300;
+                }
+                var max = h - this.heightListOffset;
+                var min = (h - this.heightListOffset) / 2;
+                this.methodsWidgetListHeight[0] = min;
+                this.methodsWidgetListHeight[1] = max;
+                this.dataWidgetListHeight[0] = min;
+                this.dataWidgetListHeight[1] = max;
+
+                // actually update the sizes
+                if (this.$methodsWidget.isMinimized()) {
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[1]);
+                } else {
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[0]);
+                }
+                if (this.$dataWidget.isMinimized()) {
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1]);
+                } else {
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0]);
+                }
+
+                var fullSize = h - this.heightPanelOffset;
+                this.$narrativesWidget.setHeight(fullSize);
+                this.$jobsWidget.setHeight(fullSize);
+            },
+
+
+            render: function() {
+                this.initOverlay();
+                // this.$methodsWidget.refreshFromService();
             }
-            retObj['panelSet'] = $panelSet;
-            return retObj;
-        },
 
-
-        /**
-         * Specialized callback controlling heights of panels when data panel is minimized.
-         * Assumes data and method panel are on the same tab.
-         */
-        handleMinimizedDataPanel: function(isMinimized) {
-            if(isMinimized) {
-                // data panel was minimized
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1], true);
-            } else {
-                // data panel was maximized
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0], true);
-            }
-        },
-
-        /**
-         * Specialized callback controlling heights of panels when method panel is minimized.
-         * Assumes data and method panel are on the same tab.
-         */
-        handleMinimizedMethodPanel: function(isMinimized) {
-            if(isMinimized) {
-                // data panel was minimized
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[1], true);
-            } else {
-                // data panel was maximized
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[0], true);
-            }
-        },
-
-
-        windowSizeChange: function() {
-
-            // determine height of panels, and set the bounds
-            var $window = $(window);
-            var h = $window.height();
-
-            if(h<300) { // below a height of 300px, don't trim anymore, just let the rest be clipped
-                h = 300;
-            }
-            var max = h - this.heightListOffset;
-            var min = (h-this.heightListOffset)/2;
-            this.methodsWidgetListHeight[0]=min;
-            this.methodsWidgetListHeight[1]=max;
-            this.dataWidgetListHeight[0]=min;
-            this.dataWidgetListHeight[1]=max;
-
-            // actually update the sizes
-            if(this.$methodsWidget.isMinimized()) {
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[1]);
-            } else {
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[0]);
-            }
-            if(this.$dataWidget.isMinimized()) {
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1]);
-            } else {
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0]);
-            }
-
-            var fullSize = h - this.heightPanelOffset;
-            this.$narrativesWidget.setHeight(fullSize);
-            this.$jobsWidget.setHeight(fullSize);
-        },
-
-
-        render: function() {
-            this.initOverlay();
-            // this.$methodsWidget.refreshFromService();
-        }
-
-    })
-});
+        })
+    });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -46,8 +46,9 @@ define([
     'common/props',
     'kb_service/client/narrativeMethodStore',
     'text!kbase/templates/report_error_button.html',
+
     'bootstrap'
-], function(
+], function (
     Jupyter,
     Runtime,
     UI,
@@ -85,9 +86,9 @@ define([
         },
         ws_client: null,
         ws_id: null,
-        defaultOutputWidget: "kbaseDefaultNarrativeOutput",
-        defaultInputWidget: "kbaseDefaultNarrativeInput",
-        errorWidget: "kbaseNarrativeError",
+        defaultOutputWidget: 'kbaseDefaultNarrativeOutput',
+        defaultInputWidget: 'kbaseDefaultNarrativeInput',
+        errorWidget: 'kbaseNarrativeError',
         connectable: {},
 
         inputsRendered: false,
@@ -116,14 +117,52 @@ define([
             'a number': 1
         },
 
-        init: function(options) {
+        init: function (options) {
             this._super(options);
             this.ws_id = this.options.ws_id;
             this.runtime = Runtime.make();
 
+            // The readOnly flag, and the sister setting readonly,
+            // is strictly associated with the the jupyter writable state.
+            // See uiMode for the runtime reconfigurable and related setting.
+            // This property is only set in accordance with the Jupyter.notebook.writable property.
+            // It is set here, at the outset, and also in a listener for the
+            // 'updateReadOnlyMode.Narrative' jquery event, which, as far as I can tell
+            // is not issued anywhere in the system. The effect of this would be to 
+            // cause a narrative to flip from edit->view or view->edit while a user is
+            // engaged with the narrative. This seems like a jarring experience, and would 
+            // certainly need some ui mechanism like a dialog to explain what is happening 
+            // to the user.
+            // So, effectively, this is a constant.
             this.narrativeIsReadOnly = !Jupyter.notebook.writable;
+
+            // This value is available through the Jupyter.narrative api.
+            // Funny thing is, Jupyter.narrative is an instance of kbaseNarrative which
+            // in turn contains an instance of kbaseNarrativeWorkspace, which is probably
+            // this very object!
+            // Still, consumers of the Jupyter.narrative api will expect this to be there.
             Jupyter.narrative.readonly = this.narrativeIsReadOnly;
-            this.inReadOnlyMode = false;
+
+            // The "inReadOnlyMode" is the user-configurable setting for this.
+            // TODO: it should be renamed to something else. It is confusing to have
+            // the permanent "not writable == narrativeIsReadOnly == readonly"  setting, 
+            // which reflects the (during this runtime session) permanent state of the 
+            // narrative.
+            // this.inReadOnlyMode = false;
+
+            // isViewMode is really a cheap way of representing edit mode.
+            // If false, the mode is 'edit', if true the mode is 'view'.
+            // If there were more than two modes, we would need to store this as 
+            // another type of value -- string or number.
+            // this.isViewMode = false;
+            // uiMode is one of 'edit', view'.
+            // A string enum, because although we have two ui states now, 
+            // edit, which basically follows read-write 
+            // view, which shadows read-only
+            // we may have additional modes (as has been discussed) - 
+            this.uiMode = this.narrativeIsReadOnly ? 'view' : 'edit';
+            Jupyter.narrative.uiMode = this.uiMode;
+
 
             this.first_readonly = true; // still trying for first check?
             this.last_readonly_check = null; // avoid frequent checks
@@ -143,14 +182,14 @@ define([
             // Whenever the notebook gets loaded, it should rebind things.
             // This *should* only happen once, but I'm putting it here anyway.
             $([Jupyter.events]).on('notebook_loaded.Notebook',
-                function() {
+                function () {
                     this.rebindActionButtons();
                     this.hideGeneratedCodeCells();
                 }.bind(this)
             );
 
             $(document).on('dataUpdated.Narrative',
-                function() {
+                function () {
                     if (Jupyter && Jupyter.notebook) {
                         // XXX: This is a hell of a hack. I hate
                         // using the 'first time' bit like this,
@@ -173,19 +212,33 @@ define([
             );
 
             $(document).on('methodClicked.Narrative',
-                function(event, method, tag) {
+                function (event, method, tag) {
+                    if (this.uiMode === 'view') {
+                        console.warn('ignoring attempt to insert app cell in view-only mode');
+                        return;
+                    }
+
                     this.buildAppCodeCell(method, tag);
                 }.bind(this)
             );
 
             $(document).on('deleteCell.Narrative',
-                function(event, index) {
+                function (event, index) {
+                    if (this.uiMode === 'view') {
+                        console.warn('ignoring attempt to delete cell in view-only mode');
+                        return;
+                    }
+
                     this.deleteCell(index);
                 }.bind(this)
             );
 
             $(document).on('createOutputCell.Narrative',
-                function(event, data) {
+                function (event, data) {
+                    if (this.uiMode === 'view') {
+                        console.warn('ignoring attempt to create output cell in view-only mode');
+                        return;
+                    }
                     var cell = Jupyter.narrative.getCellByKbaseId(data.cellId);
                     var params = {
                         embed: true,
@@ -200,48 +253,63 @@ define([
             );
 
             $(document).on('showNextSteps.Narrative',
-                function(event, obj) {
+                function (event, obj) {
                     this.showNextSteps(obj);
                 }.bind(this)
             );
 
             $(document).on('createViewerCell.Narrative',
-                function(event, data) {
+                function (event, data) {
+                    // TODO: this.uiMode !== 'edit'
+                    if (this.uiMode === 'view') {
+                        console.warn('ignoring attempt to create viewer cell in view-only mode');
+                        return;
+                    }
                     this.createViewerCell(data.nearCellIdx, data, data.widget);
                 }.bind(this)
             );
 
             // Global functions for setting icons
             $(document).on('setDataIcon.Narrative',
-                function(e, param) {
+                function (e, param) {
                     this.setDataIcon(param.elt, param.type, param.stacked, param.indent);
                 }.bind(this)
             );
 
             // Refresh the read-only or View-only mode
-            $(document).on('updateReadOnlyMode.Narrative',
-                function(e, ws, name, callback) {
-                    this.runtime.bus().emit('read-only-changed');
-                    this.updateReadOnlyMode(ws, name, callback);
-                }.bind(this)
-            );
+            // Disabled as never used.
+            // $(document).on('updateReadOnlyMode.Narrative',
+            //     function(e, ws, name, callback) {
+            //         this.runtime.bus().emit('read-only-changed');
+            //         this.updateReadOnlyMode(ws, name, callback);
+            //     }.bind(this)
+            // );
             // related: click on edit-mode toggles state
 
 
             this.initReadOnlyElements();
 
+            // Not sure about this assymetry. The assumption I guess is that everything
+            // defaults to read-write mode, and we only need to "enter" read-only mode
+            // if need be. However, this is probably what leads to the flashing of the ui
+            // when opening read-only narratives. A better design would be to have nothing
+            // or only neutral components rendered, and then to enter edit mode or view mode.
             if (this.narrativeIsReadOnly) {
-                this.readOnlyMode(false);
+                this.enterReadOnlyMode();
             }
 
             this.initDeleteCellModal();
             return this;
         },
 
-        initReadOnlyElements: function() {
+        uiModeIs: function (modeTest) {
+            return (this.uiMode === modeTest);
+        },
+
+        initReadOnlyElements: function () {
             var reportErrorBtn = Handlebars.compile(ReportErrorBtnTmpl);
             $('#kb-view-mode')
-                .click(function() {
+                .click(function () {
                     this.toggleReadOnlyMode();
                 }.bind(this))
                 .tooltip({
@@ -266,13 +334,13 @@ define([
                     placement: 'right',
                     trigger: 'manual'
                 })
-                .on('focus', function() {
+                .on('focus', function () {
                     Jupyter.narrative.disableKeyboardManager();
                 })
-                .on('blur', function() {
+                .on('blur', function () {
                     Jupyter.narrative.enableKeyboardManager();
                 })
-                .on('input', function() {
+                .on('input', function () {
                     var v = $newNameInput.val();
                     if (!v) {
                         $newNameInput.tooltip('show');
@@ -294,25 +362,25 @@ define([
             var $doCopyBtn = $('<button>')
                 .addClass('kb-primary-btn')
                 .append('Copy')
-                .click(function(e) {
+                .click(function (e) {
                     $errorMessage.empty();
                     $doCopyBtn.prop('disabled', true);
                     $cancelBtn.prop('disabled', true);
                     $newNameInput.prop('disabled', true);
                     Jupyter.narrative.sidePanel.$narrativesWidget.copyNarrative(
-                        Jupyter.narrative.workspaceRef, $newNameInput.val()
-                    )
-                        .then(function(result) {
+                            Jupyter.narrative.workspaceRef, $newNameInput.val()
+                        )
+                        .then(function (result) {
                             Jupyter.narrative.sidePanel.$narrativesWidget.refresh();
                             // show go-to button
                             $cancelBtn.html('Close');
-                            $jumpButton.click(function() {
+                            $jumpButton.click(function () {
                                 window.location.href = result.url;
                             });
                             $jumpButton.show();
                             $cancelBtn.prop('disabled', false);
                         }.bind(this))
-                        .catch(function(error) {
+                        .catch(function (error) {
                             if (error && error.error && error.error.message) {
                                 $errorMessage.append(error.error.message);
                             } else if (typeof error === 'string') {
@@ -331,7 +399,7 @@ define([
             var $cancelBtn = $('<button>')
                 .addClass('kb-default-btn')
                 .append('Cancel')
-                .click(function() {
+                .click(function () {
                     $newNameInput.tooltip('hide');
                     this.copyModal.hide();
                 }.bind(this));
@@ -356,7 +424,7 @@ define([
                 ]
             });
 
-            $('#kb-view-only-copy').click(function() {
+            $('#kb-view-only-copy').click(function () {
                 $jumpButton.hide();
                 $doCopyBtn.prop('disabled', false);
                 $cancelBtn.prop('disabled', false);
@@ -370,7 +438,7 @@ define([
 
         },
 
-        initDeleteCellModal: function() {
+        initDeleteCellModal: function () {
             this.$deleteCellModalBody = $('<div>');
 
             var buttonList = [
@@ -383,7 +451,7 @@ define([
                 .addClass('btn btn-danger')
                 .attr('data-dismiss', 'modal')
                 .append('Delete')
-                .click(function(e) {
+                .click(function (e) {
                     if (this.cellToDelete !== undefined && this.cellToDelete !== null) {
                         var cell = Jupyter.notebook.get_cell(this.cellToDelete);
                         var removeId = $(cell.element).find('[id^=kb-cell-]').attr('id');
@@ -402,7 +470,7 @@ define([
             });
         },
 
-        showDeleteCellModal: function(index, cell, message) {
+        showDeleteCellModal: function (index, cell, message) {
             if (cell && cell.metadata[this.KB_CELL]) {
                 this.cellToDelete = index;
                 if (message) {
@@ -412,8 +480,8 @@ define([
             }
         },
 
-        buildAppCodeCell: function(spec, tag) {
-            var methodName = "Unknown method";
+        buildAppCodeCell: function (spec, tag) {
+            var methodName = 'Unknown method';
             if (!spec || !spec.info) {
                 console.error('ERROR build method code cell: ', spec, tag);
                 alert('Sorry, could not find this method');
@@ -432,11 +500,7 @@ define([
             // So, for kicks, we are using the presence of the word "view" in the
             // spec name, as well as the absence of any output paramters.
 
-            // console.log('SPEC', spec);
             var cellType = this.determineMethodCellType(spec);
-            //if (cellType === 'view') {
-            //    alert('Sorry, view cells are not yet supported');
-            // }
 
             // This will also trigger the create.Cell event, which is not very
             // useful for us really since we haven't been able to set the
@@ -462,22 +526,22 @@ define([
         A little bit like duck typing, we inspect the properties of the app
         spec to determine if it is an app, editor, or viewer.
         */
-        determineMethodCellType: function(spec) {
+        determineMethodCellType: function (spec) {
 
             // An app will execute via the method described in the behavior. If
             // such a method is not described, it is by definition not an
             // executing app.
             if (spec.behavior.kb_service_name && spec.behavior.kb_service_method) {
                 switch (spec.info.app_type) {
-                    case 'editor':
-                        return 'editor';
-                    case 'app':
-                        return 'app';
-                    case 'advanced_viewer':
-                        return 'advancedView';
-                    default:
-                        console.warn('The app ' + spec.info.id + ' does not specify a valid spec.info.app_type "' + spec.info.app_type + '" - defaulting to "app"');
-                        return 'app';
+                case 'editor':
+                    return 'editor';
+                case 'app':
+                    return 'app';
+                case 'advanced_viewer':
+                    return 'advancedView';
+                default:
+                    console.warn('The app ' + spec.info.id + ' does not specify a valid spec.info.app_type "' + spec.info.app_type + '" - defaulting to "app"');
+                    return 'app';
                 }
             }
 
@@ -491,7 +555,7 @@ define([
          * @param {Object} method -
          * @public
          */
-        buildAppCell: function(method) {
+        buildAppCell: function (method) {
             var cell = Jupyter.narrative.insertAndSelectCellBelow('markdown');
             // cell.celltoolbar.hide();
 
@@ -508,12 +572,12 @@ define([
             // The various components are HTML STRINGS, not jQuery objects.
             // This is because the cell expects a text input, not a jQuery input.
             // Yeah, I know it's ugly, but that's how it goes.
-            var cellContent = "<div id='" + cellId + "'></div>" +
-                "\n<script>" +
-                "require(['kbaseNarrativeMethodCell'], function(kbaseNarrativeMethodCell) {" +
-                "var w = new kbaseNarrativeMethodCell($('#" + cellId + "'), {'method' : '" + StringUtil.safeJSONStringify(method) + "', 'cellId' : '" + cellId + "'});" +
-                "});" +
-                "</script>";
+            var cellContent = '<div id=\'' + cellId + '\'></div>' +
+                '\n<script>' +
+                'require([\'kbaseNarrativeMethodCell\'], function(kbaseNarrativeMethodCell) {' +
+                'var w = new kbaseNarrativeMethodCell($(\'#' + cellId + '\'), {\'method\' : \'' + StringUtil.safeJSONStringify(method) + '\', \'cellId\' : \'' + cellId + '\'});' +
+                '});' +
+                '</script>';
 
             cell.set_text(cellContent);
             cell.rendered = false;
@@ -689,16 +753,16 @@ define([
          *     }
          * }
          */
-        checkCellMetadata: function(cell) {
+        checkCellMetadata: function (cell) {
             if (cell.metadata[this.KB_CELL]) {
                 // if that top-level one is a string, it'll probably be an output cell, so make it one.
-                if (typeof cell.metadata[this.KB_CELL] === "string") {
+                if (typeof cell.metadata[this.KB_CELL] === 'string') {
                     var newMeta = {};
                     newMeta[this.KB_TYPE] = this.KB_OUTPUT_CELL;
                     newMeta['widget'] = undefined;
                     newMeta[this.KB_STATE] = [];
                     cell.metadata[this.KB_CELL] = newMeta;
-                } else if (typeof cell.metadata[this.KB_CELL] === "object") {
+                } else if (typeof cell.metadata[this.KB_CELL] === 'object') {
                     // The "old" version (i.e. at the beginning of the workshop starting 1/6/2013)
                     // just needs to make sure the input cells have the widget state as an array.
                     // AND it should store the widget name, as found in the method, as a separate field.
@@ -735,7 +799,7 @@ define([
          * with it, and if so, sends that to the widget.
          * @private
          */
-        refreshFunctionInputs: function(fullRender) {
+        refreshFunctionInputs: function (fullRender) {
             if (Jupyter && Jupyter.notebook) {
                 var cells = Jupyter.notebook.get_cells();
                 for (var i = 0; i < cells.length; i++) {
@@ -753,13 +817,13 @@ define([
                                 this.loadRecentCellState(cell);
                                 this.bindActionButtons(cell);
                             } else {
-                                $(cell.element).find("#inputs")[inputWidget]('refresh');
+                                $(cell.element).find('#inputs')[inputWidget]('refresh');
                             }
                         } else {
-                            $(cell.element).find("div[id^=kb-cell-]").kbaseNarrativeMethodCell('refresh');
+                            $(cell.element).find('div[id^=kb-cell-]').kbaseNarrativeMethodCell('refresh');
                         }
                     } else if (this.isAppCell(cell)) {
-                        $(cell.element).find("div[id^=kb-cell-]").kbaseNarrativeAppCell('refresh');
+                        $(cell.element).find('div[id^=kb-cell-]').kbaseNarrativeAppCell('refresh');
                     }
                 }
             }
@@ -777,7 +841,7 @@ define([
          * @param {object} method - the method to validate
          * @private
          */
-        validateMethod: function(method) {
+        validateMethod: function (method) {
             // if no title, return false
             if (!method.hasOwnProperty('title') || method.title.length == 0)
                 return false;
@@ -803,12 +867,12 @@ define([
          * @param cell - the cell to modify.
          * @private
          */
-        removeCellEditFunction: function(cell) {
+        removeCellEditFunction: function (cell) {
             return;
             // remove its double-click and return functions. sneaky!
             $(cell.element).off('dblclick');
             $(cell.element).off('keydown');
-            $(cell.element).on('click', function() {
+            $(cell.element).on('click', function () {
                 Jupyter.narrative.disableKeyboardManager();
             });
         },
@@ -820,31 +884,56 @@ define([
          * @param cell - the Jupyter Notebook cell with buttons to be bound.
          * @private
          */
-        bindActionButtons: function(cell) {
+        bindActionButtons: function (cell) {
             // get the cell.
             // look for the two buttons.
             // bind them to the right actions.
             if (this.isFunctionCell(cell)) {
-                $(cell.element).find(".buttons [id*=delete]").off('click');
-                $(cell.element).find(".buttons [id*=delete]").click(this.bindDeleteButton());
-                $(cell.element).find(".buttons [id*=run]").off('click');
-                $(cell.element).find(".buttons [id*=run]").click(this.bindRunButton());
+                $(cell.element).find('.buttons [id*=delete]').off('click');
+                $(cell.element).find('.buttons [id*=delete]').click(this.bindDeleteButton());
+                $(cell.element).find('.buttons [id*=run]').off('click');
+                $(cell.element).find('.buttons [id*=run]').click(this.bindRunButton());
             }
         },
 
-        toggleReadOnlyMode: function() {
-            if (!this.inReadOnlyMode) {
-                this.readOnlyMode(500);
+        toggleReadOnlyMode: function () {
+            // Disable any toggling if the button is somehow visible and the
+            // narrative is now read-only.
+            if (this.narrativeIsReadOnly) {
+                return;
+            }
+            if (this.uiMode === 'edit') {
+                this.enterReadOnlyMode();
             } else {
-                this.readWriteMode(500);
+                this.enterReadWriteMode();
             }
-            if (!this.narrativeIsReadOnly) {
-                var icon = $('#kb-view-mode span');
-                icon.toggleClass('fa-eye', this.inReadOnlyMode);
-                icon.toggleClass('fa-pencil', !this.inReadOnlyMode);
-            }
+            // Note that the internal narrativeIsReadOnly and uiMode are set
+            // within these enter... calls above.
+
+            // In true read-only (non-writable) mode, the view-mode toggle button
+            // is not available. Interestingly, this function can only be called 
+            // from the toggle button itself..., so I've disabled that logic and it
+            // should just be removed...
+            // If this narrative became read-only after the toggle button was rendered,
+            // then simply disabling the class-switching is not enough, the entire 
+            // mechanism should be disabled (and the button hidden as well.)
+            // if (!this.narrativeIsReadOnly) {
+            var icon = $('#kb-view-mode span');
+            icon.toggleClass('fa-eye', (this.uiMode === 'view'));
+            icon.toggleClass('fa-pencil', (this.uiMode === 'edit'));
+            //}
+            Jupyter.narrative.readonly = (this.uiMode === 'view');
+
+            // Warning, do not look for the code for this ... it will burn your
+            // eyes out to their bare sockets.
+            // Note also, there is code in this module which supposdly does the same thing 
+            // (see readOnlyMode, readWriteMode), but doesn't seem to work.
+            Jupyter.CellToolbar.rebuild_all();
             this.runtime.bus().emit('read-only-changed', {
-                readOnly: this.inReadOnlyMode
+                readOnly: (this.uiMode == 'view')
+            });
+            this.runtime.bus().emit('ui-mode-changed', {
+                mode: this.uiMode
             });
         },
 
@@ -858,14 +947,14 @@ define([
          *
          * Side-effects: modifies this.narrativeIsReadOnly to reflect current value.
          */
-        updateReadOnlyMode: function(ws, name, callback) {
-            this.checkReadOnly(ws, name, $.proxy(function(readonly) {
+        updateReadOnlyMode: function (ws, name, callback) {
+            this.checkReadOnly(ws, name, $.proxy(function (readonly) {
                 if (readonly != null) {
                     if (this.narrativeIsReadOnly != readonly) {
                         if (this.narrativeIsReadOnly == null && readonly == false) {
                             // pass: first time, and it is the default read/write
                         } else if (readonly == true) {
-                            this.readOnlyMode();
+                            this.enterReadOnlyMode();
                             $('#kb-view-mode').css({
                                 display: 'none'
                             });
@@ -884,8 +973,9 @@ define([
                         this.first_readonly = false;
                     }
                 }
-                if (callback)
+                if (callback) {
                     callback(this.narrativeIsReadOnly);
+                }
             }, this));
             return this.narrativeIsReadOnly;
         },
@@ -900,7 +990,7 @@ define([
          *          null if workspace service error or null, or if this
          *               check is too soon after the last one
          */
-        checkReadOnly: function(ws, name, callback) {
+        checkReadOnly: function (ws, name, callback) {
             // console.debug("check_readonly_mode.begin");
             // stop if no workspace client
             if (ws == null) {
@@ -922,7 +1012,7 @@ define([
             ws.get_workspace_info({
                     workspace: name
                 },
-                function(info) {
+                function (info) {
                     var is_ro = true;
                     if (info[5] == 'w' || info[5] == 'a') {
                         is_ro = false;
@@ -931,10 +1021,10 @@ define([
                     // console.debug("set_readonly_mode.end: callback_value=" + is_ro);
                     return callback(is_ro);
                 },
-                function(error) {
-                    KBError("kbaseNarrativeWorkspace.checkReadOnly",
-                        "get_workspace_info had an error for ID=" + name +
-                        ": " + error);
+                function (error) {
+                    KBError('kbaseNarrativeWorkspace.checkReadOnly',
+                        'get_workspace_info had an error for ID=' + name +
+                        ': ' + error);
                     return callback(null);
                 });
         },
@@ -944,13 +1034,13 @@ define([
          *
          * @returns {string[]}
          */
-        getReadOnlySelectors: function() {
+        getReadOnlySelectors: function () {
             return ['.kb-app-next', // next steps
                 '#kb-add-code-cell', '#kb-add-md-cell', // edit btns
                 '#kb-share-btn', '#kb-save-btn', // action btns
                 '#kb-ipy-menu', // kernel
-                '.kb-app-panel .pull-right', // app icons
-                '.kb-func-panel .pull-right', // method icons
+                // '.kb-app-panel .pull-right', // app icons
+                // '.kb-func-panel .pull-right', // method icons
                 '.kb-cell-toolbar .buttons.pull-right', // Jupyter icons
                 '.kb-title .btn-toolbar .btn .fa-arrow-right', // data panel slideout
             ];
@@ -962,21 +1052,21 @@ define([
          *
          * @param on If true, turn them on; else turn them off
          */
-        toggleRunButtons: function(on) {
+        toggleRunButtons: function (on) {
             var classes = ['.kb-app-run', '.kb-method-run',
                 'span.pull-right.kb-func-timestamp span>span'
             ];
             if (on) {
-                _.map(this.readonly_buttons, function(b) {
+                _.map(this.readonly_buttons, function (b) {
                     b.show();
                 });
                 this.readonly_buttons = []; // don't do it twice
             } else {
                 var ro = [];
-                _.map(classes, function(c) {
-                    _.map($(c), function(b) {
+                _.map(classes, function (c) {
+                    _.map($(c), function (b) {
                         var $btn = $(b);
-                        if ($btn.css('display') != "none") {
+                        if ($btn.css('display') != 'none') {
                             // it is visible, so hide it and remember it
                             ro.push($btn);
                             $btn.hide();
@@ -993,28 +1083,32 @@ define([
          *
          * @param on {bool} If true, turn them on; else turn them off
          */
-        toggleSelectBoxes: function(on) {
+        toggleSelectBoxes: function (on) {
             var disabled = 'select2-container-disabled';
             if (on) {
-                _.map(this.readonly_params, function($c) {
+                _.map(this.readonly_params, function ($c) {
                     $c.removeClass(disabled);
                 });
             } else {
                 var params = [];
-                _.map($('.select2-container'), function(c) {
+                _.map($('.select2-container'), function (c) {
                     if (!$(c).hasClass(disabled)) {
                         params.push($(c));
-                        $(c).addClass(disabled)
+                        $(c).addClass(disabled);
                     }
                 });
                 this.readonly_params = params;
             }
         },
 
-        toggleCellEditing: function(on) {
-            Jupyter.notebook.get_cells().forEach(function(cell) {
+        toggleCellEditing: function (on) {
+            Jupyter.notebook.get_cells().forEach(function (cell) {
                 if (cell.code_mirror) {
-                    cell.code_mirror.setOption('readOnly', !on);
+                    if (on) {
+                        cell.code_mirror.setOption('readOnly', false);
+                    } else {
+                        cell.code_mirror.setOption('readOnly', 'nocursor');
+                    }
                 }
                 cell.celltoolbar.rebuild();
             });
@@ -1022,20 +1116,39 @@ define([
 
         /**
          * Set narrative into read-only mode.
+         * This is called during initialization and by the view-mode toggle.
+         * Note that this is for the view-only ui mode, and thus the narrative
+         * itself may be writable (read-write). This crossover of terminology is
+         * a bit confusing to follow, and thus I've attempted to introduct the 
+         * ui view/edit mode as orthgonal to narrative 
+         * permission (read-only/read-write/read-write-share).
+         * 
+         * TODO: probably a better design to set the read / view only flags
+         * and thsn simply render everything that is interested in this.
+         * Otherwise, we just have to propogate the state that _will_ be true when
+         * this operation is complete, because sub-rendering tasks can't just
+         * look at the current state.
          */
-        readOnlyMode: function(delay) {
+        enterReadOnlyMode: function () {
+            // It is implicit that view-only mode is on when the narrative is read only.
+            // this.inReadOnlyMode = true;
+            this.uiMode = 'view';
+
             // Hide side-panel
             Jupyter.narrative.toggleSidePanel(true);
 
             // Hide things
-            _.map(this.getReadOnlySelectors(), function(id) {
-                $(id).hide()
+            _.map(this.getReadOnlySelectors(), function (id) {
+                $(id).hide();
             });
             this.toggleRunButtons(false);
             this.toggleSelectBoxes(false);
             this.toggleCellEditing(false);
 
             Jupyter.narrative.sidePanel.setReadOnlyMode(true);
+
+            // Special copy button for view  mode.
+            $('#kb-view-only-copy').removeClass('hidden');
 
             if (this.narrativeIsReadOnly) {
                 $('#kb-view-only-msg').popover({
@@ -1047,12 +1160,17 @@ define([
                         'copy that can be modified, use the ' +
                         '"Copy" button.'
                 });
-                $('#kb-view-only-copy').removeClass('hidden');
+                // No view-mode toggle for true read-only.
                 $('#kb-view-mode').hide();
 
-                // Disable clicking on name of narrative
-                $('#name').unbind();
-                // Hide save status
+                // Disable clicking on name of narrative to rename the narrative.
+                // The widget controlling this is also disabled in custom.js
+                // Note that that is a jupyter-controlled id, and may change over time.
+                $('#save_widget').unbind();
+
+                // Hide save status. Autosave will be disabled, but it may flash
+                // messages.
+                // Jupyter controlled id.
                 $('#autosave_status').hide();
             } else {
                 $('#kb-view-only-msg').popover({
@@ -1064,48 +1182,49 @@ define([
                 });
             }
             $('#kb-view-only-msg').removeClass('hidden');
-            this.inReadOnlyMode = true;
-            // console.debug('set_readonly_mode.end');
-            return;
         },
 
         /**
          * Set narrative from read-only mode to read-write mode
+         * This is only called in the context of an editable Narrative 
+         * in which the user is togging between view/edit mode in order
+         * to evaluate how the narrative appears on view-only mode.
          *
          */
-        readWriteMode: function(delay) {
-            // Remove the view-only buttons (first 1 or 2 children)
-            if (!delay)
-                delay = 0;
-
+        enterReadWriteMode: function () {
+            // Huh? This should never occur.
             if (this.narrativeIsReadOnly) {
                 Jupyter.narrative.sidePanel.setReadOnlyMode(true, this.hideControlPanels);
-            } else {
-                Jupyter.narrative.sidePanel.setReadOnlyMode(false);
-                $('#kb-view-only-msg').addClass('hidden');
-                $('#kb-view-only-copy').addClass('hidden');
-
-                // re-enable clicking on narrative name
-                $('#name').click(function(e) {
-                    if (Jupyter && Jupyter.save_widget) {
-                        Jupyter.save_widget.rename_notebook("Rename your Narrative.", true);
-                    }
-                });
-                this.toggleRunButtons(true);
-                this.toggleSelectBoxes(true);
-
-                // re-enable auto-save status
-                $('#autosave_status').show();
-                _.map(this.getReadOnlySelectors(), function(id) {
-                    $(id).show();
-                });
+                Jupyter.narrative.toggleSidePanel(false);
+                return;
             }
-            // Restore side-panel
-            // Restore margin for content
-            Jupyter.narrative.toggleSidePanel(false);
-            this.inReadOnlyMode = false;
-        },
 
+            this.uiMode = 'edit';
+
+            Jupyter.narrative.sidePanel.setReadOnlyMode(false);
+
+            // Remove the view-only buttons (first 1 or 2 children)
+            $('#kb-view-only-msg').addClass('hidden');
+            $('#kb-view-only-copy').addClass('hidden');
+
+            // re-enable clicking on narrative name
+            $('#save_widget').click(function () {
+                if (Jupyter && Jupyter.save_widget) {
+                    Jupyter.save_widget.rename_notebook('Rename your Narrative.', true);
+                }
+            });
+            this.toggleRunButtons(true);
+            this.toggleSelectBoxes(true);
+            this.toggleCellEditing(true);
+
+            // re-enable auto-save status
+            $('#autosave_status').show();
+            _.map(this.getReadOnlySelectors(), function (id) {
+                $(id).show();
+            });
+
+            Jupyter.narrative.toggleSidePanel(false);
+        },
 
         /**
          * Connect two elements with a 'line'.
@@ -1118,7 +1237,7 @@ define([
          *   container - Containing element for line
          *   line_class - CSS class for line elements (for coloring)
          */
-        connect: function(p, q, g, w, container, line_class) {
+        connect: function (p, q, g, w, container, line_class) {
             var pc = $(p).position();
             var qc = $(q).position();
             // console.debug("connect ", pc, " to ", qc);
@@ -1150,7 +1269,7 @@ define([
         /**
          * Activate "normal" R/W mode
          */
-        activateReadwriteMode: function() {
+        activateReadwriteMode: function () {
             // console.debug("activate read-write mode");
         },
 
@@ -1158,7 +1277,7 @@ define([
         /**
          * Object identifier of current narrative, extracted from page URL.
          */
-        getNarrId: function() {
+        getNarrId: function () {
             return window.location.pathname.split('/').pop();
         },
 
@@ -1169,7 +1288,7 @@ define([
          * So this function does that.
          * @private
          */
-        hideGeneratedCodeCells: function() {
+        hideGeneratedCodeCells: function () {
             var cells = Jupyter.notebook.get_cells();
             for (var i = 0; i < cells.length; i++) {
                 var cell = cells[i];
@@ -1179,15 +1298,15 @@ define([
         },
 
         // Function input cell type.
-        isFunctionCell: function(cell) {
+        isFunctionCell: function (cell) {
             return this.checkCellType(cell, this.KB_FUNCTION_CELL);
         },
 
-        isAppCell: function(cell) {
+        isAppCell: function (cell) {
             return this.checkCellType(cell, this.KB_APP_CELL);
         },
 
-        setFunctionCell: function(cell, method) {
+        setFunctionCell: function (cell, method) {
             var cellInfo = {};
             cellInfo[this.KB_TYPE] = this.KB_FUNCTION_CELL;
             cellInfo['method'] = method;
@@ -1197,7 +1316,7 @@ define([
             cell.metadata[this.KB_CELL] = cellInfo;
         },
 
-        setMethodCell: function(cell, method) {
+        setMethodCell: function (cell, method) {
             var cellInfo = {};
             cellInfo[this.KB_TYPE] = this.KB_FUNCTION_CELL;
             cellInfo['method'] = method;
@@ -1207,7 +1326,7 @@ define([
             cell.metadata[this.KB_CELL] = cellInfo;
         },
 
-        setAppCell: function(cell, appInfo) {
+        setAppCell: function (cell, appInfo) {
             var cellInfo = {};
             cellInfo[this.KB_TYPE] = this.KB_APP_CELL;
             cellInfo['app'] = appInfo;
@@ -1217,11 +1336,11 @@ define([
         },
 
         // Function output cell type.
-        isOutputCell: function(cell) {
+        isOutputCell: function (cell) {
             return this.checkCellType(cell, this.KB_OUTPUT_CELL);
         },
 
-        setOutputCell: function(cell, widget) {
+        setOutputCell: function (cell, widget) {
             var cellInfo = {};
             cellInfo[this.KB_TYPE] = this.KB_OUTPUT_CELL;
             cellInfo[this.KB_STATE] = [];
@@ -1230,24 +1349,24 @@ define([
             cell.metadata[this.KB_CELL] = cellInfo;
         },
 
-        setErrorCell: function(cell) {
+        setErrorCell: function (cell) {
             var cellInfo = {};
             cellInfo[this.KB_TYPE] = this.KB_ERROR_CELL;
             cell.metadata[this.KB_CELL] = cellInfo;
         },
 
         // Backup function code cell type (usually hidden through css... I still think this is superfluous)
-        isFunctionCodeCell: function(cell) {
+        isFunctionCodeCell: function (cell) {
             return this.checkCellType(cell, this.KB_CODE_CELL);
         },
 
-        setCodeCell: function(cell) {
+        setCodeCell: function (cell) {
             var cellInfo = {};
             cellInfo[this.KB_TYPE] = this.KB_CODE_CELL;
             cell.metadata[this.KB_CELL] = cellInfo;
         },
 
-        checkCellType: function(cell, type) {
+        checkCellType: function (cell, type) {
             return cell.metadata &&
                 cell.metadata[this.KB_CELL] &&
                 cell.metadata[this.KB_CELL][this.KB_TYPE] === type;
@@ -1266,7 +1385,7 @@ define([
          * }
          * This is prepended to the front - so the most recent state is the first element of the array.
          */
-        saveCellState: function(cell) {
+        saveCellState: function (cell) {
             // ignore it if it isn't a KBase cell with a widget state to save.
             if (!this.isFunctionCell(cell) && !this.isOutputCell(cell) && !this.isAppCell(cell))
                 return;
@@ -1322,7 +1441,7 @@ define([
          * @returns the most recent cell state, in whatever form that state takes (scalar, array, object, etc.)
          * @private
          */
-        loadRecentCellState: function(cell) {
+        loadRecentCellState: function (cell) {
 
             var state = this.getRecentState(cell);
             if (state) {
@@ -1393,11 +1512,11 @@ define([
          * @returns {Array} an array of states for that cell
          * @private
          */
-        getCellStateArray: function(cell) {
+        getCellStateArray: function (cell) {
             if (this.isFunctionCell(cell) || this.isOutputCell(cell)) {
                 var stateArr = cell.metadata[this.KB_CELL][this.KB_STATE];
                 // if it's an array, return it.
-                if (Object.prototype.toString.call(stateArr) === "[object Array]")
+                if (Object.prototype.toString.call(stateArr) === '[object Array]')
                     return stateArr;
             }
             // if the cell doesn't have a state array, or if it's NOT an array, return the empty array.
@@ -1408,9 +1527,9 @@ define([
          * Saves the state of all cells into their respective arrays.
          * @public
          */
-        saveAllCellStates: function() {
+        saveAllCellStates: function () {
             var cells = Jupyter.notebook.get_cells();
-            $.each(cells, $.proxy(function(idx, cell) {
+            $.each(cells, $.proxy(function (idx, cell) {
                 this.saveCellState(cell);
             }, this));
         },
@@ -1419,9 +1538,9 @@ define([
          * Loads the most recently saved state into all cells.
          * @public
          */
-        loadAllRecentCellStates: function() {
+        loadAllRecentCellStates: function () {
             var cells = Jupyter.notebook.get_cells();
-            $.each(cells, function(idx, cell) {
+            $.each(cells, function (idx, cell) {
                 this.loadRecentCellState(cell);
             }.bind(this));
         },
@@ -1432,11 +1551,11 @@ define([
          * This *should* make things still functional for the older (non-array-based) stateful cells.
          * XXX: eventually update this to just array, once we're out of dev-panic-mode and closer to production.
          */
-        getRecentState: function(cell) {
+        getRecentState: function (cell) {
             var state;
             if (this.isFunctionCell(cell) || this.isOutputCell(cell) || this.isAppCell(cell)) {
                 var stateList = cell.metadata[this.KB_CELL][this.KB_STATE];
-                if (Object.prototype.toString.call(stateList) === "[object Array]")
+                if (Object.prototype.toString.call(stateList) === '[object Array]')
                     state = stateList[0];
                 else
                     state = stateList;
@@ -1448,10 +1567,10 @@ define([
          * @method bindRunButton
          * @private
          */
-        bindRunButton: function() {
+        bindRunButton: function () {
             var self = this;
             return (
-                function(event) {
+                function (event) {
                     event.preventDefault();
                     // get the cell
                     var cell = Jupyter.notebook.get_selected_cell();
@@ -1460,7 +1579,7 @@ define([
                     var inputWidget = cell.metadata[self.KB_CELL].method.properties.widgets.input || self.defaultInputWidget;
 
                     // get the list of parameters and save the state in the cell's metadata
-                    var paramList = $(cell.element).find("#inputs")[inputWidget]('getParameters');
+                    var paramList = $(cell.element).find('#inputs')[inputWidget]('getParameters');
                     self.saveCellState(cell);
 
                     // var state = $(cell.element).find("#inputs")[inputWidget]('getState');
@@ -1469,7 +1588,7 @@ define([
                     // Run the method.
                     var method = cell.metadata[self.KB_CELL].method;
                     self.runCell()(cell, method.service, method.title, paramList);
-                    $(cell.element).find("#last-run").html("Last run: " + self.readableTimestamp(self.getTimestamp()));
+                    $(cell.element).find('#last-run').html('Last run: ' + self.readableTimestamp(self.getTimestamp()));
                 }
             );
         },
@@ -1486,7 +1605,7 @@ define([
          * just look to see if it is indeed a kbase cell, and if so we punt
          * to it.
          */
-        deleteCell: function(index) {
+        deleteCell: function (index) {
             if (index === undefined || index === null) {
                 return;
             }
@@ -1506,7 +1625,7 @@ define([
                             p('Are you sure you want to delete this cell?')
                         ]
                     })
-                    .then(function(confirmed) {
+                    .then(function (confirmed) {
                         if (confirmed) {
                             if (kbaseCellType && !cellId) {
                                 console.warn('KBase cell without cell id, DELETING ANYWAY!', cell.metadata);
@@ -1527,13 +1646,13 @@ define([
             });
         },
 
-        xdeleteCell: function(index) {
+        xdeleteCell: function (index) {
             if (index !== undefined && index !== null) {
                 var cell = Jupyter.notebook.get_cell(index);
                 if (cell) {
                     // if it's a kbase method or app cell, trigger a popup
                     if (cell.metadata[this.KB_CELL]) {
-                        widget = null; // default is app cell
+                        var widget = null; // default is app cell
                         var state = 'input'; // default is input... also doubles as a proxy for output cells
                         if (this.isFunctionCell(cell)) {
                             widget = 'kbaseNarrativeMethodCell';
@@ -1592,10 +1711,9 @@ define([
          * @method bindDeleteButton
          * @private
          */
-        bindDeleteButton: function() {
-            var self = this;
+        bindDeleteButton: function () {
             return (
-                function(event) {
+                function (event) {
                     event.preventDefault();
                     var idx = Jupyter.notebook.get_selected_index();
                     Jupyter.notebook.delete_cell(idx);
@@ -1612,7 +1730,7 @@ define([
          *
          * @public
          */
-        rebindActionButtons: function() {
+        rebindActionButtons: function () {
             if (!(Jupyter && Jupyter.notebook))
                 return;
 
@@ -1645,9 +1763,9 @@ define([
          * @param {}
          * @private
          */
-        runCell: function() {
+        runCell: function () {
             var self = this;
-            return function(cell, service, method, params) {
+            return function (cell, service, method, params) {
                 var nb = Jupyter.notebook;
                 var currentIndex = nb.get_selected_index();
 
@@ -1661,24 +1779,24 @@ define([
 
                 var callbacks = {
                     shell: {
-                        reply: function(content) {
+                        reply: function (content) {
                             self.handleExecuteReply(cell, content);
                         },
                         payload: {
-                            set_next_input: function(content) {
+                            set_next_input: function (content) {
                                 self.handleSetNextInput(cell, content);
                             },
                         },
                     },
                     iopub: {
-                        output: function(content) {
+                        output: function (content) {
                             self.handleOutput(cell, content);
                         },
-                        clear_output: function(content) {
+                        clear_output: function (content) {
                             self.handleClearOutput(cell, content);
                         },
                     },
-                    input: function(content) {
+                    input: function (content) {
                         self.handleInputRequest(cell, content);
                     }
                 };
@@ -1707,13 +1825,13 @@ define([
             };
         },
 
-        buildGenericRunCommand: function(data) {
+        buildGenericRunCommand: function (data) {
             var methodJSON = StringUtil.safeJSONStringify(data.method);
             var paramsJSON = StringUtil.safeJSONStringify(data.parameters);
 
-            return "import biokbase.narrative.common.service as Service\n" +
-                "method = Service.get_service('generic_service').get_method('method_call')\n" +
-                "method('" + methodJSON + "', '" + paramsJSON + "')";
+            return 'import biokbase.narrative.common.service as Service\n' +
+                'method = Service.get_service(\'generic_service\').get_method(\'method_call\')\n' +
+                'method(\'' + methodJSON + '\', \'' + paramsJSON + '\')';
         },
 
         /**
@@ -1725,26 +1843,26 @@ define([
          * @returns {String} the constructed Jupyter kernel command
          * @private
          */
-        buildRunCommand: function(service, method, params) {
+        buildRunCommand: function (service, method, params) {
             // very nice quote-escaper found here:
             // http://stackoverflow.com/questions/770523/escaping-strings-in-javascript
             // and
             // http://phpjs.org/functions/addslashes/
-            var addSlashes = function(str) {
+            var addSlashes = function (str) {
                 return (str + '').replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0');
             };
 
             var escService = addSlashes(service);
             var escMethod = addSlashes(method);
-            var cmd = "import biokbase.narrative.common.service as Service\n" +
-                "method = Service.get_service('" + escService + "').get_method('" + escMethod + "')\n";
+            var cmd = 'import biokbase.narrative.common.service as Service\n' +
+                'method = Service.get_service(\'' + escService + '\').get_method(\'' + escMethod + '\')\n';
 
             var paramList = params.map(
-                function(p) {
-                    return "'" + addSlashes(p) + "'";
+                function (p) {
+                    return '\'' + addSlashes(p) + '\'';
                 }
             );
-            cmd += "method(" + paramList + ")";
+            cmd += 'method(' + paramList + ')';
 
             return cmd;
         },
@@ -1752,37 +1870,37 @@ define([
         /**
          * Make JS dict into Python dict (string)
          */
-        _pythonDict: function(data) {
-            var dict = "{";
-            $.each(data, function(key, value) {
-                dict += "'" + key + "': ";
+        _pythonDict: function (data) {
+            var dict = '{';
+            $.each(data, function (key, value) {
+                dict += '\'' + key + '\': ';
                 // XXX: assume either more maps or simple type
                 var vtype = typeof value;
                 switch (vtype) {
-                    case "boolean":
-                        if (value)
-                            dict += "True";
-                        else
-                            dict += "False";
-                        break;
-                    case "number":
-                        dict += value;
-                        break;
-                    case "string":
-                        dict += "'" + value + "'";
-                        break;
-                    case "undefined":
-                        dict += "None";
-                        break;
-                    case "object":
-                        dict += this._pythonDict(value);
-                        break;
-                    default:
-                        console.error("Cannot convert to Python:", vtype);
+                case 'boolean':
+                    if (value)
+                        dict += 'True';
+                    else
+                        dict += 'False';
+                    break;
+                case 'number':
+                    dict += value;
+                    break;
+                case 'string':
+                    dict += '\'' + value + '\'';
+                    break;
+                case 'undefined':
+                    dict += 'None';
+                    break;
+                case 'object':
+                    dict += this._pythonDict(value);
+                    break;
+                default:
+                    console.error('Cannot convert to Python:', vtype);
                 }
-                dict += ", "
+                dict += ', '
             });
-            return dict + "}";
+            return dict + '}';
         },
 
         /* ------------------------------------------------------
@@ -1792,7 +1910,7 @@ define([
          * @method _handle_execute_reply
          * @private
          */
-        handleExecuteReply: function(cell, content) {
+        handleExecuteReply: function (cell, content) {
             this.dbg('[handleExecuteReply]');
             this.dbg(content);
 
@@ -1812,11 +1930,11 @@ define([
                     cell.metadata['kb-cell'].method)
                     errorBlob.method_name = cell.metadata['kb-cell'].method.title;
 
-                var removeVt = function(line) {
+                var removeVt = function (line) {
                     return line.replace(/\[\d+(;\d+)?m/g, '');
                 };
 
-                var errTb = content.content.traceback.map(function(line) {
+                var errTb = content.content.traceback.map(function (line) {
                     return {
                         filename: null,
                         function: null,
@@ -1829,7 +1947,7 @@ define([
                 this.createOutputCell(cell, '{"error" :' + JSON.stringify(errorBlob) + '}', true);
 
             }
-            this.showCellProgress(cell, "DONE", 0, 0);
+            this.showCellProgress(cell, 'DONE', 0, 0);
             //this.set_input_prompt(content.execution_count);
             $([Jupyter.events]).trigger('set_dirty.Notebook', {
                 value: true
@@ -1839,19 +1957,19 @@ define([
          * @method _handle_set_next_input
          * @private
          */
-        handleSetNextInput: function(cell, text) {
+        handleSetNextInput: function (cell, text) {
             var data = {
                 'cell': this,
                 'text': text
-            }
+            };
             $([Jupyter.events]).trigger('set_next_input.Notebook', data);
         },
         /**
          * @method _handle_input_request
          * @private
          */
-        handleInputRequest: function(cell, content) {
-            this.dbg("handle input request called");
+        handleInputRequest: function (cell, content) {
+            this.dbg('handle input request called');
             return;
             //this.output_area.append_raw_input(content);
         },
@@ -1859,8 +1977,8 @@ define([
          * @method _handle_clear_output
          * @private
          */
-        handleClearOutput: function(cell, content) {
-            this.dbg("handle clear output called");
+        handleClearOutput: function (cell, content) {
+            this.dbg('handle clear output called');
             return;
             //this.clear_output(content.stdout, content.stderr, content.other);
         },
@@ -1868,22 +1986,22 @@ define([
         /**
          * @method _handle_output
          */
-        handleOutput: function(cell, content, showOutput, callingWidget) {
+        handleOutput: function (cell, content, showOutput, callingWidget) {
             this.dbg('[handle output]');
             this.dbg(content);
             this.dbg(showOutput);
 
             var msgType = content.msg_type;
-            var buffer = "";
-            if (msgType === "stream") {
+            var buffer = '';
+            if (msgType === 'stream') {
                 buffer += content.content.text;
-                var lines = buffer.split("\n");
+                var lines = buffer.split('\n');
                 var offs = 0,
                     done = false,
                     self = this,
-                    result = "";
+                    result = '';
 
-                $.each(lines, function(index, line) {
+                $.each(lines, function (index, line) {
                     if (!done) {
                         if (line.length == 0) {
                             offs += 1; // blank line, move offset
@@ -1892,53 +2010,53 @@ define([
                             var matches = line.match(/^@@([ADEGJSP])(.*)/);
                             if (matches) { // if we got one
                                 switch (matches[1]) {
-                                    case 'S': // Start running
-                                        // if we're starting, init the progress bar.
-                                        break;
+                                case 'S': // Start running
+                                    // if we're starting, init the progress bar.
+                                    break;
 
-                                    case 'D': // Done running
-                                        // were done, so hide the progress bar (wait like a second or two?)
-                                        self.resetProgress(cell);
-                                        break;
+                                case 'D': // Done running
+                                    // were done, so hide the progress bar (wait like a second or two?)
+                                    self.resetProgress(cell);
+                                    break;
 
-                                    case 'P': // Progress step
-                                        var progressInfo = matches[2].split(',');
-                                        if (progressInfo.length == 3) {
-                                            self.showCellProgress(cell, progressInfo[0], progressInfo[1], progressInfo[2]);
-                                            offs += line.length;
-                                            if (index < lines.length - 1)
-                                                offs += 1;
-                                        } else
-                                            done = true;
-                                        break;
+                                case 'P': // Progress step
+                                    var progressInfo = matches[2].split(',');
+                                    if (progressInfo.length == 3) {
+                                        self.showCellProgress(cell, progressInfo[0], progressInfo[1], progressInfo[2]);
+                                        offs += line.length;
+                                        if (index < lines.length - 1)
+                                            offs += 1;
+                                    } else
+                                        done = true;
+                                    break;
 
-                                    case 'E': // Error while running
-                                        var errorJson = matches[2];
-                                        errorJson = errorJson.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\$/g, "&#36;");
-                                        self.createOutputCell(cell, '{"error" :' + errorJson + '}', true);
-                                        break;
+                                case 'E': // Error while running
+                                    var errorJson = matches[2];
+                                    errorJson = errorJson.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\$/g, '&#36;');
+                                    self.createOutputCell(cell, '{"error" :' + errorJson + '}', true);
+                                    break;
 
-                                    case 'G': // debuG message
-                                        var debug = matches[2];
-                                        self.dbg("[KERNEL] " + debug);
-                                        break;
+                                case 'G': // debuG message
+                                    var debug = matches[2];
+                                    self.dbg('[KERNEL] ' + debug);
+                                    break;
 
-                                    case 'J': // Job id register
-                                        var jobId = matches[2];
-                                        self.dbg("[JOB ID] " + jobId);
-                                        self.registerJobId(jobId, cell);
-                                        break;
+                                case 'J': // Job id register
+                                    var jobId = matches[2];
+                                    self.dbg('[JOB ID] ' + jobId);
+                                    self.registerJobId(jobId, cell);
+                                    break;
 
-                                    case 'A': // App id register
-                                        var appId = matches[2];
-                                        self.dbg("[APP ID] " + appId);
-                                        self.registerJobId(appId, cell);
-                                        break;
+                                case 'A': // App id register
+                                    var appId = matches[2];
+                                    self.dbg('[APP ID] ' + appId);
+                                    self.registerJobId(appId, cell);
+                                    break;
 
-                                    default:
-                                        // by default just dump it to the console
-                                        self.dbg("[UNKNOWN TAG] " + line);
-                                        break;
+                                default:
+                                    // by default just dump it to the console
+                                    self.dbg('[UNKNOWN TAG] ' + line);
+                                    break;
                                 }
                                 return;
                             }
@@ -1947,7 +2065,7 @@ define([
                                 result += line;
                                 // all but the last line should have \n appended
                                 if (index < lines.length - 1) {
-                                    result += "\n";
+                                    result += '\n';
                                 }
                             }
                         }
@@ -1958,7 +2076,7 @@ define([
                     buffer = buffer.substr(offs, buffer.length - offs);
                 }
                 if (result.length > 0) {
-                    if (showOutput === "app") {
+                    if (showOutput === 'app') {
                         if (!cell.metadata[this.KB_CELL].stackTrace)
                             cell.metadata[this.KB_CELL].stackTrace = [];
                         // try to parse the result as JSON - if so, then it's a final result and we just
@@ -1990,7 +2108,7 @@ define([
          * This stores the job id in the Narrative's metadata.
          * XXX: Should this trigger a save?
          */
-        registerJobId: function(jobId, sourceCell) {
+        registerJobId: function (jobId, sourceCell) {
             // This is possibly the ugliest hack here. In the future, all cells should actually know their
             // fancy UUIDs. But that *might* be backwards incompatible with existing narratives that we want
             // to show off.
@@ -2017,7 +2135,7 @@ define([
         },
 
 
-        createViewerCell: function(cellIndex, data, widget) {
+        createViewerCell: function (cellIndex, data, widget) {
             var placement = data.placement || 'below';
             var cell;
             if (placement === 'above') {
@@ -2063,7 +2181,7 @@ define([
          *
          * Also triggers a save.
          */
-        createOutputCell: function(cell, result, isError, widget) {
+        createOutputCell: function (cell, result, isError, widget) {
             if (typeof result === 'string' && !isError) {
                 // try to parse it as JSON.
                 // if we fail, then it's not something we can deal with and shouldn't
@@ -2178,7 +2296,7 @@ define([
          *   }
          * Returns the <div> that was populated.
          */
-        showNextSteps: function(obj) {
+        showNextSteps: function (obj) {
             var $elt = obj.elt,
                 next_steps = obj.next_steps;
 
@@ -2193,13 +2311,13 @@ define([
             $hide_btn = $('<span>').addClass('kb-app-next-hide').text('hide');
             $unhide_btn = $('<span>').addClass('kb-app-next-unhide')
                 .text('next steps').hide();
-            $hide_btn.click(function() { // hide
+            $hide_btn.click(function () { // hide
                 $title.hide();
                 $tgt.find('a').hide();
                 $hide_btn.hide();
                 $unhide_btn.show();
             });
-            $unhide_btn.click(function() { // unhide
+            $unhide_btn.click(function () { // unhide
                 $title.show();
                 $tgt.find('a').show();
                 $unhide_btn.hide();
@@ -2214,19 +2332,19 @@ define([
                 self = this;
             // iterate over apps and methods in the result
             var has_both = next_steps.apps && next_steps.methods;
-            _.each(['apps', 'methods'], function(mtype) {
+            _.each(['apps', 'methods'], function (mtype) {
                 if (has_both) { /* XXX: prefix with (App) or something? */ }
                 var specs = next_steps[mtype];
                 // Iterate over all specs in app/method section
-                _.each(_.values(specs), function(s) {
+                _.each(_.values(specs), function (s) {
                     var name = s.info.name; // readable name, displayed to user
                     var href = $('<a>').attr({
                             'href': 'javascript:;'
                         })
                         .text(comma.v + name);
                     // insert app/method on click
-                    href.click(function() {
-                        self.trigger(mtype.slice(0, -1) + "Clicked.Narrative", s);
+                    href.click(function () {
+                        self.trigger(mtype.slice(0, -1) + 'Clicked.Narrative', s);
                     });
                     $apps.append(href);
                     comma.v = ', ';
@@ -2243,7 +2361,7 @@ define([
          * Resets the progress bar in the given cell to not show any progress or progress message.
          * @param cell - the Jupyter notebook cell to reset.
          */
-        resetProgress: function(cell) {
+        resetProgress: function (cell) {
             $(cell.element).find('#kb-func-progress .kb-cell-progressbar .progress-bar')
                 .css('width', '0%');
             $(cell.element).find('#kb-func-progress .text-success')
@@ -2261,20 +2379,20 @@ define([
          *
          * @private
          */
-        showCellProgress: function(cell, name, done, total) {
+        showCellProgress: function (cell, name, done, total) {
             var percentDone = 0;
 
-            var $progressBar = $(cell.element).find("#kb-func-progress .kb-cell-progressbar .progress-bar");
-            var $progressMsg = $(cell.element).find("#kb-func-progress .text-success");
+            var $progressBar = $(cell.element).find('#kb-func-progress .kb-cell-progressbar .progress-bar');
+            var $progressMsg = $(cell.element).find('#kb-func-progress .text-success');
             if (name === 'DONE') {
-                $progressMsg.text("Completed");
+                $progressMsg.text('Completed');
                 percentDone = 100;
                 $progressBar.css('width', '100%');
-                $(cell.element).find("#kb-func-progress").fadeOut(1000, $.proxy(function() {
+                $(cell.element).find('#kb-func-progress').fadeOut(1000, $.proxy(function () {
                     this.resetProgress(cell);
                 }, this));
             } else {
-                $progressMsg.text("Step " + done + " / " + total + ": " + name);
+                $progressMsg.text('Step ' + done + ' / ' + total + ': ' + name);
                 percentDone = (100 * done - 100) / total;
                 $progressBar.css('width', percentDone + '%');
             }
@@ -2291,15 +2409,15 @@ define([
          * @private
          * @return id of <div> inside cell where content can be placed
          */
-        addOutputCell: function(currentIndex, widget, placement) {
+        addOutputCell: function (currentIndex, widget, placement) {
             var cell;
             switch (placement) {
-                case 'above':
-                    cell = Jupyter.notebook.insert_cell_above('markdown', currentIndex);
-                    break;
-                case 'below':
-                default:
-                    var cell = Jupyter.notebook.insert_cell_below('markdown', currentIndex);
+            case 'above':
+                cell = Jupyter.notebook.insert_cell_above('markdown', currentIndex);
+                break;
+            case 'below':
+            default:
+                var cell = Jupyter.notebook.insert_cell_below('markdown', currentIndex);
             }
             // cell.celltoolbar.hide();
             this.setOutputCell(cell, widget);
@@ -2308,7 +2426,7 @@ define([
             return cell;
         },
 
-        addErrorCell: function(currentIndex) {
+        addErrorCell: function (currentIndex) {
             var cell = Jupyter.notebook.insert_cell_below('markdown', currentIndex);
             // cell.celltoolbar.hide();
             this.setErrorCell(cell);
@@ -2317,7 +2435,7 @@ define([
         },
 
         /** Not really used right now. */
-        convert_mime_types: function(json, data) {
+        convert_mime_types: function (json, data) {
             if (data === undefined) {
                 return json;
             }
@@ -2351,11 +2469,11 @@ define([
         /* ------------------------------------------------------ */
         /* Accessors */
 
-        workspace: function(key, value) {
+        workspace: function (key, value) {
             return this._accessor('_workspace', key, value);
         },
 
-        _accessor: function(name, key, value) {
+        _accessor: function (name, key, value) {
             if (this.data(name) == undefined) {
                 this.data(name, {});
             }
@@ -2380,8 +2498,8 @@ define([
          *
          * @returns this
          */
-        render: function() {
-            return Promise.try(function() {
+        render: function () {
+            return Promise.try(function () {
                 this.rebindActionButtons();
                 this.hideGeneratedCodeCells();
                 var cells = Jupyter.notebook.get_cells();
@@ -2396,10 +2514,10 @@ define([
         /**
          * Show input/output cell connections.
          */
-        show_connections: function() {
+        show_connections: function () {
             var self = this;
             // console.debug("show_connections.start");
-            _.each(_.pairs(this.connectable), function(pair) {
+            _.each(_.pairs(this.connectable), function (pair) {
                 var e1 = $('#kb-input-' + pair[0]);
                 var e2 = $('#kb-output-' + pair[1]);
                 self.connect(e1, e2, 20, 2,
@@ -2414,7 +2532,7 @@ define([
          * @param token
          * @returns this
          */
-        loggedOut: function(token) {
+        loggedOut: function (token) {
             if (this.dataTableWidget)
                 this.dataTableWidget.loggedOut(token);
             this.ws_client = null, this.ws_auth = null;
@@ -2423,7 +2541,7 @@ define([
         /**
          * Initialize the logger
          */
-        initLogging: function(level) {
+        initLogging: function (level) {
             Logger.useDefaults();
             Logger.setLevel(level);
         },
@@ -2434,7 +2552,7 @@ define([
          * Maybe we'll want to use UTC or whatever...)
          * @public
          */
-        getTimestamp: function() {
+        getTimestamp: function () {
             return new Date().getTime();
         },
 
@@ -2445,8 +2563,8 @@ define([
          * @param {string} timestamp - a timestamp in number of milliseconds since the epoch.
          * @return {string} a human readable timestamp
          */
-        readableTimestamp: function(timestamp) {
-            var format = function(x) {
+        readableTimestamp: function (timestamp) {
+            var format = function (x) {
                 if (x < 10)
                     x = '0' + x;
                 return x;
@@ -2460,7 +2578,7 @@ define([
             var day = format(d.getDate());
             var year = d.getFullYear();
 
-            return hours + ":" + minutes + ":" + seconds + ", " + month + "/" + day + "/" + year;
+            return hours + ':' + minutes + ':' + seconds + ', ' + month + '/' + day + '/' + year;
         },
 
         /**
@@ -2470,7 +2588,7 @@ define([
          * 1. kbaseNarrativeCell -> kbaseNarrativeMethodCell
          * 2. More to come!
          */
-        scanAndUpdateCells: function() {
+        scanAndUpdateCells: function () {
             var cells = Jupyter.notebook.get_cells();
             for (var i = 0; i < cells.length; i++) {
                 var cell = cells[i];
@@ -2498,7 +2616,7 @@ define([
          *                multiple items. Undefined is false.
          * @param indent - Indent level (default is none)
          */
-        setDataIcon: function($logo, type, stacked, indent) {
+        setDataIcon: function ($logo, type, stacked, indent) {
             if (indent === undefined || indent === null) {
                 indent = 0;
             }
@@ -2506,7 +2624,7 @@ define([
             var icons = this.data_icons;
             var icon = _.has(icons, type) ? icons[type] : icons.DEFAULT;
             // background circle
-            $logo.addClass("fa-stack fa-2x").css({
+            $logo.addClass('fa-stack fa-2x').css({
                 'cursor': 'pointer'
             });
             // For 'stacked' (set) icons, add a shifted-over
@@ -2514,7 +2632,7 @@ define([
             // to the top one.
             var circle_classes = 'fa fa-circle fa-stack-2x';
             var circle_color = this.logoColorLookup(type);
-            var cmax = function(x) { return x > 255 ? 255 : x; };
+            var cmax = function (x) { return x > 255 ? 255 : x; };
             if (stacked) {
                 var parsed_color, r, g, b;
                 var cstep = 20; // color-step for overlapped circles
@@ -2557,16 +2675,16 @@ define([
                 .css({ 'color': circle_color }));
             // to avoid repetition, define the func. here that will
             // add one set of icons
-            var add_logo_func = function(fa_icon, $logo, cls) {
+            var add_logo_func = function (fa_icon, $logo, cls) {
                 $logo.append($('<i>')
                     .addClass(fa_icon + ' fa-inverse fa-stack-1x ' + cls));
             };
             if (this.isCustomIcon(icon)) {
                 // add custom icons (more than 1 will look weird, though)
-                _.each(icon, function(cls) { add_logo_func('icon', $logo, cls); });
+                _.each(icon, function (cls) { add_logo_func('icon', $logo, cls); });
             } else {
                 // add stack of font-awesome icons
-                _.each(icon, function(cls) { add_logo_func('fa', $logo, cls); });
+                _.each(icon, function (cls) { add_logo_func('fa', $logo, cls); });
             }
         },
 
@@ -2577,7 +2695,7 @@ define([
          * @param icon_list {list of str} Icon classes, from icons.json
          * @returns {boolean}
          */
-        isCustomIcon: function(icon_list) {
+        isCustomIcon: function (icon_list) {
             return (icon_list.length > 0 && icon_list[0].length > 4 &&
                 icon_list[0].substring(0, 4) == 'icon');
         },
@@ -2587,7 +2705,7 @@ define([
          * @param type
          * @returns {string} Color code
          */
-        logoColorLookup: function(type) {
+        logoColorLookup: function (type) {
             var color = this.icon_color_mapping[type];
             if (color === undefined) {
                 // fall back to primitive hack that just guesses

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/narrativeViewers.js
@@ -6,16 +6,16 @@ define([
     'underscore',
     'narrativeConfig',
     'bluebird',
-    
+
     'kbwidget',
     'bootstrap',
     'kbase-client-api'
-], function (
+], function(
     $,
     _,
     Config,
     Promise
-    ) {
+) {
     'use strict';
 
     /**
@@ -44,23 +44,23 @@ define([
         var viewers = {};
         var landingPageUrls = {};
         var typeNames = {};
-        var specs = {};
         var methodIds = [];
 
+        // TODO: FIX: global reference to NarrativeMethodStore
         var methodStoreClient = new NarrativeMethodStore(Config.url('narrative_method_store'));
 
         return Promise.resolve(methodStoreClient.list_categories({
             load_methods: 1,
             load_apps: 0,
             load_types: 1
-        })).then(function (data) {
+        })).then(function(data) {
             var methodInfo = data[1];
             var allTypes = data[3];
 
-            _.each(allTypes, function (val, key) {
+            _.each(allTypes, function(val, key) {
                 // If there's an error, whine.
                 if (val.loading_error) {
-                    console.error("Error loading method [" + key + "]: " + val.loading_error);
+                    console.error('Error loading method [' + key + ']: ' + val.loading_error);
                 }
                 // If it has at least one method id, make sure its there.
                 else if (val.view_method_ids && val.view_method_ids.length > 0) {
@@ -79,16 +79,18 @@ define([
             });
 
             methodIds = _.uniq(methodIds);
-            return Promise.resolve(methodStoreClient.get_method_spec({ids: methodIds}));
-        }).then(function (specs) {
-            _.each(specs, function (val, key) {
+            return Promise.resolve(methodStoreClient.get_method_spec({ ids: methodIds }));
+        }).then(function(specs) {
+            _.each(specs, function(val, key) {
                 specs[val.info.id] = val;
             });
-            return {viewers: viewers,
+            return {
+                viewers: viewers,
                 landingPageUrls: landingPageUrls,
                 typeNames: typeNames,
                 specs: specs,
-                methodIds: methodIds};
+                methodIds: methodIds
+            };
         });
     }
 
@@ -103,7 +105,7 @@ define([
      *
      */
     function createViewer(dataCell) {
-        var getParamValue = function (o, mapping) {
+        var getParamValue = function(o, mapping) {
             var param = null;
 
             if (mapping.input_parameter) {
@@ -122,9 +124,9 @@ define([
                 console.error('an error occurred');
             }
             return param;
-        }
+        };
 
-        var transformParam = function (o, mapping, param) {
+        var transformParam = function(o, mapping, param) {
             if (mapping.target_type_transform) {
                 switch (mapping.target_type_transform) {
                     case 'list':
@@ -138,20 +140,19 @@ define([
                 }
             }
             return param;
-        }
+        };
 
-        return loadViewerInfo().then(function (viewerInfo) {
+        return loadViewerInfo().then(function(viewerInfo) {
 
             var o = dataCell.obj_info;
             var methodId = viewerInfo.viewers[o.bare_type];
             if (!methodId) {
-                console.debug("No viewer found for type=" + o.bare_type);
-                return {widget: defaultViewer(dataCell), title: 'Unknown Data Type'};
+                console.debug('No viewer found for type=' + o.bare_type);
+                return { widget: defaultViewer(dataCell), title: 'Unknown Data Type' };
             }
             var spec = viewerInfo.specs[methodId];
-            var inputParamId = spec['parameters'][0]['id'];
-            var output = {'_obj_info':o};
-            _.each(spec.behavior.output_mapping, function (mapping) {
+            var output = { '_obj_info': o };
+            _.each(spec.behavior.output_mapping, function(mapping) {
                 // Get parameter value
                 var param = getParamValue(o, mapping);
                 if (param === null) {
@@ -161,7 +162,7 @@ define([
                 // Get transformed parameter value
                 param = transformParam(o, mapping, param);
                 if (param === null) {
-                    console.error('Method (' + methodId + ') spec: bad transformation type=', method.target_type_transform);
+                    console.error('Method (' + methodId + ') spec: bad transformation type (obj_info, mapping, param) = ', o, mapping, param);
                     return null;
                 }
                 // Get target property
@@ -187,11 +188,11 @@ define([
             // If that fails, try to load with require.
             // If THAT fails, fail with an error (though the error should be improved)
             catch (err) {
-                require([outputWidget], function (W) {
+                require([outputWidget], function(W) {
                     w = new W($elem, output);
                     return w;
-                }, function (reqErr) {
-                    console.error("errors occurred while making widget: " + outputWidget, {'firstTry': err, 'requireErr': reqErr});
+                }, function(reqErr) {
+                    console.error('errors occurred while making widget: ' + outputWidget, { 'firstTry': err, 'requireErr': reqErr });
                     $elem = defaultViewer(dataCell);
                     output.widgetTitle = 'Unknown Data Type';
                 });
@@ -213,10 +214,10 @@ define([
         var mdDesc = '';
 
         if (_.isEmpty(o.meta)) {
-            mdDesc += "No metadata";
+            mdDesc += 'No metadata';
         } else {
-            mdDesc += "Metadata";
-            _.each(_.pairs(o.meta), function (p) {
+            mdDesc += 'Metadata';
+            _.each(_.pairs(o.meta), function(p) {
                 mdDesc += '\n' + p[0] + ': ' + p[1];
             });
         }

--- a/kbase-extension/static/kbase/templates/job_status/new_objects.html
+++ b/kbase-extension/static/kbase/templates/job_status/new_objects.html
@@ -9,7 +9,7 @@
     </tr>
     {{#each this}}
     <tr>
-        <td><a id="{{name}}">{{name}}</a></td>
+        <td><a data-object-name="{{name}}" style="cursor:pointer;">{{name}}</a></td>
         <td>{{type}}</td>
     </tr>
     {{/each}}

--- a/nbextensions/advancedViewCell/main.js
+++ b/nbextensions/advancedViewCell/main.js
@@ -95,7 +95,7 @@ define([
                             result: null
                         },
                         params: null,
-                        outputWidgetState: null 
+                        outputWidgetState: null
                     }
                 };
                 cell.metadata = meta;
@@ -125,7 +125,7 @@ define([
                 showCode = utils.getCellMeta(cell, 'kbase.viewCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.addClass('hidden');
+                inputArea.classList.remove('-show');
             }
             outputArea.addClass('hidden');
             viewInputArea.addClass('hidden');
@@ -138,7 +138,9 @@ define([
                 showCode = utils.getCellMeta(cell, 'kbase.viewCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.removeClass('hidden');
+                if (!inputArea.classList.contains('-show')) {
+                    inputArea.classList.add('-show');
+                }
             }
             outputArea.removeClass('hidden');
             viewInputArea.removeClass('hidden');
@@ -287,7 +289,7 @@ define([
                 return setupNotebook();
             })
             .then(function() {
-                jupyter.onEvent('inserted.Cell', function (event, data) {
+                jupyter.onEvent('inserted.Cell', function(event, data) {
                     if (data.kbase && data.kbase.type === 'advancedView') {
                         upgradeToViewCell(data.cell, data.kbase.appSpec, data.kbase.appTag)
                             .catch(function(err) {

--- a/nbextensions/appCell2/appCell.js
+++ b/nbextensions/appCell2/appCell.js
@@ -14,7 +14,7 @@ define([
     './widgets/appInfoDialog',
     './widgets/appCellWidget',
     'common/spec'
-], function (
+], function(
     Promise,
     Uuid,
     utils,
@@ -54,41 +54,46 @@ define([
             spec;
 
         function specializeCell() {
-            cell.minimize = function () {
-                var inputArea = this.input.find('.input_area'),
+            cell.minimize = function() {
+                var inputArea = this.input.find('.input_area').get(0),
                     outputArea = this.element.find('.output_wrapper'),
                     viewInputArea = this.element.find('[data-subarea-type="app-cell-input"]'),
                     showCode = utils.getCellMeta(cell, 'kbase.appCell.user-settings.showCodeInputArea');
 
                 if (showCode) {
-                    inputArea.addClass('hidden');
+                    // inputArea.addClass('hidden');
+                    inputArea.classList.remove('-show');
                 }
                 outputArea.addClass('hidden');
                 viewInputArea.addClass('hidden');
             };
 
-            cell.maximize = function () {
-                var inputArea = this.input.find('.input_area'),
+            cell.maximize = function() {
+                var inputArea = this.input.find('.input_area').get(0),
                     outputArea = this.element.find('.output_wrapper'),
                     viewInputArea = this.element.find('[data-subarea-type="app-cell-input"]'),
                     showCode = utils.getCellMeta(cell, 'kbase.appCell.user-settings.showCodeInputArea');
 
                 if (showCode) {
-                    inputArea.removeClass('hidden');
+                    // inputArea.removeClass('hidden');
+                    if (!inputArea.classList.contains('-show')) {
+                        inputArea.classList.add('-show');
+                        cell.code_mirror.refresh();
+                    }
                 }
                 outputArea.removeClass('hidden');
                 viewInputArea.removeClass('hidden');
             };
-            cell.getIcon = function () {
+            cell.getIcon = function() {
                 return AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'));
             };
-            cell.renderIcon = function () {
+            cell.renderIcon = function() {
                 var iconNode = this.element[0].querySelector('.celltoolbar [data-element="icon"]');
                 if (iconNode) {
                     iconNode.innerHTML = AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.appCell.app.spec'));
                 }
             };
-            cell.showInfo = function () {
+            cell.showInfo = function() {
                 var app = utils.getCellMeta(cell, 'kbase.appCell.app');
                 appInfoDialog.show({
                     id: app.spec.info.id,
@@ -99,14 +104,20 @@ define([
             };
         }
 
-        
-
         function setupCell() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 // Only handle kbase cells.
                 if (!isAppCell(cell)) {
                     return;
                 }
+
+                var cellElement = cell.element;
+                cellElement.addClass('kb-cell').addClass('kb-app-cell');
+
+                // Just ide the code area. If it is to be displayed due to the cell
+                // settings, that will be handled by the app cell widget.
+                // var codeInputArea = cell.input.find('.input_area');
+                // codeInputArea[0].classList.add('hidden');
 
                 specializeCell(cell);
 
@@ -134,6 +145,7 @@ define([
                 // to insert a node before the node following the one we are 
                 // referencing. If there is no next sibling, the null value
                 // causes insertBefore to actually ... insert at the end!
+                kbaseNode.classList.add('hidden');
                 cell.input[0].parentNode.insertBefore(kbaseNode, cell.input[0].nextSibling);
 
                 /*
@@ -150,18 +162,18 @@ define([
                 // cell.kbase.$node = $(kbaseNode);
 
                 return appCellWidget.init()
-                    .then(function () {
+                    .then(function() {
                         return appCellWidget.attach(kbaseNode);
                     })
-                    .then(function () {
+                    .then(function() {
                         return appCellWidget.start();
                     })
-                    .then(function () {
+                    .then(function() {
                         return appCellWidget.run({
                             authToken: runtime.authToken()
                         });
                     })
-                    .then(function () {
+                    .then(function() {
                         cell.renderMinMax();
 
                         return {
@@ -169,7 +181,7 @@ define([
                             bus: cellBus
                         };
                     })
-                    .catch(function (err) {
+                    .catch(function(err) {
                         console.error('ERROR starting app cell', err);
                         // var ui = UI.make({
                         //     node: document.body
@@ -186,13 +198,13 @@ define([
                         // });
                         // TODO:
                         return appCellWidget.stop()
-                            .then(function () {
+                            .then(function() {
                                 return appCellWidget.detach();
                             })
-                            .catch(function (err) {
+                            .catch(function(err) {
                                 console.log('ERR in ERR', err);
                             })
-                            .finally(function () {
+                            .finally(function() {
                                 var ui = UI.make({
                                     node: document.body
                                 });
@@ -221,7 +233,7 @@ define([
         }
 
         function upgradeToAppCell(appSpec, appTag) {
-            return Promise.try(function () {
+            return Promise.try(function() {
                     // Create base app cell
 
                     // TODO: this should capture the entire app spec, so don't need
@@ -262,7 +274,7 @@ define([
                     // Complete the cell setup.
                     return setupCell();
                 })
-                .then(function (cellStuff) {
+                .then(function(cellStuff) {
                     // Initialize the cell to its default state.
                     // cellStuff.bus.emit('reset-to-defaults');
                 });
@@ -276,7 +288,7 @@ define([
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         },
         isAppCell: isAppCell

--- a/nbextensions/appCell2/main.js
+++ b/nbextensions/appCell2/main.js
@@ -28,7 +28,7 @@ define([
     'css!kbase/css/appCell.css',
     'css!./styles/main.css',
     'bootstrap'
-], function (
+], function(
     $,
     Jupyter,
     Promise,
@@ -47,14 +47,14 @@ define([
         p = t('p');
 
     function setupNotebook(workspaceInfo) {
-        return Promise.all(Jupyter.notebook.get_cells().map(function (cell) {
+        return Promise.all(Jupyter.notebook.get_cells().map(function(cell) {
             if (AppCell.isAppCell(cell)) {
                 var appCell = AppCell.make({
                     cell: cell,
                     workspaceInfo: workspaceInfo
                 });
                 return appCell.setupCell(cell)
-                    .catch(function (err) {
+                    .catch(function(err) {
                         // If we have an error here, there is a serious problem setting up the cell and it is not usable.
                         // What to do? The safest thing to do is inform the user, and then strip out the cell, leaving
                         // in it's place a markdown cell with the error info.
@@ -127,31 +127,29 @@ define([
         // dataUpdated.Narrative is emitted by the data sidebar list
         // after it has fetched and updated its data. Not the best of
         // triggers that the ws has changed, not the worst.
-        $(document).on('dataUpdated.Narrative', function () {
+        $(document).on('dataUpdated.Narrative', function() {
             // Tell each cell that the workspace has been updated.
             // This is what is interesting, no?
             runtime.bus().emit('workspace-changed');
         });
 
-
-
         // TODO: get the kbase specific info out of the notebook, specifically
         // the workspace name, ...
 
         setupWorkspace(runtime.config('services.workspace.url'))
-            .then(function (wsInfo) {
+            .then(function(wsInfo) {
                 workspaceInfo = serviceUtils.workspaceInfoToObject(wsInfo);
             })
-            .then(function () {
+            .then(function() {
                 return setupNotebook(workspaceInfo);
             })
-            .then(function () {
+            .then(function() {
                 // set up event hooks
 
                 // Primary hook for new cell creation.
                 // If the cell has been set with the metadata key kbase.type === 'app'
                 // we have a app cell.
-                $([Jupyter.events]).on('inserted.Cell', function (event, data) {
+                $([Jupyter.events]).on('inserted.Cell', function(event, data) {
                     if (!data.kbase || !(data.kbase.type === 'app2' || data.kbase.type === 'app')) {
                         return;
                     }
@@ -161,7 +159,7 @@ define([
                         workspaceInfo: workspaceInfo
                     });
                     appCell.upgradeToAppCell(data.kbase.appSpec, data.kbase.appTag)
-                        .catch(function (err) {
+                        .catch(function(err) {
                             console.error('ERROR creating cell', err);
                             Jupyter.notebook.delete_cell(Jupyter.notebook.find_cell_index(data.cell));
                             // For now, just pop up an error dialog;
@@ -190,7 +188,7 @@ define([
                 // also delete.Cell, edit_mode.Cell, select.Cell, command_mocd.Cell, output_appended.OutputArea ...
                 // preset_activated.CellToolbar, preset_added.CellToolbar
             })
-            .catch(function (err) {
+            .catch(function(err) {
 
                 console.error('ERROR setting up notebook', err);
             });
@@ -210,6 +208,6 @@ define([
         // This is the sole ipython/jupyter api call
         load_ipython_extension: load_ipython_extension
     };
-}, function (err) {
+}, function(err) {
     console.error('ERROR loading appCell main', err);
 });

--- a/nbextensions/appCell2/widgets/appCellWidget-fsm.js
+++ b/nbextensions/appCell2/widgets/appCellWidget-fsm.js
@@ -1,7 +1,7 @@
 /*global define*/
 /*jslint white:true,browser:true*/
 
-define([], function () {
+define([], function() {
     'use strict';
 
     var appStates = [{
@@ -54,22 +54,51 @@ define([], function () {
                     params: 'incomplete'
                 }
             ]
-        },
-        {
+        }, {
             state: {
                 mode: 'editing',
                 params: 'incomplete'
             },
             ui: {
                 tabs: {
-                    configure: {
-                        enabled: true,
-                        selected: true
-                    },
-                    viewConfigure: {
-                        enabled: false,
-                        hidden: true
-                    },
+                    configure: [{
+                        selector: {
+                            viewOnly: false
+                        },
+                        settings: {
+                            enabled: true,
+                            hidden: false,
+                            selected: true
+                        }
+                    }, {
+                        selector: {
+                            viewOnly: true
+                        },
+                        settings: {
+                            enabled: false,
+                            hidden: true,
+                            selected: false
+                        }
+                    }],
+                    viewConfigure: [{
+                        selector: {
+                            viewOnly: false
+                        },
+                        settings: {
+                            enabled: false,
+                            hidden: true,
+                            selected: false
+                        }
+                    }, {
+                        selector: {
+                            viewOnly: true
+                        },
+                        settings: {
+                            enabled: true,
+                            hidden: false,
+                            selected: true
+                        }
+                    }],
                     logs: {
                         enabled: false
                     },
@@ -121,14 +150,44 @@ define([], function () {
             },
             ui: {
                 tabs: {
-                    configure: {
-                        enabled: true,
-                        selected: true
-                    },
-                    viewConfigure: {
-                        enabled: false,
-                        hidden: true
-                    },
+                    configure: [{
+                        selector: {
+                            viewOnly: false
+                        },
+                        settings: {
+                            enabled: true,
+                            hidden: false,
+                            selected: true
+                        }
+                    }, {
+                        selector: {
+                            viewOnly: true
+                        },
+                        settings: {
+                            enabled: false,
+                            hidden: true,
+                            selected: false
+                        }
+                    }],
+                    viewConfigure: [{
+                        selector: {
+                            viewOnly: false
+                        },
+                        settings: {
+                            enabled: false,
+                            hidden: true,
+                            selected: false
+                        }
+                    }, {
+                        selector: {
+                            viewOnly: true
+                        },
+                        settings: {
+                            enabled: true,
+                            hidden: false,
+                            selected: true
+                        }
+                    }],
                     logs: {
                         enabled: false
                     },
@@ -280,8 +339,7 @@ define([], function () {
                     }]
                 }
             },
-            next: [
-                {
+            next: [{
                     mode: 'processing',
                     stage: 'launched'
                 },
@@ -362,8 +420,7 @@ define([], function () {
                     }]
                 }
             },
-            next: [
-                {
+            next: [{
                     mode: 'processing',
                     stage: 'launched'
                 },
@@ -468,6 +525,7 @@ define([], function () {
                     mode: 'processing',
                     stage: 'queued'
                 },
+
                 {
                     mode: 'canceled'
                 },
@@ -503,6 +561,7 @@ define([], function () {
                 }
             ]
         },
+
         {
             state: {
                 mode: 'processing',
@@ -566,6 +625,7 @@ define([], function () {
                     mode: 'processing',
                     stage: 'running'
                 },
+
                 {
                     mode: 'canceled'
                 },
@@ -592,6 +652,7 @@ define([], function () {
                 }
             ]
         },
+
         {
             state: {
                 mode: 'canceling'
@@ -797,7 +858,7 @@ define([], function () {
                 },
                 resume: {
                     messages: [{
-                        emit: 'on-success'
+                        emit: 'resume-success'
                     }]
                 },
                 exit: {
@@ -819,6 +880,7 @@ define([], function () {
                 }
             ]
         },
+
         {
             state: {
                 mode: 'error',

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -32,7 +32,7 @@ define([
     './runClock',
     'css!google-code-prettify/prettify.css',
     'css!font-awesome.css'
-], function (
+], function(
     require,
     $,
     Promise,
@@ -41,7 +41,7 @@ define([
     Runtime,
     Events,
     ToErr,
-    JupyterProxy,
+    Narrative,
     html,
     formatting,
     Props,
@@ -125,6 +125,8 @@ define([
             fsm,
             saveMaxFrequency = config.saveMaxFrequency || 5000,
             controlBarTabs = {},
+            readOnly = false,
+            viewOnly = false,
             actionButtons = {
                 current: {
                     name: null,
@@ -173,10 +175,10 @@ define([
         // NEW - TABS
 
         function pRequire(module) {
-            return new Promise(function (resolve, reject) {
-                require(module, function () {
+            return new Promise(function(resolve, reject) {
+                require(module, function() {
                     resolve(arguments);
-                }, function (err) {
+                }, function(err) {
                     reject(err);
                 });
             });
@@ -184,7 +186,7 @@ define([
 
         function loadParamsWidget(arg) {
             return pRequire(['./appParamsWidget'])
-                .spread(function (Widget) {
+                .spread(function(Widget) {
                     // TODO: widget should make own bus.
                     var bus = runtime.bus().makeChannelBus({ description: 'Parent comm bus for input widget' }),
                         widget = Widget.make({
@@ -193,8 +195,8 @@ define([
                             initialParams: model.getItem('params')
                         });
 
-                    bus.on('sync-params', function (message) {
-                        message.parameters.forEach(function (paramId) {
+                    bus.on('sync-params', function(message) {
+                        message.parameters.forEach(function(paramId) {
                             bus.send({
                                 parameter: paramId,
                                 value: model.getItem(['params', message.parameter])
@@ -207,7 +209,7 @@ define([
                         });
                     });
 
-                    bus.on('parameter-sync', function (message) {
+                    bus.on('parameter-sync', function(message) {
                         var value = model.getItem(['params', message.parameter]);
                         bus.send({
                             //                            parameter: message.parameter,
@@ -221,7 +223,7 @@ define([
                         });
                     });
 
-                    bus.on('set-param-state', function (message) {
+                    bus.on('set-param-state', function(message) {
                         model.setItem('paramState', message.id, message.state);
                     });
 
@@ -229,7 +231,7 @@ define([
                         key: {
                             type: 'get-param-state'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             return {
                                 state: model.getItem('paramState', message.id)
                             }
@@ -240,14 +242,14 @@ define([
                         key: {
                             type: 'get-parameter'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             return {
                                 value: model.getItem(['params', message.parameterName])
                             };
                         }
                     });
 
-                    bus.on('parameter-changed', function (message) {
+                    bus.on('parameter-changed', function(message) {
                         // TODO: should never get these in the following states....
 
                         var state = fsm.getCurrentState().state;
@@ -264,7 +266,7 @@ define([
                             appSpec: model.getItem('app.spec'),
                             parameters: spec.getSpec().parameters
                         })
-                        .then(function () {
+                        .then(function() {
                             return {
                                 bus: bus,
                                 instance: widget
@@ -275,7 +277,7 @@ define([
 
         function loadViewParamsWidget(arg) {
             return pRequire(['./appParamsViewWidget'])
-                .spread(function (Widget) {
+                .spread(function(Widget) {
                     // TODO: widget should make own bus.
                     var bus = runtime.bus().makeChannelBus({ description: 'Parent comm bus for input widget' }),
                         widget = Widget.make({
@@ -284,8 +286,8 @@ define([
                             initialParams: model.getItem('params')
                         });
 
-                    bus.on('sync-params', function (message) {
-                        message.parameters.forEach(function (paramId) {
+                    bus.on('sync-params', function(message) {
+                        message.parameters.forEach(function(paramId) {
                             bus.send({
                                 parameter: paramId,
                                 value: model.getItem(['params', message.parameter])
@@ -298,7 +300,7 @@ define([
                         });
                     });
 
-                    bus.on('parameter-sync', function (message) {
+                    bus.on('parameter-sync', function(message) {
                         var value = model.getItem(['params', message.parameter]);
                         bus.send({
                             //                            parameter: message.parameter,
@@ -312,7 +314,7 @@ define([
                         });
                     });
 
-                    bus.on('set-param-state', function (message) {
+                    bus.on('set-param-state', function(message) {
                         model.setItem('paramState', message.id, message.state);
                     });
 
@@ -320,7 +322,7 @@ define([
                         key: {
                             type: 'get-param-state'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             return {
                                 state: model.getItem('paramState', message.id)
                             };
@@ -331,14 +333,14 @@ define([
                         key: {
                             type: 'get-parameter'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             return {
                                 value: model.getItem(['params', message.parameterName])
                             };
                         }
                     });
 
-                    bus.on('parameter-changed', function (message) {
+                    bus.on('parameter-changed', function(message) {
                         // TODO: should never get these in the following states....
 
                         var state = fsm.getCurrentState().state;
@@ -355,7 +357,7 @@ define([
                             appSpec: model.getItem('app.spec'),
                             parameters: spec.getSpec().parameters
                         })
-                        .then(function () {
+                        .then(function() {
                             return {
                                 bus: bus,
                                 instance: widget
@@ -374,14 +376,14 @@ define([
                     return loadParamsWidget({
                             node: container
                         })
-                        .then(function (result) {
+                        .then(function(result) {
                             widget = result;
                         });
 
                 }
 
                 function stop() {
-                    return Promise.try(function () {
+                    return Promise.try(function() {
                         if (widget) {
                             return widget.instance.stop();
                         }
@@ -395,7 +397,7 @@ define([
             }
 
             return {
-                make: function (config) {
+                make: function(config) {
                     return factory(config);
                 }
             };
@@ -411,13 +413,13 @@ define([
                     return loadViewParamsWidget({
                             node: container
                         })
-                        .then(function (result) {
+                        .then(function(result) {
                             widget = result;
                         });
                 }
 
                 function stop() {
-                    return Promise.try(function () {
+                    return Promise.try(function() {
                         if (widget) {
                             return widget.instance.stop();
                         }
@@ -431,17 +433,17 @@ define([
             }
 
             return {
-                make: function (config) {
+                make: function(config) {
                     return factory(config);
                 }
             };
         }
 
         function loadWidget(name) {
-            return new Promise(function (resolve, reject) {
-                require('./tabs/' + name, function (Widget) {
+            return new Promise(function(resolve, reject) {
+                require('./tabs/' + name, function(Widget) {
                     resolve(Widget);
-                }, function (err) {
+                }, function(err) {
                     reject(err);
                 });
             });
@@ -452,7 +454,7 @@ define([
 
             if (selectedTab.widgetModule) {
                 return loadWidget(selectedTab.widgetModule)
-                    .then(function (Widget) {
+                    .then(function(Widget) {
                         controlBarTabs.selectedTab = {
                             id: tabId,
                             widget: Widget.make()
@@ -490,10 +492,10 @@ define([
             ui.deactivateButton(controlBarTabs.selectedTab.id);
 
             return controlBarTabs.selectedTab.widget.stop()
-                .catch(function (err) {
+                .catch(function(err) {
                     console.error('ERROR stopping', err);
                 })
-                .finally(function () {
+                .finally(function() {
                     var widgetNode = ui.getElement('run-control-panel.tab-pane.widget');
                     if (widgetNode.firstChild) {
                         widgetNode.removeChild(widgetNode.firstChild);
@@ -508,7 +510,7 @@ define([
                     return;
                 }
                 return stopTab()
-                    .then(function () {
+                    .then(function() {
                         return startTab(tabId);
                     });
             }
@@ -523,7 +525,7 @@ define([
         }
 
         function hidePane() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 var paneNode = ui.getElement('run-control-panel.tab-pane');
                 if (paneNode) {
                     paneNode.classList.add('hidden');
@@ -532,7 +534,7 @@ define([
         }
 
         function showPane() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 var paneNode = ui.getElement('run-control-panel.tab-pane');
                 if (paneNode) {
                     paneNode.classList.remove('hidden');
@@ -554,32 +556,33 @@ define([
         // Track whether the user has selected a tab.
         // This is reset when the user closes a tab.
         var userSelectedTab = false;
+
         function toggleTab(tabId) {
             if (controlBarTabs.selectedTab) {
                 if (controlBarTabs.selectedTab.id === tabId) {
                     return stopTab()
-                        .then(function () {
+                        .then(function() {
                             // hide the pane, since we just closed the only open
                             //tab.
                             return hidePane();
                         })
-                        .then(function () {
+                        .then(function() {
                             userSelectedTab = false;
                         });
                 }
                 return stopTab()
-                    .then(function () {
+                    .then(function() {
                         return startTab(tabId);
                     })
-                    .then(function () {
+                    .then(function() {
                         userSelectedTab = true;
                     });
             }
             return showPane()
-                .then(function () {
+                .then(function() {
                     startTab(tabId);
                 })
-                .then(function () {
+                .then(function() {
                     userSelectedTab = true;
                 });
         }
@@ -594,7 +597,7 @@ define([
                     widget: configureWidget()
                 },
                 viewConfigure: {
-                    label: 'Configure',
+                    label: 'View Configure',
                     // icon: 'pencil',
                     widget: viewConfigureWidget()
                 },
@@ -637,30 +640,30 @@ define([
             }
 
             switch (app.tag) {
-            case 'release':
-                return {
-                    ids: [app.spec.info.id],
-                    tag: 'release',
-                    version: app.spec.info.ver
-                };
-            case 'dev':
-            case 'beta':
-                return {
-                    ids: [app.spec.info.id],
-                    tag: app.tag
-                };
-            default:
-                console.error('Invalid tag', app);
-                throw new ToErr.KBError({
-                    type: 'internal-app-cell-error',
-                    message: 'This app cell is corrrupt -- the app tag ' + String(app.tag) + ' is not recognized',
-                    advice: [
-                        'This condition should never occur outside of a development environment',
-                        'The tag of the app associated with the app cell must be one of "release", "beta", or "dev"',
-                        'Chances are that this app cell was inserted in a development environment in which the app cell structure was in flux',
-                        'You should remove this app cell from the narrative an insert an new one'
-                    ]
-                });
+                case 'release':
+                    return {
+                        ids: [app.spec.info.id],
+                        tag: 'release',
+                        version: app.spec.info.ver
+                    };
+                case 'dev':
+                case 'beta':
+                    return {
+                        ids: [app.spec.info.id],
+                        tag: app.tag
+                    };
+                default:
+                    console.error('Invalid tag', app);
+                    throw new ToErr.KBError({
+                        type: 'internal-app-cell-error',
+                        message: 'This app cell is corrrupt -- the app tag ' + String(app.tag) + ' is not recognized',
+                        advice: [
+                            'This condition should never occur outside of a development environment',
+                            'The tag of the app associated with the app cell must be one of "release", "beta", or "dev"',
+                            'Chances are that this app cell was inserted in a development environment in which the app cell structure was in flux',
+                            'You should remove this app cell from the narrative an insert an new one'
+                        ]
+                    });
             }
 
         }
@@ -672,7 +675,7 @@ define([
                 });
 
             return nms.get_method_spec(appRef)
-                .then(function (data) {
+                .then(function(data) {
                     if (!data[0]) {
                         throw new Error('App not found');
                     }
@@ -713,7 +716,7 @@ define([
 
         function showFsmBar() {
             var currentState = fsm.getCurrentState(),
-                content = Object.keys(currentState.state).map(function (key) {
+                content = Object.keys(currentState.state).map(function(key) {
                     return span([
                         span({ style: { fontStyle: 'italic' } }, key),
                         ' : ',
@@ -743,7 +746,7 @@ define([
                     th('Name'),
                     td({ dataElement: 'name' })
                 ]),
-                ui.ifAdvanced(function () {
+                ui.ifAdvanced(function() {
                     return tr([
                         th('Module'),
                         td({ dataElement: 'module' })
@@ -765,7 +768,7 @@ define([
                     th('Authors'),
                     td({ dataElement: 'authors' })
                 ]),
-                ui.ifAdvanced(function () {
+                ui.ifAdvanced(function() {
                     return tr([
                         th('Git commit hash'),
                         td({ dataElement: 'git-commit-hash' })
@@ -784,13 +787,6 @@ define([
                 name: 'summary',
                 content: renderAppSummary()
             }];
-            if (ui.isDeveloper()) {
-                aboutTabs.push({
-                    label: 'Spec',
-                    name: 'spec',
-                    content: renderAppSpec()
-                });
-            }
 
             return html.makeTabs({
                 tabs: aboutTabs
@@ -824,13 +820,13 @@ define([
 
             value = model.getItem(['user-settings', settingName], setting.defaultValue);
             switch (setting.type) {
-            case 'toggle':
-                if (value) {
-                    showElement(setting.element);
-                } else {
-                    hideElement(setting.element);
-                }
-                break;
+                case 'toggle':
+                    if (value) {
+                        showElement(setting.element);
+                    } else {
+                        hideElement(setting.element);
+                    }
+                    break;
             }
         }
 
@@ -845,7 +841,7 @@ define([
 
         function renderSettings() {
             var events = Events.make({ node: container }),
-                content = Object.keys(settings).map(function (key) {
+                content = Object.keys(settings).map(function(key) {
                     var setting = settings[key],
                         settingsValue = model.getItem(['user-settings', key]) || setting.defaultValue;
                     return div({}, [
@@ -856,7 +852,7 @@ define([
                             value: key,
                             id: events.addEvent({
                                 type: 'change',
-                                handler: function (e) {
+                                handler: function(e) {
                                     doChangeSetting(e);
                                 }
                             })
@@ -871,7 +867,7 @@ define([
             events.attachEvents();
 
             //Ensure that the settings are reflected in the UI.
-            Object.keys(settings).forEach(function (key) {
+            Object.keys(settings).forEach(function(key) {
                 renderSetting(key);
             });
         }
@@ -891,7 +887,7 @@ define([
             ui.setContent('about-app.summary', appSpec.info.subtitle);
             ui.setContent('about-app.version', appSpec.info.ver);
             ui.setContent('about-app.git-commit-hash', appSpec.info.git_commit_hash || ui.na());
-            ui.setContent('about-app.authors', (function () {
+            ui.setContent('about-app.authors', (function() {
                 if (appSpec.info.authors && appSpec.info.authors.length > 0) {
                     return appSpec.info.authors.join('<br>');
                 }
@@ -914,34 +910,34 @@ define([
 
         function doActionButton(data) {
             switch (data.action) {
-            case 'runApp':
-                doRun();
-                break;
-            case 'reRunApp':
-                doRerun();
-                break;
-            case 'resetApp':
-                doResetApp();
-                break;
-            case 'cancel':
-                doCancel();
-                break;
-            default:
-                alert('Undefined action:' + data.action);
+                case 'runApp':
+                    doRun();
+                    break;
+                case 'reRunApp':
+                    doRerun();
+                    break;
+                case 'resetApp':
+                    doResetApp();
+                    break;
+                case 'cancel':
+                    doCancel();
+                    break;
+                default:
+                    alert('Undefined action:' + data.action);
             }
         }
 
         function buildRunControlPanelRunButtons(events) {
             var style = {};
-            if (Jupyter.narrative.readonly) {
-                style.display = 'none';
-            }
+            // if (Jupyter.narrative.readonly) {
+            //     style.display = 'none';
+            // }
             style.padding = '6px';
             var buttonDiv = div({
-                class: 'btn-group',
-                style: style
-            },
-                Object.keys(actionButtons.availableButtons).map(function (key) {
+                    class: 'btn-group',
+                    style: style
+                },
+                Object.keys(actionButtons.availableButtons).map(function(key) {
                     var button = actionButtons.availableButtons[key],
                         classes = [].concat(button.classes),
                         icon;
@@ -977,7 +973,7 @@ define([
         }
 
         function buildRunControlPanelDisplayButtons(events) {
-            var buttons = Object.keys(controlBarTabs.tabs).map(function (key) {
+            var buttons = Object.keys(controlBarTabs.tabs).map(function(key) {
                 var tab = controlBarTabs.tabs[key],
                     icon;
                 if (!tab) {
@@ -1010,10 +1006,10 @@ define([
                     },
                     icon: icon
                 });
-            }).filter(function (x) {
+            }).filter(function(x) {
                 return x ? true : false;
             });
-            bus.on('control-panel-tab', function (message) {
+            bus.on('control-panel-tab', function(message) {
                 var tab = message.data.tab;
                 toggleTab(tab);
             });
@@ -1133,7 +1129,7 @@ define([
                                 }, [
                                     span({ style: { 'font-weight': 'bold' } }, 'Warning'),
                                     ': this app appears to be out of date. Running it may cause undesired results. Add a new "',
-                                    span({ style: { 'font-weight': 'bold' }, dataElement: 'new-app-name'}),
+                                    span({ style: { 'font-weight': 'bold' }, dataElement: 'new-app-name' }),
                                     '" App for the most recent version.'
                                 ]),
                                 ui.buildPanel({
@@ -1165,29 +1161,6 @@ define([
                                         div({ dataElement: 'about-app' }, renderAboutApp())
                                     ]
                                 }),
-                                (function () {
-                                    if (!ui.isDeveloper()) {
-                                        return;
-                                    }
-                                    return ui.buildCollapsiblePanel({
-                                        title: 'Dev',
-                                        name: 'developer-options',
-                                        hidden: true,
-                                        type: 'default',
-                                        classes: ['kb-panel-container'],
-                                        body: [
-                                            div({ dataElement: 'fsm-display', style: { marginBottom: '4px' } }, [
-                                                span({ style: { marginRight: '4px' } }, 'FSM'),
-                                                span({ dataElement: 'content' })
-                                            ]),
-                                            div([
-                                                ui.makeButton('Show Code', 'toggle-code-view', { events: events }),
-                                                ui.makeButton('Edit Metadata', 'edit-cell-metadata', { events: events }),
-                                                ui.makeButton('Edit Notebook Metadata', 'edit-notebook-metadata', { events: events })
-                                            ])
-                                        ]
-                                    });
-                                }()),
                                 buildRunControlPanel(events)
                             ])
                         ])
@@ -1212,21 +1185,21 @@ define([
         // for a beta or release tag ...
         function fixApp(app) {
             switch (app.tag) {
-            case 'release':
-                return {
-                    id: app.id,
-                    tag: app.tag,
-                    version: app.version
-                };
-            case 'beta':
-            case 'dev':
-                return {
-                    id: app.id,
-                    tag: app.tag,
-                    version: app.gitCommitHash
-                };
-            default:
-                throw new Error('Invalid tag for app ' + app.id);
+                case 'release':
+                    return {
+                        id: app.id,
+                        tag: app.tag,
+                        version: app.version
+                    };
+                case 'beta':
+                case 'dev':
+                    return {
+                        id: app.id,
+                        tag: app.tag,
+                        version: app.gitCommitHash
+                    };
+                default:
+                    throw new Error('Invalid tag for app ' + app.id);
             }
         }
 
@@ -1256,7 +1229,7 @@ define([
                 initialState: {
                     mode: 'new'
                 },
-                onNewState: function (fsm) {
+                onNewState: function(fsm) {
                     model.setItem('fsm.currentState', fsm.getCurrentState().state);
                     // save the narrative!
 
@@ -1264,60 +1237,64 @@ define([
             });
             // fsm events
 
-            fsm.bus.on('on-execute-requested', function () {
+            fsm.bus.on('on-execute-requested', function() {
                 ui.setContent('run-control-panel.status.execMessage', 'Sending...');
             });
-            fsm.bus.on('exit-execute-requested', function () {
+            fsm.bus.on('exit-execute-requested', function() {
                 ui.setContent('run-control-panel.status.execMessage', '');
             });
-            fsm.bus.on('on-launched', function () {
+            fsm.bus.on('on-launched', function() {
                 ui.setContent('run-control-panel.status.execMessage', 'Launching...');
             });
-            fsm.bus.on('exit-launched', function () {
+            fsm.bus.on('exit-launched', function() {
                 ui.setContent('run-control-panel.status.execMessage', '');
             });
 
-            fsm.bus.on('start-queueing', function () {
+            fsm.bus.on('start-queueing', function() {
                 doStartQueueing();
             });
-            fsm.bus.on('stop-queueing', function () {
+            fsm.bus.on('stop-queueing', function() {
                 doStopQueueing();
             });
 
-            fsm.bus.on('start-running', function () {
+            fsm.bus.on('start-running', function() {
                 doStartRunning();
             });
-            fsm.bus.on('stop-running', function () {
+            fsm.bus.on('stop-running', function() {
                 doStopRunning();
             });
 
-            fsm.bus.on('on-success', function () {
+            fsm.bus.on('on-success', function() {
                 doOnSuccess();
             });
 
-            fsm.bus.on('exit-success', function () {
+            fsm.bus.on('resume-success', function() {
+                doOnSuccess(true);
+            });
+
+            fsm.bus.on('exit-success', function() {
                 doExitSuccess();
             });
 
-            fsm.bus.on('on-error', function () {
+            fsm.bus.on('on-error', function() {
                 doOnError();
             });
 
-            fsm.bus.on('exit-error', function () {
+            fsm.bus.on('exit-error', function() {
                 doExitError();
             });
-            fsm.bus.on('on-cancelling', function () {
+            fsm.bus.on('on-cancelling', function() {
                 doOnCancelling();
             });
 
-            fsm.bus.on('exit-cancelling', function () {
+            fsm.bus.on('exit-cancelling', function() {
                 doExitCancelling();
             });
-            fsm.bus.on('on-cancelled', function () {
+            fsm.bus.on('on-cancelled', function() {
                 doOnCancelled();
             });
 
-            fsm.bus.on('exit-cancelled', function () {
+            fsm.bus.on('exit-cancelled', function() {
                 doExitCancelled();
             });
 
@@ -1343,11 +1320,11 @@ define([
         // LIFECYCYLE API
 
         function doEditNotebookMetadata() {
-            JupyterProxy.editNotebookMetadata();
+            Narrative.editNotebookMetadata();
         }
 
         function doEditCellMetadata() {
-            JupyterProxy.editCellMetadata(cell);
+            Narrative.editCellMetadata(cell);
         }
 
         function initCodeInputArea() {
@@ -1355,11 +1332,15 @@ define([
         }
 
         function showCodeInputArea() {
-            var codeInputArea = cell.input.find('.input_area');
+            var codeInputArea = cell.input.find('.input_area').get(0);
             if (model.getItem('user-settings.showCodeInputArea')) {
-                codeInputArea.removeClass('hidden');
+                // codeInputArea.removeClass('hidden');
+                if (!codeInputArea.classList.contains('-show')) {
+                    codeInputArea.classList.add('-show');
+                }
             } else {
-                codeInputArea.addClass('hidden');
+                // codeInputArea.addClass('hidden');
+                codeInputArea.classList.remove('-show');
             }
         }
 
@@ -1408,7 +1389,7 @@ define([
             if (notifications.length === 0) {
                 content = span({ style: { fontStyle: 'italic' } }, 'There are currently no notifications');
             } else {
-                content = notifications.map(function (notification, index) {
+                content = notifications.map(function(notification, index) {
                     return div({ class: 'row' }, [
                         div({ class: 'col-md-10' }, notification),
                         div({ class: 'col-md-2', style: { textAlign: 'right' } }, span({}, [
@@ -1416,7 +1397,7 @@ define([
                                 class: 'btn btn-default',
                                 id: events.addEvent({
                                     type: 'click',
-                                    handler: function () {
+                                    handler: function() {
                                         doRemoveNotification(index);
                                     }
                                 })
@@ -1451,10 +1432,26 @@ define([
             renderNotifications();
             renderSettings();
             var state = fsm.getCurrentState();
-            if (model.getItem('outdated')) {
+            // var viewOnly = (state.state.perm === 'viewonly');
+            if (!viewOnly && model.getItem('outdated')) {
                 ui.setContent('outdated.new-app-name', model.getItem('newAppName', model.getItem('app.spec.info.name')));
                 ui.showElement('outdated');
             }
+
+            // In view only mode, the cell button bar is hidden.
+            // var buttonBar = container.querySelector('.kb-btn-toolbar-cell-widget');
+            // console.log('button bar?', buttonBar);
+            // if (buttonBar) {
+            //     if (viewOnly) {
+            //         if (!buttonBar.classList.contains('hidden')) {
+            //             buttonBar.classList.add('hidden');
+            //         }
+            //     } else {
+            //         if (buttonBar.classList.contains('hidden')) {
+            //             buttonBar.classList.remove('hidden');
+            //         }
+            //     }
+            // }
 
             var indicatorNode = ui.getElement('run-control-panel.status.indicator');
             var iconNode = ui.getElement('run-control-panel.status.indicator.icon');
@@ -1485,9 +1482,22 @@ define([
             }
 
             var tabSelected = false;
-            Object.keys(state.ui.tabs).forEach(function (tabId) {
+            Object.keys(state.ui.tabs).forEach(function(tabId) {
                 var tab = state.ui.tabs[tabId];
-                if (tab.enabled) {
+                var tabConfig;
+                if (tab instanceof Array) {
+                    tabConfig = tab.filter(function(mode) {
+                        if (mode.selector.viewOnly && viewOnly) {
+                            return true;
+                        }
+                        if (!mode.selector.viewOnly && !viewOnly) {
+                            return true;
+                        }
+                    })[0].settings;
+                } else {
+                    tabConfig = tab;
+                }
+                if (tabConfig.enabled) {
                     ui.enableButton(tabId);
                 } else {
                     ui.disableButton(tabId);
@@ -1495,11 +1505,11 @@ define([
                 // TODO honor user-selected tab.
                 // Unless the tab is not enabled in this state, in which case
                 // we do switch to the one called for by the state.
-                if (tab.selected && !userSelectedTab) {
+                if (tabConfig.selected && !userSelectedTab) {
                     tabSelected = true;
                     selectTab(tabId);
                 }
-                if (tab.hidden) {
+                if (tabConfig.hidden) {
                     ui.hideButton(tabId);
                 } else {
                     ui.showButton(tabId);
@@ -1511,7 +1521,8 @@ define([
                 unselectTab();
             }
 
-            if (state.ui.actionButton) {
+            // Note: viewOnly mode disables any otherwise active actionButton
+            if (state.ui.actionButton && !viewOnly) {
                 if (actionButtons.current.name) {
                     ui.hideButton(actionButtons.current.name);
                 }
@@ -1523,33 +1534,26 @@ define([
                 } else {
                     ui.enableButton(name);
                 }
+            } else {
+                if (actionButtons.current.name) {
+                    ui.hideButton(actionButtons.current.name);
+                }
             }
         }
 
-        function toggleReadOnlyMode(readOnly) {
-            if (!readOnly) {
-                // restore state based on fsm.
-                var buttonBar = container.querySelector('.kb-btn-toolbar-cell-widget');
-                if (buttonBar) {
-                    buttonBar.classList.remove('hidden');
-                }
-                renderUI();
-                var curMode = fsm.getCurrentState().state.mode;
-                if (curMode === 'processing') {
-                    startListeningForJobMessages();
-                }
-            } else {
-                // Hide the job starting/modifying buttons
-                // It'd be nice to put all the elements in view-only mode,
-                // to mimic a running state, right? Maybe that's another
-                // FSM state?
-                ui.hideElement('outdated');
-                var buttonBar = container.querySelector('.kb-btn-toolbar-cell-widget');
-                if (buttonBar) {
-                    buttonBar.classList.add('hidden');
-                }
-                stopListeningForJobMessages();
-            }
+        /*
+        setReadOnly is called to put the cell into read-only mode when it is loaded.
+        This is different than view-only, which for read/write mode is toggleable.
+        Read-only does  imply view-only as well.!
+         */
+        function setReadOnly() {
+            readOnly = true;
+            cell.code_mirror.setOption('readOnly', 'nocursor');
+            toggleViewOnlyMode(true);
+        }
+
+        function toggleViewOnlyMode(newViewOnly) {
+            viewOnly = newViewOnly;
         }
 
         var saveTimer = null;
@@ -1558,9 +1562,13 @@ define([
             if (saveTimer) {
                 return;
             }
-            saveTimer = window.setTimeout(function () {
+            if (readOnly) {
+                console.warn('cannot save narrative in read-only mode; save request ignored');
+                return;
+            }
+            saveTimer = window.setTimeout(function() {
                 saveTimer = null;
-                JupyterProxy.saveNotebook();
+                Narrative.saveNotebook();
             }, saveMaxFrequency);
         }
 
@@ -1583,29 +1591,24 @@ define([
             });
         }
 
-        function resetToEditMode() {
+        function resetToEditMode(from) {
             // only do this if we are not editing.
-
             model.deleteItem('exec');
 
             // TODO: evaluate the params again before we do this.
             fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
-
+            ui.setContent('run-control-panel.status.execMessage', '');
             clearOutput();
-
             renderUI();
         }
 
         function resetAppAndEdit() {
             // only do this if we are not editing.
-
             model.deleteItem('exec');
 
             // TODO: evaluate the params again before we do this.
             fsm.newState({ mode: 'editing', params: 'incomplete' });
-
             clearOutput();
-
             renderUI();
         }
 
@@ -1616,7 +1619,7 @@ define([
                 p('Proceed to Reset and resume editing?')
             ]);
             ui.showConfirmDialog({ title: 'Reset and resume editing?', body: confirmationMessage })
-                .then(function (confirmed) {
+                .then(function(confirmed) {
                     if (!confirmed) {
                         return;
                     }
@@ -1632,7 +1635,7 @@ define([
                 p('Proceed to Reset the app and Resume Editing?')
             ]);
             ui.showConfirmDialog({ title: 'Reset App?', body: confirmationMessage })
-                .then(function (confirmed) {
+                .then(function(confirmed) {
                     if (!confirmed) {
                         return;
                     }
@@ -1655,7 +1658,7 @@ define([
                 p('Continue to Cancel the running job?')
             ]);
             ui.showConfirmDialog({ title: 'Cancel Job?', body: confirmationMessage })
-                .then(function (confirmed) {
+                .then(function(confirmed) {
                     if (!confirmed) {
                         return;
                     }
@@ -1665,7 +1668,6 @@ define([
                         cancelJob(jobState.job_id);
 
                         fsm.newState({ mode: 'canceling' });
-                        renderUI();
                         // the job will be deleted form the notebook when the job cancellation
                         // event is received.
                     } else {
@@ -1675,28 +1677,27 @@ define([
                         // cancelled but the state machine got confused.
                         model.deleteItem('exec');
                         fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
-                        renderUI();
                     }
+                    renderUI();
                 });
         }
 
         function updateFromLaunchEvent(message) {
-
             // Update the exec state.
             // NB we need to do this because the launch events are only
             // sent once from the narrative back end.
 
             // Update FSM
-            var newFsmState = (function () {
+            var newFsmState = (function() {
                 switch (message.event) {
-                case 'launched_job':
-                    // NEW: start listening for jobs.
-                    startListeningForJobMessages(message.job_id);
-                    return { mode: 'processing', stage: 'launched' };
-                case 'error':
-                    return { mode: 'error', stage: 'launching' };
-                default:
-                    throw new Error('Invalid launch state ' + message.event);
+                    case 'launched_job':
+                        // NEW: start listening for jobs.
+                        startListeningForJobMessages(message.job_id);
+                        return { mode: 'processing', stage: 'launched' };
+                    case 'error':
+                        return { mode: 'error', stage: 'launching' };
+                    default:
+                        throw new Error('Invalid launch state ' + message.event);
                 }
             }());
             fsm.newState(newFsmState);
@@ -1704,9 +1705,9 @@ define([
         }
 
         function updateFromJobState(jobState) {
-            var currentState = fsm.getCurrentState(),
-                newFsmState = (function () {
-                    switch (jobState.job_state) {
+            var currentState = fsm.getCurrentState().state;
+            var newFsmState = (function() {
+                switch (jobState.job_state) {
                     case 'queued':
                         return { mode: 'processing', stage: 'queued' };
                     case 'job_started':
@@ -1744,8 +1745,12 @@ define([
                         };
                     default:
                         throw new Error('Invalid job state ' + jobState.job_state);
-                    }
-                }());
+                }
+            }());
+            // TODO: maybe a better way of propagating viewonly state...
+            // if (currentState.perm === 'viewonly') {
+            //     newFsmState.perm = 'viewonly';
+            // }
             fsm.newState(newFsmState);
             renderUI();
         }
@@ -1754,6 +1759,11 @@ define([
         //       it is created during the code build (since it needs to be passed
         //       to the kernel)
         function doRun() {
+            if (readOnly) {
+                // TODO: issue warning?
+                console.warn('run request ignored in readOnly mode');
+                return;
+            }
             fsm.newState({ mode: 'execute-requested' });
             renderUI();
 
@@ -1782,31 +1792,26 @@ define([
         // LIFECYCLE API
 
         function init() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 initializeFSM();
                 initCodeInputArea();
+
+                if (!Jupyter.notebook.writable || Jupyter.narrative.readonly) {
+                    setReadOnly();
+                }
+
                 return null;
             });
         }
 
         function attach(node) {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 hostNode = node;
                 container = hostNode.appendChild(document.createElement('div'));
                 ui = UI.make({
                     node: container,
                     bus: bus
                 });
-
-                // TODO: better place/way to do this:
-                if (ui.isDeveloper()) {
-                    settings.showDeveloper = {
-                        label: 'Show Developer features',
-                        defaultValue: false,
-                        type: 'toggle',
-                        element: 'developer-options'
-                    };
-                }
 
                 var layout = renderLayout();
                 container.innerHTML = layout.content;
@@ -1816,7 +1821,7 @@ define([
         }
 
         function detach() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 if (hostNode && container) {
                     hostNode.removeChild(container);
                 }
@@ -1835,7 +1840,7 @@ define([
                 key: {
                     type: 'job-status'
                 },
-                handle: function (message) {
+                handle: function(message) {
                     var existingState = model.getItem('exec.jobState'),
                         newJobState = message.jobState,
                         outputWidgetInfo = message.outputWidgetInfo;
@@ -1885,7 +1890,7 @@ define([
                 key: {
                     type: 'job-canceled'
                 },
-                handle: function () {
+                handle: function() {
                     //  reset the cell into edit mode
                     var state = fsm.getCurrentState();
                     if (state.state.mode === 'editing') {
@@ -1904,7 +1909,7 @@ define([
                 key: {
                     type: 'job-does-not-exist'
                 },
-                handle: function () {
+                handle: function() {
                     //  reset the cell into edit mode
                     var state = fsm.getCurrentState();
                     if (state.state.mode === 'editing') {
@@ -1923,7 +1928,7 @@ define([
         }
 
         function stopListeningForJobMessages() {
-            jobListeners.forEach(function (listener) {
+            jobListeners.forEach(function(listener) {
                 runtime.bus().removeListener(listener);
             });
             jobListeners = [];
@@ -1968,6 +1973,7 @@ define([
         // FSM state change events
 
         function doStartRunning() {
+            console.log('start running...');
             var jobState = model.getItem('exec.jobState');
             if (!jobState) {
                 console.warn('What, no job state?');
@@ -1975,9 +1981,9 @@ define([
             }
 
             var message = span([
-                ui.loading({size: null, color: 'green'}),
+                ui.loading({ size: null, color: 'green' }),
                 ' Running - ',
-                span({dataElement: 'clock'})
+                span({ dataElement: 'clock' })
             ]);
             ui.setContent('run-control-panel.status.execMessage', message);
 
@@ -1985,13 +1991,14 @@ define([
                 prefix: 'started ',
                 suffix: ' ago'
             });
+            console.log('start running more ...');
             widgets.runClock.start({
-                node: ui.getElement('run-control-panel.status.execMessage.clock'),
-                startTime: jobState.exec_start_time
-            })
-            .catch(function (err) {
-                ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
-            });
+                    node: ui.getElement('run-control-panel.status.execMessage.clock'),
+                    startTime: jobState.exec_start_time
+                })
+                .catch(function(err) {
+                    ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
+                });
         }
 
         function doStopRunning() {
@@ -2008,9 +2015,9 @@ define([
             }
 
             var message = span([
-                ui.loading({color: 'green'}),
+                ui.loading({ color: 'green' }),
                 ' Waiting - in Queue ',
-                span({dataElement: 'clock'})
+                span({ dataElement: 'clock' })
             ]);
             ui.setContent('run-control-panel.status.execMessage', message);
 
@@ -2018,12 +2025,12 @@ define([
                 prefix: 'for '
             });
             widgets.runClock.start({
-                node: ui.getElement('run-control-panel.status.execMessage.clock'),
-                startTime: jobState.creation_time
-            })
-            .catch(function (err) {
-                ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
-            });
+                    node: ui.getElement('run-control-panel.status.execMessage.clock'),
+                    startTime: jobState.creation_time
+                })
+                .catch(function(err) {
+                    ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
+                });
         }
 
         function doStopQueueing() {
@@ -2043,21 +2050,21 @@ define([
             var label;
             var color;
             switch (jobState) {
-            case 'completed':
-                label = 'success';
-                color = 'green';
-                break;
-            case 'suspend':
-                label = 'error';
-                color = 'red';
-                break;
-            case 'canceled':
-                label = 'cancelation';
-                color = 'orange';
-                break;
-            default:
-                label = jobState;
-                color = 'black';
+                case 'completed':
+                    label = 'success';
+                    color = 'green';
+                    break;
+                case 'suspend':
+                    label = 'error';
+                    color = 'red';
+                    break;
+                case 'canceled':
+                    label = 'cancelation';
+                    color = 'orange';
+                    break;
+                default:
+                    label = jobState;
+                    color = 'black';
             }
 
             return span({
@@ -2068,7 +2075,7 @@ define([
             }, label);
         }
 
-        function doOnSuccess() {
+        function doOnSuccess(resumed) {
             // have we created output yet?
             var jobState = model.getItem('exec.jobState'),
                 jobId = model.getItem('exec.jobState.job_id'),
@@ -2080,14 +2087,14 @@ define([
                 'Finished with ',
                 niceState(jobState.job_state),
                 ' ',
-                span({dataElement: 'clock'})
+                span({ dataElement: 'clock' })
             ]);
             ui.setContent('run-control-panel.status.execMessage', message);
 
             // Show time since this app cell run finished.
             widgets.runClock = RunClock.make({
                 on: {
-                    tick: function (elapsed) {
+                    tick: function(elapsed) {
                         var clock;
                         var day = 1000 * 60 * 60 * 24;
                         if (elapsed > day) {
@@ -2109,12 +2116,22 @@ define([
                 }
             });
             widgets.runClock.start({
-                node: ui.getElement('run-control-panel.status.execMessage.clock'),
-                startTime: jobState.finish_time
-            })
-            .catch(function (err) {
-                ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
-            });
+                    node: ui.getElement('run-control-panel.status.execMessage.clock'),
+                    startTime: jobState.finish_time
+                })
+                .catch(function(err) {
+                    ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
+                });
+
+            // Output Cell Handling
+
+            // If not in edit mode, we just skip this, and issue a warning to the console.
+            if (!Narrative.canEdit()) {
+                if (!resumed) {
+                    console.warn('App cell completion in read-only narrative, cannot process output. Please save the narrative after app cells have completed.');
+                }
+                return;
+            }
 
             // widgets named 'no-display' are a trigger to skip the output cell process.
             var skipOutputCell = model.getItem('exec.outputWidgetInfo.name') === 'no-display';
@@ -2170,7 +2187,7 @@ define([
                 ' on ',
                 format.niceTime(jobState.finish_time),
                 ' (',
-                span({dataElement: 'clock'}),
+                span({ dataElement: 'clock' }),
                 ')'
             ]);
 
@@ -2181,12 +2198,12 @@ define([
                 suffix: ' ago'
             });
             widgets.runClock.start({
-                node: ui.getElement('run-control-panel.status.execMessage.clock'),
-                startTime: jobState.finish_time
-            })
-            .catch(function (err) {
-                ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
-            });
+                    node: ui.getElement('run-control-panel.status.execMessage.clock'),
+                    startTime: jobState.finish_time
+                })
+                .catch(function(err) {
+                    ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
+                });
         }
 
         function doExitError() {
@@ -2208,11 +2225,11 @@ define([
             var jobState = model.getItem('exec.jobState');
 
             var message = span([
-                span({style: {color: 'orange'}}, 'Canceled'),
+                span({ style: { color: 'orange' } }, 'Canceled'),
                 ' on ',
                 format.niceTime(jobState.finish_time),
                 ' (',
-                span({dataElement: 'clock'}),
+                span({ dataElement: 'clock' }),
                 ')'
             ]);
 
@@ -2223,12 +2240,12 @@ define([
                 suffix: ' ago'
             });
             widgets.runClock.start({
-                node: ui.getElement('run-control-panel.status.execMessage.clock'),
-                startTime: jobState.finish_time
-            })
-            .catch(function (err) {
-                ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
-            });
+                    node: ui.getElement('run-control-panel.status.execMessage.clock'),
+                    startTime: jobState.finish_time
+                })
+                .catch(function(err) {
+                    ui.setContent('run-control-panel.status.execMessage.clock', 'ERROR:' + err.message);
+                });
         }
 
         function doExitCancelled() {
@@ -2238,13 +2255,12 @@ define([
             ui.setContent('run-control-panel.status.execMessage', '');
         }
 
-
         function doRemove() {
             var confirmationMessage = div([
                 p('Continue to remove this app cell?')
             ]);
             ui.showConfirmDialog({ title: 'Remove Cell?', body: confirmationMessage })
-                .then(function (confirmed) {
+                .then(function(confirmed) {
                     if (!confirmed) {
                         return;
                     }
@@ -2267,7 +2283,7 @@ define([
                 p('Continue to delete this app cell?')
             ]);
             ui.showConfirmDialog({ title: 'Confirm Cell Deletion', body: content })
-                .then(function (confirmed) {
+                .then(function(confirmed) {
                     if (!confirmed) {
                         return;
                     }
@@ -2279,7 +2295,7 @@ define([
 
                     // tear down all the sub widgets.
                     // TODO: make all widget behavior consistent. Either message or promise.
-                    Object.keys(widgets).forEach(function (widgetId) {
+                    Object.keys(widgets).forEach(function(widgetId) {
                         try {
                             var widget = widgets[widgetId];
                             if (widget.stop) {
@@ -2300,19 +2316,39 @@ define([
         }
 
         function start() {
-            return Semaphore.make().when('comm', 'ready', Config.get('comm_wait_timeout'))
-                .then(function () {
+            return Promise.try(function() {
+                    // Initial ui tweaks
+
+                    // Honor the code input area show/hide.
+                    // TODO: this fixup is far too late in the cell lifecycle, leaving the code
+                    // area showing if it marked as hidden. We need to at least hide the input area
+                    // by default.
+                    showCodeInputArea();
+
+                    // Honor 
+                    if (readOnly) {
+                        ui.hideElement('outdated');
+                        // var buttonBar = container.querySelector('.kb-btn-toolbar-cell-widget');
+                        // if (buttonBar) {
+                        //     buttonBar.classList.add('hidden');
+                        // }
+                    }
+                })
+                .then(function() {
+                    return Semaphore.make().when('comm', 'ready', Config.get('comm_wait_timeout'));
+                })
+                .then(function() {
                     /*
                      * listeners for the local input cell message bus
                      */
 
                     // DOM EVENTS
-                    cell.element.on('toggleCodeArea.cell', function () {
+                    cell.element.on('toggleCodeArea.cell', function() {
                         toggleCodeInputArea(cell);
                     });
                     // the settings toggle is now emitted from the toolbar, which
                     // doesn't have a reference to the bus (yet).
-                    cell.element.on('toggleCellSettings.cell', function () {
+                    cell.element.on('toggleCellSettings.cell', function() {
                         var showing = toggleSettings(cell),
                             label = span({ class: 'fa fa-cog ' }),
                             buttonNode = ui.getButton('toggle-settings');
@@ -2324,26 +2360,25 @@ define([
                         }
                     });
 
-
                     // APP CELL EVENTS
 
-                    busEventManager.add(bus.on('toggle-code-view', function () {
+                    busEventManager.add(bus.on('toggle-code-view', function() {
                         var showing = toggleCodeInputArea(),
                             label = showing ? 'Hide Code' : 'Show Code';
                         ui.setButtonLabel('toggle-code-view', label);
                     }));
-                    busEventManager.add(bus.on('show-notifications', function () {
+                    busEventManager.add(bus.on('show-notifications', function() {
                         // TODO: re-enable notifications
                         // doShowNotifications();
                     }));
-                    busEventManager.add(bus.on('edit-cell-metadata', function () {
+                    busEventManager.add(bus.on('edit-cell-metadata', function() {
                         doEditCellMetadata();
                     }));
-                    busEventManager.add(bus.on('edit-notebook-metadata', function () {
+                    busEventManager.add(bus.on('edit-notebook-metadata', function() {
                         doEditNotebookMetadata();
                     }));
 
-                    busEventManager.add(bus.on('toggle-settings', function () {
+                    busEventManager.add(bus.on('toggle-settings', function() {
                         var showing = toggleSettings(cell),
                             label = span({ class: 'fa fa-cog ' }),
                             buttonNode = ui.getButton('toggle-settings');
@@ -2354,50 +2389,28 @@ define([
                             buttonNode.classList.remove('active');
                         }
                     }));
-                    busEventManager.add(bus.on('actionButton', function (message) {
+                    busEventManager.add(bus.on('actionButton', function(message) {
                         doActionButton(message.data);
                     }));
-                    busEventManager.add(bus.on('run-app', function () {
+                    busEventManager.add(bus.on('run-app', function() {
                         doRun();
                     }));
-                    busEventManager.add(bus.on('re-run-app', function () {
+                    busEventManager.add(bus.on('re-run-app', function() {
                         doRerun();
                     }));
-                    busEventManager.add(bus.on('cancel', function () {
+                    busEventManager.add(bus.on('cancel', function() {
                         doCancel();
                     }));
-                    busEventManager.add(bus.on('remove', function () {
+                    busEventManager.add(bus.on('remove', function() {
                         doRemove();
                     }));
 
-
-                    busEventManager.add(parentBus.on('reset-to-defaults', function () {
+                    busEventManager.add(parentBus.on('reset-to-defaults', function() {
                         bus.emit('reset-to-defaults');
                     }));
 
-                    var state = model.getItem('fsm.currentState');
-                    if (state) {
-                        switch (state.mode) {
-                        case 'editing':
-                            break;
-                        case 'processing':
-                            switch (state.stage) {
-                            case 'launched':
-                            case 'queued':
-                            case 'running':
-                                startListeningForJobMessages(model.getItem('exec.jobState.job_id'));
-                                requestJobStatus(model.getItem('exec.jobState.job_id'));
-                                break;
-                            }
-                            break;
-                        case 'success':
-                        case 'error':
-                            // do nothing for now
-                        }
-                    }
-
                     // TODO: only turn this on when we need it!
-                    busEventManager.add(cellBus.on('run-status', function (message) {
+                    busEventManager.add(cellBus.on('run-status', function(message) {
                         updateFromLaunchEvent(message);
 
                         model.setItem('exec.launchState', message);
@@ -2420,11 +2433,11 @@ define([
                         });
                     }));
 
-                    busEventManager.add(cellBus.on('delete-cell', function () {
+                    busEventManager.add(cellBus.on('delete-cell', function() {
                         doDeleteCell();
                     }));
 
-                    busEventManager.add(cellBus.on('output-cell-removed', function (message) {
+                    busEventManager.add(cellBus.on('output-cell-removed', function(message) {
                         var output = model.getItem('output');
 
                         if (!output.byJob[message.jobId]) {
@@ -2439,19 +2452,19 @@ define([
                         });
                     }));
 
-                    busEventManager.add(runtime.bus().on('read-only-changed', function (msg) {
-                        toggleReadOnlyMode(msg.readOnly);
+                    busEventManager.add(runtime.bus().on('read-only-changed', function(msg) {
+                        toggleViewOnlyMode(msg.readOnly);
+                        renderUI();
                     }));
 
                     // Initialize display
-                    showCodeInputArea();
 
                     return null;
                 });
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 busEventManager.removeAll();
             });
         }
@@ -2461,8 +2474,7 @@ define([
                 paramsToExport = {},
                 parameters = spec.getSpec().parameters;
 
-
-            Object.keys(params).forEach(function (key) {
+            Object.keys(params).forEach(function(key) {
                 var value = params[key],
                     paramSpec = parameters.specs[key];
 
@@ -2490,7 +2502,7 @@ define([
 
             function harvestErrors(validations) {
                 if (validations instanceof Array) {
-                    validations.forEach(function (result, index) {
+                    validations.forEach(function(result, index) {
                         if (!result.isValid) {
                             messages.push(String(index) + ':' + result.errorMessage);
                         }
@@ -2499,7 +2511,7 @@ define([
                         }
                     });
                 } else {
-                    Object.keys(validations).forEach(function (id) {
+                    Object.keys(validations).forEach(function(id) {
                         var result = validations[id];
                         if (!result.isValid) {
                             messages.push(id + ':' + result.errorMessage);
@@ -2516,7 +2528,7 @@ define([
 
         function evaluateAppState() {
             validateModel()
-                .then(function (result) {
+                .then(function(result) {
                     // we have a tree of validations, so we need to walk the tree to see if anything
                     // does not validate.
                     var messages = gatherValidationMessages(result);
@@ -2524,14 +2536,13 @@ define([
                     if (messages.length === 0) {
                         buildPython(cell, utils.getMeta(cell, 'attributes').id, model.getItem('app'), exportParams());
                         fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
-                        renderUI();
                     } else {
                         resetPython(cell);
                         fsm.newState({ mode: 'editing', params: 'incomplete' });
-                        renderUI();
                     }
+                    renderUI();
                 })
-                .catch(function (err) {
+                .catch(function(err) {
                     alert('internal error'),
                         console.error('INTERNAL ERROR', err);
                 });
@@ -2586,15 +2597,12 @@ define([
         function run(params) {
             // First get the app specs, which is stashed in the model,
             // with the parameters returned.
-
             // If the app has been run before...
-
             // The app reference is already in the app cell metadata.
-
-            return Promise.try(function () {
+            return Promise.try(function() {
                     return getAppSpec();
                 })
-                .then(function (appSpec) {
+                .then(function(appSpec) {
                     // Ensure that the current app spec matches our existing one.
                     var warning = checkSpec(appSpec);
                     if (warning && warning.severity === 'warning') {
@@ -2611,27 +2619,43 @@ define([
                     utils.setCellMeta(cell, 'kbase.attributes.info.url', url);
                     utils.setCellMeta(cell, 'kbase.attributes.info.label', 'more...');
                 })
-                .then(function () {
+                .then(function() {
                     // this will not change, so we can just render it here.
                     showAboutApp();
                     showAppSpec();
                     PR.prettyPrint(null, container);
-                    renderUI();
-                })
-                .then(function () {
+
                     // if we start out in 'new' state, then we need to promote to
                     // editing...
                     if (fsm.getCurrentState().state.mode === 'new') {
                         fsm.newState({ mode: 'editing', params: 'incomplete' });
                         evaluateAppState();
-                    } else {
-                        renderUI();
                     }
-                    if (!Jupyter.notebook.writable || Jupyter.narrative.readonly) {
-                        toggleReadOnlyMode(true);
+
+                    renderUI();
+
+                    // Initial job state listening.
+                    switch (fsm.getCurrentState().state.mode) {
+                        case 'editing':
+                            break;
+                        case 'processing':
+                            // switch (state.stage) {
+                            //     case 'launched':
+                            //     case 'queued':
+                            //     case 'running':
+                            // if (!readOnly) {
+                            startListeningForJobMessages(model.getItem('exec.jobState.job_id'));
+                            requestJobStatus(model.getItem('exec.jobState.job_id'));
+                            // }
+                            //         break;
+                            // }
+                            break;
+                        case 'success':
+                        case 'error':
+                            // do nothing for now
                     }
                 })
-                .catch(function (err) {
+                .catch(function(err) {
                     var error = ToErr.grokError(err);
                     console.error('ERROR loading main widgets', error);
                     addNotification('Error loading main widgets: ' + error.message);
@@ -2653,7 +2677,7 @@ define([
 
         model = Props.make({
             data: utils.getMeta(cell, 'appCell'),
-            onUpdate: function (props) {
+            onUpdate: function(props) {
                 utils.setMeta(cell, 'appCell', props.getRawObject());
                 // saveNarrative();
             }
@@ -2674,10 +2698,10 @@ define([
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };
-}, function (err) {
+}, function(err) {
     console.error('ERROR loading appCell appCellWidget', err);
 });

--- a/nbextensions/appCell2/widgets/appInfoDialog.js
+++ b/nbextensions/appCell2/widgets/appInfoDialog.js
@@ -15,31 +15,37 @@ define([
     'common/ui',
     'kb_service/client/catalog',
     'kb_service/client/narrativeMethodStore'
-], function (
+], function(
     Promise,
     Runtime,
     html,
     UI,
     Catalog,
     NarrativeMethodStore
-    ) {
+) {
     'use strict';
+
     function render(data) {
         var t = html.tag,
-            div = t('div'), span = t('span'), ul = t('ul'), li = t('li');
+            div = t('div'),
+            span = t('span'),
+            ul = t('ul'),
+            li = t('li');
 
-        return div({class: 'row'}, [
-            div({class: 'col-md-8'}, div({class: 'kb-app-cell-info-desc'}, [
-                div({style: {
-                    maxHeight: '400px',
-                    overflowY: 'scroll'
-                }}, data.description)
+        return div({ class: 'row' }, [
+            div({ class: 'col-md-8' }, div({ class: 'kb-app-cell-info-desc' }, [
+                div({
+                    style: {
+                        maxHeight: '400px',
+                        overflowY: 'scroll'
+                    }
+                }, data.description)
             ])),
-            div({class: 'col-md-4'}, div({class: 'kb-app-cell-info'}, [
-                div({class: 'header'}, 'Information'),
+            div({ class: 'col-md-4' }, div({ class: 'kb-app-cell-info' }, [
+                div({ class: 'header' }, 'Information'),
                 div([
                     'Author', (data.authors.length > 1 ? 's' : ''), ': ',
-                    span({class: 'value'}, (function () {
+                    span({ class: 'value' }, (function() {
                         if (data.authors.length === 1) {
                             return data.authors[0];
                         }
@@ -50,80 +56,79 @@ define([
                 //    'ID: ', span({class: 'value'}, data.id)
                 //]),                
                 div([
-                    'Tag: ', span({class: 'value'}, data.tag)
+                    'Tag: ', span({ class: 'value' }, data.tag)
                 ]),
                 div([
-                    'Version: ', span({class: 'value'}, data.version)
+                    'Version: ', span({ class: 'value' }, data.version)
                 ]),
                 div([
-                    'Updated: ', span({class: 'value'}, data.updateDate)
+                    'Updated: ', span({ class: 'value' }, data.updateDate)
                 ]),
                 div([
-                    'Run count: ', span({class: 'value'}, data.runCount)
+                    'Run count: ', span({ class: 'value' }, data.runCount)
                 ])
             ]))
         ]);
     }
+
     function show(arg) {
         var runtime = Runtime.make(),
             nms = new NarrativeMethodStore(runtime.config('services.narrative_method_store.url')),
             catalog = new Catalog(runtime.config('services.catalog.url'));
         return Promise.all([
-            nms.get_method_full_info({ids: [arg.id], tag: arg.tag, ver: arg.version }),
-            catalog.get_exec_aggr_stats({full_app_ids: [arg.id]}),
-            catalog.get_module_info({module_name: arg.module})
-        ])
-            .spread(function (methodInfo, aggregateStats, moduleInfo) {
+                nms.get_method_full_info({ ids: [arg.id], tag: arg.tag, ver: arg.version }),
+                catalog.get_exec_aggr_stats({ full_app_ids: [arg.id] }),
+                catalog.get_module_info({ module_name: arg.module })
+            ])
+            .spread(function(methodInfo, aggregateStats, moduleInfo) {
                 // if any of these results are unexpected, we just show an error message.
                 var title = [
-                    methodInfo[0].name
-                ].join(''),
+                        methodInfo[0].name
+                    ].join(''),
                     info = {
                         id: arg.id,
                         tag: arg.tag,
-                        version: (arg.tag === 'release' ? methodInfo[0].ver : methodInfo[0].git_commit_hash.substr(0,7)),
+                        version: (arg.tag === 'release' ? methodInfo[0].ver : methodInfo[0].git_commit_hash.substr(0, 7)),
                         description: methodInfo[0].description || '',
                         authors: methodInfo[0].authors || [],
-                        runCount: aggregateStats[0].number_of_calls, 
+                        runCount: aggregateStats[0] ? aggregateStats[0].number_of_calls : 'n/a',
                         updateDate: new Date(moduleInfo[arg.tag].timestamp).toLocaleDateString()
                     },
                     url = [window.location.origin, '#appcatalog/app', arg.id, arg.tag].join('/');
-                    
+
                 return UI.showDialog({
                     title: title,
                     body: render(info),
-                    cancelLabel: 'Close', 
-                    buttons: [
-                        {
-                            action: 'link',
-                            label: 'View in App Catalog',
-                            handler: function () {
-                                return {
-                                    url: url,
-                                    name: methodInfo[0].name
-                                };
-                            }
+                    cancelLabel: 'Close',
+                    buttons: [{
+                        action: 'link',
+                        label: 'View in App Catalog',
+                        handler: function() {
+                            return {
+                                url: url,
+                                name: methodInfo[0].name
+                            };
                         }
-                    ],
+                    }],
                     options: {
                         width: '70%'
                     }
                 });
             })
-            .then(function (result) {
+            .then(function(result) {
                 switch (result.action) {
                     case 'link':
                         window.open(result.result.url, result.result.name);
                         break;
                 }
             })
-            .catch(function (err) {
+            .catch(function(err) {
                 console.error('ERROR', err);
                 return UI.showInfoDialog({
                     title: 'Error fetching app info',
                     body: err.message
                 });
-            });          
+            });
     }
 
     return {

--- a/nbextensions/appCell2/widgets/appParamsViewWidget.js
+++ b/nbextensions/appCell2/widgets/appParamsViewWidget.js
@@ -18,7 +18,7 @@ define([
     'common/runtime'
     // All the input widgets
 
-], function (
+], function(
     Promise,
     $,
     html,
@@ -97,7 +97,7 @@ define([
 
         function makeFieldWidget(appSpec, parameterSpec, value) {
             return paramResolver.loadViewControl(parameterSpec)
-                .then(function (inputWidget) {
+                .then(function(inputWidget) {
                     var fieldWidget = FieldWidget.make({
                         inputControlFactory: inputWidget,
                         showHint: true,
@@ -111,20 +111,20 @@ define([
                     });
 
                     // An input widget may ask for the current model value at any time.
-                    fieldWidget.bus.on('sync', function () {
+                    fieldWidget.bus.on('sync', function() {
                         paramsBus.emit('parameter-sync', {
                             parameter: parameterSpec.id
                         });
                     });
 
-                    fieldWidget.bus.on('sync-params', function (message) {
+                    fieldWidget.bus.on('sync-params', function(message) {
                         paramsBus.emit('sync-params', {
                             parameters: message.parameters,
                             replyToChannel: fieldWidget.bus.channelName
                         });
                     });
 
-                    fieldWidget.bus.on('set-param-state', function (message) {
+                    fieldWidget.bus.on('set-param-state', function(message) {
                         paramsBus.emit('set-param-state', {
                             id: parameterSpec.id,
                             state: message.state
@@ -135,7 +135,7 @@ define([
                         key: {
                             type: 'get-param-state'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             return paramsBus.request({ id: parameterSpec.id }, {
                                 key: {
                                     type: 'get-param-state'
@@ -148,14 +148,13 @@ define([
                     /*
                      * Or in fact any parameter value at any time...
                      */
-                    fieldWidget.bus.on('get-parameter-value', function (message) {
-                        paramsBus.request(
-                            {
+                    fieldWidget.bus.on('get-parameter-value', function(message) {
+                        paramsBus.request({
                                 parameter: message.parameter
                             }, {
                                 key: 'get-parameter-value'
                             })
-                            .then(function (message) {
+                            .then(function(message) {
                                 bus.emit('parameter-value', {
                                     parameter: message.parameter
                                 });
@@ -166,7 +165,7 @@ define([
                         key: {
                             type: 'get-parameter'
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             if (message.parameterName) {
                                 return paramsBus.request(message, {
                                     key: {
@@ -185,7 +184,7 @@ define([
                             type: 'update',
                             parameter: parameterSpec.id
                         },
-                        handle: function (message) {
+                        handle: function(message) {
                             fieldWidget.bus.emit('update', {
                                 value: message.value
                             });
@@ -212,7 +211,7 @@ define([
                 var input = advancedInputs[i];
                 input.classList.remove(removeClass);
                 input.classList.add(addClass);
-                 
+
                 var actualInput = input.querySelector('[data-element="input"]');
                 if (actualInput) {
                     $(actualInput).trigger('advanced-shown.kbase');
@@ -263,7 +262,7 @@ define([
 
         function renderLayout() {
             var events = Events.make(),
-                content = form({ dataElement: 'input-widget-form' }, [                    
+                content = form({ dataElement: 'input-widget-form' }, [
                     ui.buildPanel({
                         title: span(['Input Objects', span({ dataElement: 'advanced-hidden-message', style: { marginLeft: '6px', fontStyle: 'italic' } })]),
                         name: 'input-objects-area',
@@ -314,19 +313,19 @@ define([
         // EVENTS
 
         function attachEvents() {
-            bus.on('reset-to-defaults', function () {
-                widgets.forEach(function (widget) {
+            bus.on('reset-to-defaults', function() {
+                widgets.forEach(function(widget) {
                     widget.bus.emit('reset-to-defaults');
                 });
             });
-            bus.on('toggle-advanced', function () {
+            bus.on('toggle-advanced', function() {
                 settings.showAdvanced = !settings.showAdvanced;
                 renderAdvanced('input-objects');
                 renderAdvanced('parameters');
             });
-            runtime.bus().on('workspace-changed', function () {
+            runtime.bus().on('workspace-changed', function() {
                 // tell each input widget about this amazing event!
-                widgets.forEach(function (widget) {
+                widgets.forEach(function(widget) {
                     widget.bus.emit('workspace-changed');
                 });
             });
@@ -335,11 +334,11 @@ define([
         function makeParamsLayout(params) {
             var view = {};
             var paramMap = {};
-            var orderedParams = params.map(function (param) {
+            var orderedParams = params.map(function(param) {
                 paramMap[param.id] = param;
                 return param.id;
             });
-            var layout = orderedParams.map(function (parameterId) {
+            var layout = orderedParams.map(function(parameterId) {
                 var id = html.genId();
                 view[parameterId] = {
                     id: id
@@ -368,32 +367,32 @@ define([
             // Separate out the params into the primary groups.
             var appSpec = model.getItem('appSpec');
 
-            return Promise.try(function () {
+            return Promise.try(function() {
                 var params = model.getItem('parameters'),
                     inputParams = makeParamsLayout(
-                        params.layout.filter(function (id) {
+                        params.layout.filter(function(id) {
                             return (params.specs[id].ui.class === 'input');
                         })
-                        .map(function (id) {
+                        .map(function(id) {
                             return params.specs[id];
                         })),
                     outputParams = makeParamsLayout(
-                        params.layout.filter(function (id) {
+                        params.layout.filter(function(id) {
                             return (params.specs[id].ui.class === 'output');
                         })
-                        .map(function (id) {
+                        .map(function(id) {
                             return params.specs[id];
                         })),
                     parameterParams = makeParamsLayout(
-                        params.layout.filter(function (id) {
+                        params.layout.filter(function(id) {
                             return (params.specs[id].ui.class === 'parameter');
                         })
-                        .map(function (id) {
+                        .map(function(id) {
                             return params.specs[id];
                         }));
 
                 return Promise.resolve()
-                    .then(function () {
+                    .then(function() {
                         if (inputParams.layout.length === 0) {
                             ui.getElement('input-objects-area').classList.add('hidden');
                             // places.inputFields.innerHTML = span({
@@ -403,11 +402,11 @@ define([
                             // }, 'This app does not have input objects');
                         } else {
                             places.inputFields.innerHTML = inputParams.content;
-                            return Promise.all(inputParams.layout.map(function (parameterId) {
+                            return Promise.all(inputParams.layout.map(function(parameterId) {
                                 var spec = inputParams.paramMap[parameterId];
                                 try {
                                     return makeFieldWidget(appSpec, spec, initialParams[spec.id])
-                                        .then(function (widget) {
+                                        .then(function(widget) {
                                             widgets.push(widget);
 
                                             return widget.start({
@@ -428,17 +427,17 @@ define([
                             }));
                         }
                     })
-                    .then(function () {
+                    .then(function() {
                         if (outputParams.layout.length === 0) {
                             ui.getElement('output-objects-area').classList.add('hidden');
                             // places.outputFields.innerHTML = span({ style: { fontStyle: 'italic' } }, 'This app does not create any named output objects');
                         } else {
                             places.outputFields.innerHTML = outputParams.content;
-                            return Promise.all(outputParams.layout.map(function (parameterId) {
+                            return Promise.all(outputParams.layout.map(function(parameterId) {
                                 var spec = outputParams.paramMap[parameterId];
                                 try {
                                     return makeFieldWidget(appSpec, spec, initialParams[spec.id])
-                                        .then(function (widget) {
+                                        .then(function(widget) {
                                             widgets.push(widget);
 
                                             return widget.start({
@@ -455,19 +454,21 @@ define([
                             }));
                         }
                     })
-                    .then(function () {
+                    .then(function() {
                         if (parameterParams.layout.length === 0) {
                             // TODO: should be own node
-                            ui.getElement('parameter-objects-area').classList.add('hidden');
+                            if (ui.getElement('parameter-objects-area')) {
+                                ui.getElement('parameter-objects-area').classList.add('hidden');
+                            }
                             // places.parameterFields.innerHTML = span({ style: { fontStyle: 'italic' } }, 'No parameters for this app');
                         } else {
                             places.parameterFields.innerHTML = parameterParams.content;
 
-                            return Promise.all(parameterParams.layout.map(function (parameterId) {
+                            return Promise.all(parameterParams.layout.map(function(parameterId) {
                                 var spec = parameterParams.paramMap[parameterId];
                                 try {
                                     return makeFieldWidget(appSpec, spec, initialParams[spec.id])
-                                        .then(function (widget) {
+                                        .then(function(widget) {
                                             widgets.push(widget);
 
                                             return widget.start({
@@ -484,7 +485,7 @@ define([
                             }));
                         }
                     })
-                    .then(function () {
+                    .then(function() {
                         renderAdvanced('input-objects');
                         renderAdvanced('parameters');
                     });
@@ -492,7 +493,7 @@ define([
         }
 
         function start(arg) {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 // send parent the ready message
 
                 doAttach(arg.node);
@@ -500,11 +501,11 @@ define([
                 model.setItem('appSpec', arg.appSpec);
                 model.setItem('parameters', arg.parameters);
 
-                paramsBus.on('parameter-changed', function (message) {
+                paramsBus.on('parameter-changed', function(message) {
                     // Also, tell each of our inputs that a param has changed.
                     // TODO: use the new key address and subscription
                     // mechanism to make this more efficient.
-                    widgets.forEach(function (widget) {
+                    widgets.forEach(function(widget) {
                         widget.bus.send(message, {
                             key: {
                                 type: 'parameter-changed',
@@ -516,11 +517,11 @@ define([
                 });
                 // we then create our widgets
                 return renderParameters()
-                    .then(function () {
+                    .then(function() {
                         // do something after success
                         attachEvents();
                     })
-                    .catch(function (err) {
+                    .catch(function(err) {
                         // do somethig with the error.
                         console.error('ERROR in start', err);
                     });
@@ -528,7 +529,7 @@ define([
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 // really unhook things here.
             });
         }
@@ -541,14 +542,14 @@ define([
         return {
             start: start,
             stop: stop,
-            bus: function () {
+            bus: function() {
                 return bus;
             }
         };
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };

--- a/nbextensions/appCell2/widgets/tabs/jobStateViewer.js
+++ b/nbextensions/appCell2/widgets/tabs/jobStateViewer.js
@@ -4,7 +4,7 @@ define([
     'common/ui',
     'common/format',
     'kb_common/html'
-], function (
+], function(
     Promise,
     Runtime,
     UI,
@@ -15,27 +15,32 @@ define([
 
     var t = html.tag,
         div = t('div'),
+        p = t('p'),
         span = t('span');
 
     function niceState(jobState) {
         var label;
         var color;
         switch (jobState) {
-        case 'completed':
-            label = 'success';
-            color = 'green';
-            break;
-        case 'suspend':
-            label = 'error';
-            color = 'red';
-            break;
-        case 'canceled':
-            label = 'cancelation';
-            color = 'orange';
-            break;
-        default:
-            label = jobState;
-            color = 'black';
+            case 'completed':
+                label = 'success';
+                color = 'green';
+                break;
+            case 'suspend':
+                label = 'error';
+                color = 'red';
+                break;
+            case 'canceled':
+                label = 'cancelation';
+                color = 'orange';
+                break;
+            case 'does_not_exist':
+                label = 'does_not_exist';
+                color: 'orange';
+                break;
+            default:
+                label = jobState;
+                color = 'black';
         }
 
         return span({
@@ -49,7 +54,7 @@ define([
     function updateRunStats(ui, viewModel, jobState) {
         if (!jobState) {
             viewModel.launch._attrib.hidden = false;
-            viewModel.launch.label = 'Launching...';
+            viewModel.launch.label = 'Determining Job State...';
         } else {
             var now = new Date().getTime();
 
@@ -88,7 +93,7 @@ define([
                     } else {
                         viewModel.run._attrib.style = { fontWeight: 'bold' };
                         viewModel.run.active = true;
-                        viewModel.run.label = 'Running ' + ui.loading({size: null, color: 'green'});
+                        viewModel.run.label = 'Running ' + ui.loading({ size: null, color: 'green' });
                         viewModel.run.elapsed = format.niceDuration(now - jobState.exec_start_time);
 
                         viewModel.finish._attrib.hidden = true;
@@ -120,8 +125,7 @@ define([
                         // Queue Status - in the queue
                         viewModel.queue._attrib.style = { fontWeight: 'bold' };
                         viewModel.queue.active = true;
-                        viewModel.queue.label = 'Queued ' + ui.loading({size: null, color: 'orange'});
-                        // console.log('position???', jobState);
+                        viewModel.queue.label = 'Queued ' + ui.loading({ size: null, color: 'orange' });
                         if (jobState.position) {
                             viewModel.queue.position.label = ', currently at position ';
                             viewModel.queue.position.number = jobState.position;
@@ -136,30 +140,19 @@ define([
                         viewModel.finish.active = false;
                     }
                 }
+            } else {
+                viewModel.job_not_found._attrib.hidden = false;
             }
         }
 
         try {
             ui.updateFromViewModel(viewModel);
         } catch (err) {
-            console.log('ERROR updating from view model', err);
+            console.error('ERROR updating from view model', err);
         }
     }
 
     function renderRunStats() {
-        var labelStyle = {
-                textAlign: 'right',
-                border: '1px transparent solid',
-                padding: '4px'
-            },
-            dataStyle = {
-                border: '1px silver solid',
-                padding: '4px',
-                display: 'inline-block',
-                minWidth: '20px',
-                backgroundColor: 'gray',
-                color: '#FFF'
-            };
         return div({ dataElement: 'run-stats', style: { paddingTop: '6px' } }, [
             div({
                 class: 'row',
@@ -172,6 +165,14 @@ define([
                 span({
                     dataElement: 'elapsed',
                     class: 'kb-elapsed-time'
+                })
+            ]),
+            div({
+                class: 'row',
+                dataElement: 'job_not_found'
+            }, [
+                span({
+                    dataElement: 'message'
                 })
             ]),
             div({
@@ -231,45 +232,6 @@ define([
         ]);
     }
 
-    //  function renderRunStats() {
-    //     var labelStyle = {
-    //             textAlign: 'right',
-    //             border: '1px transparent solid',
-    //             padding: '4px'
-    //         },
-    //         dataStyle = {
-    //             border: '1px silver solid',
-    //             padding: '4px',
-    //             display: 'inline-block',
-    //             minWidth: '20px',
-    //             backgroundColor: 'gray',
-    //             color: '#FFF'
-    //         };
-    //     return div({ dataElement: 'run-stats', style: { paddingTop: '6px' } }, [
-    //         // div({ class: 'row', dataElement: 'lastUpdated' }, [
-    //         //     div({ class: 'col-md-2', style: labelStyle }, span({ dataElement: 'label' }, 'Last updated')),
-    //         //     div({ class: 'col-md-2', style: dataStyle }, span({ dataElement: 'elapsed', class: 'kb-elapsed-time' })),
-    //         //     div({ class: 'col-md-2', style: dataStyle }, span({ dataElement: 'time' }))
-    //         // ]),
-    //         div({ class: 'row', dataElement: 'queue' }, [
-    //             div({ class: 'col-md-2', style: labelStyle }, span({ dataElement: 'label' }, 'Queue')),
-    //             div({ class: 'col-md-2', style: dataStyle }, span({ dataElement: 'elapsed', class: 'kb-elapsed-time' })),
-    //             div({ class: 'col-md-2', style: labelStyle }, 'Position'),
-    //             div({ class: 'col-md-2', style: dataStyle }, span({ dataElement: 'position' }))
-    //         ]),
-    //         div({ class: 'row', dataElement: 'run' }, [
-    //             div({ class: 'col-md-2', style: labelStyle }, span({ dataElement: 'label' }, 'Run')),
-    //             div({ class: 'col-md-2', style: dataStyle }, span({ dataElement: 'elapsed', class: 'kb-elapsed-time' }))
-    //         ]),
-    //         div({ class: 'row', dataElement: 'finish' }, [
-    //             div({ class: 'col-md-2', style: labelStyle }, 'Finish'),
-    //             div({ class: 'col-md-2', style: dataStyle }, span({ dataElement: 'state' })),
-    //             div({ class: 'col-md-2', style: labelStyle }, 'When'),
-    //             div({ class: 'col-md-2', style: dataStyle }, span({ dataElement: 'when' }))
-    //         ])
-    //     ]);
-    // }
-
     function factory(config) {
         var container, ui, listeners = [],
             jobState = null,
@@ -321,6 +283,21 @@ define([
                 state: null,
                 time: null,
                 elapsed: null
+            },
+            job_not_found: {
+                _attrib: {
+                    hidden: true,
+                    style: {}
+                },
+                message: div([
+                    p([
+                        'This job was not found. It was probably started by another user. Only the ',
+                        'user who started a job may view it\'s status or associated job logs.'
+                    ]),
+                    p([
+                        'You will not be able to inspect the job status or view the job log'
+                    ])
+                ])
             }
         };
 
@@ -343,24 +320,30 @@ define([
             }
         }
 
+        function handleJobDoesNotExistUpdate(message) {
+            stopJobUpdates();
+            jobState = {
+                job_state: 'does_not_exist'
+            };
+        }
+
         function handleJobStatusUpdate(message) {
             jobState = message.jobState;
-            // console.log('got job update', message.jobState);
             switch (jobState.job_state) {
-            case 'queued':
-            case 'in-progress':
-                startJobUpdates();
-                break;
-            case 'completed':
-            case 'error':
-            case 'suspend':
-            case 'canceled':
-                stopJobUpdates();
-                break;
-            default:
-                stopJobUpdates();
-                console.error('Unknown job status', jobState.job_state, message);
-                throw new Error('Unknown job status ' + jobState.job_state);
+                case 'queued':
+                case 'in-progress':
+                    startJobUpdates();
+                    break;
+                case 'completed':
+                case 'error':
+                case 'suspend':
+                case 'canceled':
+                    stopJobUpdates();
+                    break;
+                default:
+                    stopJobUpdates();
+                    console.error('Unknown job status', jobState.job_state, message);
+                    throw new Error('Unknown job status ' + jobState.job_state);
             }
         }
 
@@ -375,6 +358,30 @@ define([
                 handle: handleJobStatusUpdate
             });
             listeners.push(ev);
+
+            ev = runtime.bus().listen({
+                channel: {
+                    jobId: jobId
+                },
+                key: {
+                    type: 'job-canceled'
+                },
+                handle: function() {
+                    console.warn('job cancelled');
+                }
+            });
+            listeners.push(ev);
+
+            ev = runtime.bus().listen({
+                channel: {
+                    jobId: jobId
+                },
+                key: {
+                    type: 'job-does-not-exist'
+                },
+                handle: handleJobDoesNotExistUpdate
+            });
+            listeners.push(ev);
         }
 
         function stopListeningForJobStatus() {
@@ -382,20 +389,15 @@ define([
         }
 
         function start(arg) {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 container = arg.node;
                 ui = UI.make({ node: container });
 
-                // var lastUpdated = model.getItem('exec.jobStateUpdated');
-
                 container.innerHTML = renderRunStats();
 
-                // updateRunStats(ui, jobState, lastUpdated);
                 jobId = arg.jobId;
-                // var jobState = model.getItem('exec.jobState');
-                // updateRunStats(ui, jobState);
 
-                listeners.push(runtime.bus().on('clock-tick', function () {
+                listeners.push(runtime.bus().on('clock-tick', function() {
                     updateRunStats(ui, viewModel, jobState);
                 }));
 
@@ -411,7 +413,7 @@ define([
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(function() {
                 stopListeningForJobStatus();
                 // runtime.bus().removeListeners(listeners);
             });
@@ -424,7 +426,7 @@ define([
     }
 
     return {
-        make: function (config) {
+        make: function(config) {
             return factory(config);
         }
     };

--- a/nbextensions/codeCell/main.js
+++ b/nbextensions/codeCell/main.js
@@ -1,0 +1,244 @@
+/*global define*/
+/*jslint white:true,browser:true*/
+
+define([
+    'bluebird',
+    'jquery',
+    'uuid',
+    'base/js/namespace',
+    'common/utils',
+    'common/appUtils',
+    'common/props',
+    'common/cellUtils',
+    'common/pythonInterop',
+    'common/ui',
+    'common/jupyter',
+    'kb_common/html',
+    './widgets/codeCell'
+], function (
+    Promise,
+    $,
+    Uuid,
+    Jupyter,
+    utils,
+    AppUtils,
+    Props,
+    cellUtils,
+    PythonInterop,
+    UI,
+    jupyter,
+    html,
+    CodeCell
+) {
+    'use strict';
+
+    var t = html.tag,
+        span = t('span');
+
+    function specializeCell(cell) {
+        cell.minimize = function () {
+            var inputArea = this.input.find('.input_area').get(0),
+                outputArea = this.element.find('.output_wrapper'),
+                showCode = utils.getCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea');
+
+            if (showCode) {
+                inputArea.classList.remove('-show');
+            }
+            outputArea.addClass('hidden');
+        };
+
+        cell.maximize = function () {
+            var inputArea = this.input.find('.input_area').get(0),
+                outputArea = this.element.find('.output_wrapper'),
+                showCode = utils.getCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea');
+
+            if (showCode) {
+                if (!inputArea.classList.contains('-show')) {
+                    inputArea.classList.add('-show');
+                    cell.code_mirror.refresh();
+                }
+            }
+            outputArea.removeClass('hidden');
+        };
+
+        cell.getIcon = function () {
+            var iconColor = 'silver';
+            var icon;
+            icon = span({ class: 'fa fa-inverse fa-stack-1x fa-' + 'terminal' });
+
+            return span({ style: '' }, [
+                span({ class: 'fa-stack fa-2x', style: { textAlign: 'center', color: iconColor } }, [
+                    span({ class: 'fa fa-square fa-stack-2x', style: { color: iconColor } }),
+                    icon
+                ])
+            ]);
+        };
+
+        cell.toggleCodeInputArea = function () {
+            var codeInputArea = this.input.find('.input_area')[0];
+            if (codeInputArea) {
+                codeInputArea.classList.toggle('-show');
+                utils.setCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea', this.isCodeShowing(), true);
+                // NB purely for side effect - toolbar refresh
+                cell.metadata = cell.metadata;
+            }
+        };
+    }
+
+    function setupCell(cell) {
+        if (cell.cell_type !== 'code') {
+            return;
+        }
+        if (cell.metadata.kbase && (cell.metadata.kbase.type !== 'code')) {
+            return;
+        }
+
+        specializeCell(cell);
+
+        // The kbase property is only used for managing runtime state of the cell
+        // for kbase. Anything to be persistent should be on the metadata.
+        cell.kbase = {};
+
+        // Code cell input area is always set to be open by default.
+
+        // import/job cells dont' show code input area, regular code cells do.
+        // TODO perhaps code cells should remember this?
+        if (utils.getCellMeta(cell, 'kbase.codeCell.jobInfo')) {
+            utils.setCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea', false);
+        } else {
+            utils.setCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea', true);
+        }
+
+        var widget = CodeCell.make({
+            cell: cell
+        });
+        widget.bus.emit('run', {
+            node: null
+        });
+
+        jupyter.disableKeyListenersForCell(cell);
+        cell.renderMinMax();
+        // force toolbar rerender.
+        cell.metadata = cell.metadata;
+        // cell.renderIcon();
+    }
+
+    function fixupCell(cell) {
+        if (cell.metadata.kbase && cell.metadata.kbase.type) {
+            return;
+        }
+        return upgradeCell({
+            cell: cell,
+            kbase: {
+                type: 'code',
+                language: 'python'
+            }
+        });
+    }
+
+    function upgradeCell(data) {
+        var cell = data.cell,
+            meta = cell.metadata,
+            cellId = data.kbase.cellId || (new Uuid(4).format());
+
+        // Accomodate import/job cells.
+        // For now we create an import property on the side.
+
+        var jobInfo;
+        if (meta.kbase && meta.kbase.state) {
+            jobInfo = {
+                jobId: meta.kbase.jobId,
+                state: meta.kbase.state
+            };
+        }
+
+        // Set the initial metadata for the output cell.
+        meta.kbase = {
+            type: 'code',
+            attributes: {
+                id: cellId,
+                status: 'new',
+                created: new Date().toGMTString(),
+                lastLoaded: new Date().toGMTString(),
+                icon: 'code',
+                title: data.kbase.title || 'Code Cell',
+                subtitle: data.kbase.language
+            },
+            codeCell: {
+                userSettings: {
+                    showCodeInputArea: true
+                }
+            }
+        };
+
+        if (jobInfo) {
+            meta.kbase.codeCell.jobInfo = jobInfo;
+        }
+
+        cell.metadata = meta;
+
+        return cell;
+    }
+
+    function ensureCodeCell(cell) {
+        if (cell.cell_type === 'code') {
+            if (cell.metadata.kbase) {
+                if (cell.metadata.kbase.type) {
+                    if (cell.metadata.kbase.type === 'code') {
+                        // fully flocked jupyter/kbase code cell
+                        return true;
+                    } else {
+                        // a typed kbase cell, and not a code cell
+                        return false;
+                    }
+                } else {
+                    // a code cell with a kbase property but no type specified
+                    // must be a pre-code-cell-extension code cell, which can be 
+                    // converted.
+                    fixupCell(cell);
+                    return true;
+                }
+            } else {
+                // a plain code cell with no kbase-stuff is possible, but unlikely, still, convert.
+                fixupCell(cell);
+                return true;
+            }
+        } else {
+            // not a code cell, sorry.
+            return false;
+        }
+    }
+
+    function load() {
+        $([Jupyter.events]).on('inserted.Cell', function (event, data) {
+            if (data.kbase && data.kbase.type === 'code') {
+                try {
+                    var cell = upgradeCell(data);
+                    setupCell(cell);
+                } catch (err) {
+                    console.error('ERROR creating cell', err);
+                    // delete cell.
+                    $(document).trigger('deleteCell.Narrative', Jupyter.notebook.find_cell_index(data.cell));
+                    alert('Could not insert cell due to errors.\n' + err.message);
+                }
+            }
+        });
+
+        Jupyter.notebook.get_cells().forEach(function (cell) {
+            try {
+                if (ensureCodeCell(cell)) {
+                    setupCell(cell);
+                }
+            } catch (ex) {
+                console.error('ERROR setting up code cell', ex);
+            }
+        });
+    }
+
+    return {
+        // This is the sole ipython/jupyter api call
+        load_ipython_extension: load
+    };
+}, function (err) {
+    console.error('ERROR loading codeCell main', err);
+});

--- a/nbextensions/codeCell/widgets/codeCell.js
+++ b/nbextensions/codeCell/widgets/codeCell.js
@@ -1,5 +1,6 @@
 /*global define*/
 /*jslint white:true,browser:true*/
+
 define([
     'common/runtime',
     'common/busEventManager',
@@ -13,7 +14,7 @@ define([
     Props,
     UI,
     html,
-    JupyterInterop
+    Narrative
 ) {
     'use strict';
 
@@ -27,58 +28,50 @@ define([
             eventManager = BusEventManager.make({
                 bus: runtime.bus()
             }),
-            bus = runtime.bus().makeChannelBus({ description: 'output cell bus' }),
+            bus = runtime.bus().makeChannelBus({ description: 'code cell bus' }),
 
             // To be instantiated at attach()
-            ui,
+            container, ui,
 
             // To be instantiated in start()
             cellBus;
 
         function doDeleteCell() {
-            var parentCellId = Props.getDataItem(cell.metadata, 'kbase.outputCell.parentCellId');
             var content = div([
                 p([
-                    'Deleting this cell will remove the data visualization, ',
-                    'but will not delete the data object, which will still be avaiable ',
-                    'in the data panel.'
+                    'Deleting this cell will remove the code and any generated code ouput.',
                 ]),
-                p(['Parent cell id is ', parentCellId]),
-                p('Continue to delete this data cell?')
+                p('Continue to delete this code cell?')
             ]);
             ui.showConfirmDialog({ title: 'Confirm Cell Deletion', body: content })
                 .then(function(confirmed) {
                     if (!confirmed) {
                         return;
                     }
-                    runtime.bus().send({
-                        jobId: Props.getDataItem(cell.metadata, 'kbase.outputCell.jobId'),
-                        outputCellId: Props.getDataItem(cell.metadata, 'kbase.attributes.id')
-                    }, {
-                        channel: {
-                            cell: parentCellId
-                        },
-                        key: {
-                            type: 'output-cell-removed'
-                        }
-                    });
 
                     bus.emit('stop');
 
-                    JupyterInterop.deleteCell(cell);
+                    Narrative.deleteCell(cell);
                 });
         }
+
+
 
         // Widget API
 
         eventManager.add(bus.on('run', function(message) {
-            // container = message.node;
-            ui = UI.make({ node: message.node });
+            container = message.node;
+            ui = UI.make({ node: container || document.body });
 
             // Events for comm from the parent.
             eventManager.add(bus.on('stop', function() {
                 eventManager.removeAll();
             }));
+
+
+            // The cell bus is for communication via the common id.
+            // This allows disassociated elements to communicate with us
+            // without a physical handle on the widget object.
 
             cellBus = runtime.bus().makeChannelBus({
                 name: {
@@ -90,6 +83,7 @@ define([
             eventManager.add(cellBus.on('delete-cell', function() {
                 doDeleteCell();
             }));
+
         }));
 
         return {

--- a/nbextensions/dataCell/main.js
+++ b/nbextensions/dataCell/main.js
@@ -15,7 +15,7 @@ define([
     'common/jupyter',
     'kb_common/html',
     './widgets/dataCell'
-], function (
+], function(
     Promise,
     $,
     Uuid,
@@ -29,30 +29,34 @@ define([
     jupyter,
     html,
     DataCell
-    ) {
+) {
     'use strict';
 
-    var t = html.tag, div = t('div');
+    var t = html.tag,
+        div = t('div');
 
     function specializeCell(cell) {
-        cell.minimize = function () {
-            var inputArea = this.input.find('.input_area'),
+        cell.minimize = function() {
+            var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
                 showCode = utils.getCellMeta(cell, 'kbase.dataCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.addClass('hidden');
+                inputArea.classList.remove('-show');
             }
             outputArea.addClass('hidden');
         };
 
-        cell.maximize = function () {
-            var inputArea = this.input.find('.input_area'),
+        cell.maximize = function() {
+            var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
                 showCode = utils.getCellMeta(cell, 'kbase.dataCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.removeClass('hidden');
+                if (!inputArea.classList.contains('-show')) {
+                    inputArea.classList.add('-show');
+                    cell.code_mirror.refresh();
+                }
             }
             outputArea.removeClass('hidden');
         };
@@ -61,27 +65,30 @@ define([
          * The data cell icon is derived by looking up the type in the 
          * narrative configuration.
          */
-        cell.renderIcon = function () {
+        cell.renderIcon = function() {
             var inputPrompt = this.element[0].querySelector('[data-element="icon"]'),
                 type = Props.getDataItem(cell.metadata, 'kbase.dataCell.objectInfo.type');
 
             if (inputPrompt) {
                 inputPrompt.innerHTML = div({
-                    style: {textAlign: 'center'}
+                    style: { textAlign: 'center' }
                 }, [
                     AppUtils.makeTypeIcon(type)
                 ]);
             }
         };
-        cell.getIcon = function () {
+
+        cell.getIcon = function() {
             var type = Props.getDataItem(cell.metadata, 'kbase.dataCell.objectInfo.type'),
                 icon = AppUtils.makeToolbarTypeIcon(type);
             return icon;
         };
-        cell.toggleCodeInputArea = function () {
+
+        cell.toggleCodeInputArea = function() {
             var codeInputArea = this.input.find('.input_area')[0];
             if (codeInputArea) {
-                codeInputArea.classList.toggle('hidden');
+                codeInputArea.classList.toggle('-show');
+                utils.setCellMeta(cell, 'kbase.dataCell.user-settings.showCodeInputArea', this.isCodeShowing(), true);
                 // NB purely for side effect - toolbar refresh
                 cell.metadata = cell.metadata;
             }
@@ -103,16 +110,19 @@ define([
 
         // The kbase property is only used for managing runtime state of the cell
         // for kbase. Anything to be persistent should be on the metadata.
-        cell.kbase = {
-        };
+        cell.kbase = {};
 
         // Update metadata.
         utils.setMeta(cell, 'attributes', 'lastLoaded', (new Date()).toUTCString());
 
+        // Ensure code showing is closed to start with.
+        // Disable this line to allow this setting to be sticky.
+        utils.setCellMeta(cell, 'kbase.dataCell.user-settings.showCodeInputArea', false);
+
         // Create our own input area for interaction with the user.
         var cellInputNode = cell.input[0],
             kbaseNode,
-            ui = UI.make({node: cellInputNode});
+            ui = UI.make({ node: cellInputNode });
 
         kbaseNode = ui.createNode(div({
             dataSubareaType: 'data-cell-input'
@@ -137,10 +147,9 @@ define([
     }
 
     function upgradeCell(data) {
-        return Promise.try(function () {
+        return Promise.try(function() {
             var cell = data.cell,
                 meta = cell.metadata,
-                outputCode, parentTitle,
                 cellId = data.kbase.cellId || (new Uuid(4).format());
 
             // Set the initial metadata for the output cell.
@@ -166,7 +175,7 @@ define([
 
             var tag = Jupyter.narrative.sidePanel.$methodsWidget.currentTag;
             if (!tag) {
-                tag = "release";
+                tag = 'release';
             }
             var objInfo = data.objectInfo;
             var ref = objInfo.ref_path;
@@ -180,9 +189,8 @@ define([
             cell.execute();
 
             // all we do for now is set up the input area
-            cell.input.find('.input_area').addClass('hidden');
             utils.setCellMeta(cell, 'kbase.dataCell.user-settings.showCodeInputArea', false);
-            
+
             utils.setCellMeta(cell, 'kbase.attributes.title', data.objectInfo.name);
             var subtitle = 'v' + String(data.objectInfo.version) + ' - ' + data.objectInfo.type;
             utils.setCellMeta(cell, 'kbase.attributes.subtitle', subtitle, true);
@@ -192,10 +200,10 @@ define([
     }
 
     function load() {
-        $([Jupyter.events]).on('inserted.Cell', function (event, data) {
+        $([Jupyter.events]).on('inserted.Cell', function(event, data) {
             if (data.kbase && data.kbase.type === 'data') {
                 upgradeCell(data)
-                    .catch(function (err) {
+                    .catch(function(err) {
                         console.error('ERROR creating cell', err);
                         // delete cell.
                         $(document).trigger('deleteCell.Narrative', Jupyter.notebook.find_cell_index(data.cell));
@@ -204,7 +212,7 @@ define([
             }
         });
 
-        Jupyter.notebook.get_cells().forEach(function (cell) {
+        Jupyter.notebook.get_cells().forEach(function(cell) {
             try {
                 setupCell(cell);
             } catch (ex) {
@@ -217,7 +225,6 @@ define([
         // This is the sole ipython/jupyter api call
         load_ipython_extension: load
     };
-}, function (err) {
-    'use strict';
-    console.log('ERROR loading viewCell main', err);
+}, function(err) {
+    console.error('ERROR loading dataCell main', err);
 });

--- a/nbextensions/editorCell/main.js
+++ b/nbextensions/editorCell/main.js
@@ -118,30 +118,33 @@ define([
 
     function specializeCell(cell) {
         cell.minimize = function() {
-            var inputArea = this.input.find('.input_area'),
+            var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
                 editorInputArea = this.element.find('[data-subarea-type="editor-cell-input"]'),
-                showCode = utils.getCellMeta(cell, 'kbase.appCell.user-settings.showCodeInputArea');
+                showCode = utils.getCellMeta(cell, 'kbase.editorCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.addClass('hidden');
+                inputArea.classList.remove('-show');
             }
             outputArea.addClass('hidden');
             editorInputArea.addClass('hidden');
         };
 
         cell.maximize = function() {
-            var inputArea = this.input.find('.input_area'),
+            var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
                 editorInputArea = this.element.find('[data-subarea-type="editor-cell-input"]'),
-                showCode = utils.getCellMeta(cell, 'kbase.appCell.user-settings.showCodeInputArea');
+                showCode = utils.getCellMeta(cell, 'kbase.editorCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.removeClass('hidden');
+                if (!inputArea.classList.contains('-show')) {
+                    inputArea.classList.add('-show');
+                }
             }
             outputArea.removeClass('hidden');
             editorInputArea.removeClass('hidden');
         };
+
         cell.renderIcon = function() {
             var inputPrompt = this.element[0].querySelector('[data-element="prompt"]');
 
@@ -153,8 +156,19 @@ define([
                 ]);
             }
         };
+
         cell.getIcon = function() {
             return AppUtils.makeToolbarAppIcon(utils.getCellMeta(cell, 'kbase.editorCell.app.spec'));
+        };
+
+        cell.toggleCodeInputArea = function() {
+            var codeInputArea = this.input.find('.input_area')[0];
+            if (codeInputArea) {
+                codeInputArea.classList.toggle('-show');
+                utils.setCellMeta(cell, 'kbase.editorCell.user-settings.showCodeInputArea', this.isCodeShowing(), true);
+                // NB purely for side effect - toolbar refresh
+                cell.metadata = cell.metadata;
+            }
         };
     }
 
@@ -264,6 +278,8 @@ define([
                         }));
 
                     // Create (above) and place the main container for the input cell.
+                    // start out hidden so we don't thrash the ui for closed cells.
+                    kbaseNode.classList.add('hidden');
                     cell.input.after($(kbaseNode));
                     cell.kbase.node = kbaseNode;
                     cell.kbase.$node = $(kbaseNode);
@@ -283,7 +299,7 @@ define([
                                 widget: editor,
                                 bus: cellBus
                             };
-                        })
+                        });
                 });
         });
     }

--- a/nbextensions/editorCell/widgets/attic/editorCellWidget.js
+++ b/nbextensions/editorCell/widgets/attic/editorCellWidget.js
@@ -817,13 +817,16 @@ define([
         }
 
         function showCodeInputArea() {
-            var codeInputArea = cell.input.find('.input_area');
+            var codeInputArea = cell.input.find('.input_area').get(0);
             if (editorState.getItem('user-settings.showCodeInputArea')) {
-                codeInputArea.removeClass('hidden');
-                // codeInputArea.css('display', cell.kbase.inputAreaDisplayStyle);
+                if (!codeInputArea.classList.contains('-show')) {
+                    codeInputArea.classList.add('-show');
+                }
+
             } else {
-                codeInputArea.addClass('hidden');
-                // codeInputArea.css('display', 'none');
+                if (codeInputArea.classList.contains('-show')) {
+                    codeInputArea.classList.remove('-show');
+                }
             }
         }
 

--- a/nbextensions/editorCell/widgets/attic/readsSetEditor2.js
+++ b/nbextensions/editorCell/widgets/attic/readsSetEditor2.js
@@ -814,13 +814,15 @@ define([
         }
 
         function showCodeInputArea() {
-            var codeInputArea = cell.input.find('.input_area');
+            var codeInputArea = cell.input.find('.input_area').get(0);
             if (editorState.getItem('user-settings.showCodeInputArea')) {
-                codeInputArea.removeClass('hidden');
-                // codeInputArea.css('display', cell.kbase.inputAreaDisplayStyle);
+                if (!codeInputArea.classList.contains('-show')) {
+                    codeInputArea.classList.add('-show');
+                }
             } else {
-                codeInputArea.addClass('hidden');
-                // codeInputArea.css('display', 'none');
+                if (codeInputArea.classList.contains('-show')) {
+                    codeInputArea.classList.remove('-show');
+                }
             }
         }
 

--- a/nbextensions/editorCell/widgets/editors/readsSet/editor.js
+++ b/nbextensions/editorCell/widgets/editors/readsSet/editor.js
@@ -406,13 +406,15 @@ define([
         }
 
         function showCodeInputArea() {
-            var codeInputArea = cell.input.find('.input_area');
+            var codeInputArea = cell.input.find('.input_area').get(0);
             if (editorState.getItem('user-settings.showCodeInputArea')) {
-                codeInputArea.removeClass('hidden');
-                // codeInputArea.css('display', cell.kbase.inputAreaDisplayStyle);
+                if (!codeInputArea.classList.contains('-show')) {
+                    codeInputArea.classList.add('-show');
+                }
             } else {
-                codeInputArea.addClass('hidden');
-                // codeInputArea.css('display', 'none');
+                if (codeInputArea.classList.contains('-show')) {
+                    codeInputArea.classList.remove('-show');
+                }
             }
         }
 

--- a/nbextensions/install.sh
+++ b/nbextensions/install.sh
@@ -36,5 +36,11 @@ jupyter nbextension enable appCell2/main --sys-prefix
 jupyter nbextension install ${dir}/advancedViewCell --symlink --sys-prefix
 jupyter nbextension enable advancedViewCell/main --sys-prefix
 
+jupyter nbextension install ${dir}/codeCell --symlink --sys-prefix
+jupyter nbextension enable codeCell/main --sys-prefix
+
+# jupyter nbextension disable codeCell/main --sys-prefix
+# jupyter nbextension install ${dir}/codeCell --symlink --sys-prefix
+
 #jupyter nbextension disable customView/main --sys-prefix
 #jupyter nbextension uninstall ${dir}/customView --sys-prefix

--- a/nbextensions/viewCell/main.js
+++ b/nbextensions/viewCell/main.js
@@ -156,26 +156,30 @@ define([
 
     function specializeCell(cell) {
         cell.minimize = function() {
-            var inputArea = this.input.find('.input_area'),
+            var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
                 viewInputArea = this.element.find('[data-subarea-type="view-cell-input"]'),
-                showCode = utils.getCellMeta(cell, 'kbase.appCell.user-settings.showCodeInputArea');
+                showCode = utils.getCellMeta(cell, 'kbase.viewCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.addClass('hidden');
+                // inputArea.addClass('hidden');
+                inputArea.classList.remove('-show');
             }
             outputArea.addClass('hidden');
             viewInputArea.addClass('hidden');
         };
 
         cell.maximize = function() {
-            var inputArea = this.input.find('.input_area'),
+            var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
                 viewInputArea = this.element.find('[data-subarea-type="view-cell-input"]'),
-                showCode = utils.getCellMeta(cell, 'kbase.appCell.user-settings.showCodeInputArea');
+                showCode = utils.getCellMeta(cell, 'kbase.viewCell.user-settings.showCodeInputArea');
 
             if (showCode) {
-                inputArea.removeClass('hidden');
+                // inputArea.removeClass('hidden');
+                if (!inputArea.classList.contains('-show')) {
+                    inputArea.classList.add('-show');
+                }
             }
             outputArea.removeClass('hidden');
             viewInputArea.removeClass('hidden');
@@ -238,6 +242,11 @@ define([
 
             specializeCell(cell);
 
+            var cellElement = cell.element;
+            cellElement.addClass('kb-cell').addClass('kb-view-cell');
+
+
+
             // The kbase property is only used for managing runtime state of the cell
             // for kbase. Anything to be persistent should be on the metadata.
             cell.kbase = {};
@@ -262,6 +271,7 @@ define([
                 }));
 
             // Create (above) and place the main container for the input cell.
+            kbaseNode.classList.add('hidden');
             cell.input.after($(kbaseNode));
             cell.kbase.node = kbaseNode;
             cell.kbase.$node = $(kbaseNode);

--- a/scripts/install_narrative_docker.sh
+++ b/scripts/install_narrative_docker.sh
@@ -106,6 +106,9 @@ jupyter nbextension enable appCell2/main --sys-prefix
 jupyter nbextension install $(pwd)/advancedViewCell --symlink --sys-prefix
 jupyter nbextension enable advancedViewCell/main --sys-prefix
 
+jupyter nbextension install $(pwd)/codeCell --symlink --sys-prefix
+jupyter nbextension enable codeCell/main --sys-prefix
+
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
 
 console "Done installing nbextension"


### PR DESCRIPTION
Most changes are described in docs/notes/TASK-938-notes.md
As we've discussed, the scope expanded out from this task (ensuring that parameters are not editable in read-only mode) to cover other read-only/view-only issues, and also the general issue of smoothing out functionality and appearance, so I addressed many rapidly fixable issues discovered during testing.

This was used/tested against CI and Production, focussing on test narratives which exercise all cell types as well as narratorials. The development and testing was through a develop-mode narrative instance (i.e. not docker), behind a proxy in a vm, so that I could point it to CI or Production with minimal effort. I did not test the dockerized deployment.

If there are any changes that seem unwise or don't jibe, well, we can deal with that.

I do apologize for the number of formatting only changes. Many of them are good, but some are arbitrary due to the differences in formatting tools. I wish I had realized how many there were and had taken another hour or two (or ??) to tweak my lint and format configs to match how most of the files were formatted to reduce it. In theory I could even do that now, run all these files through it, and resubmit the PR. It is a potential black hole of time,  but once done, it will be well worth it. The tools change frequently, and often integrated into editors/IDEs, so it is a constant challenge.
Still, high on my virtual list is for us to arrive at a common set of linting and formatting tools and their configurations to avoid this in the future.
I plan on documenting the various techniques employed for managing cell state and lifecycle, especially with regards to Jupyter events and cell object patching and extension. There are many twisty-turns pathways.