### PR TITLE
Fix subdata control [TASK-1035, PTV-295]

### DIFF
--- a/kbase-extension/static/kbase/js/common/sdk.js
+++ b/kbase-extension/static/kbase/js/common/sdk.js
@@ -20,18 +20,18 @@ define([
             return false;
         }
         switch (value.toLowerCase(value)) {
-        case 'true':
-        case 't':
-        case 'yes':
-        case 'y':
-            return true;
-        case 'false':
-        case 'f':
-        case 'no':
-        case 'n':
-            return false;
-        default:
-            return false;
+            case 'true':
+            case 't':
+            case 'yes':
+            case 'y':
+                return true;
+            case 'false':
+            case 'f':
+            case 'no':
+            case 'n':
+                return false;
+            default:
+                return false;
         }
     }
 
@@ -45,22 +45,22 @@ define([
         }
         var nullValue = (function () {
             switch (converted.data.type) {
-            case 'string':
-                return '';
-            case 'int':
-                return null;
-            case 'float':
-                return null;
-            case 'workspaceObjectRef':
-                return null;
-            case 'workspaceObjectName':
-                return null;
-            case 'struct':
-                return {};
-            case '[]struct':
-                return [];
-            default:
-                return null;
+                case 'string':
+                    return '';
+                case 'int':
+                    return null;
+                case 'float':
+                    return null;
+                case 'workspaceObjectRef':
+                    return null;
+                case 'workspaceObjectName':
+                    return null;
+                case 'struct':
+                    return {};
+                case '[]struct':
+                    return [];
+                default:
+                    return null;
             }
         }());
         return nullValue;
@@ -75,24 +75,24 @@ define([
      */
     function defaultToNative(converted, defaultValue) {
         switch (converted.data.type) {
-        case 'string':
-            return defaultValue;
-        case 'int':
-            return parseInt(defaultValue);
-        case 'float':
-            return parseFloat(defaultValue);
-        case 'workspaceObjectRef':
-            if (defaultValue === '') {
-                return null;
-            }
-            return defaultValue;
-        case 'workspaceObjectName':
-            return defaultValue;
-        case 'boolean':
-            return coerceToBoolean(defaultValue);
-        default:
-            // Assume it is a string...
-            return defaultValue;
+            case 'string':
+                return defaultValue;
+            case 'int':
+                return parseInt(defaultValue);
+            case 'float':
+                return parseFloat(defaultValue);
+            case 'workspaceObjectRef':
+                if (defaultValue === '') {
+                    return null;
+                }
+                return defaultValue;
+            case 'workspaceObjectName':
+                return defaultValue;
+            case 'boolean':
+                return coerceToBoolean(defaultValue);
+            default:
+                // Assume it is a string...
+                return defaultValue;
         }
     }
 
@@ -102,29 +102,32 @@ define([
 
         // special special cases.
         switch (spec.field_type) {
-        case 'checkbox':
-            /*
-             * handle the special case of a checkbox with no or empty
-             * default value. It will promote to the "unchecked value"
-             * TODO: more cases of bad default value? Or a generic
-             * default value validator?
-             */
-            if (!defaultValues ||
-                defaultValues.length === 0) {
-                return spec.checkbox_options.unchecked_value;
-            }
-            return coerceToIntBoolean(defaultValues[0]);
-        case 'custom_textsubdata':
-            if (!defaultValues) {
-                // ??
-            }
-            break;
-        case 'textsubdata':
-            if (spec.default_values) {
-                return spec.default_values[0].split(',');
-            } else {
-                return [];
-            }
+            case 'checkbox':
+                /*
+                 * handle the special case of a checkbox with no or empty
+                 * default value. It will promote to the "unchecked value"
+                 * TODO: more cases of bad default value? Or a generic
+                 * default value validator?
+                 */
+                if (!defaultValues ||
+                    defaultValues.length === 0) {
+                    return spec.checkbox_options.unchecked_value;
+                }
+                return coerceToIntBoolean(defaultValues[0]);
+            case 'custom_textsubdata':
+                if (!defaultValues) {
+                    // ??
+                }
+                break;
+            case 'textsubdata':
+                if (spec.default_values) {
+                    if (spec.default_values.length === 1 && spec.default_values[0] === '') {
+                        return [];
+                    }
+                    return spec.default_values[0].split(',');
+                } else {
+                    return [];
+                }
         }
 
         // No default in spec, yet required.
@@ -156,38 +159,38 @@ define([
          * is actually an int, although Mike says it can be any type...
          */
         switch (spec.field_type) {
-        case 'checkbox':
-            return 'int';
-        case 'file':
-            // file datatype is really a file which is uploaded to shock, which results in a 
-            // shock file handle. maybe this field type should be "shock_file"
-            return 'string';
-        case 'textarea':
-            return 'string';
-        case 'dropdown':
-            return 'string';
-        case 'textsubdata':
-            return 'subdata';
-        case 'custom_textsubdata':
-            return 'customSubdata';
-        case 'custom_button':
-            switch (spec.id) {
-            case 'input_check_other_params':
-                return 'boolean';
-            default:
-                return 'unspecified';
-            }
-        case 'custom_widget':
-            if (spec.dropdown_options) {
-                return '[]string';
-            }
-            break;
-        case 'group':
-            return 'struct';
-        case 'autocomplete':
-            return 'string';
-        case 'custom':
-            return 'custom';
+            case 'checkbox':
+                return 'int';
+            case 'file':
+                // file datatype is really a file which is uploaded to shock, which results in a 
+                // shock file handle. maybe this field type should be "shock_file"
+                return 'string';
+            case 'textarea':
+                return 'string';
+            case 'dropdown':
+                return 'string';
+            case 'textsubdata':
+                return 'subdata';
+            case 'custom_textsubdata':
+                return 'customSubdata';
+            case 'custom_button':
+                switch (spec.id) {
+                    case 'input_check_other_params':
+                        return 'boolean';
+                    default:
+                        return 'unspecified';
+                }
+            case 'custom_widget':
+                if (spec.dropdown_options) {
+                    return '[]string';
+                }
+                break;
+            case 'group':
+                return 'struct';
+            case 'autocomplete':
+                return 'string';
+            case 'custom':
+                return 'custom';
         }
 
         /*
@@ -210,15 +213,15 @@ define([
         if (spec.text_options.valid_ws_types && spec.text_options.valid_ws_types.length > 0) {
             // we now have refs, but no way of specifying that the 
             switch (spec.ui_class) {
-            case 'input':
-            case 'parameter':
-                // input objects are any valid ws object reference:
-                // name, traditional ref, ref path.
-                return 'workspaceObjectRef';
-            case 'output':
-                return 'workspaceObjectName';
-            default:
-                throw new Error('Unspecified ui_class, cannot determine object param data type');
+                case 'input':
+                case 'parameter':
+                    // input objects are any valid ws object reference:
+                    // name, traditional ref, ref path.
+                    return 'workspaceObjectRef';
+                case 'output':
+                    return 'workspaceObjectName';
+                default:
+                    throw new Error('Unspecified ui_class, cannot determine object param data type');
             }
         }
 
@@ -227,8 +230,8 @@ define([
         // the text_options, we assume it is a string.
 
         switch (spec.field_type) {
-        case 'text':
-            return 'string';
+            case 'text':
+                return 'string';
         }
 
         console.error('ERROR could not determine type from spec', spec);
@@ -240,17 +243,17 @@ define([
         var dataType = converted.data.type;
 
         switch (dataType) {
-        case 'subdata':
-            converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
-            converted.ui.showSourceObject = spec.textsubdata_options.show_src_obj ? true : false;
-            break;
-        case 'customSubdata':
-            if (spec.textsubdata) {
+            case 'subdata':
                 converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
-            } else {
-                converted.ui.multiSelection = false;
-            }
-            break;
+                converted.ui.showSourceObject = spec.textsubdata_options.show_src_obj ? true : false;
+                break;
+            case 'customSubdata':
+                if (spec.textsubdata) {
+                    converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
+                } else {
+                    converted.ui.multiSelection = false;
+                }
+                break;
         }
     }
 
@@ -268,195 +271,195 @@ define([
         // a dropdown even though the field_type is 'text'.
 
         switch (dataType) {
-        case 'custom': 
-            constraints = {
-                type: Props.getDataItem(spec, 'text_options.validate_as')
-            };
-            // HACK
-            converted.ui.class = 'parameter';
-            break;
-        case 'sequence':
-            constraints = {};
-            break;
-        case 'string':
-        case 'text':
-            switch (fieldType) {
-            case 'text':
+            case 'custom':
                 constraints = {
-                    min: Props.getDataItem(spec, 'text_options.min_length'),
-                    max: Props.getDataItem(spec, 'text_options.max_length'),
-                    regexp: Props.getDataItem(spec, 'text_options.regex_constraint'),
-                    validate: Props.getDataItem(spec, 'text_options.validate_as')
+                    type: Props.getDataItem(spec, 'text_options.validate_as')
                 };
+                // HACK
+                converted.ui.class = 'parameter';
                 break;
-            case 'dropdown':
-                constraints = {
-                    options: spec.dropdown_options.options
-                };
-                break;
-            case 'textarea':
-                constraints = {
-                    min: Props.getDataItem(spec, 'text_options.min_length'),
-                    max: Props.getDataItem(spec, 'text_options.max_length'),
-                    nRows: Props.getDataItem(spec, 'text_options.n_rows', 5)
-                };
-                break;
-            case 'autocomplete':
+            case 'sequence':
                 constraints = {};
                 break;
-            case 'file':
-                constraints = {};
-                break;
-            default:
-                throw new Error('Unknown text param field type "' + fieldType + '"');
-            }
-            break;
-        case 'int':
-            switch (fieldType) {
+            case 'string':
             case 'text':
+                switch (fieldType) {
+                    case 'text':
+                        constraints = {
+                            min: Props.getDataItem(spec, 'text_options.min_length'),
+                            max: Props.getDataItem(spec, 'text_options.max_length'),
+                            regexp: Props.getDataItem(spec, 'text_options.regex_constraint'),
+                            validate: Props.getDataItem(spec, 'text_options.validate_as')
+                        };
+                        break;
+                    case 'dropdown':
+                        constraints = {
+                            options: spec.dropdown_options.options
+                        };
+                        break;
+                    case 'textarea':
+                        constraints = {
+                            min: Props.getDataItem(spec, 'text_options.min_length'),
+                            max: Props.getDataItem(spec, 'text_options.max_length'),
+                            nRows: Props.getDataItem(spec, 'text_options.n_rows', 5)
+                        };
+                        break;
+                    case 'autocomplete':
+                        constraints = {};
+                        break;
+                    case 'file':
+                        constraints = {};
+                        break;
+                    default:
+                        throw new Error('Unknown text param field type "' + fieldType + '"');
+                }
+                break;
+            case 'int':
+                switch (fieldType) {
+                    case 'text':
+                        constraints = {
+                            min: Props.getDataItem(spec, 'text_options.min_int'),
+                            max: Props.getDataItem(spec, 'text_options.max_int')
+                        };
+                        break;
+                    case 'checkbox':
+                        // In theory, the checkbox
+                        constraints = {
+                            min: 0,
+                            max: 0
+                        };
+                        break;
+                }
+                break;
+            case 'float':
                 constraints = {
-                    min: Props.getDataItem(spec, 'text_options.min_int'),
-                    max: Props.getDataItem(spec, 'text_options.max_int')
+                    min: Props.getDataItem(spec, 'text_options.min_float'),
+                    max: Props.getDataItem(spec, 'text_options.max_float')
                 };
                 break;
-            case 'checkbox':
-                // In theory, the checkbox
+            case 'workspaceObjectRef':
+            case 'workspaceObjectName':
                 constraints = {
-                    min: 0,
-                    max: 0
+                    types: spec.text_options.valid_ws_types
                 };
                 break;
-            }
-            break;
-        case 'float':
-            constraints = {
-                min: Props.getDataItem(spec, 'text_options.min_float'),
-                max: Props.getDataItem(spec, 'text_options.max_float')
-            };
-            break;
-        case 'workspaceObjectRef':
-        case 'workspaceObjectName':
-            constraints = {
-                types: spec.text_options.valid_ws_types
-            };
-            break;
-        case '[]string':
-            switch (fieldType) {
-            case 'dropdown':
+            case '[]string':
+                switch (fieldType) {
+                    case 'dropdown':
+                        break;
+                    case 'text':
+                        break;
+                    case 'textarea':
+                        break;
+                    default:
+                        // throw new Error('Unknown []string field type: ' + fieldType);
+                }
                 break;
-            case 'text':
+            case 'subdata':
+                constraints = {
+                    multiple: false,
+                    subdataSelection: spec.textsubdata_options.subdata_selection
+                };
                 break;
-            case 'textarea':
+            case 'customSubdata':
+                constraints = {
+                    multiple: false
+                };
                 break;
-            default:
-                // throw new Error('Unknown []string field type: ' + fieldType);
-            }
-            break;
-        case 'subdata':
-            constraints = {
-                multiple: false,
-                subdataSelection: spec.textsubdata_options.subdata_selection
-            };
-            break;
-        case 'customSubdata':
-            constraints = {
-                multiple: false
-            };
-            break;
-            //                case 'xxinput_property_x':
-            //                    return {
-            //                        defaultValue: defaultValue(),
-            //                        referredParameter: 'input_sample_property_matrix',
-            //                        subdataIncluded: 'metadata/column_metadata',
-            //                        path: 'metadata/column_metadata',
-            //                        // custom function to collect
-            //                        mapper: {
-            //                            before: function () {
-            //                                return {
-            //                                    collected: {}
-            //                                };
-            //                            },
-            //                            during: function (values, state) {
-            //                                values.forEach(function (value) {
-            //                                    if (value.entity === 'Condition') {
-            //                                        state.collected[value.property_name] = true;
-            //                                    }
-            //                                });
-            //                            },
-            //                            after: function (state) {
-            //                                return Object.keys(state.collected).map(function (key) {
-            //                                    return {
-            //                                        id: key,
-            //                                        desc: key
-            //                                    };
-            //                                });
-            //                            }
-            //                        }
-            //                    };
-            //                case 'sample_property':
-            //                    return {
-            //                        required: required(),
-            //                        defaultValue: defaultValue(),
-            //                        referredParameter: 'input_sample_property_matrix',
-            //                        subdataIncluded: 'metadata/column_metadata',
-            //                        subdataPath: 'metadata.column_metadata',
-            //                        // custom function to collect
-            //                        map: function (subdata) {
-            //                            var collected = {};
-            //                            Object.keys(subdata).forEach(function (key) {
-            //                                    var id, name, column = subdata[key];
-            //                                    column.forEach(function (value) {
-            //                                        if (value.category === 'DataSeries' && value.property_name === 'SeriesID') {
-            //                                            id = value.property_value;
-            //                                        } else if (value.category === 'Property' && value.property_name === 'Name') {
-            //                                            name = value.property_value;
-            //                                        }
-            //                                        if (id && name) {
-            //                                            collected[id] = name;
-            //                                        }
-            //                                    });
-            //                                });
-            //                                return Object.keys(collected).map(function (key) {
-            //                                    return {
-            //                                        id: key,
-            //                                        desc: collected[key]
-            //                                    };
-            //                                })
-            //                                    .sort(function (a, b) {
-            //                                        if (a.desc < b.desc) {
-            //                                            return -1;
-            //                                        } else if (a.desc > b.desc) {
-            //                                            return 1;
-            //                                        }
-            //                                        return 0;
-            //                                    });
-            //                        }
-            //                    };
-        case 'struct':
-            break;
-        case 'unspecified':
-            // a bunch of field types are untyped, and there are no
-            // options for them...
-            switch (fieldType) {
-            case 'text':
-            case 'checkbox':
-            case 'textarea':
-            case 'dropdown':
-            case 'custom_button':
-            case 'textsubdata':
-            case 'file':
-            case 'custom_textsubdata':
-            case 'custom_widget':
-            case 'tab':
+                //                case 'xxinput_property_x':
+                //                    return {
+                //                        defaultValue: defaultValue(),
+                //                        referredParameter: 'input_sample_property_matrix',
+                //                        subdataIncluded: 'metadata/column_metadata',
+                //                        path: 'metadata/column_metadata',
+                //                        // custom function to collect
+                //                        mapper: {
+                //                            before: function () {
+                //                                return {
+                //                                    collected: {}
+                //                                };
+                //                            },
+                //                            during: function (values, state) {
+                //                                values.forEach(function (value) {
+                //                                    if (value.entity === 'Condition') {
+                //                                        state.collected[value.property_name] = true;
+                //                                    }
+                //                                });
+                //                            },
+                //                            after: function (state) {
+                //                                return Object.keys(state.collected).map(function (key) {
+                //                                    return {
+                //                                        id: key,
+                //                                        desc: key
+                //                                    };
+                //                                });
+                //                            }
+                //                        }
+                //                    };
+                //                case 'sample_property':
+                //                    return {
+                //                        required: required(),
+                //                        defaultValue: defaultValue(),
+                //                        referredParameter: 'input_sample_property_matrix',
+                //                        subdataIncluded: 'metadata/column_metadata',
+                //                        subdataPath: 'metadata.column_metadata',
+                //                        // custom function to collect
+                //                        map: function (subdata) {
+                //                            var collected = {};
+                //                            Object.keys(subdata).forEach(function (key) {
+                //                                    var id, name, column = subdata[key];
+                //                                    column.forEach(function (value) {
+                //                                        if (value.category === 'DataSeries' && value.property_name === 'SeriesID') {
+                //                                            id = value.property_value;
+                //                                        } else if (value.category === 'Property' && value.property_name === 'Name') {
+                //                                            name = value.property_value;
+                //                                        }
+                //                                        if (id && name) {
+                //                                            collected[id] = name;
+                //                                        }
+                //                                    });
+                //                                });
+                //                                return Object.keys(collected).map(function (key) {
+                //                                    return {
+                //                                        id: key,
+                //                                        desc: collected[key]
+                //                                    };
+                //                                })
+                //                                    .sort(function (a, b) {
+                //                                        if (a.desc < b.desc) {
+                //                                            return -1;
+                //                                        } else if (a.desc > b.desc) {
+                //                                            return 1;
+                //                                        }
+                //                                        return 0;
+                //                                    });
+                //                        }
+                //                    };
+            case 'struct':
+                break;
+            case 'unspecified':
+                // a bunch of field types are untyped, and there are no
+                // options for them...
+                switch (fieldType) {
+                    case 'text':
+                    case 'checkbox':
+                    case 'textarea':
+                    case 'dropdown':
+                    case 'custom_button':
+                    case 'textsubdata':
+                    case 'file':
+                    case 'custom_textsubdata':
+                    case 'custom_widget':
+                    case 'tab':
+                        break;
+                    default:
+                        console.error('ERROR unspecified field type', converted, spec)
+                        throw new Error('Unknown unspecified field type');
+                }
                 break;
             default:
-                console.error('ERROR unspecified field type', converted, spec)
-                throw new Error('Unknown unspecified field type');
-            }
-            break;
-        default:
-            console.error('Unknown data type', dataType);
-            throw new Error('Unknown data type: ' + dataType);
+                console.error('Unknown data type', dataType);
+                throw new Error('Unknown data type: ' + dataType);
         }
         if (constraints) {
             Object.keys(constraints).forEach(function (key) {
@@ -469,10 +472,10 @@ define([
     // Stepwise conversion
     function updateData(converted, spec) {
         switch (converted.data.type) {
-        case 'subdata':
-            converted.data.multiple = spec.textsubdata_options.multipleitems ? true : false;
-            break;
-        default:
+            case 'subdata':
+                converted.data.multiple = spec.textsubdata_options.multipleitems ? true : false;
+                break;
+            default:
         }
     }
 
@@ -711,7 +714,7 @@ define([
         if (structSpec.parameters.layout.length === 0) {
             throw new Error('Empty parameter group not allowed in ' + group.id);
         }
-        
+
         if (group.allow_multiple === 1) {
             params[group.id] = makeGroupSequence(group, structSpec);
         } else {
@@ -745,7 +748,7 @@ define([
                 convertGroup(group, parameterSpecs);
                 // don't know how the group is ordered in the spec ... so just append it later.
             });
-        }      
+        }
 
         // first filter out the paramters which have been moved into groups,
         // and then add the groups in.

--- a/kbase-extension/static/kbase/js/common/sdk.js
+++ b/kbase-extension/static/kbase/js/common/sdk.js
@@ -20,18 +20,18 @@ define([
             return false;
         }
         switch (value.toLowerCase(value)) {
-            case 'true':
-            case 't':
-            case 'yes':
-            case 'y':
-                return true;
-            case 'false':
-            case 'f':
-            case 'no':
-            case 'n':
-                return false;
-            default:
-                return false;
+        case 'true':
+        case 't':
+        case 'yes':
+        case 'y':
+            return true;
+        case 'false':
+        case 'f':
+        case 'no':
+        case 'n':
+            return false;
+        default:
+            return false;
         }
     }
 
@@ -45,22 +45,22 @@ define([
         }
         var nullValue = (function () {
             switch (converted.data.type) {
-                case 'string':
-                    return '';
-                case 'int':
-                    return null;
-                case 'float':
-                    return null;
-                case 'workspaceObjectRef':
-                    return null;
-                case 'workspaceObjectName':
-                    return null;
-                case 'struct':
-                    return {};
-                case '[]struct':
-                    return [];
-                default:
-                    return null;
+            case 'string':
+                return '';
+            case 'int':
+                return null;
+            case 'float':
+                return null;
+            case 'workspaceObjectRef':
+                return null;
+            case 'workspaceObjectName':
+                return null;
+            case 'struct':
+                return {};
+            case '[]struct':
+                return [];
+            default:
+                return null;
             }
         }());
         return nullValue;
@@ -75,24 +75,24 @@ define([
      */
     function defaultToNative(converted, defaultValue) {
         switch (converted.data.type) {
-            case 'string':
-                return defaultValue;
-            case 'int':
-                return parseInt(defaultValue);
-            case 'float':
-                return parseFloat(defaultValue);
-            case 'workspaceObjectRef':
-                if (defaultValue === '') {
-                    return null;
-                }
-                return defaultValue;
-            case 'workspaceObjectName':
-                return defaultValue;
-            case 'boolean':
-                return coerceToBoolean(defaultValue);
-            default:
-                // Assume it is a string...
-                return defaultValue;
+        case 'string':
+            return defaultValue;
+        case 'int':
+            return parseInt(defaultValue);
+        case 'float':
+            return parseFloat(defaultValue);
+        case 'workspaceObjectRef':
+            if (defaultValue === '') {
+                return null;
+            }
+            return defaultValue;
+        case 'workspaceObjectName':
+            return defaultValue;
+        case 'boolean':
+            return coerceToBoolean(defaultValue);
+        default:
+            // Assume it is a string...
+            return defaultValue;
         }
     }
 
@@ -102,32 +102,32 @@ define([
 
         // special special cases.
         switch (spec.field_type) {
-            case 'checkbox':
-                /*
-                 * handle the special case of a checkbox with no or empty
-                 * default value. It will promote to the "unchecked value"
-                 * TODO: more cases of bad default value? Or a generic
-                 * default value validator?
-                 */
-                if (!defaultValues ||
-                    defaultValues.length === 0) {
-                    return spec.checkbox_options.unchecked_value;
-                }
-                return coerceToIntBoolean(defaultValues[0]);
-            case 'custom_textsubdata':
-                if (!defaultValues) {
-                    // ??
-                }
-                break;
-            case 'textsubdata':
-                if (spec.default_values) {
-                    if (spec.default_values.length === 1 && spec.default_values[0] === '') {
-                        return [];
-                    }
-                    return spec.default_values[0].split(',');
-                } else {
+        case 'checkbox':
+            /*
+             * handle the special case of a checkbox with no or empty
+             * default value. It will promote to the "unchecked value"
+             * TODO: more cases of bad default value? Or a generic
+             * default value validator?
+             */
+            if (!defaultValues ||
+                defaultValues.length === 0) {
+                return spec.checkbox_options.unchecked_value;
+            }
+            return coerceToIntBoolean(defaultValues[0]);
+        case 'custom_textsubdata':
+            if (!defaultValues) {
+                // ??
+            }
+            break;
+        case 'textsubdata':
+            if (spec.default_values) {
+                if (spec.default_values.length === 1 && spec.default_values[0] === '') {
                     return [];
                 }
+                return spec.default_values[0].split(',');
+            } else {
+                return [];
+            }
         }
 
         // No default in spec, yet required.
@@ -159,38 +159,38 @@ define([
          * is actually an int, although Mike says it can be any type...
          */
         switch (spec.field_type) {
-            case 'checkbox':
-                return 'int';
-            case 'file':
-                // file datatype is really a file which is uploaded to shock, which results in a 
-                // shock file handle. maybe this field type should be "shock_file"
-                return 'string';
-            case 'textarea':
-                return 'string';
-            case 'dropdown':
-                return 'string';
-            case 'textsubdata':
-                return 'subdata';
-            case 'custom_textsubdata':
-                return 'customSubdata';
-            case 'custom_button':
-                switch (spec.id) {
-                    case 'input_check_other_params':
-                        return 'boolean';
-                    default:
-                        return 'unspecified';
-                }
-            case 'custom_widget':
-                if (spec.dropdown_options) {
-                    return '[]string';
-                }
-                break;
-            case 'group':
-                return 'struct';
-            case 'autocomplete':
-                return 'string';
-            case 'custom':
-                return 'custom';
+        case 'checkbox':
+            return 'int';
+        case 'file':
+            // file datatype is really a file which is uploaded to shock, which results in a 
+            // shock file handle. maybe this field type should be "shock_file"
+            return 'string';
+        case 'textarea':
+            return 'string';
+        case 'dropdown':
+            return 'string';
+        case 'textsubdata':
+            return 'subdata';
+        case 'custom_textsubdata':
+            return 'customSubdata';
+        case 'custom_button':
+            switch (spec.id) {
+            case 'input_check_other_params':
+                return 'boolean';
+            default:
+                return 'unspecified';
+            }
+        case 'custom_widget':
+            if (spec.dropdown_options) {
+                return '[]string';
+            }
+            break;
+        case 'group':
+            return 'struct';
+        case 'autocomplete':
+            return 'string';
+        case 'custom':
+            return 'custom';
         }
 
         /*
@@ -213,15 +213,15 @@ define([
         if (spec.text_options.valid_ws_types && spec.text_options.valid_ws_types.length > 0) {
             // we now have refs, but no way of specifying that the 
             switch (spec.ui_class) {
-                case 'input':
-                case 'parameter':
-                    // input objects are any valid ws object reference:
-                    // name, traditional ref, ref path.
-                    return 'workspaceObjectRef';
-                case 'output':
-                    return 'workspaceObjectName';
-                default:
-                    throw new Error('Unspecified ui_class, cannot determine object param data type');
+            case 'input':
+            case 'parameter':
+                // input objects are any valid ws object reference:
+                // name, traditional ref, ref path.
+                return 'workspaceObjectRef';
+            case 'output':
+                return 'workspaceObjectName';
+            default:
+                throw new Error('Unspecified ui_class, cannot determine object param data type');
             }
         }
 
@@ -230,8 +230,8 @@ define([
         // the text_options, we assume it is a string.
 
         switch (spec.field_type) {
-            case 'text':
-                return 'string';
+        case 'text':
+            return 'string';
         }
 
         console.error('ERROR could not determine type from spec', spec);
@@ -243,17 +243,17 @@ define([
         var dataType = converted.data.type;
 
         switch (dataType) {
-            case 'subdata':
+        case 'subdata':
+            converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
+            converted.ui.showSourceObject = spec.textsubdata_options.show_src_obj ? true : false;
+            break;
+        case 'customSubdata':
+            if (spec.textsubdata) {
                 converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
-                converted.ui.showSourceObject = spec.textsubdata_options.show_src_obj ? true : false;
-                break;
-            case 'customSubdata':
-                if (spec.textsubdata) {
-                    converted.ui.multiSelection = spec.textsubdata_options.multiselection ? true : false;
-                } else {
-                    converted.ui.multiSelection = false;
-                }
-                break;
+            } else {
+                converted.ui.multiSelection = false;
+            }
+            break;
         }
     }
 
@@ -271,195 +271,195 @@ define([
         // a dropdown even though the field_type is 'text'.
 
         switch (dataType) {
-            case 'custom':
+        case 'custom':
+            constraints = {
+                type: Props.getDataItem(spec, 'text_options.validate_as')
+            };
+            // HACK
+            converted.ui.class = 'parameter';
+            break;
+        case 'sequence':
+            constraints = {};
+            break;
+        case 'string':
+        case 'text':
+            switch (fieldType) {
+            case 'text':
                 constraints = {
-                    type: Props.getDataItem(spec, 'text_options.validate_as')
+                    min: Props.getDataItem(spec, 'text_options.min_length'),
+                    max: Props.getDataItem(spec, 'text_options.max_length'),
+                    regexp: Props.getDataItem(spec, 'text_options.regex_constraint'),
+                    validate: Props.getDataItem(spec, 'text_options.validate_as')
                 };
-                // HACK
-                converted.ui.class = 'parameter';
                 break;
-            case 'sequence':
+            case 'dropdown':
+                constraints = {
+                    options: spec.dropdown_options.options
+                };
+                break;
+            case 'textarea':
+                constraints = {
+                    min: Props.getDataItem(spec, 'text_options.min_length'),
+                    max: Props.getDataItem(spec, 'text_options.max_length'),
+                    nRows: Props.getDataItem(spec, 'text_options.n_rows', 5)
+                };
+                break;
+            case 'autocomplete':
                 constraints = {};
                 break;
-            case 'string':
-            case 'text':
-                switch (fieldType) {
-                    case 'text':
-                        constraints = {
-                            min: Props.getDataItem(spec, 'text_options.min_length'),
-                            max: Props.getDataItem(spec, 'text_options.max_length'),
-                            regexp: Props.getDataItem(spec, 'text_options.regex_constraint'),
-                            validate: Props.getDataItem(spec, 'text_options.validate_as')
-                        };
-                        break;
-                    case 'dropdown':
-                        constraints = {
-                            options: spec.dropdown_options.options
-                        };
-                        break;
-                    case 'textarea':
-                        constraints = {
-                            min: Props.getDataItem(spec, 'text_options.min_length'),
-                            max: Props.getDataItem(spec, 'text_options.max_length'),
-                            nRows: Props.getDataItem(spec, 'text_options.n_rows', 5)
-                        };
-                        break;
-                    case 'autocomplete':
-                        constraints = {};
-                        break;
-                    case 'file':
-                        constraints = {};
-                        break;
-                    default:
-                        throw new Error('Unknown text param field type "' + fieldType + '"');
-                }
-                break;
-            case 'int':
-                switch (fieldType) {
-                    case 'text':
-                        constraints = {
-                            min: Props.getDataItem(spec, 'text_options.min_int'),
-                            max: Props.getDataItem(spec, 'text_options.max_int')
-                        };
-                        break;
-                    case 'checkbox':
-                        // In theory, the checkbox
-                        constraints = {
-                            min: 0,
-                            max: 0
-                        };
-                        break;
-                }
-                break;
-            case 'float':
-                constraints = {
-                    min: Props.getDataItem(spec, 'text_options.min_float'),
-                    max: Props.getDataItem(spec, 'text_options.max_float')
-                };
-                break;
-            case 'workspaceObjectRef':
-            case 'workspaceObjectName':
-                constraints = {
-                    types: spec.text_options.valid_ws_types
-                };
-                break;
-            case '[]string':
-                switch (fieldType) {
-                    case 'dropdown':
-                        break;
-                    case 'text':
-                        break;
-                    case 'textarea':
-                        break;
-                    default:
-                        // throw new Error('Unknown []string field type: ' + fieldType);
-                }
-                break;
-            case 'subdata':
-                constraints = {
-                    multiple: false,
-                    subdataSelection: spec.textsubdata_options.subdata_selection
-                };
-                break;
-            case 'customSubdata':
-                constraints = {
-                    multiple: false
-                };
-                break;
-                //                case 'xxinput_property_x':
-                //                    return {
-                //                        defaultValue: defaultValue(),
-                //                        referredParameter: 'input_sample_property_matrix',
-                //                        subdataIncluded: 'metadata/column_metadata',
-                //                        path: 'metadata/column_metadata',
-                //                        // custom function to collect
-                //                        mapper: {
-                //                            before: function () {
-                //                                return {
-                //                                    collected: {}
-                //                                };
-                //                            },
-                //                            during: function (values, state) {
-                //                                values.forEach(function (value) {
-                //                                    if (value.entity === 'Condition') {
-                //                                        state.collected[value.property_name] = true;
-                //                                    }
-                //                                });
-                //                            },
-                //                            after: function (state) {
-                //                                return Object.keys(state.collected).map(function (key) {
-                //                                    return {
-                //                                        id: key,
-                //                                        desc: key
-                //                                    };
-                //                                });
-                //                            }
-                //                        }
-                //                    };
-                //                case 'sample_property':
-                //                    return {
-                //                        required: required(),
-                //                        defaultValue: defaultValue(),
-                //                        referredParameter: 'input_sample_property_matrix',
-                //                        subdataIncluded: 'metadata/column_metadata',
-                //                        subdataPath: 'metadata.column_metadata',
-                //                        // custom function to collect
-                //                        map: function (subdata) {
-                //                            var collected = {};
-                //                            Object.keys(subdata).forEach(function (key) {
-                //                                    var id, name, column = subdata[key];
-                //                                    column.forEach(function (value) {
-                //                                        if (value.category === 'DataSeries' && value.property_name === 'SeriesID') {
-                //                                            id = value.property_value;
-                //                                        } else if (value.category === 'Property' && value.property_name === 'Name') {
-                //                                            name = value.property_value;
-                //                                        }
-                //                                        if (id && name) {
-                //                                            collected[id] = name;
-                //                                        }
-                //                                    });
-                //                                });
-                //                                return Object.keys(collected).map(function (key) {
-                //                                    return {
-                //                                        id: key,
-                //                                        desc: collected[key]
-                //                                    };
-                //                                })
-                //                                    .sort(function (a, b) {
-                //                                        if (a.desc < b.desc) {
-                //                                            return -1;
-                //                                        } else if (a.desc > b.desc) {
-                //                                            return 1;
-                //                                        }
-                //                                        return 0;
-                //                                    });
-                //                        }
-                //                    };
-            case 'struct':
-                break;
-            case 'unspecified':
-                // a bunch of field types are untyped, and there are no
-                // options for them...
-                switch (fieldType) {
-                    case 'text':
-                    case 'checkbox':
-                    case 'textarea':
-                    case 'dropdown':
-                    case 'custom_button':
-                    case 'textsubdata':
-                    case 'file':
-                    case 'custom_textsubdata':
-                    case 'custom_widget':
-                    case 'tab':
-                        break;
-                    default:
-                        console.error('ERROR unspecified field type', converted, spec)
-                        throw new Error('Unknown unspecified field type');
-                }
+            case 'file':
+                constraints = {};
                 break;
             default:
-                console.error('Unknown data type', dataType);
-                throw new Error('Unknown data type: ' + dataType);
+                throw new Error('Unknown text param field type "' + fieldType + '"');
+            }
+            break;
+        case 'int':
+            switch (fieldType) {
+            case 'text':
+                constraints = {
+                    min: Props.getDataItem(spec, 'text_options.min_int'),
+                    max: Props.getDataItem(spec, 'text_options.max_int')
+                };
+                break;
+            case 'checkbox':
+                // In theory, the checkbox
+                constraints = {
+                    min: 0,
+                    max: 0
+                };
+                break;
+            }
+            break;
+        case 'float':
+            constraints = {
+                min: Props.getDataItem(spec, 'text_options.min_float'),
+                max: Props.getDataItem(spec, 'text_options.max_float')
+            };
+            break;
+        case 'workspaceObjectRef':
+        case 'workspaceObjectName':
+            constraints = {
+                types: spec.text_options.valid_ws_types
+            };
+            break;
+        case '[]string':
+            switch (fieldType) {
+            case 'dropdown':
+                break;
+            case 'text':
+                break;
+            case 'textarea':
+                break;
+            default:
+                // throw new Error('Unknown []string field type: ' + fieldType);
+            }
+            break;
+        case 'subdata':
+            constraints = {
+                multiple: false,
+                subdataSelection: spec.textsubdata_options.subdata_selection
+            };
+            break;
+        case 'customSubdata':
+            constraints = {
+                multiple: false
+            };
+            break;
+            //                case 'xxinput_property_x':
+            //                    return {
+            //                        defaultValue: defaultValue(),
+            //                        referredParameter: 'input_sample_property_matrix',
+            //                        subdataIncluded: 'metadata/column_metadata',
+            //                        path: 'metadata/column_metadata',
+            //                        // custom function to collect
+            //                        mapper: {
+            //                            before: function () {
+            //                                return {
+            //                                    collected: {}
+            //                                };
+            //                            },
+            //                            during: function (values, state) {
+            //                                values.forEach(function (value) {
+            //                                    if (value.entity === 'Condition') {
+            //                                        state.collected[value.property_name] = true;
+            //                                    }
+            //                                });
+            //                            },
+            //                            after: function (state) {
+            //                                return Object.keys(state.collected).map(function (key) {
+            //                                    return {
+            //                                        id: key,
+            //                                        desc: key
+            //                                    };
+            //                                });
+            //                            }
+            //                        }
+            //                    };
+            //                case 'sample_property':
+            //                    return {
+            //                        required: required(),
+            //                        defaultValue: defaultValue(),
+            //                        referredParameter: 'input_sample_property_matrix',
+            //                        subdataIncluded: 'metadata/column_metadata',
+            //                        subdataPath: 'metadata.column_metadata',
+            //                        // custom function to collect
+            //                        map: function (subdata) {
+            //                            var collected = {};
+            //                            Object.keys(subdata).forEach(function (key) {
+            //                                    var id, name, column = subdata[key];
+            //                                    column.forEach(function (value) {
+            //                                        if (value.category === 'DataSeries' && value.property_name === 'SeriesID') {
+            //                                            id = value.property_value;
+            //                                        } else if (value.category === 'Property' && value.property_name === 'Name') {
+            //                                            name = value.property_value;
+            //                                        }
+            //                                        if (id && name) {
+            //                                            collected[id] = name;
+            //                                        }
+            //                                    });
+            //                                });
+            //                                return Object.keys(collected).map(function (key) {
+            //                                    return {
+            //                                        id: key,
+            //                                        desc: collected[key]
+            //                                    };
+            //                                })
+            //                                    .sort(function (a, b) {
+            //                                        if (a.desc < b.desc) {
+            //                                            return -1;
+            //                                        } else if (a.desc > b.desc) {
+            //                                            return 1;
+            //                                        }
+            //                                        return 0;
+            //                                    });
+            //                        }
+            //                    };
+        case 'struct':
+            break;
+        case 'unspecified':
+            // a bunch of field types are untyped, and there are no
+            // options for them...
+            switch (fieldType) {
+            case 'text':
+            case 'checkbox':
+            case 'textarea':
+            case 'dropdown':
+            case 'custom_button':
+            case 'textsubdata':
+            case 'file':
+            case 'custom_textsubdata':
+            case 'custom_widget':
+            case 'tab':
+                break;
+            default:
+                console.error('ERROR unspecified field type', converted, spec)
+                throw new Error('Unknown unspecified field type');
+            }
+            break;
+        default:
+            console.error('Unknown data type', dataType);
+            throw new Error('Unknown data type: ' + dataType);
         }
         if (constraints) {
             Object.keys(constraints).forEach(function (key) {
@@ -472,10 +472,10 @@ define([
     // Stepwise conversion
     function updateData(converted, spec) {
         switch (converted.data.type) {
-            case 'subdata':
-                converted.data.multiple = spec.textsubdata_options.multipleitems ? true : false;
-                break;
-            default:
+        case 'subdata':
+            converted.data.multiple = spec.textsubdata_options.multipleitems ? true : false;
+            break;
+        default:
         }
     }
 

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -691,6 +691,10 @@ define([
 
         $([Jupyter.events]).on('notebook_loaded.Notebook', function () {
             // Disable autosave so as not to spam the Workspace.
+
+            // Tricky with inter/intra-dependencies between kbaseNarrative and kbaseNarrativeWorkspace...
+            this.sidePanel = new KBaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
+
             this.narrController = new KBaseNarrativeWorkspace($('#notebook_panel'), {
                 ws_id: this.getWorkspaceName()
             });
@@ -721,9 +725,8 @@ define([
                 this.workspaceId = wsInfo[1];
             }
 
-            this.sidePanel = new KBaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
             // init the controller
-            
+
             this.narrController.render()
                 .finally(function () {
                     this.sidePanel.render();
@@ -783,7 +786,7 @@ define([
         Jupyter.notebook.save_checkpoint();
     };
 
-    Narrative.prototype.addAndPopulateApp = function(appId, tag, parameters) {
+    Narrative.prototype.addAndPopulateApp = function (appId, tag, parameters) {
         this.sidePanel.$methodsWidget.triggerApp(appId, tag, parameters);
     };
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/subdataInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/subdataInput.js
@@ -13,7 +13,7 @@ define([
     '../subdataMethods/manager',
     'bootstrap',
     'css!font-awesome'
-], function(
+], function (
     $,
     Promise,
     html,
@@ -63,6 +63,7 @@ define([
             model,
             subdataMethods,
             isAvailableValuesInitialized = false,
+            haveReferenceData = false,
             options = {
                 objectSelectionPageSize: 20
             },
@@ -77,7 +78,7 @@ define([
             if (!availableValues) {
                 return selectOptions;
             }
-            return selectOptions.concat(availableValues.map(function(availableValue) {
+            return selectOptions.concat(availableValues.map(function (availableValue) {
                 var selected = false,
                     optionLabel = availableValue.id,
                     optionValue = availableValue.id;
@@ -104,7 +105,7 @@ define([
                 return items;
             }
             var re = new RegExp(filter);
-            return items.filter(function(item) {
+            return items.filter(function (item) {
                 if (item.text && item.text.match(re, 'i')) {
                     return true;
                 }
@@ -125,7 +126,7 @@ define([
 
         function didChange() {
             validate()
-                .then(function(result) {
+                .then(function (result) {
                     if (result.isValid) {
                         model.setItem('value', result.value);
                         updateInputControl('value');
@@ -173,7 +174,7 @@ define([
         function doRemoveSelectedAvailableItem(idToRemove) {
             var selectedItems = model.getItem('selectedItems', []);
 
-            model.setItem('selectedItems', selectedItems.filter(function(id) {
+            model.setItem('selectedItems', selectedItems.filter(function (id) {
                 if (idToRemove === id) {
                     return false;
                 }
@@ -194,11 +195,13 @@ define([
 
             if (!isAvailableValuesInitialized) {
                 content = div({ style: { textAlign: 'center' } }, html.loading('Loading data...'));
+                // } else if (!haveReferenceData) {
+                //     content = div({ style: { textAlign: 'center' } }, 'no values available until reference data selected in parameter ' + spec.data.constraints.subdataSelection.parameter_id);
             } else if (itemsToShow.length === 0) {
                 content = div({ style: { textAlign: 'center' } }, 'no available values');
             } else {
-                content = itemsToShow.map(function(item, index) {
-                        var isSelected = selected.some(function(id) {
+                content = itemsToShow.map(function (item, index) {
+                        var isSelected = selected.some(function (id) {
                                 return (item.id === id);
                             }),
                             disabled = isSelected;
@@ -230,7 +233,7 @@ define([
                                     verticalAlign: 'top'
                                 }
                             }, [
-                                (function() {
+                                (function () {
                                     if (disabled) {
                                         return span({
                                             class: 'kb-btn-icon',
@@ -239,7 +242,7 @@ define([
                                             title: 'Remove from selected',
                                             id: events.addEvent({
                                                 type: 'click',
-                                                handler: function() {
+                                                handler: function () {
                                                     doRemoveSelectedAvailableItem(item.id);
                                                 }
                                             })
@@ -262,7 +265,7 @@ define([
                                             dataItemId: item.id,
                                             id: events.addEvent({
                                                 type: 'click',
-                                                handler: function() {
+                                                handler: function () {
                                                     doAddItem(item.id);
                                                 }
                                             })
@@ -302,8 +305,10 @@ define([
 
             if (selectedItems.length === 0) {
                 content = div({ style: { textAlign: 'center' } }, 'no selected values');
+                // } else {if (!haveReferenceData) {
+                //     content = div({ style: { textAlign: 'center' } }, 'no values may be chosen until reference data selected in parameter ' + spec.data.constraints.subdataSelection.parameter_id);
             } else {
-                content = selectedItems.map(function(itemId, index) {
+                content = selectedItems.map(function (itemId, index) {
                     var item = valuesMap[itemId];
                     if (item === undefined || item === null) {
                         item = {
@@ -311,12 +316,17 @@ define([
                         };
                     }
 
-                    return div({ class: 'row', style: { border: '1px #CCC solid', borderCollapse: 'collapse', boxSizing: 'border-box' } }, [
+                    return div({
+                        class: 'row',
+                        style: {
+                            border: '1px #CCC solid',
+                            borderCollapse: 'collapse',
+                            boxSizing: 'border-box'
+                        }
+                    }, [
                         div({
                             class: 'col-md-2',
                             style: {
-                                xdisplay: 'inline-block',
-                                xwidth: '20%',
                                 verticalAlign: 'middle',
                                 borderRadius: '3px',
                                 padding: '2px',
@@ -330,18 +340,12 @@ define([
                         div({
                             class: 'col-md-8',
                             style: {
-                                xdisplay: 'inline-block',
-                                xwidth: '90%',
                                 padding: '2px'
                             }
                         }, item.text),
                         div({
                             class: 'col-md-2',
                             style: {
-                                xdisplay: 'inline-block',
-                                xwidth: '10%',
-                                //minWidth: '6em',
-                                //maxWidth: '6em',
                                 padding: '2px',
                                 textAlign: 'right',
                                 verticalAlign: 'top'
@@ -354,11 +358,17 @@ define([
                                 title: 'Remove from selected',
                                 id: events.addEvent({
                                     type: 'click',
-                                    handler: function() {
+                                    handler: function () {
                                         doRemoveSelectedItem(index);
                                     }
                                 })
-                            }, span({ class: 'fa fa-minus-circle', style: { color: 'red', fontSize: '200%' } }))
+                            }, span({
+                                class: 'fa fa-minus-circle',
+                                style: {
+                                    color: 'red',
+                                    fontSize: '200%'
+                                }
+                            }))
                         ])
                     ]);
                 }).join('\n');
@@ -369,13 +379,9 @@ define([
         }
 
         function renderSearchBox() {
-            var items = model.getItem('availableValues', []),
-                events = Events.make({ node: container }),
+            var events = Events.make({ node: container }),
                 content;
 
-            //if (items.length === 0) {
-            //    content = '';
-            //} else {
             content = input({
                 class: 'form-contol',
                 style: { xwidth: '100%' },
@@ -384,33 +390,32 @@ define([
                 id: events.addEvents({
                     events: [{
                             type: 'keyup',
-                            handler: function(e) {
+                            handler: function (e) {
                                 doSearchKeyUp(e);
                             }
                         },
                         {
                             type: 'focus',
-                            handler: function() {
+                            handler: function () {
                                 Jupyter.narrative.disableKeyboardManager();
                             }
                         },
                         {
                             type: 'blur',
-                            handler: function() {
+                            handler: function () {
                                 // console.log('SingleSubData Search BLUR');
                                 // Jupyter.narrative.enableKeyboardManager();
                             }
                         },
                         {
                             type: 'click',
-                            handler: function() {
+                            handler: function () {
                                 Jupyter.narrative.disableKeyboardManager();
                             }
                         }
                     ]
                 })
             });
-            //}
 
             ui.setContent('search-box', content);
             events.attachEvents();
@@ -457,7 +462,7 @@ define([
                         style: { xwidth: '100%' },
                         id: events.addEvent({
                             type: 'click',
-                            handler: function() {
+                            handler: function () {
                                 doFirstPage();
                             }
                         })
@@ -468,7 +473,7 @@ define([
                         style: { xwidth: '50%' },
                         id: events.addEvent({
                             type: 'click',
-                            handler: function() {
+                            handler: function () {
                                 doPreviousPage();
                             }
                         })
@@ -479,7 +484,7 @@ define([
                         style: { xwidth: '100%' },
                         id: events.addEvent({
                             type: 'click',
-                            handler: function() {
+                            handler: function () {
                                 doNextPage();
                             }
                         })
@@ -490,7 +495,7 @@ define([
                         style: { xwidth: '100%' },
                         id: events.addEvent({
                             type: 'click',
-                            handler: function() {
+                            handler: function () {
                                 doLastPage();
                             }
                         })
@@ -634,25 +639,25 @@ define([
          */
         function updateInputControl(changedProperty) {
             switch (changedProperty) {
-                case 'value':
-                    // just change the selections.
-                    var count = buildCount();
-                    ui.setContent('input-control.count', count);
+            case 'value':
+                // just change the selections.
+                var count = buildCount();
+                ui.setContent('input-control.count', count);
 
-                    break;
-                case 'availableValues':
-                    // rebuild the options
-                    // re-apply the selections from the value
-                    var options = buildOptions();
-                    ui.setContent('input-control.input', options);
-                    ui.setContent('input-control.count', count);
+                break;
+            case 'availableValues':
+                // rebuild the options
+                // re-apply the selections from the value
+                var options = buildOptions();
+                ui.setContent('input-control.input', options);
+                ui.setContent('input-control.count', count);
 
-                    break;
-                case 'referenceObjectName':
-                    // refetch the available values
-                    // set available values
-                    // update input control for available values
-                    // set value to null
+                break;
+            case 'referenceObjectName':
+                // refetch the available values
+                // set available values
+                // update input control for available values
+                // set value to null
 
 
             }
@@ -667,17 +672,6 @@ define([
          * values.
          */
         function getInputValue() {
-            //            var control = ui.getElement('input-container.input');
-            //            if (!control) {
-            //                return null;
-            //            }
-            //            var input = control.selectedOptions,
-            //                i, values = [];
-            //            for (i = 0; i < input.length; i += 1) {
-            //                values.push(input.item(i).value);
-            //            }
-            //            // cute ... allows selecting multiple values but does not expect a sequence...
-            //            return values;
             return model.getItem('selectedItems');
         }
 
@@ -687,42 +681,44 @@ define([
         }
 
         function validate() {
-            return Promise.try(function() {
+            return Promise.try(function () {
                 var rawValue = getInputValue(),
                     validationOptions = {
                         required: spec.data.constraints.required
                     };
 
                 return Validation.validateStringSet(rawValue, validationOptions);
-            })
+            });
         }
 
         function fetchData() {
             var referenceObjectName = model.getItem('referenceObjectName'),
                 referenceObjectRef = spec.data.constraints.subdataSelection.constant_ref;
 
+            if (!referenceObjectName) {
+                return [false, null];
+            }
+
             if (!referenceObjectRef) {
-                if (!referenceObjectName) {
-                    return [];
-                }
                 referenceObjectRef = workspaceId + '/' + referenceObjectName;
             }
 
             return subdataMethods.fetchData({
-                referenceObjectRef: referenceObjectRef,
-                spec: spec
-            });
+                    referenceObjectRef: referenceObjectRef,
+                    spec: spec
+                })
+                .then(function (values) {
+                    return [true, values];
+                });
         }
 
         function syncAvailableValues() {
-            return Promise.try(function() {
+            return Promise.try(function () {
                     return fetchData();
                 })
-                .then(function(data) {
+                .spread(function (haveRefData, data) {
                     isAvailableValuesInitialized = true;
-                    if (!data) {
-                        return ' no data? ';
-                    }
+                    haveReferenceData = haveRefData;
 
                     // If default values have been provided, prepend them to the data.
 
@@ -730,13 +726,16 @@ define([
                     // it as the default value, but as a set of additional items
                     // to select.
                     var defaultValues = spec.data.defaultValue;
+                    var newAvailableValues = data || [];
                     if (defaultValues && (defaultValues instanceof Array) && (defaultValues.length > 0)) {
-                        defaultValues.forEach(function(itemId) {
+                        defaultValues.forEach(function (itemId) {
                             if (itemId && itemId.trim().length > 0) {
-                                data.unshift({
+                                // Add the item to the available data
+                                var newItem = {
                                     id: itemId,
                                     text: itemId
-                                });
+                                };
+                                newAvailableValues.unshift(newItem);
                             }
                         });
                     }
@@ -748,19 +747,21 @@ define([
                     // - a set of available ids
                     // - a set of selected ids
                     // - a set of filtered ids
-                    model.setItem('availableValues', data);
+                    model.setItem('availableValues', newAvailableValues);
 
                     // TODO: generate all of this in the fetchData -- it will be a bit faster.
                     var map = {};
-                    data.forEach(function(datum) {
+                    newAvailableValues.forEach(function (datum) {
                         map[datum.id] = datum;
                     });
 
-                    //var availableIds = data.map(function (datum) {
-                    //    return datum.id;
-                    //});
-
                     model.setItem('availableValuesMap', map);
+
+                    // Ensure that selectedValues not in the new available values are removed.
+                    var selectedValues = model.getItem('selectedItems', []).filter(function (value) {
+                        return map[value];
+                    });
+                    model.setItem('selectedItems', selectedValues);
 
                     doFilterItems();
                 });
@@ -768,7 +769,7 @@ define([
 
         function autoValidate() {
             return validate()
-                .then(function(result) {
+                .then(function (result) {
                     channel.emit('validation', {
                         errorMessage: result.errorMessage,
                         diagnosis: result.diagnosis
@@ -776,14 +777,13 @@ define([
                 });
         }
 
-
         /*
          * Creates the markup
          * Places it into the ui node
          * Hooks up event listeners
          */
         function render() {
-            return Promise.try(function() {
+            return Promise.try(function () {
                     // check to see if we have to render inputControl.
                     var events = Events.make({ node: container }),
                         inputControl = makeInputControl(events),
@@ -803,10 +803,10 @@ define([
 
                     events.attachEvents();
                 })
-                .then(function() {
+                .then(function () {
                     return autoValidate();
                 })
-                .catch(function(err) {
+                .catch(function (err) {
                     console.error('ERROR in render', err);
                 });
         }
@@ -835,9 +835,8 @@ define([
              * Issued when thre is a need to have all params reset to their
              * default value.
              */
-            channel.on('reset-to-defaults', function(message) {
+            channel.on('reset-to-defaults', function (message) {
                 resetModelValue();
-                // model.reset();
                 // TODO: this should really be set when the linked field is reset...
                 model.setItem('availableValues', []);
                 model.setItem('referenceObjectName', null);
@@ -848,7 +847,7 @@ define([
             /*
              * Issued when there is an update for this param.
              */
-            channel.on('update', function(message) {
+            channel.on('update', function (message) {
                 model.setItem('value', message.value);
                 updateInputControl('value');
             });
@@ -865,7 +864,7 @@ define([
                         type: 'parameter-changed',
                         parameter: spec.data.constraints.subdataSelection.constant_ref
                     },
-                    handle: function(message) {
+                    handle: function (message) {
                         var newValue = message.newValue;
                         if (message.newValue === '') {
                             newValue = null;
@@ -874,10 +873,10 @@ define([
                         model.reset();
                         model.setItem('referenceObjectName', newValue);
                         syncAvailableValues()
-                            .then(function() {
+                            .then(function () {
                                 updateInputControl('availableValues');
                             })
-                            .catch(function(err) {
+                            .catch(function (err) {
                                 console.error('ERROR syncing available values', err);
                             });
                     }
@@ -890,19 +889,21 @@ define([
                         type: 'parameter-changed',
                         parameter: spec.data.constraints.subdataSelection.parameter_id
                     },
-                    handle: function(message) {
+                    handle: function (message) {
                         var newValue = message.newValue;
                         if (message.newValue === '') {
                             newValue = null;
                         }
                         // reset the entire model.
+                        var selectedItems = model.getItem('selectedItems');
                         model.reset();
+                        model.setItem('selectedItems', selectedItems);
                         model.setItem('referenceObjectName', newValue);
                         syncAvailableValues()
-                            .then(function() {
+                            .then(function () {
                                 updateInputControl('availableValues');
                             })
-                            .catch(function(err) {
+                            .catch(function (err) {
                                 console.error('ERROR syncing available values', err);
                             });
                     }
@@ -915,7 +916,7 @@ define([
                         type: 'parameter-value',
                         parameter: spec.data.constraints.subdataSelection.parameter_id
                     },
-                    handle: function(message) {
+                    handle: function (message) {
                         var newValue = message.newValue;
                         if (message.newValue === '') {
                             newValue = null;
@@ -923,10 +924,10 @@ define([
                         model.reset();
                         model.setItem('referenceObjectName', newValue);
                         syncAvailableValues()
-                            .then(function() {
+                            .then(function () {
                                 updateInputControl('availableValues');
                             })
-                            .catch(function(err) {
+                            .catch(function (err) {
                                 console.error('ERROR syncing available values', err);
                             });
                     }
@@ -952,7 +953,7 @@ define([
                         type: 'get-parameter'
                     }
                 })
-                .then(function(message) {
+                .then(function (message) {
                     // console.log('Now i got it again', message);
                 });
 
@@ -978,13 +979,10 @@ define([
          *
          */
 
-
-
-
         // LIFECYCLE API
 
         function start(arg) {
-            return Promise.try(function() {
+            return Promise.try(function () {
                 parent = arg.node;
                 container = parent.appendChild(document.createElement('div'));
                 ui = UI.make({
@@ -1004,7 +1002,7 @@ define([
 
                 // Get initial data.
                 // Weird, but will make it look nicer.
-                Promise.all([
+                return Promise.all([
                         paramsChannel.request({
                             parameterName: spec.id
                         }, {
@@ -1020,21 +1018,7 @@ define([
                             }
                         })
                     ])
-                    .spread(function(paramValue, referencedParamValue) {
-                        // hmm, the default value of a subdata is null, but that does
-                        // not play nice with the model props defaulting mechanism which
-                        // works with absent or undefined (null being considered an actual value, which
-                        // it is of course!)
-                        // if (paramValue.value === null || paramValue.value === undefined) {
-                        //     model.setItem('selectedItems', []);
-                        // } else {
-                        //     var selectedItems = paramValue.value;
-                        //     if (!(selectedItems instanceof Array)) {
-                        //         selectedItems = [selectedItems];
-                        //     }
-                        //     model.setItem('selectedItems', selectedItems);
-                        // }
-                        // updateInputControl('value');
+                    .spread(function (paramValue, referencedParamValue) {
                         if (!config.initialValue) {
                             model.setItem('selectedItems', []);
                         } else {
@@ -1050,22 +1034,21 @@ define([
                             model.setItem('referenceObjectName', referencedParamValue.value);
                         }
                         return syncAvailableValues()
-                            .then(function() {
+                            .then(function () {
                                 updateInputControl('availableValues');
                             })
-                            .catch(function(err) {
+                            .catch(function (err) {
                                 console.error('ERROR syncing available values', err);
                             });
-
                     })
-                    .catch(function(err) {
+                    .catch(function (err) {
                         console.error('ERROR fetching initial data', err);
                     });
             });
         }
 
         function stop() {
-            return Promise.try(function() {
+            return Promise.try(function () {
                 if (parent && container) {
                     parent.removeChild(container);
                 }
@@ -1084,7 +1067,7 @@ define([
                 showFrom: 0,
                 showTo: 5
             },
-            onUpdate: function(props) {
+            onUpdate: function (props) {
                 renderStats();
                 renderToolbar();
                 renderAvailableItems();
@@ -1099,7 +1082,7 @@ define([
     }
 
     return {
-        make: function(config) {
+        make: function (config) {
             return factory(config);
         }
     };

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -214,8 +214,8 @@ define([
             );
 
             $(document).on('appClicked.Narrative',
-                function(event, method, tag, parameters) {
-                     if (this.uiMode === 'view') {
+                function (event, method, tag, parameters) {
+                    if (this.uiMode === 'view') {
                         console.warn('ignoring attempt to insert app cell in view-only mode');
                         return;
                     }
@@ -481,7 +481,7 @@ define([
             }
         },
 
-        buildAppCodeCell: function(spec, tag, parameters) {
+        buildAppCodeCell: function (spec, tag, parameters) {
             if (!spec || !spec.info) {
                 console.error('ERROR build method code cell: ', spec, tag);
                 alert('Sorry, could not find this method');
@@ -516,7 +516,7 @@ define([
             // Finally, if we have parameters, wedge them in the new cell's metadata.
             if (parameters) {
                 var meta = cell.metadata;
-                Object.keys(parameters).forEach(function(param) {
+                Object.keys(parameters).forEach(function (param) {
                     meta.kbase.appCell.params[param] = parameters[param];
                 });
                 cell.metadata = meta;
@@ -537,15 +537,15 @@ define([
             // executing app.
             if (spec.behavior.kb_service_name && spec.behavior.kb_service_method) {
                 switch (spec.info.app_type) {
-                case 'editor':
-                    return 'editor';
-                case 'app':
-                    return 'app';
-                case 'advanced_viewer':
-                    return 'advancedView';
-                default:
-                    console.warn('The app ' + spec.info.id + ' does not specify a valid spec.info.app_type "' + spec.info.app_type + '" - defaulting to "app"');
-                    return 'app';
+                    case 'editor':
+                        return 'editor';
+                    case 'app':
+                        return 'app';
+                    case 'advanced_viewer':
+                        return 'advancedView';
+                    default:
+                        console.warn('The app ' + spec.info.id + ' does not specify a valid spec.info.app_type "' + spec.info.app_type + '" - defaulting to "app"');
+                        return 'app';
                 }
             }
 
@@ -591,7 +591,7 @@ define([
             this.removeCellEditFunction(cell);
         },
 
-        
+
 
         /**
          * A TEMPORARY FUNCTION that should refresh and update the given cell's metadata to the new(er) version,
@@ -1620,15 +1620,6 @@ define([
             var self = this;
             return function (cell, service, method, params) {
                 var nb = Jupyter.notebook;
-                var currentIndex = nb.get_selected_index();
-
-                // var callbacks = {
-                //     'execute_reply' : function(content) { self.handleExecuteReply(cell, content); },
-                //     'output' : function(msgType, content) { self.handleOutput(cell, msgType, content); },
-                //     'clear_output' : function(content) { self.handleClearOutput(cell, content); },
-                //     'set_next_input' : function(text) { self.handleSetNextInput(cell, content); },
-                //     'input_request' : function(content) { self.handleInputRequest(cell, content); }
-                // };
 
                 var callbacks = {
                     shell: {
@@ -1730,26 +1721,26 @@ define([
                 // XXX: assume either more maps or simple type
                 var vtype = typeof value;
                 switch (vtype) {
-                case 'boolean':
-                    if (value)
-                        dict += 'True';
-                    else
-                        dict += 'False';
-                    break;
-                case 'number':
-                    dict += value;
-                    break;
-                case 'string':
-                    dict += '\'' + value + '\'';
-                    break;
-                case 'undefined':
-                    dict += 'None';
-                    break;
-                case 'object':
-                    dict += this._pythonDict(value);
-                    break;
-                default:
-                    console.error('Cannot convert to Python:', vtype);
+                    case 'boolean':
+                        if (value)
+                            dict += 'True';
+                        else
+                            dict += 'False';
+                        break;
+                    case 'number':
+                        dict += value;
+                        break;
+                    case 'string':
+                        dict += '\'' + value + '\'';
+                        break;
+                    case 'undefined':
+                        dict += 'None';
+                        break;
+                    case 'object':
+                        dict += this._pythonDict(value);
+                        break;
+                    default:
+                        console.error('Cannot convert to Python:', vtype);
                 }
                 dict += ', '
             });
@@ -1863,53 +1854,53 @@ define([
                             var matches = line.match(/^@@([ADEGJSP])(.*)/);
                             if (matches) { // if we got one
                                 switch (matches[1]) {
-                                case 'S': // Start running
-                                    // if we're starting, init the progress bar.
-                                    break;
+                                    case 'S': // Start running
+                                        // if we're starting, init the progress bar.
+                                        break;
 
-                                case 'D': // Done running
-                                    // were done, so hide the progress bar (wait like a second or two?)
-                                    self.resetProgress(cell);
-                                    break;
+                                    case 'D': // Done running
+                                        // were done, so hide the progress bar (wait like a second or two?)
+                                        self.resetProgress(cell);
+                                        break;
 
-                                case 'P': // Progress step
-                                    var progressInfo = matches[2].split(',');
-                                    if (progressInfo.length == 3) {
-                                        self.showCellProgress(cell, progressInfo[0], progressInfo[1], progressInfo[2]);
-                                        offs += line.length;
-                                        if (index < lines.length - 1)
-                                            offs += 1;
-                                    } else
-                                        done = true;
-                                    break;
+                                    case 'P': // Progress step
+                                        var progressInfo = matches[2].split(',');
+                                        if (progressInfo.length == 3) {
+                                            self.showCellProgress(cell, progressInfo[0], progressInfo[1], progressInfo[2]);
+                                            offs += line.length;
+                                            if (index < lines.length - 1)
+                                                offs += 1;
+                                        } else
+                                            done = true;
+                                        break;
 
-                                case 'E': // Error while running
-                                    var errorJson = matches[2];
-                                    errorJson = errorJson.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\$/g, '&#36;');
-                                    self.createOutputCell(cell, '{"error" :' + errorJson + '}', true);
-                                    break;
+                                    case 'E': // Error while running
+                                        var errorJson = matches[2];
+                                        errorJson = errorJson.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\$/g, '&#36;');
+                                        self.createOutputCell(cell, '{"error" :' + errorJson + '}', true);
+                                        break;
 
-                                case 'G': // debuG message
-                                    var debug = matches[2];
-                                    self.dbg('[KERNEL] ' + debug);
-                                    break;
+                                    case 'G': // debuG message
+                                        var debug = matches[2];
+                                        self.dbg('[KERNEL] ' + debug);
+                                        break;
 
-                                case 'J': // Job id register
-                                    var jobId = matches[2];
-                                    self.dbg('[JOB ID] ' + jobId);
-                                    self.registerJobId(jobId, cell);
-                                    break;
+                                    case 'J': // Job id register
+                                        var jobId = matches[2];
+                                        self.dbg('[JOB ID] ' + jobId);
+                                        self.registerJobId(jobId, cell);
+                                        break;
 
-                                case 'A': // App id register
-                                    var appId = matches[2];
-                                    self.dbg('[APP ID] ' + appId);
-                                    self.registerJobId(appId, cell);
-                                    break;
+                                    case 'A': // App id register
+                                        var appId = matches[2];
+                                        self.dbg('[APP ID] ' + appId);
+                                        self.registerJobId(appId, cell);
+                                        break;
 
-                                default:
-                                    // by default just dump it to the console
-                                    self.dbg('[UNKNOWN TAG] ' + line);
-                                    break;
+                                    default:
+                                        // by default just dump it to the console
+                                        self.dbg('[UNKNOWN TAG] ' + line);
+                                        break;
                                 }
                                 return;
                             }
@@ -2165,8 +2156,8 @@ define([
             var $title = $('<h3>').text('Suggested next steps:');
             $tgt.append($title);
             // init hide/unhide behavior
-            $hide_btn = $('<span>').addClass('kb-app-next-hide').text('hide');
-            $unhide_btn = $('<span>').addClass('kb-app-next-unhide')
+            var $hide_btn = $('<span>').addClass('kb-app-next-hide').text('hide');
+            var $unhide_btn = $('<span>').addClass('kb-app-next-unhide')
                 .text('next steps').hide();
             $hide_btn.click(function () { // hide
                 $title.hide();
@@ -2269,12 +2260,12 @@ define([
         addOutputCell: function (currentIndex, widget, placement) {
             var cell;
             switch (placement) {
-            case 'above':
-                cell = Jupyter.notebook.insert_cell_above('markdown', currentIndex);
-                break;
-            case 'below':
-            default:
-                var cell = Jupyter.notebook.insert_cell_below('markdown', currentIndex);
+                case 'above':
+                    cell = Jupyter.notebook.insert_cell_above('markdown', currentIndex);
+                    break;
+                case 'below':
+                default:
+                    var cell = Jupyter.notebook.insert_cell_below('markdown', currentIndex);
             }
             // cell.celltoolbar.hide();
             this.setOutputCell(cell, widget);


### PR DESCRIPTION
The subdata control was, in some cases, interpreting an empty default value (a spec with a default value of [""]), as a default value, and populating the initial parameter object thus.
In addition there was other weird behavior with the subdata control with regard to preserving, or not, the default value when the dependent parameter (the one supplying the subdata values to select from) was changed. The fix will preserve any previously selected values which occur in the new subdata.

One minor fix to resolve a race between the kbaseNarrativeWorkspace object and the sidePanel.