### PR TITLE
Add method for programmatically inserting a viewer

### DIFF
--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -30,11 +30,13 @@ define([
     'notebook/js/notebook',
     'util/display',
     'util/bootstrapDialog',
+    'util/bootstrapAlert',
     'text!kbase/templates/update_dialog_body.html',
     'narrativeLogin',
     'common/ui',
     'common/html',
     'narrativeTour',
+    'kb_service/utils',
 
     // for effect
     'bootstrap',
@@ -59,11 +61,13 @@ define([
     Notebook,
     DisplayUtil,
     BootstrapDialog,
+    BootstrapAlert,
     UpdateDialogBodyTemplate,
     NarrativeLogin,
     UI,
     html,
-    Tour
+    Tour,
+    ServiceUtils
 ) {
     'use strict';
 
@@ -782,8 +786,64 @@ define([
         Jupyter.notebook.save_checkpoint();
     };
 
+    /**
+     * @method
+     * @public
+     * Insert a new App cell into a narrative and pre-populate its parameters with a given set of
+     * values. The cell is inserted below the currently selected cell.
+     * @param {string} appId - The id of the app (should be in form module_name/app_name)
+     * @param {string} tag - The release tag of the app (one of release, beta, dev)
+     * @param {object} parameters - Key-value-pairs describing the parameters to initialize the app
+     * with. Keys are param ids (should match the spec), and values are the values of those
+     * parameters.
+     */
     Narrative.prototype.addAndPopulateApp = function(appId, tag, parameters) {
         this.sidePanel.$methodsWidget.triggerApp(appId, tag, parameters);
+    };
+
+    /**
+     * @method
+     * @public
+     * Insert a new Viewer cell into a narrative for a given object. The new cell is inserted below
+     * the currently selected cell.
+     * @param {string|object|array} obj - If a string, expected to be an object reference. If an object,
+     * expected to be a set of Key-value-pairs describing the object. If an array, expected to be
+     * the usual workspace info array for an object.
+     */
+    Narrative.prototype.addViewerCell = function(obj) {
+        if (Jupyter.narrative.readonly) {
+            new BootstrapAlert({
+                type: 'warning',
+                title: 'Warning',
+                body: 'Read-only Narrative -- may not add a data viewer to this Narrative'
+            });
+            return;
+        }
+        var cell = Jupyter.notebook.get_selected_cell(),
+            nearIdx = 0;
+        if (cell) {
+            nearIdx = Jupyter.notebook.find_cell_index(cell);
+            $(cell.element).off('dblclick');
+            $(cell.element).off('keydown');
+        }
+        var objInfo = {};
+        // If a string, expect a ref, and fetch the info.
+        if (typeof obj === 'string') {
+            objInfo = this.sidePanel.$dataWidget.getDataObjectByRef(obj, true);
+        }
+        // If an array, expect it to be an array of the info, and convert it.
+        else if (obj instanceof Array) {
+            objInfo = ServiceUtils.objectInfoToObject(obj);
+        }
+        // If not an array or a string, it's our object already.
+        else {
+            objInfo = obj;
+        }
+        this.narrController.trigger('createViewerCell.Narrative', {
+            'nearCellIdx': nearIdx,
+            'widget': 'kbaseNarrativeDataCell',
+            'info': objInfo
+        });
     };
 
     /**

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReadsSetView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReadsSetView.js
@@ -1,279 +1,278 @@
-define (
-    [
-        'kbwidget',
-        'jquery',
-        'SetAPI-client-api',
-        'jquery-dataTables',
-        'jquery-dataTables-bootstrap',
-        'kbaseAuthenticatedWidget',
-        'kbaseTable',
-        'kbaseTabs',
-        'narrativeConfig',
-        'bluebird',
-        'numeral',
-    ], function(
-        KBWidget,
-        $,
-        SetAPI_client_api,
-        jquery_dataTables,
-        bootstrap,
-        kbaseAuthenticatedWidget,
-        kbaseTable,
-        kbaseTabs,
-        Config,
-        Promise,
-        Numeral
-    ) {
-        'use strict';
+define ([
+    'kbwidget',
+    'jquery',
+    'SetAPI-client-api',
+    'jquery-dataTables',
+    'jquery-dataTables-bootstrap',
+    'kbaseAuthenticatedWidget',
+    'kbaseTable',
+    'kbaseTabs',
+    'narrativeConfig',
+    'bluebird',
+    'numeral',
+], function(
+    KBWidget,
+    $,
+    SetAPI_client_api,
+    jquery_dataTables,
+    bootstrap,
+    kbaseAuthenticatedWidget,
+    kbaseTable,
+    kbaseTabs,
+    Config,
+    Promise,
+    Numeral
+) {
+    'use strict';
 
-        return KBWidget({
-            name: "kbaseReadsSetView.js",
-            parent : kbaseAuthenticatedWidget,
-            version: "1.0.0",
-            options: {},
-            loadingImage: Config.get('loading_gif'),
-            init: function (options) {
-                var $self = this;
-                $self._super(options);
+    return KBWidget({
+        name: 'kbaseReadsSetView',
+        parent : kbaseAuthenticatedWidget,
+        version: '1.0.0',
+        options: {},
+        loadingImage: Config.get('loading_gif'),
+        init: function (options) {
+            var $self = this;
+            $self._super(options);
 
-                /* Setup default data for the overview tab */
-                $self.set_overview = {
-                            'link_ref': '',
-                            'name': '',
-                            'description':'',
-                            'n_read_libraries':'',
-                            'total_reads':'',
-                            'avg_reads_per_library':''
-                        };
-                $self.set_items = [];
+            /* Setup default data for the overview tab */
+            $self.set_overview = {
+                'link_ref': '',
+                'name': '',
+                'description':'',
+                'n_read_libraries':'',
+                'total_reads':'',
+                'avg_reads_per_library':''
+            };
+            $self.set_items = [];
 
-                if (options._obj_info) {
-                    $self.obj_info = options._obj_info;
-                    $self.obj_ref = $self.obj_info.ws_id + '/' +
-                                    $self.obj_info.id + '/' +
-                                    $self.obj_info.version;
-                    $self.link_ref = $self.obj_info.ws_id + '/' +
-                                     $self.obj_info.name + '/' +
-                                     $self.obj_info.version;
-                    $self.update_overview_info_from_nar_info($self.obj_info);
-                } else {
-                    $self.obj_ref = $self.options.wsId + '/' +
-                                    $self.options.objId;
-                    $self.link_ref = $self.obj_ref;
-                    $self.set_overview.name = $self.options.objId;
-                    $self.set_overview.link_ref = $self.link_ref;
-                }
-                $self.render();
-
-                $self.setAPI = new SetAPI(
-                                    Config.url('service_wizard'),
-                                    {'token': this.authToken()});
-
-                return Promise.resolve($self.setAPI.get_reads_set_v1({
-                        'ref': $self.obj_ref,
-                        'include_item_info': 1
-                    }))
-                    .then(function (results) {
-                        var info = results.info;
-                        var data = results.data;
-                        var items = results.data.items;
-                        $self.update_overview_info_from_ws_info(info);
-
-                        $self.set_items = [];
-
-                        /* return null if not an int */
-                        var asInt = function(string_number) {
-                            if(string_number===null) return null;
-                            var value = string_number.toString().match(/^\d+$/);
-                            if(value) {
-                                value = parseInt(value[0]);
-                            }
-                            return value;
-                        }
-
-                        var total_reads = 0;
-
-                        // pull all reads objects to calculate summary stats
-                        // and individual browse row contents
-                        for (var i = 0; i < items.length; i++) {
-                            var lib = items[i];
-
-                            var readLibData = {
-                                'ref': lib['ref'],
-                                'label': lib['label'],
-                                'n_reads': ''
-                            };
-                            readLibData['name'] = '<a href="/#dataview/' +lib['ref'] + '" target="_blank">' +
-                                                    lib['info'][1] + '</a>';
-                            var readMetadata = lib['info'][10];
-                            if(readMetadata['read_count']){
-                                if(asInt(readMetadata['read_count'])) {
-                                    readLibData['n_reads'] = readMetadata['read_count'];
-                                    if(asInt(total_reads)!==null) {
-                                        total_reads += asInt(readLibData['n_reads']);
-                                    } else {
-                                    }
-                                } else {
-                                    total_reads = '';
-                                }
-                            }
-                            $self.set_items.push(readLibData);
-                        }
-                        if(asInt(total_reads)) {
-                            $self.set_overview['total_reads'] = total_reads;
-                        }
-
-                        $self.render();
-                    })
-                    .catch(function (error) {
-                        console.error("READSSET VIEWER Render Function Error : ", error);
-                        var errorMssg = '';
-                        if (error && typeof error === 'object'){
-                            if(error.error) {
-                                errorMssg = JSON.stringify(error.error);
-                                if(error.error.message){
-                                    errorMssg = error.error.message;
-                                    if(error.error.error){
-                                        errorMssg += '<br><b>Error Trace:</b>:' + error.error.error;
-                                    }
-                                } else {
-                                    errorMssg = JSON.stringify(error.error);
-                                }
-                            } else { errorMssg = error.message; }
-                        }
-                        else{ errorMssg = "Undefined error"; }
-                        $self.$elem.append($('<div>').addClass('alert alert-danger').append(errorMssg));
-                    });
-            },
-
-            /* the narrative provides info differently from WS, so we need two functions.
-            these could be combined for cleaner code */
-            update_overview_info_from_nar_info: function(info) {
-                var $self = this;
-                $self.set_overview.link_ref = info['ws_id'] + '/' + info['name'] + '/' + info['version'];
-                $self.set_overview.name = info['name'];
-
-                var metadata = info['meta'];
-                if(metadata) {
-                    if(metadata['description']) {
-                        $self.set_overview.description = metadata['description'];
-                    }
-                    if(metadata['item_count']) {
-                        $self.set_overview.n_read_libraries = metadata['item_count'];
-                    }
-                }
-            },
-
-            update_overview_info_from_ws_info: function(info) {
-                var $self = this;
-                $self.set_overview.link_ref = info[6] + '/' + info[1] + '/' + info[4];
-                $self.set_overview.name = info[1];
-
-                var metadata = info[10];
-                if(metadata) {
-                    if(metadata['description']) {
-                        $self.set_overview.description = metadata['description'];
-                    }
-                    if(metadata['item_count']) {
-                        $self.set_overview.n_read_libraries = metadata['item_count'];
-                    }
-                }
-            },
-
-
-            render: function () {
-                var $self = this,
-                    $container = this.$elem,
-                    tab_ids = {
-                        'overview': 'reads-set-overview-' + $self.get_uuid4(),
-                        'browse': 'reads-set-browse-' + $self.get_uuid4()
-                    },
-                    $tabs = $('<ul class="nav nav-tabs">' +
-                              '<li class="active"><a data-toggle="tab" href="#' + tab_ids.overview + '">Overview</a></li>' +
-                              '<li><a data-toggle="tab" href="#' + tab_ids.browse + '">Browse Read Libraries</a></li>' +
-                              '</ul>'),
-                    $divs = $('<div class="tab-content">'),
-                    row = {'read_count': null, 'read_size': null, 'insert_size_mean': null};
-
-                $container.empty();
-                var $overviewTable = $('<table>')
-                                            .addClass('table table-striped table-bordered table-hover')
-                                            .css({'margin-left':'auto', 'margin-right':'auto'})
-                                            .css({'word-wrap':'break-word', 'table-layout':'fixed'})
-                                            .append($('<colgroup>')
-                                                        .append($('<col span="1" style="width: 25%;">')));
-
-                $overviewTable.append($('<tbody>'));
-                $overviewTable.append('<tr>' +
-                                          '<th><b>KBase Object Name</b></th>' +
-                                          '<td><a href="/#dataview/' +
-                                          $self.set_overview.link_ref +
-                                          '" target="_blank">' +
-                                          $self.set_overview.name +
-                                          '</a>' +
-                                          '</tr>');
-                $overviewTable.append('<tr><th><b>Description</b></th><td>' +
-                                      $self.set_overview.description +
-                                      '</td></tr>');
-                $overviewTable.append('<tr><th><b>Read Libraries</b></th><td>' +
-                                      $self.set_overview.n_read_libraries +
-                                      '</td></tr>');
-                $overviewTable.append(
-                                      '<tr><th><b>Total reads</b></th><td>' +
-                                      $self.set_overview.total_reads +
-                                      '</td></tr>');
-
-                $divs.append($('<div id="' + tab_ids.overview + '" class="tab-pane active">')
-                             .append($('<div>').css('margin-top','15px')
-                                .append($overviewTable)));
-
-                var $browseTable = $('<table>')
-                                            .addClass('table table-striped table-bordered table-hover')
-                                            .css({'margin-left':'auto', 'margin-right':'auto', 'width':'100%', 'border': '1px solid #ddd'})
-                                            .css({'word-wrap':'break-word'});
-
-                $divs.append($('<div id="' + tab_ids.browse + '" class="tab-pane">')
-                             .append($('<div>').css({'margin-top':'15px', 'margin-bottom':'20px'})
-                                .append($browseTable)));
-
-                var libsPerPage = 10;
-                var sDom = 'lft<ip>';
-                if($self.set_items.length<libsPerPage) {
-                    sDom = 'fti';
-                }
-
-                var browseTableSettings = {
-                        "bFilter": true,
-                        "sPaginationType": "full_numbers",
-                        "iDisplayLength": 10,
-                        "sDom": sDom,
-                        "aaSorting": [[ 0, "dsc" ]],
-                        "columns": [
-                            {sTitle: "<b>Label</b>", data: "label"},
-                            {sTitle: '<b>Library Data Name</b>', data: "name"},
-                            {sTitle: "<b>Number of Reads</b>", data: "n_reads"}
-                        ],
-                        "data": $self.set_items,
-                        "language": {
-                            "lengthMenu": "_MENU_ Read Libraries per page",
-                            "zeroRecords": "No Matching Read Libraries Found",
-                            "info": "Showing _START_ to _END_ of _TOTAL_ Read Libraries",
-                            "infoEmpty": "No Read Libraries in set.",
-                            "infoFiltered": "(filtered from _MAX_)",
-                            "search" : "Search"
-                        }
-                    };
-                $browseTable.DataTable(browseTableSettings);
-                $browseTable.find('th').css('cursor','pointer');
-
-                $container.append($tabs);
-                $container.append($divs);
-            },
-            get_uuid4: function() {
-                return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-                     var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
-                     return v.toString(16);
-                });
+            if (options._obj_info) {
+                $self.obj_info = options._obj_info;
+                $self.obj_ref = $self.obj_info.ws_id + '/' +
+                                $self.obj_info.id + '/' +
+                                $self.obj_info.version;
+                $self.link_ref = $self.obj_info.ws_id + '/' +
+                                 $self.obj_info.name + '/' +
+                                 $self.obj_info.version;
+                $self.update_overview_info_from_nar_info($self.obj_info);
+            } else {
+                $self.obj_ref = $self.options.wsId + '/' +
+                                $self.options.objId;
+                $self.link_ref = $self.obj_ref;
+                $self.set_overview.name = $self.options.objId;
+                $self.set_overview.link_ref = $self.link_ref;
             }
-        });
+            $self.render();
+
+            $self.setAPI = new SetAPI(
+                Config.url('service_wizard'),
+                {'token': this.authToken()});
+
+            return Promise.resolve($self.setAPI.get_reads_set_v1({
+                'ref': $self.obj_ref,
+                'include_item_info': 1
+            }))
+                .then(function (results) {
+                    var info = results.info;
+                    var items = results.data.items;
+                    $self.update_overview_info_from_ws_info(info);
+
+                    $self.set_items = [];
+
+                    /* return null if not an int */
+                    var asInt = function(string_number) {
+                        if (string_number === null)
+                            return null;
+                        var value = string_number.toString().match(/^\d+$/);
+                        if (value) {
+                            value = parseInt(value[0]);
+                        }
+                        return value;
+                    };
+
+                    var total_reads = 0;
+
+                    // pull all reads objects to calculate summary stats
+                    // and individual browse row contents
+                    for (var i = 0; i < items.length; i++) {
+                        var lib = items[i];
+
+                        var readLibData = {
+                            'ref': lib['ref'],
+                            'label': lib['label'],
+                            'n_reads': ''
+                        };
+                        readLibData['name'] = '<a href="/#dataview/' +lib['ref'] + '" target="_blank">' +
+                                                lib['info'][1] + '</a>';
+                        var readMetadata = lib['info'][10];
+                        if (readMetadata['read_count']) {
+                            if (asInt(readMetadata['read_count'])) {
+                                readLibData['n_reads'] = readMetadata['read_count'];
+                                if(asInt(total_reads) !== null) {
+                                    total_reads += asInt(readLibData['n_reads']);
+                                } else {
+                                }
+                            } else {
+                                total_reads = '';
+                            }
+                        }
+                        $self.set_items.push(readLibData);
+                    }
+                    if(asInt(total_reads)) {
+                        $self.set_overview['total_reads'] = total_reads;
+                    }
+
+                    $self.render();
+                })
+                .catch(function (error) {
+                    console.error("READSSET VIEWER Render Function Error : ", error);
+                    var errorMssg = '';
+                    if (error && typeof error === 'object'){
+                        if(error.error) {
+                            errorMssg = JSON.stringify(error.error);
+                            if(error.error.message){
+                                errorMssg = error.error.message;
+                                if(error.error.error){
+                                    errorMssg += '<br><b>Error Trace:</b>:' + error.error.error;
+                                }
+                            } else {
+                                errorMssg = JSON.stringify(error.error);
+                            }
+                        } else { errorMssg = error.message; }
+                    }
+                    else{ errorMssg = "Undefined error"; }
+                    $self.$elem.append($('<div>').addClass('alert alert-danger').append(errorMssg));
+                });
+        },
+
+        /* the narrative provides info differently from WS, so we need two functions.
+        these could be combined for cleaner code */
+        update_overview_info_from_nar_info: function(info) {
+            var $self = this;
+            $self.set_overview.link_ref = info['ws_id'] + '/' + info['name'] + '/' + info['version'];
+            $self.set_overview.name = info['name'];
+
+            var metadata = info['meta'];
+            if(metadata) {
+                if(metadata['description']) {
+                    $self.set_overview.description = metadata['description'];
+                }
+                if(metadata['item_count']) {
+                    $self.set_overview.n_read_libraries = metadata['item_count'];
+                }
+            }
+        },
+
+        update_overview_info_from_ws_info: function(info) {
+            var $self = this;
+            $self.set_overview.link_ref = info[6] + '/' + info[1] + '/' + info[4];
+            $self.set_overview.name = info[1];
+
+            var metadata = info[10];
+            if(metadata) {
+                if(metadata['description']) {
+                    $self.set_overview.description = metadata['description'];
+                }
+                if(metadata['item_count']) {
+                    $self.set_overview.n_read_libraries = metadata['item_count'];
+                }
+            }
+        },
+
+
+        render: function () {
+            var $self = this,
+                $container = this.$elem,
+                tab_ids = {
+                    'overview': 'reads-set-overview-' + $self.get_uuid4(),
+                    'browse': 'reads-set-browse-' + $self.get_uuid4()
+                },
+                $tabs = $('<ul class="nav nav-tabs">' +
+                          '<li class="active"><a data-toggle="tab" href="#' + tab_ids.overview + '">Overview</a></li>' +
+                          '<li><a data-toggle="tab" href="#' + tab_ids.browse + '">Browse Read Libraries</a></li>' +
+                          '</ul>'),
+                $divs = $('<div class="tab-content">'),
+                row = {'read_count': null, 'read_size': null, 'insert_size_mean': null};
+
+            $container.empty();
+            var $overviewTable = $('<table>')
+                                        .addClass('table table-striped table-bordered table-hover')
+                                        .css({'margin-left':'auto', 'margin-right':'auto'})
+                                        .css({'word-wrap':'break-word', 'table-layout':'fixed'})
+                                        .append($('<colgroup>')
+                                                    .append($('<col span="1" style="width: 25%;">')));
+
+            $overviewTable.append($('<tbody>'));
+            $overviewTable.append('<tr>' +
+                                      '<th><b>KBase Object Name</b></th>' +
+                                      '<td><a href="/#dataview/' +
+                                      $self.set_overview.link_ref +
+                                      '" target="_blank">' +
+                                      $self.set_overview.name +
+                                      '</a>' +
+                                      '</tr>');
+            $overviewTable.append('<tr><th><b>Description</b></th><td>' +
+                                  $self.set_overview.description +
+                                  '</td></tr>');
+            $overviewTable.append('<tr><th><b>Read Libraries</b></th><td>' +
+                                  $self.set_overview.n_read_libraries +
+                                  '</td></tr>');
+            $overviewTable.append(
+                                  '<tr><th><b>Total reads</b></th><td>' +
+                                  $self.set_overview.total_reads +
+                                  '</td></tr>');
+
+            $divs.append($('<div id="' + tab_ids.overview + '" class="tab-pane active">')
+                         .append($('<div>').css('margin-top','15px')
+                            .append($overviewTable)));
+
+            var $browseTable = $('<table>')
+                                        .addClass('table table-striped table-bordered table-hover')
+                                        .css({'margin-left':'auto', 'margin-right':'auto', 'width':'100%', 'border': '1px solid #ddd'})
+                                        .css({'word-wrap':'break-word'});
+
+            $divs.append($('<div id="' + tab_ids.browse + '" class="tab-pane">')
+                         .append($('<div>').css({'margin-top':'15px', 'margin-bottom':'20px'})
+                            .append($browseTable)));
+
+            var libsPerPage = 10;
+            var sDom = 'lft<ip>';
+            if($self.set_items.length<libsPerPage) {
+                sDom = 'fti';
+            }
+
+            var browseTableSettings = {
+                    "bFilter": true,
+                    "sPaginationType": "full_numbers",
+                    "iDisplayLength": 10,
+                    "sDom": sDom,
+                    "aaSorting": [[ 0, "dsc" ]],
+                    "columns": [
+                        {sTitle: "<b>Label</b>", data: "label"},
+                        {sTitle: '<b>Library Data Name</b>', data: "name"},
+                        {sTitle: "<b>Number of Reads</b>", data: "n_reads"}
+                    ],
+                    "data": $self.set_items,
+                    "language": {
+                        "lengthMenu": "_MENU_ Read Libraries per page",
+                        "zeroRecords": "No Matching Read Libraries Found",
+                        "info": "Showing _START_ to _END_ of _TOTAL_ Read Libraries",
+                        "infoEmpty": "No Read Libraries in set.",
+                        "infoFiltered": "(filtered from _MAX_)",
+                        "search" : "Search"
+                    }
+                };
+            $browseTable.DataTable(browseTableSettings);
+            $browseTable.find('th').css('cursor','pointer');
+
+            $container.append($tabs);
+            $container.append($divs);
+        },
+        get_uuid4: function() {
+            return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+                 var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+                 return v.toString(16);
+            });
+        }
+    });
 });

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -15,6 +15,7 @@ define([
     'kb_common/html',
     'kb_sdk_clients/genericClient',
     'kb_service/client/workspace',
+    'kb_service/utils',
     'common/ui',
     'common/iframe/hostMessages',
     'common/events',
@@ -34,6 +35,7 @@ define([
     html,
     GenericClient,
     Workspace,
+    ServiceUtils,
     UI,
     HostMessages,
     Events,
@@ -380,7 +382,7 @@ define([
                         // We may receive this if a 'ready' was received
                         // from another cell. Perhaps there is a better
                         // way of filtering messages before getting here!
-                        // TODO: implement an address feature to allow a 
+                        // TODO: implement an address feature to allow a
                         //   message bus to ignore messages not sent to it.
                         //   we use the frame id for this, but it should actually
                         //   be a feature of the message bus itself.
@@ -492,7 +494,7 @@ define([
                                             e.stopPropagation();
                                             e.preventDefault();
                                             var objName = [$(this).data('objname')];
-                                            self.openViewerCell(dataNameToInfo[objName]);
+                                            Jupyter.narrative.addViewerCell(dataNameToInfo[objName]);
                                         });
                                     }
 
@@ -604,7 +606,7 @@ define([
                 // REPORT SECTION
 
                 /*
-                The "inline" report can come from either the direct_html property or the direct_html_link_index. 
+                The "inline" report can come from either the direct_html property or the direct_html_link_index.
                 The direct_html_link_index will take precedence since it offers a better method for referencing
                 content within an iframe. Generally the app developer should use either method, not both
                  */
@@ -653,7 +655,7 @@ define([
                                 };
                             }
                         } else {
-                            // If the direct_html is a full document we cannot (yet?) insert 
+                            // If the direct_html is a full document we cannot (yet?) insert
                             // the necessary code to gracefully handle resizing and click-passthrough.
                             if (/<html/.test(report.direct_html)) {
                                 console.warn('Html document inserted into iframe', report);
@@ -663,8 +665,8 @@ define([
                                     events: events
                                 });
                             } else {
-                                // note that for direct_html, we set the max height. this content is expected 
-                                // to be smaller than linked content, and we will want the container 
+                                // note that for direct_html, we set the max height. this content is expected
+                                // to be smaller than linked content, and we will want the container
                                 // to shrink, but if it is larger, we simply don't want it to be too tall.
                                 iframe = _this.makeIframe({
                                     content: report.direct_html,
@@ -822,36 +824,6 @@ define([
             events.attachEvents();
 
             this.loading(false);
-        },
-        openViewerCell: function(ws_info) {
-            if (Jupyter.narrative.readonly) {
-                new Alert({
-                    type: 'warning',
-                    title: 'Warning: Read-only Narrative',
-                    body: 'You cannot insert a data viewer cell into this Narrative because it is read-only'
-                });
-                return;
-            }
-            var self = this;
-            var cell = Jupyter.notebook.get_selected_cell();
-            var near_idx = 0;
-            if (cell) {
-                near_idx = Jupyter.notebook.find_cell_index(cell);
-                $(cell.element).off('dblclick');
-                $(cell.element).off('keydown');
-            }
-            var info = self.createInfoObject(ws_info);
-            self.trigger('createViewerCell.Narrative', {
-                'nearCellIdx': near_idx,
-                'widget': 'kbaseNarrativeDataCell',
-                'info': info
-            });
-        },
-        createInfoObject: function(info) {
-            return _.object(['id', 'name', 'type', 'save_date', 'version',
-                'saved_by', 'ws_id', 'ws_name', 'chsum', 'size',
-                'meta'
-            ], info);
         },
         loading: function(isLoading) {
             if (isLoading) {

--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
@@ -8,7 +8,8 @@ define (
 		'kbaseTable',
 		'kbaseAuthenticatedWidget',
 		'kbase-client-api',
-		'jquery-dataTables'
+		'jquery-dataTables',
+        'kb_service/utils'
 	], function(
 		KBWidget,
 		bootstrap,
@@ -16,7 +17,8 @@ define (
 		kbaseTable,
 		kbaseAuthenticatedWidget,
 		kbase_client_api,
-		jquery_dataTables
+		jquery_dataTables,
+        ServiceUtils
 	) {
 
     'use strict';
@@ -144,12 +146,6 @@ define (
                     .html("Could not load object : " + d.error.message);
             });
 
-        },
-
-        createInfoObject: function (info) {
-            return _.object(['id', 'name', 'type', 'save_date', 'version',
-                'saved_by', 'ws_id', 'ws_name', 'chsum', 'size',
-                'meta'], info);
         },
 
         linkFromData : function(info_obj) {
@@ -323,10 +319,10 @@ define (
                                 .attr('target', '_blank')
                                 .append('Download'),
                               'Condition' : this.dataset().condition.join('<br>'),
-                              'Alignment Set' : this.linkFromData(this.createInfoObject(this.dataset().alignmentset) ),
-                              'Expression Set' : this.linkFromData(this.createInfoObject(this.dataset().expressionset)),
-                              'Genome' : this.linkFromData(this.createInfoObject(this.dataset().genome)),
-                              'Sample Set' : this.linkFromData(this.createInfoObject(this.dataset().sampleset)),
+                              'Alignment Set' : this.linkFromData(ServiceUtils.objectInfoToObject(this.dataset().alignmentset)),
+                              'Expression Set' : this.linkFromData(ServiceUtils.objectInfoToObject(this.dataset().expressionset)),
+                              'Genome' : this.linkFromData(ServiceUtils.objectInfoToObject(this.dataset().genome)),
+                              'Sample Set' : this.linkFromData(ServiceUtils.objectInfoToObject(this.dataset().sampleset)),
                           },
                       }
                   }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
@@ -65,6 +65,7 @@ define (
             //console.log("kbaseNarrativeDataCell: options=", JSON.stringify(options, null, 2));
             if (options.info_tuple) {
                 this.obj_info = ServiceUtils.objectInfoToObject(options.info_tuple);
+                this.obj_info.ws_id = this.obj_info.wsid;
             } else {
                 this.obj_info = options.info;
             }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataCell.js
@@ -17,7 +17,8 @@ define (
 		'underscore',
 		'narrativeConfig',
 		'narrativeViewers',
-		'kbaseNarrativeCell'
+		'kbaseNarrativeCell',
+        'kb_service/utils'
 	], function(
 		KBWidget,
 		bootstrap,
@@ -25,7 +26,8 @@ define (
 		_,
 		Config,
 		Viewers,
-		kbaseNarrativeCell
+		kbaseNarrativeCell,
+        ServiceUtils
 	) {
     'use strict';
 
@@ -62,7 +64,7 @@ define (
             this._super(options);
             //console.log("kbaseNarrativeDataCell: options=", JSON.stringify(options, null, 2));
             if (options.info_tuple) {
-                this.obj_info = this.createInfoObject(options.info_tuple);
+                this.obj_info = ServiceUtils.objectInfoToObject(options.info_tuple);
             } else {
                 this.obj_info = options.info;
             }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1376,30 +1376,6 @@ define([
 
         insertViewer: function (key) {
             Jupyter.narrative.addViewerCell(this.keyToObjId[key]);
-            // if (Jupyter.narrative.readonly) {
-            //     new BootstrapAlert({
-            //         type: 'warning',
-            //         title: 'Warning',
-            //         body: 'Read-only Narrative -- may not add a data viewer to this Narrative'
-            //     });
-            //     return;
-            // }
-            // var cell = Jupyter.notebook.get_selected_cell(),
-            //     near_idx = 0;
-            // if (cell) {
-            //     near_idx = Jupyter.notebook.find_cell_index(cell);
-            //     $(cell.element).off('dblclick');
-            //     $(cell.element).off('keydown');
-            // }
-            // var obj = this.dataObjects[this.keyToObjId[key]], // _.findWhere(self.objectList, {key: key});
-            //     info = this.createInfoObject(obj.info, obj.refPath);
-            // // Insert the narrative data cell into the div we just rendered
-            // // new kbaseNarrativeDataCell($('#' + cell_id), {cell: cell, info: info});
-            // this.trigger('createViewerCell.Narrative', {
-            //     'nearCellIdx': near_idx,
-            //     'widget': 'kbaseNarrativeDataCell',
-            //     'info': info
-            // });
         },
 
         renderMore: function () {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -47,7 +47,7 @@ define([
     Runtime,
     Handlebars,
     ObjectRowHtml,
-    serviceUtils,
+    ServiceUtils,
     BootstrapAlert
 ) {
     'use strict';
@@ -418,7 +418,7 @@ define([
                         // see code below this function for the format of
                         // items in the dataObjects collection
                         var dataObject = this.dataObjects[objId];
-                        var info = serviceUtils.objectInfoToObject(dataObject.info);
+                        var info = this.createInfoObject(dataObject.info);
                         info.dataPaletteRef = dataObject.refPath;
                         return info;
                     }.bind(this));
@@ -603,7 +603,12 @@ define([
             return this.objData;
         },
 
-        getDataObjectByRef: function (ref) {
+        /**
+         * Returns the object info for the given object.
+         * if asObject is truthy, it will package this array up as an object and include the reference
+         * path as key refPath.
+         */
+        getDataObjectByRef: function (ref, asObject) {
             if (!ref) {
                 return null;
             }
@@ -618,10 +623,15 @@ define([
                 return null;
             }
             ref = refSegments[0] + '/' + refSegments[1];
+            var retVal = null;
             if (this.dataObjects[ref]) {
-                return this.dataObjects[ref].info;
+                retVal = this.dataObjects[ref].info;
+                if (asObject) {
+                    retVal = ServiceUtils.objectInfoToObject(retVal);
+                    retVal['ref_path'] = this.dataObjects[ref].refPath;
+                }
             }
-            return null;
+            return retVal;
         },
 
         getDataObjectByName: function (name, wsId) {
@@ -971,17 +981,14 @@ define([
                             })));
                 });
 
-            // if (!Jupyter.narrative.readonly) {
             $btnToolbar.append($filterMethodInput)
-                .append($filterMethodOutput);
-            // }
-            $btnToolbar.append($openLandingPage);
+                .append($filterMethodOutput)
+                .append($openLandingPage);
             if (!Jupyter.narrative.readonly && !fromPalette) {
                 $btnToolbar.append($openHistory);
             }
             $btnToolbar.append($openProvenance)
                 .append($download);
-
             if (!Jupyter.narrative.readonly && !fromPalette) {
                 $btnToolbar.append($rename)
                     .append($delete);
@@ -1357,10 +1364,8 @@ define([
          * list of fields returned from Workspace service.
          */
         createInfoObject: function (info, refPath) {
-            var ret = _.object(['id', 'name', 'type', 'save_date', 'version',
-                'saved_by', 'ws_id', 'ws_name', 'chsum', 'size',
-                'meta'
-            ], info);
+            var ret = ServiceUtils.objectInfoToObject(info);
+
             if (refPath) {
                 ret['ref_path'] = refPath;
             }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -628,7 +628,8 @@ define([
                 retVal = this.dataObjects[ref].info;
                 if (asObject) {
                     retVal = ServiceUtils.objectInfoToObject(retVal);
-                    retVal['ref_path'] = this.dataObjects[ref].refPath;
+                    retVal.ws_id = retVal.wsid;
+                    retVal.ref_path = this.dataObjects[ref].refPath;
                 }
             }
             return retVal;
@@ -1374,30 +1375,31 @@ define([
         // ============= end DnD ================
 
         insertViewer: function (key) {
-            if (Jupyter.narrative.readonly) {
-                new BootstrapAlert({
-                    type: 'warning',
-                    title: 'Warning',
-                    body: 'Read-only Narrative -- may not add a data viewer to this Narrative'
-                });
-                return;
-            }
-            var cell = Jupyter.notebook.get_selected_cell(),
-                near_idx = 0;
-            if (cell) {
-                near_idx = Jupyter.notebook.find_cell_index(cell);
-                $(cell.element).off('dblclick');
-                $(cell.element).off('keydown');
-            }
-            var obj = this.dataObjects[this.keyToObjId[key]], // _.findWhere(self.objectList, {key: key});
-                info = this.createInfoObject(obj.info, obj.refPath);
-            // Insert the narrative data cell into the div we just rendered
-            // new kbaseNarrativeDataCell($('#' + cell_id), {cell: cell, info: info});
-            this.trigger('createViewerCell.Narrative', {
-                'nearCellIdx': near_idx,
-                'widget': 'kbaseNarrativeDataCell',
-                'info': info
-            });
+            Jupyter.narrative.addViewerCell(this.keyToObjId[key]);
+            // if (Jupyter.narrative.readonly) {
+            //     new BootstrapAlert({
+            //         type: 'warning',
+            //         title: 'Warning',
+            //         body: 'Read-only Narrative -- may not add a data viewer to this Narrative'
+            //     });
+            //     return;
+            // }
+            // var cell = Jupyter.notebook.get_selected_cell(),
+            //     near_idx = 0;
+            // if (cell) {
+            //     near_idx = Jupyter.notebook.find_cell_index(cell);
+            //     $(cell.element).off('dblclick');
+            //     $(cell.element).off('keydown');
+            // }
+            // var obj = this.dataObjects[this.keyToObjId[key]], // _.findWhere(self.objectList, {key: key});
+            //     info = this.createInfoObject(obj.info, obj.refPath);
+            // // Insert the narrative data cell into the div we just rendered
+            // // new kbaseNarrativeDataCell($('#' + cell_id), {cell: cell, info: info});
+            // this.trigger('createViewerCell.Narrative', {
+            //     'nearCellIdx': near_idx,
+            //     'widget': 'kbaseNarrativeDataCell',
+            //     'info': info
+            // });
         },
 
         renderMore: function () {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -299,9 +299,9 @@ define([
             }
         },
 
-        getDataObjectByRef: function(ref) {
+        getDataObjectByRef: function(ref, asObject) {
             if (this.dataListWidget) {
-                return this.dataListWidget.getDataObjectByRef(ref);
+                return this.dataListWidget.getDataObjectByRef(ref, asObject);
             }
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -13,6 +13,7 @@ define([
     'util/timeFormat',
     'util/string',
     'kb_service/client/workspace',
+    'kb_service/utils',
     'kbaseAuthenticatedWidget',
     'kbaseTabs',
     'kbaseReportView',
@@ -40,6 +41,7 @@ define([
     TimeFormat,
     StringUtil,
     Workspace,
+    ServiceUtils,
     KBaseAuthenticatedWidget,
     KBaseTabs,
     KBaseReportView,
@@ -463,7 +465,7 @@ define([
                                                     });
                                                     return;
                                                 }
-                                                this.openViewerCell(this.createInfoObject(info));
+                                                Jupyter.narrative.addViewerCell(info);
                                             }.bind(this));
                                         }
                                         $div.append($objTable);
@@ -478,28 +480,6 @@ define([
                 }
                 this.showingNewObjects = true;
             }
-        },
-
-        openViewerCell: function (info) {
-            var cell = Jupyter.notebook.get_selected_cell();
-            var near_idx = 0;
-            if (cell) {
-                near_idx = Jupyter.notebook.find_cell_index(cell);
-                $(cell.element).off('dblclick');
-                $(cell.element).off('keydown');
-            }
-            this.trigger('createViewerCell.Narrative', {
-                'nearCellIdx': near_idx,
-                'widget': 'kbaseNarrativeDataCell',
-                'info': info
-            });
-        },
-
-        createInfoObject: function (info) {
-            return _.object(['id', 'name', 'type', 'save_date', 'version',
-                'saved_by', 'ws_id', 'ws_name', 'chsum', 'size',
-                'meta'
-            ], info);
         },
 
         /**

--- a/nbextensions/dataCell/main.js
+++ b/nbextensions/dataCell/main.js
@@ -62,7 +62,7 @@ define([
         };
 
         /*
-         * The data cell icon is derived by looking up the type in the 
+         * The data cell icon is derived by looking up the type in the
          * narrative configuration.
          */
         cell.renderIcon = function() {
@@ -178,8 +178,9 @@ define([
             }
             var objInfo = setupData.objectInfo;
             var ref = objInfo.ref_path;
+            var wsId = objInfo.ws_id || objInfo.wsid;
             if (!ref) {
-                ref = objInfo.ws_id + '/' + objInfo.id + '/' + objInfo.version;
+                ref = wsId + '/' + objInfo.id + '/' + objInfo.version;
             }
             var title = (objInfo && objInfo.name) ? objInfo.name : 'Data Viewer';
             var cellText = PythonInterop.buildDataWidgetRunner(ref, cellId, title, tag);
@@ -205,7 +206,7 @@ define([
             var jupyterCellType = payload.type;
 
             if (jupyterCellType === 'code' &&
-                setupData && 
+                setupData &&
                 setupData.type === 'data') {
                 upgradeCell(cell, setupData)
                     .catch(function(err) {


### PR DESCRIPTION
Adds the command `Jupyter.narrative.addViewerCell(obj)` to the Narrative object.

`obj` can be one of three things.
1. a string, as an object reference.
2. an array, the typical object info returned from Workspace.get_object_info*
3. an object, with key-value-pairs defined by kb_service/utils/getDataObjectByRef (keys = id, name, version, etc. These all match up the array returned by Workspace.get_object_info*).

This inserts a Viewer cell below the currently selected cell.