### PR TITLE
Test refactor

### DIFF
--- a/scripts/narrative_backend_tests.sh
+++ b/scripts/narrative_backend_tests.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 export NARRATIVE_DIR=$(pwd)
-python -m nose --with-coverage --cover-html --cover-package=biokbase.narrative src/biokbase/narrative/tests/
+python -m nose $@ --with-coverage --cover-html --cover-package=biokbase.narrative src/biokbase/narrative/tests/

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -1,0 +1,81 @@
+from ..util import TestConfig
+
+
+class MockClients(object):
+    """
+    Mock KBase service clients as needed for Narrative backend tests.
+
+    These are specially put together to handle common use cases, and in some cases, expected test
+    inputs (e.g. special workspace names)
+
+    Will likely be removed (or modified, at least), when a minified KBase deploy becomes available.
+    Then we don't need to mock as much.
+    """
+    def __init__(self):
+        self.config = TestConfig()
+        self.job_info = self.config.load_json_file(self.config.get('jobs', 'job_info_file'))
+        self.test_job_id = self.config.get('app_tests', 'test_job_id')
+
+    # ----- User and Job State functions -----
+
+    def list_jobs2(self, params):
+        return self.job_info.get('job_info')
+
+    def delete_job(self, job):
+        return "bar"
+
+    # ----- Narrative Method Store functions ------
+
+    def list_methods_spec(self, params):
+        return self.config.load_json_file(self.config.get('specs', 'app_specs_file'))
+
+    def list_categories(self, params):
+        return self.config.load_json_file(self.config.get('specs', 'type_specs_file'))
+
+    # ----- Workspace functions -----
+
+    def get_workspace_info(self, params):
+        if params.get('workspace', '') != 'invalid_workspace':
+            return [12345, 'foo', 'bar']
+        else:
+            raise Exception('not found')
+
+    def get_object_info_new(self, params):
+        infos = [[5, u'Sbicolor2', u'KBaseGenomes.Genome-12.3', u'2017-03-31T23:42:59+0000', 1,
+                  u'wjriehl', 18836, u'wjriehl:1490995018528', u'278abf8f0dbf8ab5ce349598a8674a6e',
+                  109180038, None]]
+        ret_val = infos * len(params.get('objects', [0]))
+        return ret_val
+
+    # ----- Narrative Job Service functions -----
+
+    def run_job(self, params):
+        return self.test_job_id
+
+    def cancel_job(self, job_id):
+        return "done"
+
+    def get_job_params(self, job_id):
+        return [self.job_info.get('job_param_info', {}).get(job_id, None)]
+
+    def check_job(self, job_id):
+        return self.job_info.get('job_status_info', {}).get(job_id, None)
+
+    def check_jobs(self, params):
+        states = dict()
+        job_params = dict()
+        for job_id in params['job_ids']:
+            states[job_id] = self.job_info.get('job_status_info', {}).get(job_id, {})
+        if params.get('with_job_params', 0) == 1:
+            for job_id in params['job_ids']:
+                job_params[job_id] = self.job_info.get('job_param_info', {}).get(job_id, None)
+        ret = {
+            'job_states': states
+        }
+        if len(job_params) > 0:
+            ret['job_params'] = job_params
+        return ret
+
+
+def get_mock_client(client_name):
+    return MockClients()

--- a/src/biokbase/narrative/tests/narrative_mock/mockcomm.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockcomm.py
@@ -1,0 +1,20 @@
+class MockComm(object):
+    """
+    Mock class for ipython.kernel.Comm
+    This keeps the last message that was sent, so it can be retrieved and
+    analyzed during the test.
+    """
+    def __init__(self, *args, **kwargs):
+        """Mock the init"""
+        self.last_message = None
+
+    def on_msg(self, *args, **kwargs):
+        """Mock the msg router"""
+        pass
+
+    def send(self, data=None, content=None):
+        """Mock sending a msg"""
+        self.last_message = {"data": data, "content": content}
+
+    def clear_message_cache(self):
+        self.last_message = None

--- a/src/biokbase/narrative/tests/test_app_util.py
+++ b/src/biokbase/narrative/tests/test_app_util.py
@@ -9,6 +9,7 @@ from biokbase.narrative.app_util import (
     map_inputs_from_job,
     map_outputs_from_state
 )
+from narrative_mock.mockclients import get_mock_client
 import os
 import mock
 
@@ -30,7 +31,7 @@ class AppUtilTestCase(unittest.TestCase):
         self.user_id = "KBaseTest"
         self.good_fake_token = "un={}|tokenid=12345|expiry=1592895594|client_id={}|token_type=bearer|SigningSubject=whaaaaaaaaaaat".format(self.user_id, self.user_id)
         self.bad_fake_token = "NotAGoodTokenLOL"
-        self.workspace = "{}:12345".format(self.user_id)
+        self.workspace = "valid_workspace"
 
     def test_check_tag_good(self):
         self.assertTrue(check_tag(self.good_tag))
@@ -39,7 +40,7 @@ class AppUtilTestCase(unittest.TestCase):
         self.assertFalse(check_tag(self.bad_tag))
 
     def test_check_tag_bad_except(self):
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(ValueError):
             check_tag(self.bad_tag, raise_exception=True)
 
     def test_sys_var_user(self):
@@ -64,16 +65,16 @@ class AppUtilTestCase(unittest.TestCase):
             del os.environ['KB_WORKSPACE_ID']
         self.assertIsNone(system_variable('workspace_id'))
 
-    @mock.patch('biokbase.narrative.app_util._ws_client')
-    def test_sys_var_workspace_id(self, m):
+    @mock.patch('biokbase.narrative.app_util.clients.get', get_mock_client)
+    def test_sys_var_workspace_id(self):
         os.environ['KB_WORKSPACE_ID'] = self.workspace
-        m.get_workspace_info.return_value = [12345, 'foo', 'bar']
+        # m.get_workspace_info.return_value = [12345, 'foo', 'bar']
         self.assertEquals(system_variable('workspace_id'), 12345)
 
-    @mock.patch('biokbase.narrative.app_util._ws_client')
-    def test_sys_var_workspace_id_except(self, m):
-        os.environ['KB_WORKSPACE_ID'] = '12345'
-        m.get_workspace_info.side_effect = Exception('not found')
+    @mock.patch('biokbase.narrative.app_util.clients.get', get_mock_client)
+    def test_sys_var_workspace_id_except(self):
+        os.environ['KB_WORKSPACE_ID'] = 'invalid_workspace'
+        # m.get_workspace_info.side_effect = Exception('not found')
         self.assertIsNone(system_variable('workspace_id'))
 
     def test_sys_var_bad_token(self):

--- a/src/biokbase/narrative/tests/test_app_util.py
+++ b/src/biokbase/narrative/tests/test_app_util.py
@@ -68,13 +68,11 @@ class AppUtilTestCase(unittest.TestCase):
     @mock.patch('biokbase.narrative.app_util.clients.get', get_mock_client)
     def test_sys_var_workspace_id(self):
         os.environ['KB_WORKSPACE_ID'] = self.workspace
-        # m.get_workspace_info.return_value = [12345, 'foo', 'bar']
         self.assertEquals(system_variable('workspace_id'), 12345)
 
     @mock.patch('biokbase.narrative.app_util.clients.get', get_mock_client)
     def test_sys_var_workspace_id_except(self):
         os.environ['KB_WORKSPACE_ID'] = 'invalid_workspace'
-        # m.get_workspace_info.side_effect = Exception('not found')
         self.assertIsNone(system_variable('workspace_id'))
 
     def test_sys_var_bad_token(self):
@@ -259,7 +257,7 @@ class AppUtilTestCase(unittest.TestCase):
             'an_input': 'input_val'
         }
         state = {}
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(ValueError):
             map_outputs_from_state(state, params, app_spec)
 
 

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -7,6 +7,7 @@ from biokbase.narrative.jobs.job import Job
 from IPython.display import HTML
 import unittest
 import mock
+from narrative_mock.mockclients import get_mock_client
 import os
 from util import TestConfig
 
@@ -81,10 +82,11 @@ class AppManagerTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.am.available_apps(self.bad_tag)
 
-    @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService.run_job', side_effect=mock_run_job)
+    @mock.patch('biokbase.narrative.jobs.appmanager.clients.get', get_mock_client)
+    # @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService.run_job', side_effect=mock_run_job)
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     @mock.patch('biokbase.narrative.jobs.appmanager.auth.get_agent_token', side_effect=mock_agent_token)
-    def test_run_app_good_inputs(self, m, njs, auth):
+    def test_run_app_good_inputs(self, m, auth):
         m.return_value._send_comm_message.return_value = None
         os.environ['KB_WORKSPACE_ID'] = self.public_ws
         new_job = self.am.run_app(
@@ -98,12 +100,13 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertEquals(new_job.tag, self.test_tag)
         self.assertIsNone(new_job.cell_id)
 
-    @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService')
+    # @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService')
+    @mock.patch('biokbase.narrative.jobs.appmanager.clients.get', get_mock_client)
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     @mock.patch('biokbase.narrative.jobs.appmanager.auth.get_agent_token', side_effect=mock_agent_token)
-    def test_run_app_from_gui_cell(self, m, njs, auth):
+    def test_run_app_from_gui_cell(self, m, auth):
         m.return_value._send_comm_message.return_value = None
-        njs.run_job.return_value = self.test_job_id
+        # njs.run_job.return_value = self.test_job_id
         os.environ['KB_WORKSPACE_ID'] = self.public_ws
         self.assertIsNone(self.am.run_app(
             self.test_app_id,
@@ -135,12 +138,13 @@ class AppManagerTestCase(unittest.TestCase):
 
     # Running an app with missing inputs is now allowed. The app can
     # crash if it wants to, it can leave its process behind.
-    @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService')
+    # @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService')
+    @mock.patch('biokbase.narrative.jobs.appmanager.clients.get', get_mock_client)
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     @mock.patch('biokbase.narrative.jobs.appmanager.auth.get_agent_token', side_effect=mock_agent_token)
-    def test_run_app_missing_inputs(self, m, njs, auth):
+    def test_run_app_missing_inputs(self, m, auth):
         m.return_value._send_comm_message.return_value = None
-        njs.run_job.return_value = self.test_job_id
+        # njs.run_job.return_value = self.test_job_id
         self.assertIsNotNone(self.am.run_app(self.good_app_id,
                                              None,
                                              tag=self.good_tag))

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -83,7 +83,6 @@ class AppManagerTestCase(unittest.TestCase):
             self.am.available_apps(self.bad_tag)
 
     @mock.patch('biokbase.narrative.jobs.appmanager.clients.get', get_mock_client)
-    # @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService.run_job', side_effect=mock_run_job)
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     @mock.patch('biokbase.narrative.jobs.appmanager.auth.get_agent_token', side_effect=mock_agent_token)
     def test_run_app_good_inputs(self, m, auth):
@@ -100,13 +99,11 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertEquals(new_job.tag, self.test_tag)
         self.assertIsNone(new_job.cell_id)
 
-    # @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService')
     @mock.patch('biokbase.narrative.jobs.appmanager.clients.get', get_mock_client)
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     @mock.patch('biokbase.narrative.jobs.appmanager.auth.get_agent_token', side_effect=mock_agent_token)
     def test_run_app_from_gui_cell(self, m, auth):
         m.return_value._send_comm_message.return_value = None
-        # njs.run_job.return_value = self.test_job_id
         os.environ['KB_WORKSPACE_ID'] = self.public_ws
         self.assertIsNone(self.am.run_app(
             self.test_app_id,
@@ -138,13 +135,11 @@ class AppManagerTestCase(unittest.TestCase):
 
     # Running an app with missing inputs is now allowed. The app can
     # crash if it wants to, it can leave its process behind.
-    # @mock.patch('biokbase.narrative.jobs.appmanager.NarrativeJobService')
     @mock.patch('biokbase.narrative.jobs.appmanager.clients.get', get_mock_client)
     @mock.patch('biokbase.narrative.jobs.appmanager.JobManager')
     @mock.patch('biokbase.narrative.jobs.appmanager.auth.get_agent_token', side_effect=mock_agent_token)
     def test_run_app_missing_inputs(self, m, auth):
         m.return_value._send_comm_message.return_value = None
-        # njs.run_job.return_value = self.test_job_id
         self.assertIsNotNone(self.am.run_app(self.good_app_id,
                                              None,
                                              tag=self.good_tag))

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -15,11 +15,6 @@ __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
 config = TestConfig()
 job_info = config.load_json_file(config.get('jobs', 'job_info_file'))
-# job_info = read_json_file(config.get('jobs', 'job_info_file'))
-
-
-# def get_mock_client(client_name):
-#     return MockClients()
 
 
 @mock.patch('biokbase.narrative.jobs.job.clients.get', get_mock_client)

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -8,7 +8,8 @@ from biokbase.narrative.jobs.job import Job
 from util import TestConfig
 import os
 from IPython.display import HTML
-from pprint import pprint
+from narrative_mock.mockclients import get_mock_client
+from narrative_mock.mockcomm import MockComm
 
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
@@ -17,74 +18,8 @@ job_info = config.load_json_file(config.get('jobs', 'job_info_file'))
 # job_info = read_json_file(config.get('jobs', 'job_info_file'))
 
 
-class MockComm(object):
-    """
-    Mock class for ipython.kernel.Comm
-    This keeps the last message that was sent, so it can be retrieved and
-    analyzed during the test.
-    """
-    def __init__(self, *args, **kwargs):
-        """Mock the init"""
-        self.last_message = None
-
-    def on_msg(self, *args, **kwargs):
-        """Mock the msg router"""
-        pass
-
-    def send(self, data=None, content=None):
-        """Mock sending a msg"""
-        self.last_message = {"data": data, "content": content}
-
-    def clear_message_cache(self):
-        self.last_message = None
-
-
-class MockAllClients(object):
-    """
-    Mock KBase service clients as needed for JobManager tests. This covers all of them,
-    just need to add more methods as needed.
-    """
-    def list_jobs2(self, params):
-        return job_info.get('job_info')
-
-    def delete_job(self, job):
-        return "bar"
-
-    def cancel_job(self, job_id):
-        return "done"
-
-    def get_job_params(self, job_id):
-        return [job_info.get('job_param_info', {}).get(job_id, None)]
-
-    def check_job(self, job_id):
-        return job_info.get('job_status_info', {}).get(job_id, None)
-
-    def check_jobs(self, params):
-        states = dict()
-        job_params = dict()
-        for job_id in params['job_ids']:
-            states[job_id] = job_info.get('job_status_info', {}).get(job_id, {})
-        if params.get('with_job_params', 0) == 1:
-            for job_id in params['job_ids']:
-                job_params[job_id] = job_info.get('job_param_info', {}).get(job_id, None)
-        ret = {
-            'job_states': states
-        }
-        if len(job_params) > 0:
-            ret['job_params'] = job_params
-        return ret
-
-    def list_methods_spec(self, params):
-        return config.load_json_file(config.get('specs', 'app_specs_file'))
-        # return read_json_file(config.get('specs', 'app_specs_file'))
-
-    def list_categories(self, params):
-        return config.load_json_file(config.get('specs', 'type_specs_file'))
-        # return read_json_file(config.get('specs', 'type_specs_file'))
-
-
-def get_mock_client(client_name):
-    return MockAllClients()
+# def get_mock_client(client_name):
+#     return MockClients()
 
 
 @mock.patch('biokbase.narrative.jobs.job.clients.get', get_mock_client)

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -3,7 +3,6 @@ Tests for Mixin class that handles IO between the
 Narrative and workspace service.
 """
 import unittest
-from getpass import getpass
 from biokbase.narrative.contents.narrativeio import (
     KBaseWSManagerMixin,
     PermissionsError
@@ -32,6 +31,7 @@ class NarrIOTestCase(unittest.TestCase):
         def deco(f):
             def wrapper(self, *args, **kwargs):
                 if self.test_token is None:
+                    print("Skipping test due to missing auth token")
                     self.skipTest()
                 else:
                     f(self, *args, **kwargs)
@@ -47,6 +47,13 @@ class NarrIOTestCase(unittest.TestCase):
 
         self.test_token = util.read_token_file(config.get_path('token_files', 'test_user'))
         self.private_token = util.read_token_file(config.get_path('token_files', 'private_user'))
+
+        if self.test_token is None or self.private_token is None:
+            print("Skipping most narrativeio.py tests due to missing tokens.")
+            print("To enable these, place a valid auth token in files\n{}\nand\n{}".format(
+                config.get_path('token_files', 'test_user'),
+                config.get_path('token_files', 'private_user')))
+            print("Note that these should belong to different users.")
 
         self.ws_uri = URLS.workspace
 

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -34,17 +34,6 @@ class NarrIOTestCase(unittest.TestCase):
     test_token = None
     private_token = None
 
-        # def deco(f):
-        #     @wraps(f)
-        #     def wrapper(self, *args, **kwargs):
-        #         if self.test_token is None:
-        #             print("Skipping test due to missing auth token")
-        #             self.skipTest()
-        #         else:
-        #             f(self, *args, **kwargs)
-        #     return wrapper
-        # return deco
-
     @classmethod
     def setUpClass(self):
         config = util.TestConfig()

--- a/src/biokbase/narrative/tests/test_specmanager.py
+++ b/src/biokbase/narrative/tests/test_specmanager.py
@@ -1,6 +1,6 @@
 from biokbase.narrative.jobs.specmanager import SpecManager
 import unittest
-import mock
+
 
 class SpecManagerTestCase(unittest.TestCase):
     @classmethod
@@ -26,7 +26,7 @@ class SpecManagerTestCase(unittest.TestCase):
         self.assertFalse(self.sm.check_app(self.bad_app_id, self.good_tag))
 
         # bad id with raise
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(ValueError):
             self.sm.check_app(self.bad_app_id, raise_exception=True)
 
 

--- a/src/biokbase/narrative/tests/test_updater.py
+++ b/src/biokbase/narrative/tests/test_updater.py
@@ -7,6 +7,7 @@ from biokbase.narrative.contents.updater import (
 import json
 from util import TestConfig
 
+
 class TestKeyError(ValueError):
     def __init__(self, keyname, source):
         ValueError.__init__(self, "Key {} not found in {}".format(keyname, source))

--- a/test/unit/initTestEnvironment.js
+++ b/test/unit/initTestEnvironment.js
@@ -1,0 +1,42 @@
+define([
+    'jquery',
+    'narrativeConfig',
+    'json!testConfig.json'
+], function($, Config, TestConfig) {
+    var token = null;
+    var currentNarrative = null;
+    var currentWorkspace = null;
+
+    function getToken() {
+        if (token) {
+            return token;
+        }
+        // pull out of testConfig
+
+        // if not there, throw an Error
+        throw new Error('Auth token not found. Please enter one in testConfig.json');
+    }
+
+    function getCurrentNarrative() {
+        if (currentNarrative) {
+            return currentNarrative;
+        }
+        var token = getToken();
+        // make a new workspace
+        // make a new narrative object and add it to the workspace
+        // add some data to the workspace
+    }
+
+    function loadNarrativeData() {
+
+    }
+
+    function getCurrentWorkspace() {
+
+    }
+
+    return {
+        token: getToken(),
+        currentNarrative: getCurrentNarrative()
+    }
+});


### PR DESCRIPTION
Updates and fixes backend tests in the following ways:
1. Support for auth2 (finally...). Requires manually adding a token to a couple of files as defined in `src/biokbase/narrative/tests/test.cfg`
2. More widespread support for service client mocking.
3. Test recent changes made to better support token timeouts.