### PR TITLE
TASK-1041 notify users when a concurrent sessions updates their narrative

### DIFF
--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -188,6 +188,10 @@
                         <div class="fa fa-refresh fa-spin"></div>
                         <div class="kb-nav-btn-txt">Get new version!</div>
                     </button>
+                    <button id="kb-narr-version-btn" class="btn btn-default navbar-btn kb-nav-btn kb-nav-btn-upgrade">
+                        <div class="fa fa-exclamation-circle"></div>
+                        <div class="kb-nav-btn-txt">Narrative updated in another session</div>
+                    </button>
                     <div class="btn-group">
                         <button id="kb-help-menu" class="btn btn-default navbar-btn kb-nav-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <div id="kb-help-icon" class="fa fa-question"><span class="caret"></div>

--- a/kbase-extension/static/kbase/js/common/jupyter.js
+++ b/kbase-extension/static/kbase/js/common/jupyter.js
@@ -42,7 +42,7 @@ define([
     }
 
     function saveNotebook() {
-        Jupyter.notebook.save_checkpoint();
+        Jupyter.narrative.saveNarrative();
     }
 
     function findCellIndex(cell) {
@@ -70,23 +70,23 @@ define([
 
     /*
      * Disables the Jupyter keyboard manager for a given cell.
-     * 
+     *
      * It works by capturing the focus event. Note the usage of the useCapture
      * argument. This ensures that the cell container element receives the focus
      * event. Normally the focus event is only received by the target element.
-     * Note that the target element also receives the focus. This allows 
-     * the target element to override the keyboard manager itself. 
+     * Note that the target element also receives the focus. This allows
+     * the target element to override the keyboard manager itself.
      * For instance, in kbase code cells, if the user clicks into a code input
-     * area, Jupyter will itself turn the keyboard manager back on. 
-     * 
+     * area, Jupyter will itself turn the keyboard manager back on.
+     *
      * The primary use case is to disable all of Jupyter's helpful but
      * diabolically destructive keyboard shortcuts, while a user is interacting
      * with kbase cells. For instance, although we also may remap Jupyter
      * key bindings to disable ones we definitely don't want users to ever use
      * (e.g. merge cells, delete cells), we do need to keep certain ones
-     * available - save via alt-s, code running via shift-enter/return, 
+     * available - save via alt-s, code running via shift-enter/return,
      * ctrl-enter/return.
-     * 
+     *
      * Ideally Jupyter would provide support for custom keymaps as well as
      * hooks for keymappings to be invoked within
      * specific cells or cell types, and within specific areas.

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -30,6 +30,8 @@ define([
     'notebook/js/notebook',
     'util/display',
     'util/bootstrapDialog',
+    'util/bootstrapAlert',
+    'util/timeFormat',
     'text!kbase/templates/update_dialog_body.html',
     'text!kbase/templates/document_version_change.html',
     'narrativeLogin',
@@ -60,6 +62,8 @@ define([
     Notebook,
     DisplayUtil,
     BootstrapDialog,
+    BootstrapAlert,
+    TimeFormat,
     UpdateDialogBodyTemplate,
     DocumentVersionDialogBodyTemplate,
     NarrativeLogin,
@@ -344,12 +348,15 @@ define([
     Narrative.prototype.showDocumentVersionDialog = function (newVerInfo) {
         var bodyTemplate = Handlebars.compile(DocumentVersionDialogBodyTemplate);
 
-        var versionDialog = new BootstrapDialog({
+        var versionDialog = new BootstrapAlert({
             title: 'Showing an older Narrative document',
-            buttons: [$('<button type="button" data-dismiss="modal">OK</button>')],
             body: bodyTemplate({
                 currentVer: this.documentVersionInfo,
-                newVer: newVerInfo
+                currentDate: TimeFormat.readableTimestamp(this.documentVersionInfo[3]),
+                newVer: newVerInfo,
+                newDate: TimeFormat.readableTimestamp(newVerInfo[3]),
+                sameUser: this.documentVersionInfo[5] === newVerInfo[5],
+                readOnly: this.readonly
             })
         });
 
@@ -754,6 +761,7 @@ define([
     Narrative.prototype.saveNarrative = function () {
         this.narrController.saveAllCellStates();
         Jupyter.notebook.save_checkpoint();
+        this.toggleDocumentVersionBtn(false);
     };
 
     Narrative.prototype.addAndPopulateApp = function (appId, tag, parameters) {

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -31,6 +31,7 @@ define([
     'util/display',
     'util/bootstrapDialog',
     'text!kbase/templates/update_dialog_body.html',
+    'text!kbase/templates/document_version_change.html',
     'narrativeLogin',
     'common/ui',
     'common/html',
@@ -60,6 +61,7 @@ define([
     DisplayUtil,
     BootstrapDialog,
     UpdateDialogBodyTemplate,
+    DocumentVersionDialogBodyTemplate,
     NarrativeLogin,
     UI,
     html,
@@ -111,6 +113,9 @@ define([
 
         // The version of the Narrative UI (semantic version)
         this.currentVersion = Config.get('version');
+
+        // The version of the currently loaded Narrative document object.
+        this.documentVersionInfo = [];
 
         //
         this.dataViewers = null;
@@ -207,7 +212,8 @@ define([
         });
         $([Jupyter.events]).on('notebook_saved.Notebook', function () {
             $('#kb-save-btn').find('div.fa-save').removeClass('fa-spin');
-        });
+            this.updateDocumentVersion();
+        }.bind(this));
         $([Jupyter.events]).on('kernel_idle.Kernel', function () {
             $('#kb-kernel-icon').removeClass().addClass('fa fa-circle-o');
         });
@@ -272,58 +278,6 @@ define([
         }.bind(this));
     };
 
-    /**
-     */
-    // function renderSettingsDialog(settings) {
-    //     var t = html.tag,
-    //         div = t('div'),
-    //         input = t('input'),
-    //         label = t('label'),
-    //         p = t('p');
-
-    //     return div([
-    //         p({}, [
-    //             'These settings apply to and are saved with this Narrative. Changes ',
-    //             'made here will not affect existing Narratives or new Narratives that you ',
-    //             'may create.'
-    //         ]),
-    //         p({ style: { fontStyle: 'italic' } }, [
-    //             'Please note that you will need to refresh the browser in order to ',
-    //             'enable any changes.'
-    //         ]),
-    //         div({ class: 'form-horizontal settings-dialog' }, [
-    //             div({ class: 'form-group' }, [
-    //                 div({ class: 'col-md-8 checkbox' }, [
-    //                     label([
-    //                         input({
-    //                             type: 'checkbox',
-    //                             name: 'advanced',
-    //                             value: 'advanced',
-    //                             checked: settings.advanced
-    //                         }),
-    //                         'Use Advanced features'
-    //                     ])
-    //                 ]),
-    //                 div({ class: 'col-md-4' })
-    //             ]),
-    //             div({ class: 'form-group' }, [
-    //                 div({ class: 'col-md-8 checkbox' }, [
-    //                     label([
-    //                         input({
-    //                             type: 'checkbox',
-    //                             name: 'developer',
-    //                             value: 'developer',
-    //                             checked: settings.developer
-    //                         }),
-    //                         'Use Developer features'
-    //                     ])
-    //                 ]),
-    //                 div({ class: 'col-md-4' })
-    //             ])
-    //         ])
-    //     ]);
-    // }
-
     /*
      * Given an inner node, which is probably a button, inspect the contents
      * of the submitted form.
@@ -341,70 +295,82 @@ define([
         return findParent(node.parentNode, selector);
     }
 
-    // function doCheckSettings(innerNode) {
-    //     var dialogNode = findParent(innerNode, '.modal-dialog');
+    /**
+     * Expects docInfo to be a workspace object info array, especially where the 4th element is
+     * an int > 0.
+     */
+    Narrative.prototype.checkDocumentVersion = function (docInfo) {
+        if (docInfo.length < 5) {
+            return;
+        }
+        if (docInfo[4] !== this.documentVersionInfo[4]) {
+            // now we make the dialog and all that.
+            $('#kb-narr-version-btn')
+                .off('click')
+                .on('click', function() {
+                    this.showDocumentVersionDialog(docInfo);
+                }.bind(this));
+            this.toggleDocumentVersionBtn(true);
+        }
+    };
 
-    //     if (!dialogNode) {
-    //         console.error('COULD NOT FIND PARENT NODE');
-    //         throw new Error('Could not find the parent node!');
-    //     }
+    /**
+     * Expects the usual workspace object info array. If that's present, it's captured. If not,
+     * we run get_object_info_new and fetch it ourselves. Note that it should have its metadata.
+     */
+    Narrative.prototype.updateDocumentVersion = function (docInfo) {
+        var self = this;
+        return Promise.try(function () {
+            if (docInfo) {
+                self.documentVersionInfo = docInfo;
+            }
+            else {
+                var workspace = new Workspace(Config.url('workspace'), {token: self.authToken});
+                Promise.resolve(workspace.get_object_info_new({
+                    'objects': [{'ref': self.workspaceRef}],
+                    'includeMetadata': 1
+                }))
+                    .then(function (info) {
+                        self.documentVersionInfo = info[0];
+                    })
+                    .catch(function (error) {
+                        // no op for now.
+                        console.error(error);
+                    });
+            }
+        });
+    };
 
-    //     var settings = {};
-    //     var advanced = dialogNode.querySelector('[name="advanced"]').checked;
-    //     settings.advanced = advanced;
+    Narrative.prototype.showDocumentVersionDialog = function (newVerInfo) {
+        var bodyTemplate = Handlebars.compile(DocumentVersionDialogBodyTemplate);
 
-    //     var developer = dialogNode.querySelector('[name="developer"]').checked;
-    //     settings.developer = developer;
+        var versionDialog = new BootstrapDialog({
+            title: 'Showing an older Narrative document',
+            buttons: [$('<button type="button" data-dismiss="modal">OK</button>')],
+            body: bodyTemplate({
+                currentVer: this.documentVersionInfo,
+                newVer: newVerInfo
+            })
+        });
 
-    //     return settings;
-    // }
+        versionDialog.show();
+    };
 
-    // function doSaveSettings(settings) {
-    //     var existingSettings = Jupyter.notebook.metadata.kbase.userSettings;
-    //     Object.keys(settings).forEach(function(key) {
-    //         existingSettings[key] = settings[key];
-    //     });
-    //     Jupyter.notebook.metadata.kbase.userSettings = existingSettings;
-    //     Jupyter.notebook.save_checkpoint();
-    // }
-
-    // function showSettingsDialog() {
-    //     var ui = UI.make({ node: document.body }),
-    //         existingSettings = Jupyter.notebook.metadata.kbase.userSettings;
-
-    //     if (!existingSettings) {
-    //         existingSettings = {};
-    //         Jupyter.notebook.metadata.kbase.userSettings = {};
-    //     }
-    //     ui.showDialog({
-    //             title: 'Narrative User Settings',
-    //             body: renderSettingsDialog(existingSettings),
-    //             buttons: [{
-    //                 type: 'primary',
-    //                 label: 'Save Settings',
-    //                 action: 'save',
-    //                 handler: function(e) {
-    //                     return doCheckSettings(e.target);
-    //                 }
-    //             }]
-    //         })
-    //         .then(function(result) {
-    //             if (result.action === 'save') {
-    //                 doSaveSettings(result.result);
-    //             }
-    //         });
-    // }
-
-    // Narrative.prototype.initSettingsDialog = function() {
-    //     var settingsButtonNode = document.getElementById('kb-settings-btn');
-    //     if (!settingsButtonNode) {
-    //         return;
-    //     }
-
-    //     settingsButtonNode.addEventListener('click', function() {
-    //         showSettingsDialog();
-    //     });
-    // };
+    /**
+     * @method
+     * @public
+     * This shows or hides the "narrative has been saved in a different window" button.
+     * If show is truthy, show it. Otherwise, hide it.
+     */
+    Narrative.prototype.toggleDocumentVersionBtn = function (show) {
+        var $btn = $('#kb-narr-version-btn');
+        if (show && !$btn.is(':visible')) {
+            $btn.fadeIn('fast');
+        }
+        else if (!show && $btn.is(':visible')){
+            $btn.fadeOut('fast');
+        }
+    };
 
     /**
      * The "Upgrade your container" dialog should be made available when
@@ -725,13 +691,16 @@ define([
                 this.workspaceId = wsInfo[1];
             }
 
-            // init the controller
-
-            this.narrController.render()
-                .finally(function () {
-                    this.sidePanel.render();
-                    $('#kb-wait-for-ws').remove();
-                }.bind(this));
+            this.updateDocumentVersion()
+            .then(function() {
+                // init the controller
+                return this.narrController.render();
+            }.bind(this))
+            .finally(function () {
+                this.sidePanel.render();
+                this.updateDocumentVersion();
+                $('#kb-wait-for-ws').remove();
+            }.bind(this));
             $([Jupyter.events]).trigger('loaded.Narrative');
             $([Jupyter.events]).on('kernel_ready.Kernel',
                 function () {
@@ -759,7 +728,8 @@ define([
      */
     Narrative.prototype.updateVersion = function () {
         var user = NarrativeLogin.sessionInfo.user; //.loginWidget($('#signin-button')).session('user_id');
-        Promise.resolve($.ajax({
+        Promise.resolve(
+            $.ajax({
                 contentType: 'application/json',
                 url: '/narrative_shutdown/' + user,
                 type: 'DELETE',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -564,6 +564,9 @@ define([
                         // Skip any Narrative objects.
                         var objInfo = obj.object_info;
                         if (objInfo[2].indexOf('KBaseNarrative') === 0) {
+                            if (objInfo[2].indexOf('KBaseNarrative.Narrative') === 0) {
+                                Jupyter.narrative.checkDocumentVersion(objInfo);
+                            }
                             continue;
                         }
                         // Only adds to dataObjects, etc., if it's not already there.

--- a/kbase-extension/static/kbase/templates/document_version_change.html
+++ b/kbase-extension/static/kbase/templates/document_version_change.html
@@ -1,0 +1,23 @@
+<div>
+    <h2>The currently loaded Narrative document is out of date.</h2>
+    <div>
+        <b>Currently loaded version:</b>
+        <div>
+            {{currentVer.[10].name}} (v{{currentVer.[4]}})<br>
+            Saved by {{currentVer.[5]}}
+            at {{currentVer.[3]}}
+        </div>
+    </div>
+    <div>
+        <b>Updated version:</b>
+        <div>
+            {{newVer.[10].name}} (v{{newVer.[4]}})<br>
+            Saved by {{newVer.[5]}}
+            at {{newVer.[3]}}
+        </div>
+    </div>
+    <p>
+    You can update to the latest version by simply refreshing this page. However, any changes will be lost.
+    <p>
+    If you save here, you might delete any changes made in the newer version.
+</div>

--- a/kbase-extension/static/kbase/templates/document_version_change.html
+++ b/kbase-extension/static/kbase/templates/document_version_change.html
@@ -1,23 +1,33 @@
 <div>
-    <h2>The currently loaded Narrative document is out of date.</h2>
+    <h3>The currently loaded Narrative document is out of date.</h3>
     <div>
         <b>Currently loaded version:</b>
-        <div>
-            {{currentVer.[10].name}} (v{{currentVer.[4]}})<br>
-            Saved by {{currentVer.[5]}}
-            at {{currentVer.[3]}}
+        <div style="margin-left: 30px">
+            {{currentVer.[10].name}} (v<b>{{currentVer.[4]}}</b>)<br>
+            Saved by <b>{{currentVer.[5]}}</b>
+            at {{currentDate}}
         </div>
     </div>
     <div>
         <b>Updated version:</b>
-        <div>
-            {{newVer.[10].name}} (v{{newVer.[4]}})<br>
-            Saved by {{newVer.[5]}}
-            at {{newVer.[3]}}
+        <div style="margin-left: 30px">
+            {{newVer.[10].name}} (v<b>{{newVer.[4]}}</b>)<br>
+            Saved by <b>{{newVer.[5]}}</b>
+            at {{newDate}}
         </div>
     </div>
+    <br>
     <p>
-    You can update to the latest version by simply refreshing this page. However, any changes will be lost.
-    <p>
-    If you save here, you might delete any changes made in the newer version.
+        You can update to the latest version by simply refreshing this page. {{#unless readOnly}}However, any changes will be lost.{{/unless}}
+    </p>
+    {{#unless readOnly}}
+        <p>
+            If you save here, you might delete any changes made in the newer version.
+        </p>
+        {{#unless sameUser}}
+        <p>
+            You might consider getting in contact with <b>{{newVer.[4]}}</b> before saving over their work.
+        </p>
+        {{/unless}}
+    {{/unless}}
 </div>


### PR DESCRIPTION
Here's the main use case.
A single Narrative is open in both Window A and Window B. The user at Window A saves that Narrative, creating a new version. The user at Window B now has a Narrative document that's out of date, and saving it would likely clobber any changes made in Window A.

This adds a notification button that alerts the user when a change has been made. It's on the same timer as the data panel update (~30 seconds), so there's a little lag. Clicking that button will open an alert saying what your current version is, and what's the newer one (and who saved it). Along with some simple instructions.

I'm not tied to the layout of, well, anything, but I want to get this on CI for some product team testing.