### PR TITLE
Don't show Suggested Next Steps if there aren't any

### DIFF
--- a/nbextensions/appCell2/widgets/tabs/resultsTab.js
+++ b/nbextensions/appCell2/widgets/tabs/resultsTab.js
@@ -117,6 +117,7 @@ define([
             apps = apps.filter(function(app) {
                 return app.info.module_name;
             });
+            // If there are no next apps to suggest, don't even show the Suggested Next Steps panel
             if (apps.length > 0) {
                 appList = apps.map(function(app, index) {
                     return div([
@@ -132,18 +133,18 @@ define([
                         span(' - ' + app.info.module_name)
                     ]);
                 }).join('\n');
+                ui.setContent('next-steps',
+                    ui.buildCollapsiblePanel({
+                        title: 'Suggested Next Steps',
+                        name: 'next-steps-toggle',
+                        hidden: false,
+                        type: 'default',
+                        classes: ['kb-panel-container'],
+                        body: appList
+                    })
+                );
+                events.attachEvents(container);
             }
-            ui.setContent('next-steps',
-                ui.buildCollapsiblePanel({
-                    title: 'Suggested Next Steps',
-                    name: 'next-steps-toggle',
-                    hidden: false,
-                    type: 'default',
-                    classes: ['kb-panel-container'],
-                    body: appList
-                })
-            );
-            events.attachEvents(container);
         }
 
         function stop() {


### PR DESCRIPTION
Some time ago, the Suggested Next Steps stopped showing up (https://kbase-jira.atlassian.net/browse/KBASE-3778). While awaiting a fix for that, I suggested in https://kbase-jira.atlassian.net/browse/TASK-1017 that we should just not show that Suggested Next Steps panel if there aren't any (otherwise it looks like all the apps are dead ends, which they're not).
I am suggesting this fix (which simply moves the ui.setContent('next-steps') call into the if (apps.length > 0) block) but I am not set up to test it. Hopefully @thomasoniii  can test my fix and see if it works. If it does, it would be great to get this deployed to prod ASAP! @RoyKBase @sychan 