### PR TITLE
Fix problem with app insertion API not respecting app tag

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -595,15 +595,15 @@ define([
                     if (self.moduleVersions[spec.info.module_name]) {
                         spec.info.ver = self.moduleVersions[spec.info.module_name];
                     }
-                    self.trigger('appClicked.Narrative', [spec, self.currentTag, parameters]);
+                    self.trigger('appClicked.Narrative', [spec, tag, parameters]);
                 })
                 .catch(function (err) {
                     var errorId = new Uuid(4).format();
-                    console.error('Error getting method spec #' + errorId, err, app, self.currentTag);
+                    console.error('Error getting method spec #' + errorId, err, app, tag);
                     alert('Error getting app spec, see console for error info #' + errorId);
                 });
             } else {
-                self.trigger('appClicked.Narrative', [app, self.currentTag, parameters]);
+                self.trigger('appClicked.Narrative', [app, tag, parameters]);
             }
         },
 


### PR DESCRIPTION
Even if you use 'dev' it would default to 'release'. Actually, it was defaulting to whatever was set in the App Panel, which is typically release.