### PR TITLE
updated to assume lots of extra_args with infos [PTV-535]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseRNASeqAnalysisNew.js
@@ -89,19 +89,23 @@ define (
                 var ref_map = {};
                 var ref_map_by_id = {};
                 $.each(
-                    extra_args.infos,
-                    function(i, v) {
-
-                        var info_obj = {};
-                        $.each(
-                            info_keys,
-                            function(i,key) {
-                                info_obj[key] = v[0][i];
-                            }
-                        );
-                        ref_map_by_id[ [ v[0][6], v[0][0], v[0][4] ].join('/')] = info_obj;
-                        ref_map[info_obj['name']] = info_obj;
-                    }
+                  extra_args,
+                  function (eaIdx, extra_arg) {
+                    $.each(
+                      extra_arg.infos,
+                      function(i, v) {
+                          var info_obj = {};
+                          $.each(
+                              info_keys,
+                              function(i,key) {
+                                  info_obj[key] = v[i];
+                              }
+                          );
+                          ref_map_by_id[ [ v[6], v[0], v[4] ].join('/')] = info_obj;
+                          ref_map[info_obj['name']] = info_obj;
+                      }
+                    )
+                  }
                 );
 
                 if (analysis.sample_ids) {
@@ -110,7 +114,6 @@ define (
                     $.each(
                       analysis.sample_ids,
                       function (i, v) {
-
                         sample_id_data.push(
                           [
                             ref_map_by_id[v] ? ref_map_by_id[v].name : v,


### PR DESCRIPTION
The inputs to the widget changed at some point.

It has always been wired up to display the name if it was available, and to fall back on the ref if it wasn't. It looks like it was previously assuming it would receive one list of infos items from get_object_info3, but now it's receiving multiple lists, each with multiple infos. Or maybe different data inputs would sometimes produce multiple lists and it was never tested with those combos in the past? Dunno.

Regardless, it's updated to allow for lists of multiple objects, each with their own infos, which resolves the issue. Again, if no name is available, it'll fall back on displaying the ref.