### PR TITLE
TASK-1041 - fix problem where version shows up where username should

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 - TASK-1054 - Create a new loading window with a set of tasks to load and connect to (treats the problem of slowly loading websockets, still probably needs some adjusting).
 - TASK-588 - Change status of importers from "suspend" to "error" if the import job fails.
 - KBASE-3778/TASK-1017 - hide "next steps" area of app results tab if there are no next steps available.
+- KBASE-1041 - fix error that shows a version number instead of username for who saved the most recent narrative.
 
 
 ### Version 3.4.4

--- a/kbase-extension/static/kbase/templates/document_version_change.html
+++ b/kbase-extension/static/kbase/templates/document_version_change.html
@@ -26,7 +26,7 @@
         </p>
         {{#unless sameUser}}
         <p>
-            You might consider getting in contact with <b>{{newVer.[4]}}</b> before saving over their work.
+            You might consider getting in contact with <b>{{newVer.[10].name}}</b> before saving over their work.
         </p>
         {{/unless}}
     {{/unless}}


### PR DESCRIPTION
Fixes a problem with the popup template where it said "you might consider getting in contact with (some version number)" instead of a real user name.