### PR TITLE
TASK-1069 Fix problem with app panel filtering.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,13 @@ This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 - TASK-588 - Change status of importers from "suspend" to "error" if the import job fails.
 - KBASE-3778/TASK-1017 - hide "next steps" area of app results tab if there are no next steps available.
 - KBASE-1041 - fix error that shows a version number instead of username for who saved the most recent narrative.
+- KBASE-1069 - fix problems with searching and filtering the App panel
+    - Searching by output object type works again.
+    - Added "input:" and "output:" as filters for input object types and output object types (same as "in_type:" and "out_type:", respectively)
+    - Made type search more stringent.
+        - If no "." separator is present, will only match by the type name. E.g. "in_type:Genome" will not match "GenomeSet" or "PanGenome" or "KBaseGenomes.ContigSet", just "ANYMODULE.Genome"
+        - If a "." is present, will only match a full type name, like "KBaseGenomes.Genome"
+    - Non-type search will also search i/o fields now and do fuzzy matching. E.g. "Genome" will match "Annotate Domains in a GenomeSet" (by the name), and "Assemble Reads with MEGAHIT" (by the output object KBaseGenomeAnnotations.Assembly)
 
 
 ### Version 3.4.4

--- a/kbase-extension/static/kbase/js/tour.js
+++ b/kbase-extension/static/kbase/js/tour.js
@@ -237,11 +237,16 @@ define([
     };
 
     NarrativeTour.prototype.start = function() {
-        console.log("let's start the tour");
         this.tour.init();
         this.tour.start();
         if (this.tour.ended()) {
             this.tour.restart();
+        }
+    };
+
+    NarrativeTour.prototype.stop = function() {
+        if (this.tour && !this.tour.ended()) {
+            this.tour.end();
         }
     };
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -137,6 +137,7 @@ define([
                     'overflow-y': 'auto',
                     'overflow-x': 'hidden'
                 });
+
             // Make a function panel for everything to sit inside.
             this.$functionPanel = $('<div>')
                 .addClass('kb-function-body')
@@ -643,7 +644,6 @@ define([
                 for (var i = 0; i < appSet[app].info.categories.length; i++) {
                     if (self.ignoreCategories[appSet[app].info.categories[i]]) {
                         ignoreFlag = true;
-                        console.log('ignoring app: ' + app);
                         break;
                     }
                 }
@@ -655,7 +655,6 @@ define([
                 appSet[app].info.short_output_types = shortenTypes(appSet[app].info.output_types);
                 this.renderedApps[app] = appSet[app];
             }
-            console.log('rendering ' + Object.keys(this.renderedApps).length);
             this.refreshPanel();
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -1,5 +1,6 @@
 /*global define*/
 /*jslint white: true*/
+/*global Catalog*/
 /**
  * A widget that contains functions and function information for the Narrative.
  * When initialized, it uses a loading gif while waiting for functions to load
@@ -549,6 +550,7 @@ define([
                         });
                 })
                 .catch(function(error) {
+                    console.error(error);
                     self.showError('Sorry, an error occurred while loading Apps.', error);
                 });
         },
@@ -607,8 +609,28 @@ define([
             }
         },
 
+        /**
+         * "Parses" the apps to do some preliminary filtering of ignored categories and
+         * do some internal string chopping (i.e. keep an abbreviated list of objects -
+         * input_types = ['KBaseGenomes.Genome', 'KBaseGenomeAnnotations.Assembly'] ->).
+         *
+         * Sets the renderedApps property of the widget (the set of apps to render)
+         * and runs refreshPanel() when it's done.
+         */
         parseApps: function(catSet, appSet) {
             var self = this;
+
+            var shortenTypes = function(typeList) {
+                var shortTypes = [];
+                if (typeList) {
+                    typeList.forEach(function(t) {
+                        if (t.indexOf('.') !== -1) {
+                            shortTypes.push(t.split('.')[1]);
+                        }
+                    });
+                }
+                return shortTypes;
+            };
 
             this.catSet = catSet;
             this.renderedApps = {};
@@ -616,16 +638,24 @@ define([
                 if (!appSet.hasOwnProperty(app)) {
                     continue;
                 }
+                // skip this if its to be ignored.
                 var ignoreFlag = false;
                 for (var i = 0; i < appSet[app].info.categories.length; i++) {
                     if (self.ignoreCategories[appSet[app].info.categories[i]]) {
                         ignoreFlag = true;
+                        console.log('ignoring app: ' + app);
+                        break;
                     }
                 }
-                if (!ignoreFlag) {
-                    this.renderedApps[app] = appSet[app];
+                if (ignoreFlag) {
+                    continue;
                 }
+                // passed all the filters, now add the short version of inputs/outputs...?
+                appSet[app].info.short_input_types = shortenTypes(appSet[app].info.input_types);
+                appSet[app].info.short_output_types = shortenTypes(appSet[app].info.output_types);
+                this.renderedApps[app] = appSet[app];
             }
+            console.log('rendering ' + Object.keys(this.renderedApps).length);
             this.refreshPanel();
         },
 
@@ -637,24 +667,24 @@ define([
             Object.keys(appSet).forEach(function(appId) {
                 var categoryList = [];
                 switch (style) {
-                    default:
-                        case 'category':
-                        categoryList = appSet[appId].info.categories;
+                default:
+                case 'category':
+                    categoryList = appSet[appId].info.categories;
                     var activeIndex = categoryList.indexOf('active');
                     if (activeIndex !== -1) {
                         categoryList.splice(activeIndex, 1);
                     }
                     break;
-                    case 'input':
-                            categoryList = appSet[appId].info.input_types.map(function(input) {
-                            return input.split('.')[1];
-                        });
-                        break;
-                    case 'output':
-                            categoryList = appSet[appId].info.output_types.map(function(output) {
-                            return output.split('.')[1];
-                        });
-                        break;
+                case 'input':
+                    categoryList = appSet[appId].info.input_types.map(function(input) {
+                        return input.split('.')[1];
+                    });
+                    break;
+                case 'output':
+                    categoryList = appSet[appId].info.output_types.map(function(output) {
+                        return output.split('.')[1];
+                    });
+                    break;
                 }
                 if (categoryList.length === 0) {
                     allCategories.uncategorized.push(appId);
@@ -794,26 +824,25 @@ define([
 
             // 2. Switch over panelStyle and build the view based on that.
             switch (panelStyle) {
-                case 'a-z':
-                    buildFlatPanel(true);
-                    break;
-                case 'z-a':
-                    buildFlatPanel(false);
-                    break;
-                case 'category':
-                case 'input':
-                case 'output':
-                    buildAccordionPanel(panelStyle);
-                    break;
-                default:
-                    break;
+            case 'a-z':
+                buildFlatPanel(true);
+                break;
+            case 'z-a':
+                buildFlatPanel(false);
+                break;
+            case 'category':
+            case 'input':
+            case 'output':
+                buildAccordionPanel(panelStyle);
+                break;
+            default:
+                break;
             }
             this.$methodList.empty().append($appPanel);
         },
 
         /**
          * Using the filterString, this returns only those apps that pass the filter.
-         * The string is applied to app names (to start)
          * filterString - just a string. includes prefixes in_type:, out_type:
          * appSet - keys=appIds, values=appSpecs
          */
@@ -825,23 +854,43 @@ define([
             filterString = filterString.toLowerCase();
             var filter = filterString.split(':');
             if (filter.length === 2) {
-                if (filter[0] === 'in_type' || filter[1] === 'out_type') {
+                if (['in_type', 'out_type', 'input', 'output'].indexOf(filter[0]) !== -1) {
                     filterType = filter[0];
                     filterString = filter[1];
                 }
             }
             var filteredIds = Object.keys(appSet);
             filteredIds = Object.keys(appSet).filter(function(id) {
+                var searchSet;
+                var app = appSet[id];
                 switch (filterType) {
-                    case 'in_type':
-                        var inputTypes = appSet[id].info.input_types;
-                        return inputTypes.join().toLowerCase().indexOf(filterString) !== -1;
-                    case 'out_type':
-                        var outputTypes = appSet[id].info.output_types;
-                        return outputTypes.join().toLowerCase().indexOf(filterString) !== -1;
-                    default:
-                        return appSet[id].info.name.toLowerCase().indexOf(filterString) !== -1;
+                case 'in_type':
+                case 'input':
+                    if (filterString.indexOf('.') !== -1) {
+                        searchSet = app.info.input_types;
+                    }
+                    else {
+                        searchSet = app.info.short_input_types;
+                    }
+                    break;
+                case 'out_type':
+                case 'output':
+                    if (filterString.indexOf('.') !== -1) {
+                        searchSet = app.info.output_types;
+                    }
+                    else {
+                        searchSet = app.info.short_output_types;
+                    }
+                    break;
+                default:
+                    return [
+                        app.info.name,
+                        app.info.input_types.join(';'),
+                        app.info.output_types.join(';')
+                    ].join(';').toLowerCase().indexOf(filterString) !== -1;
                 }
+                var lowerSearchSet = searchSet.map(function(val) { return val.toLowerCase(); });
+                return lowerSearchSet.indexOf(filterString) !== -1;
             });
             var filteredSet = {};
             filteredIds.forEach(function(id) {
@@ -935,7 +984,7 @@ define([
                                     e.stopPropagation();
                                     self.triggerApp(app);
                                 }));
-            var versionStr = 'v'+app.info.ver; // note that app versions are meaningless right now; need to update!
+            var versionStr = 'v'+app.info.ver;
             if (app.info.module_name) {
                 versionStr = '<a href="'+this.options.moduleLink+'/'+app.info.module_name+'" target="_blank">' +
                                 app.info.namespace + '</a> ' + versionStr;
@@ -1042,7 +1091,7 @@ define([
                         callback(results);
                     })
                     .catch(function(err) {
-                        console.error("Error in method panel on 'getFunctionSpecs' when contacting NMS");
+                        console.error('Error in method panel on "getFunctionSpecs" when contacting NMS');
                         console.error(err);
                         callback(results); // still return even if we couldn't get the methods
                     });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -818,7 +818,6 @@ define([
             };
 
             // 1. Go through filterString and keep those that pass the filter (not yet).
-
             appSet = this.filterApps(filterString, appSet);
 
             // 2. Switch over panelStyle and build the view based on that.

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -691,7 +691,7 @@ define([
                 .addClass(btnClasses)
                 .append($('<span>').addClass('fa fa-sign-in').css(css))
                 .click(function () {
-                    this.trigger('filterMethods.Narrative', 'in_type:' + object_info[2].split('-')[0].split('.')[1]);
+                    this.trigger('filterMethods.Narrative', 'input:' + object_info[2].split('-')[0]);
                 }.bind(this));
 
             var $filterMethodOutput = $('<span>')
@@ -706,7 +706,7 @@ define([
                 .addClass(btnClasses)
                 .append($('<span>').addClass('fa fa-sign-out').css(css))
                 .click(function () {
-                    this.trigger('filterMethods.Narrative', 'out_type:' + object_info[2].split('-')[0].split('.')[1]);
+                    this.trigger('filterMethods.Narrative', 'output:' + object_info[2].split('-')[0]);
                 }.bind(this));
 
             var $openLandingPage = $('<span>')

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -13,9 +13,12 @@ define([
     var appPanel = null;
 
     describe('Test the kbaseNarrativeAppPanel widget', function() {
-        beforeEach(function() {
+        beforeEach(function(done) {
             Jupyter.narrative = new Narrative();
             appPanel = new AppPanel($panel);
+            appPanel.refreshFromService().then(function() {
+                done();
+            });
         });
         afterEach(function() {
             $panel = $('<div>');
@@ -27,6 +30,23 @@ define([
         });
 
         it('Should have a working search interface', function() {
+            expect(appPanel.$methodList.children().children().length).not.toBe(0);
+
+            appPanel.$searchInput.val('should show nothing');
+            appPanel.refreshPanel();
+            expect(appPanel.$methodList.children().children().length).toBe(0);
+
+            appPanel.$searchInput.val('genome');
+            appPanel.refreshPanel();
+            expect(appPanel.$methodList.children().children().length).not.toBe(0);
+        });
+
+        it('Should trigger search by jquery event filterMethods.Narrative', function () {
+            expect(appPanel.$methodList.children().children().length).not.toBe(0);
+
+            $(document).trigger('filterMethods.Narrative', 'should show nothing');
+            // appPanel.refreshPanel();
+            expect(appPanel.$methodList.children().children().length).toBe(0);
 
         });
 

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -39,15 +39,15 @@ define([
             appPanel.$searchInput.val('genome');
             appPanel.refreshPanel();
             expect(appPanel.$methodList.children().children().length).not.toBe(0);
+            //TODO:
+            // verify by setting output:genome and making sure there's only one output category
         });
 
         it('Should trigger search by jquery event filterMethods.Narrative', function () {
             expect(appPanel.$methodList.children().children().length).not.toBe(0);
 
             $(document).trigger('filterMethods.Narrative', 'should show nothing');
-            // appPanel.refreshPanel();
             expect(appPanel.$methodList.children().children().length).toBe(0);
-
         });
 
         it('Should have a working filter menu', function() {

--- a/test/unit/spec/tourSpec.js
+++ b/test/unit/spec/tourSpec.js
@@ -33,6 +33,7 @@ define ([
             var tourInstance = new Tour.Tour();
             tourInstance.start();
             expect($.find('.kb-tour')).toBeTruthy();
+            tourInstance.stop();
         });
     });
 });


### PR DESCRIPTION
Changes some behavior along with the fix.
* fixed the output filter button from the data panel
* now accepts "input:" and "output:" along with "in_type:" and "out_type:" (I figured it looks a little cleaner and more obvious)
* the input and output setting are more stringent - it will only accept the complete token. E.g. input:Genome will no longer match GenomeSet or PanGenome.
* adding the complete type name (prefixed with Module name) is similar in its strictness - KBaseGenomes.Genome will not match KBaseGenomes.GenomeSet.
* pretty much anything goes with the non-typed search. Searching for anything (not prefixed with "input:" or "output:") will do a simple string search in the name, input types, and output types.
