### PR TITLE
Fixes PUBLIC-123: Bad reaction counts

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbasePathways.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbasePathways.js
@@ -43,15 +43,15 @@ return KBWidget({
                         }},
                         { title: 'Map ID', mData: 1},
                         { title: 'Rxn Count', sWidth: '10%', mData: function(d){
-                            if ('reaction_ids' in d[10]){
-                                return d[10].reaction_ids.split(',').length;
+                            if ('Number reactions' in d[10]){
+                                return d[10]['Number reactions'];
                             } else {
                                 return 'N/A';
                             }
                         }},
                         { title: 'Cpd Count', sWidth: '10%', mData: function(d) {
-                            if ('compound_ids' in d[10]) {
-                                return d[10].compound_ids.split(',').length;
+                            if ('Number compounds' in d[10]) {
+                                return d[10]['Number compounds'];
                             } else {
                                 return 'N/A';
                             }


### PR DESCRIPTION
The number of reactions and compounds associated with pathways was maxing out at 95 because the number was calculated incorrectly. 