### PR TITLE
Fixes PTV-225

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1492,8 +1492,8 @@ define([
                 .append('type')
                 .on('click', function () {
                     self.sortData(function (a, b) {
-                        let aType = self.dataObjects[a.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
-                        let bType = self.dataObjects[b.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
+                        var aType = self.dataObjects[a.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
+                        var bType = self.dataObjects[b.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
                         if (aType > bType)
                             return -1; // sort by type
                         if (aType < bType)

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1492,9 +1492,11 @@ define([
                 .append('type')
                 .on('click', function () {
                     self.sortData(function (a, b) {
-                        if (self.dataObjects[a.objId].info[2].toUpperCase() > self.dataObjects[b.objId].info[2].toUpperCase())
+                        let aType = self.dataObjects[a.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
+                        let bType = self.dataObjects[b.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
+                        if (aType > bType)
                             return -1; // sort by type
-                        if (self.dataObjects[a.objId].info[2].toUpperCase() < self.dataObjects[b.objId].info[2].toUpperCase())
+                        if (aType < bType)
                             return 1;
                         return 0;
                     });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1492,9 +1492,9 @@ define([
                 .append('type')
                 .on('click', function () {
                     self.sortData(function (a, b) {
-                        if (self.dataObjects[a].info[2].toUpperCase() > self.dataObjects[b].info[2].toUpperCase())
+                        if (self.dataObjects[a.objId].info[2].toUpperCase() > self.dataObjects[b.objId].info[2].toUpperCase())
                             return -1; // sort by type
-                        if (self.dataObjects[a].info[2].toUpperCase() < self.dataObjects[b].info[2].toUpperCase())
+                        if (self.dataObjects[a.objId].info[2].toUpperCase() < self.dataObjects[b.objId].info[2].toUpperCase())
                             return 1;
                         return 0;
                     });


### PR DESCRIPTION
This fixes sorting by type, with a caveat -

The type will sort by the fully qualified name, which may be a little confusing to the user. e.g., in the collapsed view of the data, the user may see "GenomeAnnotation" and "Media" and expect "GenomeAnnotation" to be first in the sorted list. It won't be. 

That's because the actual types are "KBaseGenomeAnnotations.GenomeAnnotation" and "KBaseBioChem.Media", and will in turn sort KBaseBioChem.Media first.

I left the behavior as is, since the user could expand the data item and see the full name, but we may want to change this.