### PR TITLE
Fixes filtering [KBASE-4756]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -575,9 +575,9 @@ define([
                         return cleanupData(data, view);
                     })
                     .then(function (data) {
-                        let dataTypes = {};
+                        var dataTypes = {};
                         data.forEach(datum => {
-                          let [module, type] = datum[2].match(/([^.]+)\.([^-]+)/).slice(1,3);
+                          var [module, type] = datum[2].match(/([^.]+)\.([^-]+)/).slice(1,3);
                           if (dataTypes[type] === undefined) {
                             dataTypes[type] = {};
                           }
@@ -1109,8 +1109,8 @@ define([
                 // create type filter
                 var typeInput = $('<select class="form-control kb-import-filter">');
                 typeInput.append('<option>All types...</option>');
-                let typeKeys = Object.keys(knownTypes).sort();
-                for (let typeKey of typeKeys) {
+                var typeKeys = Object.keys(knownTypes).sort();
+                for (var typeKey of typeKeys) {
                     typeInput.append('<option data-type="' + Object.keys(knownTypes[typeKey]).sort().join(',') + '">' +
                         typeKey +
                         '</option>');

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -1112,11 +1112,11 @@ define([
                 var typeInput = $('<select class="form-control kb-import-filter">');
                 typeInput.append('<option>All types...</option>');
                 var typeKeys = Object.keys(knownTypes).sort();
-                for (var typeKey of typeKeys) {
+                typeKeys.forEach( function(typeKey) {
                     typeInput.append('<option data-type="' + Object.keys(knownTypes[typeKey]).sort().join(',') + '">' +
                         typeKey +
                         '</option>');
-                }
+                });
                 var typeFilter = $('<div class="col-sm-3">').append(typeInput);
 
                 // event for type dropdown

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -576,7 +576,7 @@ define([
                     })
                     .then(function (data) {
                         var dataTypes = {};
-                        data.forEach(datum => {
+                        data.forEach(function(datum) {
                           var match = datum[2].match(/([^.]+)\.([^-]+)/)
                           var module = match[1];
                           var type = match[2];

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -577,11 +577,13 @@ define([
                     .then(function (data) {
                         var dataTypes = {};
                         data.forEach(datum => {
-                          var [module, type] = datum[2].match(/([^.]+)\.([^-]+)/).slice(1,3);
+                          var match = datum[2].match(/([^.]+)\.([^-]+)/)
+                          var module = match[1];
+                          var type = match[2];
                           if (dataTypes[type] === undefined) {
                             dataTypes[type] = {};
                           }
-                          dataTypes[type][`${module}.${type}`] = true;
+                          dataTypes[type][module + '.' + type] = true;
                         });
                         knownTypes = dataTypes;
                         if (view === 'mine') {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -561,10 +561,9 @@ define([
                         */
                         if (a[3] > b[3])
                             return -1;
-                        else
                         return 1;
                     });
-                    console.log("DATA IS NOW :", data);
+                    
                     return data;
                 });
             }


### PR DESCRIPTION
This fixes Ticket KBASE-4756.

The filter list on the data panel only presented the type name to the user, but there are types which exist in multiple modules. As a result, filtering didn't work. If a user had a "KBaseAlpha.Foo" object, but the widget was filtering on "KBaseBeta.Foo", nothing would show up.

This change does a couple of things:
* It removes the hardwired list of types from the widget. It was incomplete and out of date.
* It dynamically builds a new list of types to present to the user, based upon the results of getAndRenderData. That way, the user will only see the option to filter to types that they have, instead of the massive list of all possible types.
* The filter list includes all modules in its filtering. So it'll show "Foo" in the dropdown, but actually filter on "KBaseAlpha.Foo" and "KBaseBeta.Foo", as well as any other "Foo" types in arbitrary modules that the user may have.

There may be other tickets that reference this issue. Kbase-5051 is tangentially related.