### PR TITLE
Fix Travis-CI testing

### DIFF
--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -74,10 +74,10 @@ module.exports = function (config) {
         singleRun: true,
         proxies: {
             '/narrative/static/': '/base/kbase-extension/static/',
-            '/narrative/static/base': 'http://localhost:9999/narrative/static/base',
-            '/narrative/static/notebook': 'http://localhost:9999/narrative/static/notebook',
-            '/narrative/static/components': 'http://localhost:9999/narrative/static/components',
-            '/narrative/static/services': 'http://localhost:9999/narrative/static/services',
+            '/narrative/static/base': 'http://localhost:32323/narrative/static/base',
+            '/narrative/static/notebook': 'http://localhost:32323/narrative/static/notebook',
+            '/narrative/static/components': 'http://localhost:32323/narrative/static/components',
+            '/narrative/static/services': 'http://localhost:32323/narrative/static/services',
             '/static/kbase/config': '/base/kbase-extension/static/kbase/config',
             '/test/': '/base/test/'
         }

--- a/test/unit/run_tests.py
+++ b/test/unit/run_tests.py
@@ -18,7 +18,7 @@ import os
 import signal
 
 KARMA_PORT = 9876
-JUPYTER_PORT = 9999
+JUPYTER_PORT = 32323
 
 argparser = argparse.ArgumentParser(
         description='Run KBase Narrative unit tests'
@@ -29,7 +29,7 @@ argparser.add_argument('-d', '--debug', action='store_true',
                        help="Whether to enter debug mode in Karma")
 options = argparser.parse_args(sys.argv[1:])
 
-nb_command = ['kbase-narrative', '--no-browser', '--NotebookApp.allow_origin="*"', '--port={}'.format(JUPYTER_PORT)]
+nb_command = ['kbase-narrative', '--no-browser', '--NotebookApp.allow_origin="*"', '--ip=127.0.0.1', '--port={}'.format(JUPYTER_PORT)]
 
 if not hasattr(sys, 'real_prefix'):
     nb_command[0] = 'narrative-venv/bin/kbase-narrative'
@@ -46,7 +46,7 @@ while 1:
     if not line:
         continue
     print(line)
-    if 'The Jupyter Notebook is running at: http://localhost:{}/'.format(JUPYTER_PORT) in line:
+    if 'The Jupyter Notebook is running at: http://127.0.0.1:{}/'.format(JUPYTER_PORT) in line:
         break
     if 'is already in use' in line:
         os.killpg(os.getpgid(nb_server.pid), signal.SIGTERM)


### PR DESCRIPTION
Apparently Travis-CI no longer likes the Jupyter notebook being started up on `localhost`, but it will handle `127.0.0.1`.

As of, like, Tuesday.

Hopefully this fixes it for the foreseeable future.