### PR TITLE
Staging panel updates

### DIFF
--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -19,6 +19,21 @@
     padding : 8px;
 }
 
+.kb-data-staging-metadata-list {
+  font-family : 'OxygenBold';
+  width : 115px;
+  display : inline-block;
+  font-size : 90%;
+}
+
+.kb-data-staging-metadata-file-lines {
+  white-space : pre;
+ overflow : scroll;
+ font-family : monospace;
+ font-size : 90%;
+ background-color : #DDDDDD
+}
+
 .kb-dropzone {
     border: 2px dashed #2196F3 !important;
     margin-bottom:5px;

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -10,6 +10,15 @@
     text-overflow: ellipsis;
 }
 
+.kb-data-staging-footer {
+    font-family : "OxygenBold", Arial, sans-serif;
+    font-size : 105%;
+    text-align : center;
+    background-color : #EEEEEE;
+    height : 32px;
+    padding : 8px;
+}
+
 .kb-dropzone {
     border: 2px dashed #2196F3 !important;
     margin-bottom:5px;

--- a/kbase-extension/static/kbase/js/api/StagingServiceClient.js
+++ b/kbase-extension/static/kbase/js/api/StagingServiceClient.js
@@ -19,6 +19,7 @@ define([
                 upload      : { method : 'post', path : 'upload' },
                 delete      : { method : 'delete', path : 'delete/${path}' },
                 rename      : { method : 'post', path : 'rename/${path}' },
+                decompress  : { method : 'patch', path : 'decompress/${path}' },
             }
         });
     };

--- a/kbase-extension/static/kbase/js/util/timeFormat.js
+++ b/kbase-extension/static/kbase/js/util/timeFormat.js
@@ -236,6 +236,7 @@ define([], function() {
      * edited from: http://stackoverflow.com/questions/3177836/how-to-format-time-since-xxx-e-g-4-minutes-ago-similar-to-stack-exchange-site
      */
     function getTimeStampStr (objInfoTimeStamp, alwaysExact) {
+
         var date = new Date(objInfoTimeStamp);
         var seconds = Math.floor((new Date() - date) / 1000);
         if (seconds < 0) {
@@ -298,6 +299,22 @@ define([], function() {
         return pluralizeTimeStr(Math.floor(seconds), 'second');
     }
 
+    // There was a request that the staging panel tighten up the display a little bit, which was using getTimeStampStr to format the age.
+    // So this function will just take the output of regular getTimeStampStr and shorten it up a little bit.
+    // * Replace "long" durations with shortened ones.
+    // * drop " ago" from the end.
+
+    function getShortTimeStampStr (objInfoTimeStamp, alwaysExact) {
+      var longTimeStampStr = getTimeStampStr(objInfoTimeStamp, alwaysExact);
+      longTimeStampStr = longTimeStampStr.replace(/month/, 'mon');
+      longTimeStampStr = longTimeStampStr.replace(/hour/, 'hr');
+      longTimeStampStr = longTimeStampStr.replace(/minute/, 'min');
+      longTimeStampStr = longTimeStampStr.replace(/second/, 'sec');
+      longTimeStampStr = longTimeStampStr.replace(/\s*ago\s*/, '');
+
+      return longTimeStampStr;
+    }
+
     /**
      * @private
      * @method
@@ -345,6 +362,7 @@ define([], function() {
         reformatDate: reformatDate,
         reformatISOTimeString: reformatISOTimeString,
         getTimeStampStr: getTimeStampStr,
+        getShortTimeStampStr : getShortTimeStampStr,
         readableTimestamp: readableTimestamp
     };
 });

--- a/kbase-extension/static/kbase/js/util/timeFormat.js
+++ b/kbase-extension/static/kbase/js/util/timeFormat.js
@@ -285,15 +285,15 @@ define([], function() {
             }
         }
         interval = Math.floor(seconds / 86400);
-        if (interval > 1) {
+        if (interval >= 1) {
             return pluralizeTimeStr(interval, 'day');
         }
         interval = Math.floor(seconds / 3600);
-        if (interval > 1) {
+        if (interval >= 1) {
             return pluralizeTimeStr(interval, 'hour');
         }
         interval = Math.floor(seconds / 60);
-        if (interval > 1) {
+        if (interval >= 1) {
             return pluralizeTimeStr(interval, 'minute');
         }
         return pluralizeTimeStr(Math.floor(seconds), 'second');

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -197,6 +197,7 @@ define([
                 })
                 .append('<span class="fa fa-arrow-right"></span>')
                 .click(function () {
+                    this.$slideoutBtn.children().toggleClass('fa-arrow-right fa-arrow-left');
                     this.$slideoutBtn.tooltip('hide');
                     this.trigger('hideGalleryPanelOverlay.Narrative');
                     this.trigger('toggleSidePanelOverlay.Narrative', this.$overlayPanel);
@@ -549,6 +550,7 @@ define([
             var serviceClient = new GenericClient(Config.url('service_wizard'), auth);
 
             closeBtn.click(function () {
+                self.$slideoutBtn.children().toggleClass('fa-arrow-right fa-arrow-left');
                 self.trigger('hideSidePanelOverlay.Narrative');
             });
             footer.append(closeBtn);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -69,6 +69,7 @@ define([
         },
 
         updateView: function() {
+        console.log("ELEM IS ", this.$elem);
             this.stagingServiceClient.list()
                 .then(function(data) {
                   var files = JSON.parse(data);
@@ -158,7 +159,7 @@ define([
                                 disp = '<button data-name="' + full[1] + '" class="btn btn-xs btn-default">' + disp + '</button>';
                             }
                             else {
-                              disp = "<i class='fa fa-caret-right' data-name='" + full[1] + "' style='cursor : pointer'></i> " + disp;
+                              disp = "<i class='fa fa-caret-right' data-caret='" + full[1] + "' style='cursor : pointer'></i> " + disp;
                             }
                             return disp;
                         } else {
@@ -170,8 +171,15 @@ define([
                     sClass: 'staging-name',
                     mRender: function(data, type, full) {
                         if (type === 'display') {
+
+                            var decompressButton = '';
+console.log("FULL IS ", full);
+                            if (data.match(/\.(zip|tar\.gz|tgz|tar\.bz|tar\.bz2|tar|gz|bz2)$/)) {
+                              decompressButton = " <button class='btn btn-default btn-xs' style='border : 1px solid #cccccc; border-radius : 1px' data-decompress='" + data + "'><i class='fa fa-expand'></i>";
+                            }
+
                             return '<div class="kb-data-staging-table-name">' + data
-                            //+ "<i style='margin-left : '10px' class='fa fa-expand'></i><i class='fa fa-binoculars'></i><i class='fa fa-trash'></i>"
+                              + decompressButton
                             + '</div>';
                         }
                         return data;
@@ -190,7 +198,7 @@ define([
                     aTargets: [ 3 ],
                     mRender: function(data, type) {
                         if (type === 'display') {
-                            return TimeFormat.getTimeStampStr(Number(data));
+                            return TimeFormat.getShortTimeStampStr(Number(data));
                         } else {
                             return data;
                         }
@@ -224,9 +232,9 @@ define([
                     $('td:eq(0)', nRow).find('button[data-name]').on('click', function(e) {
                         this.updatePathFn(this.path += '/' + $(e.currentTarget).data().name);
                     }.bind(this));
-
-                    $('td:eq(0)', nRow).find('i[data-name]').on('click', function(e) {
-                        var fileName = $(e.currentTarget).data().name;
+                    $('td:eq(0)', nRow).find('i[data-caret]').off('click');
+                    $('td:eq(0)', nRow).find('i[data-caret]').on('click', function(e) {
+                        var fileName = $(e.currentTarget).data().caret;
 
                         var myFile = getFileFromName(fileName);
 
@@ -235,14 +243,32 @@ define([
 
                         if ($(e.currentTarget).hasClass('fa-caret-down')) {
                           $('.kb-dropzone').css('min-height', '75px');
+                          $('.dz-message').css('margin', '0em 0');
                           $tr.after(
                             this.renderMoreFileInfo( myFile )
                           );
                         }
                         else {
                           $('.kb-dropzone').css('min-height', '200px');
+                          $('.dz-message').css('margin', '3em 0');
                           $tr.next().remove();
                         }
+                    }.bind(this));
+
+                    $('td:eq(1)', nRow).find('button[data-decompress]').off('click');
+                    $('td:eq(1)', nRow).find('button[data-decompress]').on('click', function(e) {
+                        var fileName = $(e.currentTarget).data().decompress;
+                        var myFile = getFileFromName(fileName);
+console.log("DECOMPRESSES : ", fileName, myFile);
+                        this.stagingServiceClient.decompress({ path : myFile.name })
+                            .then(function(data) {
+                              this.updateView();
+                            }.bind(this))
+                            .fail(function (xhr) {
+                              console.log("FAILED", xhr);
+                              alert(xhr.responseText);
+                            }.bind(this));
+
                     }.bind(this));
                 }.bind(this)
             });
@@ -259,11 +285,21 @@ define([
           }
 
           var $tabsDiv = $.jqElem('div')
+            .css({'width' : '90%', display : 'inline-block'})
             .append('Loading file info...please wait');
 
           this.stagingServiceClient.metadata({ path : fileData.name }).then( function(dataString, status, xhr) {
             $tabsDiv.empty();
             var data = JSON.parse(dataString);
+console.log("GOT ME BACK DATA : " , data);
+            var ulCSS = {
+              'font-family' : 'OxygenBold',
+              width : '115px',
+              display : 'inline-block',
+              'font-size' : '90%',
+            }
+
+            var linesCSS = {'white-space' : 'pre', 'overflow' : 'scroll', 'font-family' : 'monospace', 'font-size' : '90%', 'background-color' : '#DDDDDD'};
 
             var $tabs = new KBaseTabs($tabsDiv, {
               tabs : [
@@ -271,23 +307,24 @@ define([
                   tab : 'Info',
                   content :
                     $.jqElem('ul')
-                      .append( $.jqElem('li').append($.jqElem('span').css({'font-weight' : 'bold', width : '115px', display : 'inline-block'}).append('Name : ')).append(data.name) )
-                      .append( $.jqElem('li').append($.jqElem('span').css({'font-weight' : 'bold', width : '115px', display : 'inline-block'}).append('Created : ')).append(TimeFormat.reformatDate(new Date(data.mtime)) ) )
-                      .append( $.jqElem('li').append($.jqElem('span').css({'font-weight' : 'bold', width : '115px', display : 'inline-block'}).append('Size : ')).append(StringUtil.readableBytes(Number(data.size)) ) )
-                      .append( $.jqElem('li').append($.jqElem('span').css({'font-weight' : 'bold', width : '115px', display : 'inline-block'}).append('Line Count : ')).append(data.lineCount ) )
-                      .append( $.jqElem('li').append($.jqElem('span').css({'font-weight' : 'bold', width : '115px', display : 'inline-block'}).append('MD5 : ')).append(data.md5 ) )
-                      //.append( $.jqElem('li').append('Imported : ' + data.imported) )
+                      .css('list-style', 'none')
+                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Name')).append(data.name) )
+                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Created')).append(TimeFormat.reformatDate(new Date(data.mtime)) ) )
+                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Size')).append(StringUtil.readableBytes(Number(data.size)) ) )
+                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Line Count')).append(parseInt(data.lineCount).toLocaleString() ) )
+                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('MD5')).append(data.md5 ) )
+                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Imported as')).append(data.UPA ) )
                 },
                 {
                   tab : 'First 10 lines',
                   content : $.jqElem('div')
-                    .css({'white-space' : 'pre', 'overflow' : 'scroll'})
+                    .css(linesCSS)
                     .append( data.head )
                 },
                 {
                   tab : 'Last 10 lines',
                   content : $.jqElem('div')
-                    .css({'white-space' : 'pre', 'overflow' : 'scroll'})
+                    .css(linesCSS)
                     .append( data.tail )
                 }
               ]
@@ -306,9 +343,14 @@ define([
           return fileData.loaded = $.jqElem('tr')
             .append(
               $.jqElem('td')
+                .attr('colspan', 5)
+                .css('vertical-align', 'top')
+                .append($tabsDiv)
                 .append(
-                  $.jqElem('i')
-                    .addClass('fa fa-trash')
+                  $.jqElem('button')
+                    .css({'float' : 'right', border : '1px solid #CCCCCC', 'border-radius' : '2px'})
+                    .addClass('btn btn-default btn-xs')
+                    .tooltip({ title : 'Delete ' + fileData.name })
                     .on('click', function(e) {
                       if (window.confirm('Really delete file ' + fileData.name + '?')) {
                         this.stagingServiceClient.delete({ path : fileData.name}).then(function(d,s,x) {
@@ -321,17 +363,13 @@ define([
                               .addClass('alert alert-danger')
                               .append('Error ' + xhr.status + '<br/>' + xhr.responseText)
                           );
-                        }.bind(this));
+                        }.bind(this))
                       }
                     }.bind(this))
+                  .append($.jqElem('i').addClass('fa fa-trash'))
+
                 )
             )
-            .append(
-              $.jqElem('td')
-                .attr('colspan', 4)
-                .append($tabsDiv)
-            );
-
         },
 
         initImportApp: function(type, file) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -296,14 +296,9 @@ define([
             $tabsDiv.empty();
             var data = JSON.parse(dataString);
 
-            var ulCSS = {
-              'font-family' : 'OxygenBold',
-              width : '115px',
-              display : 'inline-block',
-              'font-size' : '90%',
-            }
-
-            var linesCSS = {'white-space' : 'pre', 'overflow' : 'scroll', 'font-family' : 'monospace', 'font-size' : '90%', 'background-color' : '#DDDDDD'};
+            var $upa = data.UPA
+              ? $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Imported as')).append(data.UPA )
+              : '';
 
             var $tabs = new KBaseTabs($tabsDiv, {
               tabs : [
@@ -312,23 +307,23 @@ define([
                   content :
                     $.jqElem('ul')
                       .css('list-style', 'none')
-                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Name')).append(data.name) )
-                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Created')).append(TimeFormat.reformatDate(new Date(data.mtime)) ) )
-                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Size')).append(StringUtil.readableBytes(Number(data.size)) ) )
-                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Line Count')).append(parseInt(data.lineCount).toLocaleString() ) )
-                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('MD5')).append(data.md5 ) )
-                      .append( $.jqElem('li').append($.jqElem('span').css(ulCSS).append('Imported as')).append(data.UPA ) )
+                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Name')).append(data.name) )
+                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Created')).append(TimeFormat.reformatDate(new Date(data.mtime)) ) )
+                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Size')).append(StringUtil.readableBytes(Number(data.size)) ) )
+                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Line Count')).append(parseInt(data.lineCount).toLocaleString() ) )
+                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('MD5')).append(data.md5 ) )
+                      .append( $upa )
                 },
                 {
                   tab : 'First 10 lines',
                   content : $.jqElem('div')
-                    .css(linesCSS)
+                    .addClass('kb-data-staging-metadata-file-lines')
                     .append( data.head )
                 },
                 {
                   tab : 'Last 10 lines',
                   content : $.jqElem('div')
-                    .css(linesCSS)
+                    .addClass('kb-data-staging-metadata-file-lines')
                     .append( data.tail )
                 }
               ]

--- a/kbase-extension/static/kbase/templates/data_staging/ftp_file_table.html
+++ b/kbase-extension/static/kbase/templates/data_staging/ftp_file_table.html
@@ -32,3 +32,6 @@
     {{/each}}
     </tbody>
 </table>
+<div class='kb-data-staging-footer'>
+    All files will be deleted after 90 days
+</div>

--- a/test/unit/spec/Util/TimeFormatSpec.js
+++ b/test/unit/spec/Util/TimeFormatSpec.js
@@ -35,6 +35,69 @@ define ([
             expect(d).toBe('2 days ago');
         });
 
+        it('getTimeStampStr should return a fuzzy relative time string @ 2 days 2 hours', function() {
+            var prevDay = new Date();
+            prevDay.setDate(prevDay.getDate()-2);
+            prevDay.setHours(prevDay.getHours()-2);
+            var d = TF.getTimeStampStr(prevDay, false);
+            expect(d).toBe('2 days ago');
+        });
+
+        it('getTimeStampStr should return a fuzzy relative time string @ 1 day', function() {
+            var prevDay = new Date();
+            prevDay.setDate(prevDay.getDate()-1);
+            var d = TF.getTimeStampStr(prevDay, false);
+            expect(d).toBe('1 day ago');
+        });
+
+        it('getTimeStampStr should return a fuzzy relative time string @ 1 hour', function() {
+            var prevDay = new Date();
+            prevDay.setHours(prevDay.getHours()-1);
+            var d = TF.getTimeStampStr(prevDay, false);
+            expect(d).toBe('1 hour ago');
+        });
+
+        it('getTimeStampStr should return a fuzzy relative time string @ 1 minute', function() {
+            var prevDay = new Date();
+            prevDay.setMinutes(prevDay.getMinutes()-1);
+            var d = TF.getTimeStampStr(prevDay, false);
+            expect(d).toBe('1 minute ago');
+        });
+
+        it('getShortTimeStampStr should properly output an exact time string', function() {
+            var d = TF.getShortTimeStampStr(testISOTime, true);
+            expect(d).toBe(testExactDayStr);
+        });
+
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 2 mons ]', function() {
+            var prevDay = new Date();
+            prevDay.setMonth(prevDay.getMonth()-2);
+            var d = TF.getShortTimeStampStr(prevDay, false);
+            expect(d).toBe('2 mons');
+        });
+
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 1 hr ]', function() {
+            var prevDay = new Date();
+            prevDay.setHours(prevDay.getHours()-1);
+            var d = TF.getShortTimeStampStr(prevDay, false);
+            expect(d).toBe('1 hr');
+        });
+
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 3 mins ]', function() {
+            var prevDay = new Date();
+            prevDay.setSeconds(prevDay.getSeconds()-5);
+            var d = TF.getShortTimeStampStr(prevDay, false);
+            expect(d).toBe('5 secs');
+        });
+
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 5 secs ]', function() {
+            var prevDay = new Date();
+            prevDay.setMinutes(prevDay.getMinutes()-3);
+            var d = TF.getShortTimeStampStr(prevDay, false);
+            expect(d).toBe('3 mins');
+        });
+
+
         it('parseDate should properly parse an ISO date string', function() {
             var d = TF.parseDate(testISOTime);
             expect(d).toEqual(jasmine.any(Object));


### PR DESCRIPTION
This integrates changes from the feedback doc here:
https://docs.google.com/document/d/1LLhFVipqMRkZ16IGFwwbKeX5-VDecMkombH1hk-6_2g/edit#

* Age is now rendered with "short" names, i.e. "88 secs" instead of "88 seconds ago"
* The remove button is moved to the right, and framed in a button. Still inside the expanded area, though.
* Changed formatting of Info field - bolded text, changed size, removed colons, added commas to line count.
* first 10 / last 10 are in a slightly different gray and monospace font
* fixed the bug that could cause metadata to not appear if sorted
* added the decompression button, which only shows up for files assumed to be compressed.
* Added "All files will be deleted after 90 days" footer.

errata -
* I also added a change to swap the directional arrow on the data panel. It's not *quite* perfect, since the uploader button won't toggle it back. But it's real close. I'll roll it back if we don't want it.
* I was unable to reproduce the first 10 / last 10 unresponsiveness.
* I left it so that it remains open unless explicitly closed, due to ambiguousness of request. Will revisit if we're sure we want to do this.
* I'm confirming with Josh, but it sounds like the "Imported as" metadata item (which lists any UPAs the file was inserted into) won't work without updates to the importers to add the metadata. So the field is there, but I think the importers need to be updated to populate it. Will re-visit if I was mistaken and the widget can address it.