### PR TITLE
resolves [KBASE-5410]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -357,8 +357,6 @@ define([
               $upaField.append(xhr.error.message);
             });
 
-console.log("DATA IS : ", data);
-
             var lineCount = parseInt(data.lineCount, 10);
             if (!Number.isNaN(lineCount)) {
               lineCount = lineCount.toLocaleString()

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -17,6 +17,7 @@ define([
     'text!kbase/templates/data_staging/ftp_file_header.html',
     'text!kbase/templates/data_staging/file_path.html',
     'kb_service/client/workspace',
+    'api/auth',
     'jquery-dataTables',
     'select2',
 ], function(
@@ -37,7 +38,8 @@ define([
     FtpFileTableHtml,
     FtpFileHeaderHtml,
     FilePathHtml,
-    Workspace
+    Workspace,
+    Auth
 ) {
     'use strict';
     return new KBWidget({
@@ -64,6 +66,22 @@ define([
             this.updatePathFn = options.updatePathFn || this.setPath;
             this.uploaders = Config.get('uploaders');
             this.userId = runtime.userId();
+
+            var self = this; // GAH I miss fat arrow functions.
+            this.authClient = Auth.make({url: Config.url('auth')});
+            this.authClient.getCurrentProfile( runtime.authToken() ).then( function(res) {
+
+              // check out the identities available for the user - if globus is a provider, then hang onto the user name and re-render the page.
+              res.idents.forEach( function(i) {
+                if (i.provider === 'Globus') {
+                  self.globus_name = res.user;
+                  this.render();
+                }
+              });
+            })
+            .catch(function(xhr) {
+              // we really don't care here, honestly. If the auth service fails, it'll just prevent the globus link from showing up.
+            });
 
             // Get this party started.
             this.setPath(options.path);
@@ -115,6 +133,16 @@ define([
 
         renderFileHeader: function() {
             this.$elem.append(this.ftpFileHeaderTmpl());
+
+            if (this.globus_name) {
+              var $globus_link = this.$elem.find('.globus_link');
+              var href = $globus_link.attr('href');
+              href += this.globus_name;
+              $globus_link.attr('href', href);
+            }
+            else {
+              this.$elem.find('.globus_div').remove();
+            }
             this.$elem.find('button#help').click(function() {
                 this.startTour();
             }.bind(this));
@@ -329,7 +357,15 @@ define([
               $upaField.append(xhr.error.message);
             });
 
+console.log("DATA IS : ", data);
 
+            var lineCount = parseInt(data.lineCount, 10);
+            if (!Number.isNaN(lineCount)) {
+              lineCount = lineCount.toLocaleString()
+            }
+            else {
+              lineCount = 'Not provided';
+            }
 
             var $tabs = new KBaseTabs($tabsDiv, {
               tabs : [
@@ -341,8 +377,8 @@ define([
                       .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Name')).append(data.name) )
                       .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Created')).append(TimeFormat.reformatDate(new Date(data.mtime)) ) )
                       .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Size')).append(StringUtil.readableBytes(Number(data.size)) ) )
-                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Line Count')).append(parseInt(data.lineCount).toLocaleString() ) )
-                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('MD5')).append(data.md5 ) )
+                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('Line Count')).append( lineCount ) )
+                      .append( $.jqElem('li').append($.jqElem('span').addClass('kb-data-staging-metadata-list').append('MD5')).append(data.md5 || 'Not provided' ) )
                       .append( $upa )
                 },
                 {

--- a/kbase-extension/static/kbase/templates/data_staging/ftp_file_header.html
+++ b/kbase-extension/static/kbase/templates/data_staging/ftp_file_header.html
@@ -1,8 +1,8 @@
 <div class="row" style="margin-bottom: 5px">
-    <div class="pull-left">
+    <div class="pull-left globus_div">
         Or upload to this staging area by using
         <a href="https://www.globus.org/app/transfer?destination_id=3aca022a-5e5b-11e6-8309-22000b97daec&destination_path=%2F"
-           target="_blank">
+           target="_blank" class="globus_link">
             <i class="fa fa-cloud-upload"></i> Globus Online
         </a>
     </div>


### PR DESCRIPTION
This tacks on the KBase username to the globus link.

It also hides the globus link entirely if the user doesn't have globus as a provider. We may want to re-visit this to instead display a "signup for globus link" instead.

Also brings along two minor tweaks to the metadata - there's apparently a bug in the service wherein it may not hand back a line count or md5, this just adds some extra prettiness to the user to change the blank or NaN into "Not provided".