### PR TITLE
adds contents of metadata file to metadata tab [STC-284]

### DIFF
--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -31,7 +31,8 @@
  overflow : scroll;
  font-family : monospace;
  font-size : 90%;
- background-color : #DDDDDD
+ background-color : #DDDDDD;
+ max-height : 200px;
 }
 
 .kb-dropzone {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -327,7 +327,14 @@ define([
           if (filePath.length) {
               filePath += '/';
           }
+
+          // we need to chop up the file to see if a metadata file exists. Assume that the first part of the file name is the ID
+          // and that it ends in .metadata. Route it into the appropriate subfolder.
+          var fileParts = fileData.name.split('.');
+          var metaDataFilePath = filePath + fileParts[0] + '.metadata';
+
           filePath += fileData.name;
+
           this.stagingServiceClient.metadata({ path : filePath }).then( function(dataString, status, xhr) {
             $tabsDiv.empty();
             var data = JSON.parse(dataString);
@@ -394,8 +401,37 @@ define([
               ]
             });
 
+            // if the metaDataFilePath is not our file (i.e., the user didn't click on a metadata file, then we want to extract out that metadata file itself.
+            // We can't do it in parallel, since if the metadata file doesn't exist the promise wouldn't properly complete. The net effect is a quick blink
+            // wherein the table loads and a split second later we get the metadata tab.
+            if (filePath !== metaDataFilePath) {
+              self.stagingServiceClient.metadata({ path : metaDataFilePath }).then( function(dataString, status, xhr) {
+                var metadataFile = JSON.parse(dataString);
+                // these files are always a single line, so the head will contain the contents.
+                // but we parse it out and re-stringify it so it's pretty.
+                // XXX - while doing this, I ran into a NaN issue in the file, specifically on the key illumina_read_insert_size_avg_insert.
+                //       So we nuke any NaN fields to make it valid again.
+                var metadataJSON = JSON.parse(metadataFile.head.replace(/NaN/g, '\"\"'));
+                var metadataContents = JSON.stringify(metadataJSON, null, 2)
+
+                $tabs.addTab(
+                  {
+                    tab : 'Metadata',
+                    content : $.jqElem('div')
+                      .addClass('kb-data-staging-metadata-file-lines')
+                      .append( metadataContents )
+                  }
+                );
+              })
+              .fail(function(xhr) {
+                // Don't actually need to do anything here - we assume that if it failed, it was due to the metadata file not existing. Yes, we generate
+                // a lot of messy extra metadata calls here since it's the only way to know if there's metadata is to look.
+              });
+            }
+
           })
           .fail(function (xhr) {
+            console.log("FAILED TO LOAD METADATA : ", fileData, xhr);
             $tabsDiv.empty();
             $tabsDiv.append(
               $.jqElem('div')


### PR DESCRIPTION
This will add an additional tab to populate file metadata, if it exists.

Notes:
* It manually finds the metadata file by looking at the first part of the filename before the first period, and then appends ".metadata" to the end. So that if your file is "foo.bar.baz.fasta.gz", it'll look for a metadata file called "foo.metadata". This is reasonably brittle, in that if the naming convention changes it won't find metadata. Arguably, this should be wrapped up into the staging service client, but as of yet this is the only way to get at it.

* It was mentioned on the call yesterday that metadata files will no longer be visible to the user - we need to make sure that this method still works even if the metadata files cannot be seen. If not, then we're back to what was said above about adding it into the service call itself.

* While testing, I discovered an issue with a NaN in the JSON, which is elaborated upon here: https://kbase.slack.com/archives/C4E7KUGTD/p1513782220000601

* There's a momentary blink before the metadata shows up, since it's two requests which happen in parallel. Again, I don't have a good way to fix this unless it's added into the service as an explicit key associated with the original file's metadata.

* If the metadata is created with line breaks, this method will fail. It assumes all contents are on the first line.

* The original ticket alluded to a "jgi_metadta" key, which I didn't see. This just dumps out the entire metadata file on a tab called "Metadata", assuming one exists as per the conditions up above.