### PR TITLE
add 'is_temporary' field to saved narrative objects, not just workspace metadata

### DIFF
--- a/src/biokbase/narrative/contents/narrativeio.py
+++ b/src/biokbase/narrative/contents/narrativeio.py
@@ -144,7 +144,7 @@ class KBaseWSManagerMixin(object):
         self._test_obj_ref(obj_ref)
         try:
             if content:
-                nar_data = self.ws_client().get_objects([{'ref':obj_ref}])
+                nar_data = self.ws_client().get_objects([{'ref': obj_ref}])
                 if nar_data:
                     nar = nar_data[0]
                     nar['data'] = update_narrative(nar['data'])
@@ -211,6 +211,7 @@ class KBaseWSManagerMixin(object):
                 meta[u'job_ids'][u'apps'] = list()
             if 'job_usage' not in meta[u'job_ids']:
                 meta[u'job_ids'][u'job_usage'] = {u'queue_time': 0, u'run_time': 0}
+            meta[u'is_temporary'] = 'false'
             meta[u'format'] = u'ipynb'
 
             if len(meta[u'name']) > MAX_METADATA_STRING_BYTES - len(u'name'):


### PR DESCRIPTION
All this needs to do from here (other work is in kbaseapps/NarrativeService) is to ensure that there's an "is_temporary" field in the saved object metadata, and it's set to "false" on save.

The user should be prevented from saving an "untitled" narrative elsewhere.