### PR TITLE
Update to use jgi-metadata method [SCT-284]

### DIFF
--- a/kbase-extension/static/kbase/js/api/StagingServiceClient.js
+++ b/kbase-extension/static/kbase/js/api/StagingServiceClient.js
@@ -16,6 +16,7 @@ define([
                 list        : { method : 'get', path : 'list/${path}?${type}' },
                 search      : { method : 'get', path : 'search/${query}' },
                 metadata    : { method : 'get', path : 'metadata/${path}' },
+                jgi_metadata: { method : 'get', path : 'jgi-metadata/${path}' },
                 upload      : { method : 'post', path : 'upload' },
                 delete      : { method : 'delete', path : 'delete/${path}' },
                 rename      : { method : 'post', path : 'rename/${path}' },


### PR DESCRIPTION
We now have a jgi-metadata endpoint to vend back jgi-metadata files.

So the logic is the same as before - when the expanded view on a file is opened, it attempts to load jgi metadata. If any is found, it is tossed into a new tab, now named "JGI Metadata" instead of just "Metadata".

While I was at it, I slowed down the load by a fraction of a second but got rid of the "JGI Metadata" tab blinking into view after the other tabs. I felt this was the lesser of the evils.

IMPORTANT NOTE - this is explicitly *not* backwards compatible with older styles of storing jgi metadata. Previously, the importer would create a second file with a .metadata extension (foo.jgi.fasta and foo.jgi.metadata), and the frontend would look for that file. It doesn't do that any more. So any older imports would not get the JGI tab automatically. A user could still get at the metadata (though not pretty-printed) by opening the extended view on the metadata file, looking at the first 10 lines, and copying and pasting.

Newer files (from the last 22 days onward, at least) function properly.