### PR TITLE
SCT-401 Inject the correct auth token on kernel restart

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,15 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 
+### Version 3.6.1
+- SCT-533 - Remove the accidental test uploader that crept into production.
+- SCT-516 - Set staging panel to auto-refresh after various updates.
+- SCT-531 - Updated App Panel to have the same category names as the external App Catalog.
+- Added fungal genomes as a Public Data option.
+- Added Phytozome plant genomes as a Public Data option.
+- Repaired somewhat broken Doman Annotation viewer.
+- Text fixes to Import Tab tour.
+
 ### Version 3.6.0
 - SCT-400 - Deprecates the old Import panel, change text from "Staging (beta)" -> "Import (new)"
 - SCT-417
@@ -17,7 +26,6 @@ This is built on the Jupyter Notebook v4.4.1 (more notes will follow).
 - SCT-291 - Initial addition of tools for programmatically accessing the FTP file staging area.
 - SCT-405 - Custom compounds will now display properly in the media viewer.
 - KBASE-5417 - Fix long strings not wrapping correctly when showing object metadata in the Data panel.
-
 
 ### Version 3.5.2
 - PTV-682 - Fix problem with rendering a Pangenome widget in a copied Narrative.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "homepage": "https://kbase.us",
   "dependencies": {
     "bluebird": "3.4.7",

--- a/kbase-extension/static/custom/custom.js
+++ b/kbase-extension/static/custom/custom.js
@@ -146,7 +146,7 @@ define([
     $([Jupyter.events]).on('kernel_ready.Kernel', function () {
         Jupyter.notebook.kernel.execute(
             'import os;' +
-            'os.environ["KB_AUTH_TOKEN"]="' + Jupyter.narrative.authToken + '";' +
+            'os.environ["KB_AUTH_TOKEN"]="' + Jupyter.narrative.getAuthToken() + '";' +
             'os.environ["KB_WORKSPACE_ID"]="' + Jupyter.notebook.metadata.ws_name + '"'
         );
     });

--- a/kbase-extension/static/kbase/js/common/runtime.js
+++ b/kbase-extension/static/kbase/js/common/runtime.js
@@ -56,7 +56,7 @@ define([
         // These are still module scope
 
         function authToken() {
-            return Jupyter.narrative.authToken;
+            return Jupyter.narrative.getAuthToken();
         }
 
         function userId() {

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -150,6 +150,10 @@ define([
         return this;
     };
 
+    Narrative.prototype.getAuthToken = function () {
+        return NarrativeLogin.getAuthToken();
+    };
+
     /**
      * A wrapper around the Jupyter.notebook.kernel.execute() function.
      * If any KBase widget needs to make a kernel call, it should go through here.
@@ -356,7 +360,7 @@ define([
                 self.documentVersionInfo = docInfo;
             }
             else {
-                var workspace = new Workspace(Config.url('workspace'), {token: self.authToken});
+                var workspace = new Workspace(Config.url('workspace'), {token: self.getAuthToken()});
                 Promise.resolve(workspace.get_object_info_new({
                     'objects': [{'ref': self.workspaceRef}],
                     'includeMetadata': 1
@@ -661,7 +665,7 @@ define([
         // NAR-271 - Firefox needs to be told where the top of the page is. :P
         window.scrollTo(0, 0);
 
-        this.authToken = NarrativeLogin.sessionInfo.token;
+        this.authToken = NarrativeLogin.getAuthToken();
         this.userId = NarrativeLogin.sessionInfo.user;
 
         Jupyter.narrative.patchKeyboardMapping();

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -710,20 +710,20 @@ define([
                 this.loadingWidget.updateProgress('apps', true);
             }.bind(this));
 
+            // Tricky with inter/intra-dependencies between kbaseNarrative and kbaseNarrativeWorkspace...
+            this.narrController = new KBaseNarrativeWorkspace($('#notebook_panel'), {
+                ws_id: this.getWorkspaceName()
+            });
+            this.sidePanel = new KBaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
+
             this.updateDocumentVersion()
                 .then(function() {
                     // init the controller
-                    // Tricky with inter/intra-dependencies between kbaseNarrative and kbaseNarrativeWorkspace...
-                    this.narrController = new KBaseNarrativeWorkspace($('#notebook_panel'), {
-                        ws_id: this.getWorkspaceName()
-                    });
-                    this.sidePanel = new KBaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
                     return this.narrController.render();
                 }.bind(this))
                 .finally(function () {
                     this.sidePanel.render();
                 }.bind(this));
-
 
             // Disable autosave so as not to spam the Workspace.
             Jupyter.notebook.set_autosave_interval(0);

--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -68,20 +68,20 @@ define ([
     function showTokenInjectionDialog() {
         var $inputField = $('<input type="text" class="form-control">');
         var $body = $('<div>')
-                    .append('<div>You appear to be working on a local development environment of the Narrative Interface, but you don\'t have a valid auth token. You can paste one in below.</div>')
-                    .append('<div><b>You are operating in the ' + Config.get('environment') + ' environment.')
-                    .append($('<div>').append($inputField));
+            .append('<div>You appear to be working on a local development environment of the Narrative Interface, but you don\'t have a valid auth token. You can paste one in below.</div>')
+            .append('<div><b>You are operating in the ' + Config.get('environment') + ' environment.')
+            .append($('<div>').append($inputField));
         var dialog = new BootstrapDialog({
             'title': 'Insert an authentication token?',
             'body': $body,
             'buttons': [$('<a type="button" class="btn btn-default">')
-                        .append('OK')
-                        .click(function () {
-                            dialog.hide();
-                            var newToken = $inputField.val();
-                            authClient.setAuthToken(newToken);
-                            location.reload();
-                        })]
+                .append('OK')
+                .click(function () {
+                    dialog.hide();
+                    var newToken = $inputField.val();
+                    authClient.setAuthToken(newToken);
+                    location.reload();
+                })]
         });
         dialog.show();
     }
@@ -90,12 +90,14 @@ define ([
         var dialog = new BootstrapDialog({
             'title': 'Not Logged In',
             'body': $('<div>').append('You are not logged in (or your session has expired), and you will be redirected to the sign in page shortly.'),
-            'buttons': [$('<a type="button" class="btn btn-default">')
-                        .append('OK')
-                        .click(function () {
-                            dialog.hide();
-                            ipythonLogout();
-                        })]
+            'buttons': [
+                $('<a type="button" class="btn btn-default">')
+                    .append('OK')
+                    .click(function () {
+                        dialog.hide();
+                        ipythonLogout();
+                    })
+            ]
         });
         dialog.show();
     }
@@ -104,18 +106,20 @@ define ([
         var dialog = new BootstrapDialog({
             'title': 'Expiring session',
             'body': $('<div>').append('Your authenticated KBase session will expire in approximately 5 minutes. To continue using KBase, we suggest you log out and back in.'),
-            'buttons': [$('<a type="button" class="btn btn-default">')
-                        .append('OK')
-                        .click(function () {
-                            var remainingTime = tokenExpirationTime - new Date().getTime();
-                            if (remainingTime < 0) {
-                                remainingTime = 0;
-                            }
-                            tokenWarningTimer = setTimeout(function() {
-                                tokenTimeout();
-                            });
-                            dialog.hide();
-                        })]
+            'buttons': [
+                $('<a type="button" class="btn btn-default">')
+                    .append('OK')
+                    .click(function () {
+                        var remainingTime = tokenExpirationTime - new Date().getTime();
+                        if (remainingTime < 0) {
+                            remainingTime = 0;
+                        }
+                        tokenWarningTimer = setTimeout(function() {
+                            tokenTimeout();
+                        });
+                        dialog.hide();
+                    })
+            ]
         });
         dialog.show();
     }
@@ -152,19 +156,19 @@ define ([
             if (validateOnCheck) {
                 console.warn('Revalidating token after sleeping for ' + (lastCheckInterval/1000) + 's');
                 authClient.validateToken(token)
-                .then(function(info) {
-                    if (info === true) {
-                        console.warn('Auth is still valid. Carry on.');
-                    } else {
-                        console.warn('Auth is invalid! Logging out.');
-                        tokenTimeout(true);
-                    }
-                    validateOnCheck = false;
-                })
-                .catch(function(error) {
-                    console.error('Error while validating token after sleep. Trying again...');
-                    console.error(error);
-                });
+                    .then(function(info) {
+                        if (info === true) {
+                            console.warn('Auth is still valid. Carry on.');
+                        } else {
+                            console.warn('Auth is invalid! Logging out.');
+                            tokenTimeout(true);
+                        }
+                        validateOnCheck = false;
+                    })
+                    .catch(function(error) {
+                        console.error('Error while validating token after sleep. Trying again...');
+                        console.error(error);
+                    });
             }
             lastCheckTime = new Date().getTime();
         }, 1000);
@@ -215,6 +219,10 @@ define ([
         }
     }
 
+    function getAuthToken() {
+        return authClient.getAuthToken();
+    }
+
     function init($elem) {
         /* Flow.
          * 1. Get cookie. If present and valid, yay. If not, dialog / redirect to login page.
@@ -260,6 +268,7 @@ define ([
 
     return {
         init: init,
-        sessionInfo: sessionInfo
+        sessionInfo: sessionInfo,
+        getAuthToken: getAuthToken
     };
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -27,6 +27,7 @@ define([
     'narrative_core/catalog/kbaseCatalogBrowser',
     'kbase/js/widgets/narrative_core/kbaseAppCard',
     'util/bootstrapAlert',
+    'common/runtime',
     'kbaseNarrative',
     'catalog-client-api',
     'kbase-client-api',
@@ -48,7 +49,8 @@ define([
     Uuid,
     KBaseCatalogBrowser,
     kbaseAppCard,
-    BootstrapAlert
+    BootstrapAlert,
+    Runtime
 ) {
     'use strict';
     return KBWidget({
@@ -420,7 +422,7 @@ define([
             }
 
             this.methClient = new NarrativeMethodStore(this.options.methodStoreURL);
-            this.catalog = new Catalog(this.options.catalogURL, {token: Jupyter.narrative.authToken});
+            this.catalog = new Catalog(this.options.catalogURL, {token: Runtime.make().authToken()});
             this.refreshFromService();
             return this;
         },
@@ -923,11 +925,11 @@ define([
         buildAppItem: function(app) {
             /**
              app.info:
-                authors:["rsutormin"], categories:["annotation"], icon:{url:}, id: str, 
-                input_types: ['KbaseGenomeAnnotations.Assembly'], module_name: str, 
+                authors:["rsutormin"], categories:["annotation"], icon:{url:}, id: str,
+                input_types: ['KbaseGenomeAnnotations.Assembly'], module_name: str,
                 name: str, namespace: str, output_types:["KBaseGenomes.Genome"],
                 subtitle: str, tooltip: str, ver: str
-             * 
+             *
             */
             var self = this;
 
@@ -951,7 +953,7 @@ define([
                         .append('more...')
                         .attr('target', '_blank')
                         .attr('href', moreLink)));
-  
+
             var $card = kbaseAppCard.apply(this, [
                 {
                     createdBy:false,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -34,6 +34,7 @@ define([
     'kbase-generic-client-api',
     'util/bootstrapDialog',
     'kbase/js/widgets/narrative_core/kbaseDataCard',
+    'common/runtime',
     'bootstrap'
 ], function (
     KBWidget,
@@ -52,7 +53,8 @@ define([
     kbaseNarrativeStagingDataTab,
     GenericClient,
     BootstrapDialog,
-    kbaseDataCard
+    kbaseDataCard,
+    Runtime
 ) {
     'use strict';
 
@@ -545,7 +547,7 @@ define([
             }
 
             // It is silly to invoke a new object for each widget
-            var auth = {token: Jupyter.narrative.authToken};
+            var auth = {token: Runtime.make().authToken()};
             var ws = new Workspace(this.options.workspaceURL, auth);
             var serviceClient = new GenericClient(Config.url('service_wizard'), auth);
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobsPanel.js
@@ -665,7 +665,7 @@ define([
 
             Promise.try(function () {
                 if (curUser !== owner) {
-                    var wsClient = new Workspace(Config.url('workspace'), { token: Jupyter.narrative.authToken });
+                    var wsClient = new Workspace(Config.url('workspace'), { token: this.runtime.authToken() });
                     return Promise.resolve(wsClient.get_permissions({
                             id: Jupyter.narrative.workspaceId
                         }))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbase-narrative-core",
   "description": "Core components for the KBase Narrative Interface",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager']
 
 from semantic_version import Version
-__version__ = Version("3.6.0")
+__version__ = Version("3.6.1")
 version = lambda: __version__
 
 # if run directly:

--- a/src/config.json
+++ b/src/config.json
@@ -248,5 +248,5 @@
         "showDelay": 750
     },
     "use_local_widgets": true,
-    "version": "3.6.0"
+    "version": "3.6.1"
 }

--- a/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
@@ -17,7 +17,7 @@ define([
         var $dummyNode = $('<div>'),
             stagingWidget;
         beforeEach(function() {
-            Jupyter.narrative = { userId: 'fakeUser' };
+            Jupyter.narrative = { userId: 'fakeUser', getAuthToken: function() { return 'fakeToken'; } };
             stagingWidget = new StagingDataTab($dummyNode);
         });
 


### PR DESCRIPTION
It was using a somewhat hidden, cached copy instead of straight from the browser cookie. Now, when the kernel restarts, it should do so with the browser's cookie, which should be up to date.