### PR TITLE
added auto-refreshing of staging panel [SCT-516]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -201,6 +201,11 @@ define([
                     this.$slideoutBtn.tooltip('hide');
                     this.trigger('hideGalleryPanelOverlay.Narrative');
                     this.trigger('toggleSidePanelOverlay.Narrative', this.$overlayPanel);
+
+                    // NOTE - this will be missed and a widget will remain active if the panel is closed by means other than clicking this button.
+                    // This should be re-visited at some point.
+                    this.deactivateLastRenderedPanel();
+
                     //once we've clicked it 10 times, meaning we've open and shut the browser 5x, we reveal its TRUE NAME.
                     if (++numDataBrowserClicks >= 10) {
                       this.$slideoutBtn.attr('data-original-title', 'Hide / Show Slidey McSliderface')
@@ -244,29 +249,45 @@ define([
             this.isLoggedIn = true;
             if (this.ws_name) {
                 this.importerThing = this.dataImporter(this.ws_name);
-                this.renderFn = [
-                    function () {
+
+                this.tabMapping = [
+                  {
+                    widget : this.importerThing,
+                    render : function () {
                         this.importerThing.updateView('mine', this.ws_name);
                     }.bind(this),
-                    function () {
+                  },
+                  {
+                    widget : this.importerThing,
+                    render : function () {
                         this.importerThing.updateView('shared', this.ws_name);
                     }.bind(this),
-                    function () {
+                  },
+                  {
+                    widget : this.publicTab,
+                    render : function () {
                         this.publicTab.render();
                     }.bind(this),
-                    function () {
+                  },
+                  {
+                    widget : this.exampleTab,
+                    render : function () {
                         this.exampleTab.getExampleDataAndRender();
                     }.bind(this),
-                    function () {
-                    }.bind(this)
+                  },
                 ];
+
                 if (Config.get('features').stagingDataViewer) {
-                    this.renderFn.push(
-                        function () {
+                    this.tabMapping.push(
+                      {
+                        widget : this.stagingTab,
+                        render : function () {
                             this.stagingTab.updateView();
                         }.bind(this)
+                      }
                     );
                 }
+
             } else {
                 //console.error("ws_name is not defined");
             }
@@ -388,11 +409,28 @@ define([
                 body: $body
             };
         },
+
+        deactivateLastRenderedPanel : function() {
+          if (this.$lastRenderedWidget && this.$lastRenderedWidget.deactivate) {
+            this.$lastRenderedWidget.deactivate();
+            this.$lastRenderedWidget = undefined;
+          }
+        },
+
         updateSlideoutRendering: function (panelIdx) {
+
+            this.deactivateLastRenderedPanel();
+
             if (!this.renderedTabs[panelIdx]) {
-                this.renderFn[panelIdx]();
+                this.tabMapping[panelIdx].render();
                 this.renderedTabs[panelIdx] = true;
             }
+            var $widget = this.tabMapping[panelIdx].widget;
+            if ($widget && $widget.activate) {
+              $widget.activate();
+            }
+
+            this.$lastRenderedWidget = $widget;
         },
         /**
          * Renders the data importer panel

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
@@ -28,6 +28,14 @@ define([
             return this;
         },
 
+        activate : function() {
+          this.stagingAreaViewer.activate();
+        },
+
+        deactivate : function() {
+          this.stagingAreaViewer.deactivate();
+        },
+
         updatePath: function(newPath) {
             this.path = newPath;
             this.uploadWidget.setPath(newPath);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -201,7 +201,7 @@ define([
 
         renderFiles: function(files) {
 
-          let parent = this.$elem.parent().get(0);
+          var parent = this.$elem.parent().get(0);
 
             var $fileTable = $(this.ftpFileTableTmpl({files: files, uploaders: this.uploaders.dropdown_order}));
             this.$elem.append($fileTable);


### PR DESCRIPTION
This pull does a couple of things -

* kbaseNarrativeDataPanel and kbaseNarrativeStagingTab are updated to allow a widget on the panel to have an activate() / deactivate() method to be called when the panel they are on respectively comes into view / leaves view. These methods are not required to be defined. But they're generic in nature, so that if we want a tab to do extra processing when it comes to the foreground, it can.

There is a gotcha in that an active widget will not be told to deactivate() if the panel is closed by any means other than hitting the toggle button. This should be re-visited.

* stagingAreaViewer now auto-refreshes its view every 30 seconds. The timer will start when the widget has been sent an activate() and stopped when the user sends it a deactivate(). Per the above listed gotcha, if the uploader tab is active, and the data panel is closed via any means other than hitting the toggle button, it will continue to refresh needlessly in the background.

The rest of the mods in the stagingAreaViewer are just to ensure that when the auto-refresh occurs, that any detailed metadata views of the files remain open, and that the tab is scrolled to the same point the user was at. Sometimes there is a blink for a fraction of a second as it redraws, but not always. It's very minor, and I worry that eliminating it entirely would provoke major effort.

It may be reasonable to move the code to append the open metadata on files to outside data tables' row callback, but for now I'm leaving that as an exercise to the reader.

If there was already a method in place for noting when a tab becomes active/inactive, I missed it. If that's the case, please let me know and I'll rip this out and refactor to use the existing method.