### PR TITLE
restored required empty function which does nothing

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -277,6 +277,7 @@ define([
                         this.exampleTab.getExampleDataAndRender();
                     }.bind(this),
                   },
+                  { render : function() {} },
                 ];
 
                 if (Config.get('features').stagingDataViewer) {


### PR DESCRIPTION
I have no idea why this is necessary.

The pre-autorefresh version of kbaseNarrativeDataPanel.js had a list (this.renderFn) that mapped tab -> render function. The last item was an empty function, which you can see here: https://goo.gl/wvPvxd

When I modified it to allow tab activate/deactivate (to turn on and off the auto-refresh timer on the import panel), I retooled that to have a tabMapping object instead which just contained the render() function and a reference to the widget involved. While doing that, I found that my mods didn't work in my local environment if I kept that empty render function there. So, foolishly assuming it be an artifact, I removed it. My code them worked locally.

Apparently after pull and merge, the panel started failing when you closed it on the Import tab. Fortunately, I remembered this weird change and put back an empty render function to fill the place. Lo! It works again - the panel properly stays open and doesn't collapse the side when you close/re-open on the import panel.

So this is literally putting back the missing function which did nothing. Why is this necessary and how does it work? I didn't see where it's used in the code at all.