### PR TITLE
Staging panel [SCT-585]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
@@ -22,7 +22,7 @@ define([
 
         init: function(options) {
             this._super(options);
-            this.path = '/' + Jupyter.narrative.userId;
+            this.path = '/';
 
             this.render();
             return this;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -28,7 +28,7 @@ define([
             this.dropzoneTmpl = Handlebars.compile(DropzoneAreaHtml);
             this.dropFileTmpl = Handlebars.compile(DropFileHtml);
             this.path = options.path;
-            this.ftpUrl = Config.url('ftp_api_url');
+            this.stagingUrl = Config.url('staging_api_url');
             this.userId = options.userId;
             this.render();
             return this;
@@ -44,8 +44,10 @@ define([
             }.bind(this));
 
             this.$elem.append($dropzoneElem);
+            var self = this;
+
             this.dropzone = new Dropzone($dropzoneElem.get(0), {
-                url: this.ftpUrl + '/upload',
+                url: this.stagingUrl + '/upload',
                 accept: function(file, done) {
                     console.log('uploading ' + file.name + ' = ' + file.size + 'B');
                     done();
@@ -82,8 +84,20 @@ define([
                         $(file.previewElement.querySelector('.btn')).trigger('click');
                     });
                 }.bind(this))
-                .on('sending', function(file) {
+                .on('sending', function(file, xhr, data) {
+
                     $dropzoneElem.find('#global-info').css({'display': 'inline'});
+                    //okay, if we've been given a full path, then we pull out the pieces (ignoring the filename at the end) and then
+                    //tack it onto our set path, then set that as the destPath form param.
+                    if (file.fullPath) {
+                      var subPath = file.fullPath.replace(new RegExp('/' + file.name + '$'), '');
+console.log("WTF IS DAMN DATA : ", data);
+                      data.append('destPath', [this.path, subPath].join('/'));
+                    }
+                    //if we don't have a fullPath, then we're uploading a file and not a folder. Just use the current path.
+                    else {
+                      data.append('destPath', this.path);
+                    }
                     $($dropzoneElem.find('#total-progress')).show();
                     $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());
                 }.bind(this))
@@ -118,7 +132,6 @@ define([
 
         setPath: function(path) {
             this.path = path;
-            this.$elem.find('input[name="destPath"]').val(path);
         },
 
         getPath: function() {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -91,7 +91,6 @@ define([
                     //tack it onto our set path, then set that as the destPath form param.
                     if (file.fullPath) {
                       var subPath = file.fullPath.replace(new RegExp('/' + file.name + '$'), '');
-console.log("WTF IS DAMN DATA : ", data);
                       data.append('destPath', [this.path, subPath].join('/'));
                     }
                     //if we don't have a fullPath, then we're uploading a file and not a folder. Just use the current path.

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -306,18 +306,20 @@ define([
                     // What a @#*$!ing PITA. First, we find the expansion caret in the first cell.
                     var $caret = $('td:eq(0)', nRow).find('i[data-caret]');
                     //next, we use that caret to find the fileName, and the file Data.
-                    var fileName = $caret.data().caret;
-                    var myFile = getFileFromName(fileName);
-                    //now, if there's openFileInfo on it, that means that the user had the detailed view open during a refresh.
-                    if (this.openFileInfo[fileName]) {
-                      //so we note that we've already loaded the info.
-                      myFile.loaded = this.openFileInfo[fileName].loaded;
-                      //toggle the caret
-                      $caret.toggleClass('fa-caret-down fa-caret-right');
-                      //and append the detailed view, which we do in a timeout in the next pass through to ensure that everything is properly here.
-                      setTimeout( function() {$caret.parent().parent().after(
-                        this.renderMoreFileInfo( myFile )
-                      )}.bind(this), 0);
+                    if ($caret.length) {
+                      var fileName = $caret.data().caret;
+                      var myFile = getFileFromName(fileName);
+                      //now, if there's openFileInfo on it, that means that the user had the detailed view open during a refresh.
+                      if (this.openFileInfo[fileName]) {
+                        //so we note that we've already loaded the info.
+                        myFile.loaded = this.openFileInfo[fileName].loaded;
+                        //toggle the caret
+                        $caret.toggleClass('fa-caret-down fa-caret-right');
+                        //and append the detailed view, which we do in a timeout in the next pass through to ensure that everything is properly here.
+                        setTimeout( function() {$caret.parent().parent().after(
+                          this.renderMoreFileInfo( myFile )
+                        )}.bind(this), 0);
+                      }
                     }
 
                     $('td:eq(0)', nRow).find('i[data-caret]').on('click', function(e) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -195,6 +195,7 @@ define([
             if (splitPath.startsWith('/')) {
                 splitPath = splitPath.substring(1);
             }
+            // the staging service doesn't want the username as part of the path, but we still want to display it to the user for navigation purposes
             splitPath = splitPath.split('/').filter(function(p) { return p.length });
             splitPath.unshift(this.userId);
             var pathTerms = [];
@@ -409,7 +410,6 @@ define([
           }
 
           var $tabsDiv = $.jqElem('div')
-            //.css({'width' : '90%', display : 'inline-block'})
             .append('<i class="fa fa-spinner fa-spin"></i> Loading file info...please wait')
           ;
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -348,6 +348,8 @@ define([
                         var fileName = $(e.currentTarget).data().decompress;
                         var myFile = getFileFromName(fileName);
 
+                        $(e.currentTarget).replaceWith($.jqElem('i').addClass('fa fa-spinner fa-spin'));
+
                         this.stagingServiceClient.decompress({ path : myFile.name })
                             .then(function(data) {
                               this.updateView();

--- a/kbase-extension/static/kbase/templates/data_staging/dropzone_area.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropzone_area.html
@@ -10,7 +10,6 @@
             </div>
         </div>
     </div>
-    <input type="hidden" name="destPath" value="/{{username}}"/>
     <div class="dz-message">
         <p>Drag and drop data files (or click) in this box to upload them to your staging area.<br><br>
         <p>Click the <i class="fa fa-question-circle"></i> below for help.

--- a/kbase-extension/static/kbase/templates/data_staging/ftp_file_table.html
+++ b/kbase-extension/static/kbase/templates/data_staging/ftp_file_table.html
@@ -16,17 +16,22 @@
             <td>{{size}}</td>
             <td>{{mtime}}</td>
             <td>
-                {{#if imported}}
-                    <select id="import-type" style="width:80%">
+                {{#if imported }}
+                    <select id="import-type" style="width:70%">
                         <option></option>
                         {{#each ../uploaders}}
                             <option value="{{id}}">{{name}}</option>
                         {{/each}}
                     </select>
-                    <button data-import="{{name}}" class="btn btn-xs btn-primary">
+                {{ else }}
+                    <span style = 'display : inline-block; width : 70%'>&nbsp;</span>
+                {{/if}}
+                    <button data-import="{{name}}" class="btn btn-xs btn-primary" style='opacity :  {{#if imported}}1{{else}}0{{/if}}'>
                         <span><i class="fa fa-upload"></i></span>
                     </button>
-                {{/if}}
+                <button data-delete="{{name}}" class="btn btn-xs btn-danger">
+                    <span><i class="fa fa-trash"></i></span>
+                </button>
             </td>
         </tr>
     {{/each}}


### PR DESCRIPTION
The main purpose of this pull is to add drag 'n drop support of folders.

NOTE - DnD of folders does _not_ work in Safari. Chrome and Firefox work properly. This is a browser limitation and not something we can get around atm (AFAIK). Once Safari is updated to support the mods to the FormData object, it should automatically start working.

To that end, several things were changed on the staging panel:
* Clicking on the decompress button will now pop up a spinner as it decompresses.
* The delete button was moved to the row that the file is in (from within the detailed view) and will also now allow the user to delete directories.
* Several bugs were fixed regarding handling of subdirectories - including viewing and deleting files within them.
* The list endpoint on staging_service was recursive - so the root directory would hold all subdirectories as well. Fixed to only show files at that level.
* DnD support of folders now works, except in Safari, because Apple is stupid.
* Some other mods were needed to the path storing variables, since they now use the staging service and not the ftp service. Basically just dropped the username from the path.
* Props to Tian for the staging service not needing any modifications to allow this, it's strictly client side work.