### PR TITLE
SCT-590 cache busting for data_source_config.json

### DIFF
--- a/kbase-extension/static/kbase/js/narrativeConfig.js
+++ b/kbase-extension/static/kbase/js/narrativeConfig.js
@@ -128,7 +128,11 @@ define([
             }
         }).then(function (config) {
             console.log('Config: fetching remote data configuration.');
-            return Promise.resolve($.getJSON(config.urls.data_panel_sources));
+            return Promise.resolve($.ajax({
+                dataType: 'json',
+                cache: false,
+                url: config.urls.data_panel_sources
+            }));
         }).then(function (dataCategories) {
             console.log('Config: processing remote data configuration.');
             var env = config.environment;
@@ -148,7 +152,11 @@ define([
             // the filename is the last step of that url path (after the last /)
             var path = config.urls.data_panel_sources.split('/');
 
-            return Promise.resolve($.getJSON('static/kbase/config/' + path[path.length - 1]))
+            return Promise.resolve($.ajax({
+                dataType: 'json',
+                cache: false,
+                url: 'static/kbase/config/' + path[path.length - 1]
+            }))
                 .then(function (dataCategories) {
                     console.log('Config: processing local data configuration.');
                     var env = config.environment;


### PR DESCRIPTION
It doesn't happen often, but when the data source config (the config file for updating the sources for Public data in the data slideout) gets changed, the Narrative tends to not pick it up as it's cached in the browser.

This adds an explicit cache busting call, instead of just being lazy and using $.getJSON.

Also, this expects #1272 to be merged first.