### PR TITLE
SCT-690 - fix narrative navbar with long name

### DIFF
--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -137,7 +137,7 @@
     {% endblock %}
 
     <nav class="navbar-kbase navbar-static-top" id="header">
-        <div class="container-fluid">
+        <div class="container-fluid kb-navbar-container">
             <div class="navbar-header">
                 <div style="display:inline-block">
                     <button id="kb-nav-menu" class="btn btn-default navbar-btn kb-nav-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -73,6 +73,14 @@
     font-family: 'OxygenBold';
     font-size: 130%;
     padding-bottom: 7px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#kb-narr-name:hover {
+    text-overflow: inherit;
+    white-space: normal;
 }
 
 #kb-narr-name > #save_widget {
@@ -88,9 +96,13 @@
 .kb-narr-namestamp {
     margin-bottom: 0px;
     margin-top: 5px;
+    margin-left: auto;
+    margin-right: auto;
     padding-left: 20px;
     border-left: 2px solid #CECECE;
     display: block;
+    flex: 2;
+    min-width: 0;
 }
 
 .ui-draggable.kb-data-inflight {
@@ -247,6 +259,12 @@ span#searchspan{
 .navbar-right .fa::before { /* color nav icons */
     color: #2196F3;
 }
+
+.kb-navbar-container {
+    display: flex;
+    justify-content: space-between;
+}
+
 #kb-nav-menu { /* don't add shadows here */
     box-shadow: none;
 }


### PR DESCRIPTION
Long narrative names cause the navbar to hang over the rest of the app and prevent seeing the tops of cells and such. Other apps (including Jupyter notebook) hide long names with an ellipsis. This PR does the same, but mousing over the truncated name will temporarily show the whole thing. Gif below.

![out](https://user-images.githubusercontent.com/2152243/37690619-54f717fe-2c69-11e8-9e49-acc1c9faf4e1.gif)