### PR TITLE
SCT-706 - fix app panel search not accepting spaces

### DIFF
--- a/kbase-extension/static/kbase/js/util/bootstrapSearch.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapSearch.js
@@ -1,0 +1,133 @@
+/**
+ * Implements a simple search input box with an attached icon button. The icon switches from
+ * the magnifying glass to an X when something is input.
+ *
+ * Like most other KBase widgets, this follows this paradigm:
+ * let $div = $('<div>');
+ * let searchInput = new BootstrapSearch($div, options);
+ *
+ * Options:
+ * placeholder - placeholder text
+ * emptyIcon - font-awesome icon name (either fa-xxx or just xxx), placed when the input field is
+ *             empty.
+ * filledIcon - font-awesome icon name as above, placed when there's text present.
+ * inputFunction - gets fired off when a user inputs something
+ * escFunction - gets fired off if escape (key 27) is hit while the input is focused
+ */
+
+define([
+    'jquery',
+    'bluebird',
+    'base/js/namespace',
+    'bootstrap'
+], function (
+    $,
+    Promise,
+    Jupyter
+) {
+    'use strict';
+
+    var BootstrapSearch = function($target, options) {
+        if (!options.placeholder) {
+            options.placeholder = '';
+        }
+        if (!options.emptyIcon) {
+            options.emptyIcon = 'fa-times';
+        }
+        if (!options.emptyIcon.startsWith('fa-')) {
+            options.emptyIcon = 'fa-' + options.emptyIcon;
+        }
+        if (!options.filledIcon) {
+            options.filledIcon = 'fa-times';
+        }
+        if (!options.filledIcon.startsWith('fa-')) {
+            options.filledIcon = 'fa-' + options.filledIcon;
+        }
+
+        this.options = options;
+        this.initialize($target);
+    };
+
+    BootstrapSearch.prototype.initialize = function($target) {
+        var self = this;
+
+        // structure.
+        var $input = $('<input type="text">')
+            .attr('Placeholder', this.options.placeholder)
+            .addClass('form-control');
+
+        var $addonBtn = $('<span>')
+            .addClass('input-group-addon btn btn-default kb-method-search-clear')
+            .attr('type', 'button')
+            .css({
+                'border': '1px solid #ccc',
+                'border-radius': '2px',
+                'border-left': 'none'
+            });
+
+        var $addonIcon = $('<span>')
+            .addClass('fa ' + this.options.emptyIcon);
+
+        $addonBtn.append($addonIcon);
+
+        var $container = $('<div>')
+            .addClass('input-group')
+            .append($input)
+            .append($addonBtn);
+
+        $target.append($container);
+
+        // event bindings.
+        $input.on('focus', function () {
+            if (Jupyter && Jupyter.narrative) {
+                Jupyter.narrative.disableKeyboardManager();
+            }
+        }).on('blur', function () {
+            if (Jupyter && Jupyter.narrative) {
+                Jupyter.narrative.disableKeyboardManager();
+            }
+        }).on('input change', function (e) {
+            if ($input.val) {
+                $addonIcon.removeClass(self.options.emptyIcon);
+                $addonIcon.addClass(self.options.filledIcon);
+            }
+            else {
+                $addonIcon.removeClass(self.options.filledIcon);
+                $addonIcon.addClass(self.options.emptyIcon);
+            }
+            if (self.options.inputFunction) {
+                self.options.inputFunction(e);
+            }
+        }).on('keyup', function (e) {
+            if (e.keyCode === 27 && self.options.escFunction) {
+                self.options.escFunction(e);
+            }
+        });
+
+        $addonBtn.click(function(e) {
+            if (!self.options.addonFunction) {
+                $input.val('');
+                $input.trigger('input');
+            }
+            else {
+                self.options.addonFunction(e);
+            }
+        });
+
+        this.$input = $input;
+    };
+
+    BootstrapSearch.prototype.val = function(val) {
+        var retVal = val ? this.$input.val(val) : this.$input.val();
+        if (val) {
+            this.$input.trigger('input');
+        }
+        return retVal;
+    };
+
+    BootstrapSearch.prototype.focus = function() {
+        this.$input.focus();
+    };
+
+    return BootstrapSearch;
+});

--- a/kbase-extension/static/kbase/js/util/bootstrapSearch.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapSearch.js
@@ -90,7 +90,7 @@ define([
                 Jupyter.narrative.disableKeyboardManager();
             }
         }).on('input change', function (e) {
-            if ($input.val) {
+            if ($input.val()) {
                 $addonIcon.removeClass(self.options.emptyIcon);
                 $addonIcon.addClass(self.options.filledIcon);
             }
@@ -102,8 +102,10 @@ define([
                 self.options.inputFunction(e);
             }
         }).on('keyup', function (e) {
-            if (e.keyCode === 27 && self.options.escFunction) {
-                self.options.escFunction(e);
+            if (e.keyCode === 27) {
+                if (self.options.escFunction) {
+                    self.options.escFunction(e);
+                }
             }
         });
 
@@ -122,8 +124,12 @@ define([
     };
 
     BootstrapSearch.prototype.val = function(val) {
-        var retVal = val ? this.$input.val(val) : this.$input.val();
-        if (val) {
+        var retVal;
+        if (val === undefined || val === null) {
+            retVal = this.$input.val();
+        }
+        else {
+            retVal = this.$input.val(val);
             this.$input.trigger('input');
         }
         return retVal;

--- a/kbase-extension/static/kbase/js/util/bootstrapSearch.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapSearch.js
@@ -11,8 +11,9 @@
  * emptyIcon - font-awesome icon name (either fa-xxx or just xxx), placed when the input field is
  *             empty.
  * filledIcon - font-awesome icon name as above, placed when there's text present.
- * inputFunction - gets fired off when a user inputs something
- * escFunction - gets fired off if escape (key 27) is hit while the input is focused
+ * inputFunction - gets fired off when a user inputs something.
+ * addonFunction - gets fired off when a user clicks the addon area. default = clear input.
+ * escFunction - gets fired off if escape (key 27) is hit while the input is focused.
  */
 
 define([
@@ -28,6 +29,8 @@ define([
     'use strict';
 
     var BootstrapSearch = function($target, options) {
+        options = options || {};
+
         if (!options.placeholder) {
             options.placeholder = '';
         }
@@ -115,6 +118,7 @@ define([
         });
 
         this.$input = $input;
+        this.$container = $container;
     };
 
     BootstrapSearch.prototype.val = function(val) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -130,7 +130,8 @@ define([
             this.bsSearch = new BootstrapSearch(this.$searchDiv, {
                 inputFunction: function(e) {
                     self.refreshPanel(this);
-                }
+                },
+                placeholder: 'Search apps'
             });
 
             // The 'loading' panel should just have a spinning gif in it.

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -17,6 +17,7 @@ define([
     'narrativeConfig',
     'util/display',
     'util/bootstrapDialog',
+    'util/bootstrapSearch',
     'util/icon',
     'text!kbase/templates/beta_warning_body.html',
     'yaml!ext_components/kbase-ui-plugin-catalog/src/plugin/modules/data/categories.yml',
@@ -42,6 +43,7 @@ define([
     Config,
     DisplayUtil,
     BootstrapDialog,
+    BootstrapSearch,
     Icon,
     BetaWarningTemplate,
     Categories,
@@ -92,22 +94,7 @@ define([
 
             this.icon_colors = Config.get('icons').colors;
 
-            this.$searchDiv = $('<div>')
-                .addClass('input-group')
-                .css({ 'margin-bottom': '3px' })
-                .hide();
-
-            this.$searchInput = $('<input type="text">')
-                .addClass('form-control')
-                .attr('Placeholder', 'Search apps')
-                .on('input', function() {
-                    self.refreshPanel(this);
-                })
-                .on('keyup', function(e) {
-                    if (e.keyCode === 27) {
-                        self.$searchDiv.toggle({ effect: 'blind', duration: 'fast' });
-                    }
-                });
+            this.$searchDiv = $('<div>').hide();
 
             this.$numHiddenSpan = $('<span>0</span>');
             this.$showHideSpan = $('<span>show</span>');
@@ -124,20 +111,6 @@ define([
                     this.$showHideSpan.text(curText === 'show' ? 'hide' : 'show');
                 }, this));
 
-            var $clearSearchBtn = $('<span>')
-                .addClass('input-group-addon btn btn-default kb-method-search-clear')
-                .attr('type', 'button')
-                .append($('<span class="fa fa-times">'))
-                .click(
-                    $.proxy(function() {
-                        this.$searchInput.val('');
-                        this.$searchInput.trigger('input');
-                    }, this)
-                );
-
-            this.$searchDiv.append(this.$searchInput)
-                .append($clearSearchBtn);
-
             // placeholder for apps and methods once they're loaded.
             this.$methodList = $('<div>')
                 .css({
@@ -153,6 +126,12 @@ define([
                     .append(this.$searchDiv)
                     .append(this.$toggleHiddenDiv))
                 .append(this.$methodList);
+
+            this.bsSearch = new BootstrapSearch(this.$searchDiv, {
+                inputFunction: function(e) {
+                    self.refreshPanel(this);
+                }
+            });
 
             // The 'loading' panel should just have a spinning gif in it.
             this.$loadingPanel = $('<div>')
@@ -175,23 +154,17 @@ define([
                 .append(this.$loadingPanel)
                 .append(this.$errorPanel));
 
-            $(document).on('filterMethods.Narrative',
-                $.proxy(function(e, filterString) {
-                    if (filterString) {
-                        this.$searchDiv.show({ effect: 'blind', duration: 'fast' });
-                        this.$searchInput.val(filterString);
-                        this.$searchInput.trigger('input');
-                    }
-                }, this)
-            );
+            $(document).on('filterMethods.Narrative', function(e, filterString) {
+                if (filterString) {
+                    this.$searchDiv.show({ effect: 'blind', duration: 'fast' });
+                    this.bsSearch.val(filterString);
+                }
+            }.bind(this));
 
-            $(document).on('removeFilterMethods.Narrative',
-                $.proxy(function() {
-                    this.$searchDiv.toggle({ effect: 'blind', duration: 'fast' });
-                    this.$searchInput.val('');
-                    this.$searchInput.trigger('input');
-                }, this)
-            );
+            $(document).on('removeFilterMethods.Narrative', function() {
+                this.$searchDiv.toggle({ effect: 'blind', duration: 'fast' });
+                this.bsSearch.val('');
+            }.bind(this));
 
             /* 'request' should be expected to be an object like this:
              * {
@@ -279,14 +252,14 @@ define([
                 .click(function() {
                     this.$searchDiv.toggle({ effect: 'blind', duration: 'fast' });
                     var new_height = this.$methodList.height();
-                    if(this.app_offset){
+                    if (this.app_offset) {
                         new_height = (new_height - 40) + 'px';
-                    }else{
+                    } else {
                         new_height = (new_height + 40) + 'px';
                     }
                     this.$methodList.css('height', new_height);
                     this.app_offset = !this.app_offset;
-                    this.$searchInput.focus();
+                    this.bsSearch.focus();
                 }.bind(this)));
 
             // Refresh button
@@ -750,7 +723,7 @@ define([
 
         refreshPanel: function() {
             var panelStyle = this.currentPanelStyle,
-                filterString = this.$searchInput.val(),
+                filterString = this.bsSearch.val(),
                 appSet = this.renderedApps,
                 self = this,
                 $appPanel = $('<div>');
@@ -826,12 +799,12 @@ define([
             };
 
             var withCategories = function(a,b) {
-              var catA = (Categories.categories[a] || a).toLowerCase();
-              var catB = (Categories.categories[b] || b).toLowerCase();
-                   if (catA < catB) { return -1}
-              else if (catA > catB) { return  1}
-              else                  { return  0}
-            }
+                var catA = (Categories.categories[a] || a).toLowerCase();
+                var catB = (Categories.categories[b] || b).toLowerCase();
+                if (catA < catB) { return -1; }
+                else if (catA > catB) { return  1; }
+                else                  { return  0; }
+            };
 
             var buildAccordionPanel = function(style) {
                 /* first, get elements in order like this:

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -26,6 +26,7 @@ define([
     'text!kbase/templates/data_list/object_row.html',
     'kb_service/utils',
     'util/bootstrapAlert',
+    'util/bootstrapSearch',
     'kbase/js/widgets/narrative_core/kbaseDataCard',
     'bootstrap',
     'jquery-nearest'
@@ -49,6 +50,7 @@ define([
     ObjectRowHtml,
     ServiceUtils,
     BootstrapAlert,
+    BootstrapSearch,
     kbaseDataCard
 ) {
     'use strict';
@@ -74,7 +76,6 @@ define([
         maxWsObjId: null,
         n_objs_rendered: 0,
         real_name_lookup: {},
-        $searchInput: null,
         $filterTypeSelect: null,
         availableTypes: {},
         $searchDiv: null,
@@ -1498,7 +1499,7 @@ define([
                     self.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
                     self.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
                     self.$searchDiv.show({ effect: 'blind', duration: 'fast' });
-                    self.$searchInput.focus();
+                    self.bsSearch.focus();
                 } else {
                     self.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
                 }
@@ -1582,37 +1583,12 @@ define([
                     this.writingLock = false;
                     self.refresh();
                 });
-            self.$searchInput = $('<input type="text">')
-                .attr('Placeholder', 'Search in your data')
-                .addClass('form-control')
-                .on('focus', function () {
-                    if (Jupyter && Jupyter.narrative) {
-                        Jupyter.narrative.disableKeyboardManager();
-                    }
-                })
-                .on('blur', function () {
-                    if (Jupyter && Jupyter.narrative) {
-                        Jupyter.narrative.enableKeyboardManager();
-                    }
-                })
-                .on('input change blur', function () {
-                    this.search();
-                }.bind(this))
-                .on('keyup', function (e) {
-                    if (e.keyCode === 27) {
-                        this.search();
-                    }
-                }.bind(this));
-
-            self.$searchDiv = $('<div>').addClass('input-group').css({ 'margin-bottom': '10px' })
-                .append(self.$searchInput)
-                .append($('<span>').addClass('input-group-addon')
-                    .append($('<span>')
-                        .addClass('fa fa-search')
-                        .css({ 'cursor': 'pointer' })
-                        .on('click', function () {
-                            self.search();
-                        })));
+            self.$searchDiv = $('<div>');
+            self.bsSearch = new BootstrapSearch(self.$searchDiv, {
+                inputFunction: function() {
+                    self.search();
+                }
+            });
 
             self.$sortByDiv = $('<div>').css('text-align', 'center')
                 .append('<small>sort by: </small>')
@@ -1713,8 +1689,8 @@ define([
                 return;
             }
 
-            if (!term && this.$searchInput) {
-                term = this.$searchInput.val();
+            if (!term) {
+                term = this.bsSearch.val();
             }
 
             // if type wasn't selected, then we try to get something that was set

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1587,7 +1587,8 @@ define([
             self.bsSearch = new BootstrapSearch(self.$searchDiv, {
                 inputFunction: function() {
                     self.search();
-                }
+                },
+                placeholder: 'Search in your data'
             });
 
             self.$sortByDiv = $('<div>').css('text-align', 'center')

--- a/test/unit/spec/Util/BootstrapSearchSpec.js
+++ b/test/unit/spec/Util/BootstrapSearchSpec.js
@@ -51,6 +51,8 @@ define ([
             expect(addon.hasClass(emptyFa)).toBe(true);
             bsSearch.val('stuff');
             expect(addon.hasClass(filledFa)).toBe(true);
+            bsSearch.val('');
+            expect(addon.hasClass(emptyFa)).toBe(true);
         });
 
         it('Should auto-set fa- in front of icons without it', function() {
@@ -67,6 +69,8 @@ define ([
             expect(addon.hasClass(emptyFa)).toBe(true);
             bsSearch.val('stuff');
             expect(addon.hasClass(filledFa)).toBe(true);
+            bsSearch.val('');
+            expect(addon.hasClass(emptyFa)).toBe(true);
         });
 
         it('Should clear input by default when clicking addon', function() {
@@ -93,6 +97,39 @@ define ([
             var bsSearch = new BootstrapSearch($targetElem);
             bsSearch.val('stuff');
             expect(bsSearch.val()).toEqual('stuff');
+        });
+
+        it('Should have a working focus function', function() {
+            var bsSearch = new BootstrapSearch($targetElem);
+            var passed = false;
+            $('body').append($targetElem);
+            $targetElem.find('input.form-control').on('focus', function() {
+                passed = true;
+            });
+            bsSearch.focus();
+            expect(passed).toBe(true);
+        });
+
+        it('Should set placeholder text', function() {
+            var placeholder = 'some text';
+            var bsSearch = new BootstrapSearch($targetElem, {
+                placeholder: placeholder
+            });
+            expect($targetElem.find('input.form-control').attr('placeholder')).toEqual(placeholder);
+        });
+
+        it('Should trigger an escape function', function() {
+            var passed = false;
+            var bsSearch = new BootstrapSearch($targetElem, {
+                escFunction: function() {
+                    passed = true;
+                }
+            });
+            var e = $.Event('keyup');
+            e.which = 27;
+            e.keyCode = 27;
+            $targetElem.find('input.form-control').trigger(e);
+            expect(passed).toBe(true);
         });
     });
 });

--- a/test/unit/spec/Util/BootstrapSearchSpec.js
+++ b/test/unit/spec/Util/BootstrapSearchSpec.js
@@ -1,0 +1,98 @@
+/*global define*/
+/*global describe, it, expect*/
+/*global jasmine*/
+/*global beforeEach, afterEach*/
+/*jslint white: true*/
+
+define ([
+    'jquery',
+    'util/bootstrapSearch'
+], function(
+    $,
+    BootstrapSearch
+) {
+    'use strict';
+    var $targetElem;
+
+    beforeEach(function() {
+        $targetElem = $('<div>');
+    });
+
+    afterEach(function() {
+        $targetElem.empty();
+    });
+
+    describe('Test the BootstrapSearch module', function() {
+        it('Should create a new search object', function() {
+            var bsSearch = new BootstrapSearch($targetElem, {});
+            expect(bsSearch).not.toBeNull();
+        });
+
+        it('Should fire an input function when triggered by input', function() {
+            var passed = false;
+            var bsSearch = new BootstrapSearch($targetElem, {
+                inputFunction: function() {
+                    passed = true;
+                }
+            });
+            bsSearch.val('stuff');
+            expect(passed).toBe(true);
+        });
+
+        it('Should have empty and filled icons at the right time', function() {
+            var emptyFa = 'fa-battery-0',
+                filledFa = 'fa-battery-4';
+
+            var bsSearch = new BootstrapSearch($targetElem, {
+                emptyIcon: emptyFa,
+                filledIcon: filledFa
+            });
+            var addon = $targetElem.find('span.input-group-addon > span');
+            expect(addon.hasClass(emptyFa)).toBe(true);
+            bsSearch.val('stuff');
+            expect(addon.hasClass(filledFa)).toBe(true);
+        });
+
+        it('Should auto-set fa- in front of icons without it', function() {
+            var empty = 'battery-0',
+                emptyFa = 'fa-battery-0',
+                filled = 'battery-4',
+                filledFa = 'fa-battery-4';
+
+            var bsSearch = new BootstrapSearch($targetElem, {
+                emptyIcon: empty,
+                filledIcon: filled
+            });
+            var addon = $targetElem.find('span.input-group-addon > span');
+            expect(addon.hasClass(emptyFa)).toBe(true);
+            bsSearch.val('stuff');
+            expect(addon.hasClass(filledFa)).toBe(true);
+        });
+
+        it('Should clear input by default when clicking addon', function() {
+            var bsSearch = new BootstrapSearch($targetElem);
+            bsSearch.val('stuff');
+            $targetElem.find('span.input-group-addon').click();
+            expect(bsSearch.val()).toBeFalsy();
+        });
+
+        it('Should fire a function when clicking the addon - overrides default clear', function() {
+            var passed = false;
+            var bsSearch = new BootstrapSearch($targetElem, {
+                addonFunction: function() {
+                    passed = true;
+                }
+            });
+            bsSearch.val('stuff');
+            $targetElem.find('span.input-group-addon').click();
+            expect(passed).toBe(true);
+            expect(bsSearch.val()).toEqual('stuff');
+        });
+
+        it('Should have a val function that works as in vanilla JS', function() {
+            var bsSearch = new BootstrapSearch($targetElem);
+            bsSearch.val('stuff');
+            expect(bsSearch.val()).toEqual('stuff');
+        });
+    });
+});

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -32,11 +32,11 @@ define([
         it('Should have a working search interface', function() {
             expect(appPanel.$methodList.children().children().length).not.toBe(0);
 
-            appPanel.$searchInput.val('should show nothing');
+            appPanel.bsSearch.val('should show nothing');
             appPanel.refreshPanel();
             expect(appPanel.$methodList.children().children().length).toBe(0);
 
-            appPanel.$searchInput.val('genome');
+            appPanel.bsSearch.val('genome');
             appPanel.refreshPanel();
             expect(appPanel.$methodList.children().children().length).not.toBe(0);
             //TODO:


### PR DESCRIPTION
The fix was reasonably simple, but playing around exposed that the search boxes in the app panel and data panel were different. They (more or less) should act the same, but looked slightly different. To avoid keeping duplicate code around, this factors that search box out into a generic, though specialized, widget. It might be a little much, but it keeps things consistent.

The widget - BootstrapSearch - makes a simple Bootstrap input form with an attached clear button. Options sent to it on initialization set its functionality, mainly what to do when a user types.

This also includes some whitespace and style cleanup to the App panel.