### PR TITLE
Fix broken pangenome viewer [SCT-793]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "select2": "4.0.3",
     "select2-bootstrap-theme": "^0.1.0-beta.9",
     "underscore": "1.8.3",
-    "file-saver": "^1.3.3",
+    "file-saver": "1.3.4",
     "SparkMD5": "spark-md5#^3.0.0",
     "js-yaml": "3.3.1",
     "require-yaml": "^0.1.2",


### PR DESCRIPTION
The problem was a unconstrained dependency on the "file-saver" library. The "^" operator causes the narrative build process to pick up the most recent version of the library; a change in 1.3.6 (current version is 1.3.8) broke the library by, um, omitting the javascript file which implements the library.