### PR TITLE
Fix SCT-809: subdata view control bug in within repeating parameter

### DIFF
--- a/kbase-extension/static/kbase/js/common/ui.js
+++ b/kbase-extension/static/kbase/js/common/ui.js
@@ -723,6 +723,13 @@ define([
             });
         }
 
+        function setText(path, text) {
+            var node = getElements(path);
+            node.forEach(function (node) {
+                node.innerText = text;
+            });
+        }
+
         function enableTooltips(path) {
             var node = getElement(path);
             if (!node) {
@@ -1280,6 +1287,7 @@ define([
             expandPanel: expandPanel,
             createNode: createNode,
             setContent: setContent,
+            setText: setText,
             na: na,
             ifAdvanced: ifAdvanced,
             ifDeveloper: ifDeveloper,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/subdataInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/subdataInput.js
@@ -201,94 +201,94 @@ define([
                 content = div({ style: { textAlign: 'center' } }, 'no available values');
             } else {
                 content = itemsToShow.map(function (item, index) {
-                        var isSelected = selected.some(function (id) {
-                                return (item.id === id);
-                            }),
-                            disabled = isSelected;
-                        return div({ class: 'row', style: { border: '1px #CCC solid' } }, [
-                            div({
-                                class: 'col-md-2',
-                                style: {
-                                    verticalAlign: 'middle',
-                                    borderRadius: '3px',
-                                    padding: '2px',
-                                    backgroundColor: '#EEE',
-                                    color: '#444',
-                                    textAlign: 'right',
-                                    paddingRight: '6px',
-                                    fontFamily: 'monospace'
-                                }
-                            }, String(from + index + 1)),
-                            div({
-                                class: 'col-md-8',
-                                style: {
-                                    padding: '2px'
-                                }
-                            }, item.text),
-                            div({
-                                class: 'col-md-2',
-                                style: {
-                                    padding: '2px',
-                                    textAlign: 'right',
-                                    verticalAlign: 'top'
-                                }
-                            }, [
-                                (function () {
-                                    if (disabled) {
-                                        return span({
-                                            class: 'kb-btn-icon',
-                                            type: 'button',
-                                            dataToggle: 'tooltip',
-                                            title: 'Remove from selected',
-                                            id: events.addEvent({
-                                                type: 'click',
-                                                handler: function () {
-                                                    doRemoveSelectedAvailableItem(item.id);
-                                                }
-                                            })
-                                        }, [
-                                            span({
-                                                class: 'fa fa-minus-circle',
-                                                style: {
-                                                    color: 'red',
-                                                    fontSize: '200%'
-                                                }
-                                            })
-                                        ]);
-                                    }
-                                    if (allowSelection) {
-                                        return span({
-                                            class: 'kb-btn-icon',
-                                            type: 'button',
-                                            dataToggle: 'tooltip',
-                                            title: 'Add to selected',
-                                            dataItemId: item.id,
-                                            id: events.addEvent({
-                                                type: 'click',
-                                                handler: function () {
-                                                    doAddItem(item.id);
-                                                }
-                                            })
-                                        }, [span({
-                                            class: 'fa fa-plus-circle',
-                                            style: {
-                                                color: 'green',
-                                                fontSize: '200%'
-                                            }
-                                        })]);
-                                    }
+                    var isSelected = selected.some(function (id) {
+                            return (item.id === id);
+                        }),
+                        disabled = isSelected;
+                    return div({ class: 'row', style: { border: '1px #CCC solid' } }, [
+                        div({
+                            class: 'col-md-2',
+                            style: {
+                                verticalAlign: 'middle',
+                                borderRadius: '3px',
+                                padding: '2px',
+                                backgroundColor: '#EEE',
+                                color: '#444',
+                                textAlign: 'right',
+                                paddingRight: '6px',
+                                fontFamily: 'monospace'
+                            }
+                        }, String(from + index + 1)),
+                        div({
+                            class: 'col-md-8',
+                            style: {
+                                padding: '2px'
+                            }
+                        }, item.text),
+                        div({
+                            class: 'col-md-2',
+                            style: {
+                                padding: '2px',
+                                textAlign: 'right',
+                                verticalAlign: 'top'
+                            }
+                        }, [
+                            (function () {
+                                if (disabled) {
                                     return span({
                                         class: 'kb-btn-icon',
                                         type: 'button',
                                         dataToggle: 'tooltip',
-                                        title: 'Can\'t add - remove one first',
-                                        dataItemId: item.id
-                                    }, span({ class: 'fa fa-ban', style: { color: 'silver', fontSize: '200%' } }));
-                                }())
+                                        title: 'Remove from selected',
+                                        id: events.addEvent({
+                                            type: 'click',
+                                            handler: function () {
+                                                doRemoveSelectedAvailableItem(item.id);
+                                            }
+                                        })
+                                    }, [
+                                        span({
+                                            class: 'fa fa-minus-circle',
+                                            style: {
+                                                color: 'red',
+                                                fontSize: '200%'
+                                            }
+                                        })
+                                    ]);
+                                }
+                                if (allowSelection) {
+                                    return span({
+                                        class: 'kb-btn-icon',
+                                        type: 'button',
+                                        dataToggle: 'tooltip',
+                                        title: 'Add to selected',
+                                        dataItemId: item.id,
+                                        id: events.addEvent({
+                                            type: 'click',
+                                            handler: function () {
+                                                doAddItem(item.id);
+                                            }
+                                        })
+                                    }, [span({
+                                        class: 'fa fa-plus-circle',
+                                        style: {
+                                            color: 'green',
+                                            fontSize: '200%'
+                                        }
+                                    })]);
+                                }
+                                return span({
+                                    class: 'kb-btn-icon',
+                                    type: 'button',
+                                    dataToggle: 'tooltip',
+                                    title: 'Can\'t add - remove one first',
+                                    dataItemId: item.id
+                                }, span({ class: 'fa fa-ban', style: { color: 'silver', fontSize: '200%' } }));
+                            }())
 
-                            ])
-                        ]);
-                    })
+                        ])
+                    ]);
+                })
                     .join('\n');
             }
 
@@ -389,30 +389,30 @@ define([
                 value: model.getItem('filter') || '',
                 id: events.addEvents({
                     events: [{
-                            type: 'keyup',
-                            handler: function (e) {
-                                doSearchKeyUp(e);
-                            }
-                        },
-                        {
-                            type: 'focus',
-                            handler: function () {
-                                Jupyter.narrative.disableKeyboardManager();
-                            }
-                        },
-                        {
-                            type: 'blur',
-                            handler: function () {
-                                // console.log('SingleSubData Search BLUR');
-                                // Jupyter.narrative.enableKeyboardManager();
-                            }
-                        },
-                        {
-                            type: 'click',
-                            handler: function () {
-                                Jupyter.narrative.disableKeyboardManager();
-                            }
+                        type: 'keyup',
+                        handler: function (e) {
+                            doSearchKeyUp(e);
                         }
+                    },
+                    {
+                        type: 'focus',
+                        handler: function () {
+                            Jupyter.narrative.disableKeyboardManager();
+                        }
+                    },
+                    {
+                        type: 'blur',
+                        handler: function () {
+                            // console.log('SingleSubData Search BLUR');
+                            // Jupyter.narrative.enableKeyboardManager();
+                        }
+                    },
+                    {
+                        type: 'click',
+                        handler: function () {
+                            Jupyter.narrative.disableKeyboardManager();
+                        }
+                    }
                     ]
                 })
             });
@@ -568,7 +568,7 @@ define([
             }
         }
 
-        function makeInputControl(events) {
+        function makeInputControl() {
             // There is an input control, and a dropdown,
             // TODO select2 after we get a handle on this...
             var availableValues = model.getItem('availableValues');
@@ -709,9 +709,9 @@ define([
             }
 
             return subdataMethods.fetchData({
-                    referenceObjectRef: referenceObjectRef,
-                    spec: spec
-                })
+                referenceObjectRef: referenceObjectRef,
+                spec: spec
+            })
                 .then(function (values) {
                     return [true, values];
                 });
@@ -719,8 +719,8 @@ define([
 
         function syncAvailableValues() {
             return Promise.try(function () {
-                    return fetchData();
-                })
+                return fetchData();
+            })
                 .spread(function (haveRefData, data) {
                     isAvailableValuesInitialized = true;
                     haveReferenceData = haveRefData;
@@ -789,25 +789,25 @@ define([
          */
         function render() {
             return Promise.try(function () {
-                    // check to see if we have to render inputControl.
-                    var events = Events.make({ node: container }),
-                        inputControl = makeInputControl(events),
-                        content = div({
-                            class: 'input-group',
-                            style: {
-                                width: '100%'
-                            }
-                        }, inputControl);
+                // check to see if we have to render inputControl.
+                var events = Events.make({ node: container }),
+                    inputControl = makeInputControl(events),
+                    content = div({
+                        class: 'input-group',
+                        style: {
+                            width: '100%'
+                        }
+                    }, inputControl);
 
-                    ui.setContent('input-container', content);
-                    renderSearchBox();
-                    renderStats();
-                    renderToolbar();
-                    renderAvailableItems();
-                    renderSelectedItems();
+                ui.setContent('input-container', content);
+                renderSearchBox();
+                renderStats();
+                renderToolbar();
+                renderAvailableItems();
+                renderSelectedItems();
 
-                    events.attachEvents();
-                })
+                events.attachEvents();
+            })
                 .then(function () {
                     return autoValidate();
                 })
@@ -840,7 +840,7 @@ define([
              * Issued when thre is a need to have all params reset to their
              * default value.
              */
-            channel.on('reset-to-defaults', function (message) {
+            channel.on('reset-to-defaults', function () {
                 resetModelValue();
                 // TODO: this should really be set when the linked field is reset...
                 model.setItem('availableValues', []);
@@ -952,13 +952,13 @@ define([
             // channel.emit('sync');
 
             paramsChannel.request({
-                    parameterName: spec.id
-                }, {
-                    key: {
-                        type: 'get-parameter'
-                    }
-                })
-                .then(function (message) {
+                parameterName: spec.id
+            }, {
+                key: {
+                    type: 'get-parameter'
+                }
+            })
+                .then(function () {
                     // console.log('Now i got it again', message);
                 });
 
@@ -1008,21 +1008,21 @@ define([
                 // Get initial data.
                 // Weird, but will make it look nicer.
                 return Promise.all([
-                        paramsChannel.request({
-                            parameterName: spec.id
-                        }, {
-                            key: {
-                                type: 'get-parameter'
-                            }
-                        }),
-                        paramsChannel.request({
-                            parameterName: spec.data.constraints.subdataSelection.parameter_id
-                        }, {
-                            key: {
-                                type: 'get-parameter'
-                            }
-                        })
-                    ])
+                    paramsChannel.request({
+                        parameterName: spec.id
+                    }, {
+                        key: {
+                            type: 'get-parameter'
+                        }
+                    }),
+                    paramsChannel.request({
+                        parameterName: spec.data.constraints.subdataSelection.parameter_id
+                    }, {
+                        key: {
+                            type: 'get-parameter'
+                        }
+                    })
+                ])
                     .spread(function (paramValue, referencedParamValue) {
                         if (!config.initialValue) {
                             model.setItem('selectedItems', []);
@@ -1072,7 +1072,7 @@ define([
                 showFrom: 0,
                 showTo: 5
             },
-            onUpdate: function (props) {
+            onUpdate: function () {
                 renderStats();
                 renderToolbar();
                 renderAvailableItems();

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/subdataMethods/manager.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/subdataMethods/manager.js
@@ -29,26 +29,26 @@ define([
     var t = html.tag,
         div = t('div');
 
-    function factory(config) {
+    function factory() {
 
         var runtime = Runtime.make();
 
         function workspaceCall(subObjectIdentity) {
             return new Workspace(runtime.config('services.workspace.url'), {
-                    token: runtime.authToken()
-                })
+                token: runtime.authToken()
+            })
                 .get_object_subset([subObjectIdentity]);
         }
 
         function genericClientCall(subdataSelection, subObjectIdentity) {
-            var swUrl = runtime.config('services.workspace.url').replace("ws", "service_wizard"),
+            var swUrl = runtime.config('services.workspace.url').replace('ws', 'service_wizard'),
                 genericClient = new GenericClient(swUrl, {
                     token: runtime.authToken()
                 });
             return genericClient.sync_call(subdataSelection.service_function, [
-                    [subObjectIdentity]
-                ], null, null,
-                subdataSelection.service_version);
+                [subObjectIdentity]
+            ], null, null,
+            subdataSelection.service_version);
         }
 
         function makeLabel(item, showSourceObjectName) {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/sequenceView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/sequenceView.js
@@ -31,7 +31,6 @@ define([
     // Constants
     var t = html.tag,
         div = t('div'),
-        span = t('span'),
         button = t('button');
 
     function factory(config) {
@@ -63,21 +62,21 @@ define([
 
         function setModelValue(value, index) {
             return Promise.try(function() {
-                    if (index !== undefined) {
-                        if (value) {
-                            model.value[index] = value;
-                        } else {
-                            model.value.splice(index, 1);
-                        }
+                if (index !== undefined) {
+                    if (value) {
+                        model.value[index] = value;
                     } else {
-                        if (value) {
-                            model.value = value;
-                        } else {
-                            unsetModelValue();
-                        }
+                        model.value.splice(index, 1);
                     }
-                    normalizeModel();
-                })
+                } else {
+                    if (value) {
+                        model.value = value;
+                    } else {
+                        unsetModelValue();
+                    }
+                }
+                normalizeModel();
+            })
                 .then(function() {
                     return render();
                 });
@@ -85,8 +84,8 @@ define([
 
         function unsetModelValue() {
             return Promise.try(function() {
-                    model.value = [];
-                })
+                model.value = [];
+            })
                 .then(function() {
                     return render();
                 });
@@ -112,11 +111,11 @@ define([
 
         // TODO: wrap this in a new type of field control -- 
         //   specialized to be very lightweight for the sequence control.
-        function makeSingleViewControl(control, events) {
+        function makeSingleViewControl(control) {
             return resolver.loadViewControl(itemSpec)
                 .then(function(widgetFactory) {
                     // CONTROL
-                    var preButton, postButton,
+                    var postButton,
                         widgetId = html.genId(),
                         inputBus = runtime.bus().makeChannelBus({
                             description: 'Array input control'
@@ -160,16 +159,6 @@ define([
                         }
                     });
 
-                    preButton = div({
-                        class: 'input-group-addon kb-input-group-addon',
-                        dataElement: 'index-label',
-                        style: {
-                            width: '5ex',
-                            padding: '0'
-                        }
-                    }, [
-                        span({ dataElement: 'index' }, String(control.index + 1)), '.'
-                    ]);
                     postButton = div({
                         class: 'input-group-addon kb-input-group-addon',
                         style: {
@@ -256,7 +245,7 @@ define([
                         return index;
                     })
                     .catch(function(err) {
-                        console.log('ERROR!!!', err);
+                        console.error('ERROR!!!', err);
                     });
             });
         }
@@ -280,8 +269,8 @@ define([
                     return addEmptyControl();
                 }
                 return Promise.all(initialValue.map(function(value) {
-                        return addNewControl(value);
-                    }))
+                    return addNewControl(value);
+                }))
                     .then(function() {
                         autoValidate();
                     });
@@ -315,7 +304,7 @@ define([
 
                 return render(config.initialValue)
                     .then(function() {
-                        channel.on('reset-to-defaults', function(message) {
+                        channel.on('reset-to-defaults', function() {
                             resetModelValue();
                         });
                         channel.on('update', function(message) {
@@ -333,8 +322,8 @@ define([
         function stop() {
             return Promise.try(function() {
                 return Promise.all(viewModel.getItem('items').map(function(item) {
-                        return item.inputControl.instance.stop();
-                    }))
+                    return item.inputControl.instance.stop();
+                }))
                     .then(function() {
                         busConnection.stop();
                     });

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
@@ -153,7 +153,8 @@ define([
                             // appSpec: appSpec,
                             parameterSpec: fieldSpec,
                             // workspaceId: workspaceInfo.id,
-                            referenceType: 'ref'
+                            referenceType: 'ref',
+                            paramsChannelName: config.paramsChannelName
                         });
 
                     // set up listeners for the input

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
@@ -26,8 +26,6 @@ define([
     // Constants
     var t = html.tag,
         div = t('div'),
-        input = t('input'),
-        span = t('span'),
         resolver = Resolver.make();
 
     function factory(config) {
@@ -49,8 +47,7 @@ define([
             // },
             // structFields,
             fieldLayout = spec.ui.layout,
-            struct = spec.parameters,
-            places = {};
+            struct = spec.parameters;
 
         if (spec.data.constraints.required || config.initialValue) {
             viewModel.state.enabled = true;
@@ -60,8 +57,8 @@ define([
 
         function setModelValue(value) {
             return Promise.try(function() {
-                    viewModel.data = value;
-                })
+                viewModel.data = value;
+            })
                 .then(function() {
                     // render();
                 })
@@ -72,9 +69,9 @@ define([
 
         function unsetModelValue() {
             return Promise.try(function() {
-                    viewModel.data = {};
-                })
-                .then(function(changed) {
+                viewModel.data = {};
+            })
+                .then(function() {
                     // render();
                 });
         }
@@ -144,7 +141,7 @@ define([
          * The single input control wraps a field widget, which provides the 
          * wrapper around the input widget itself.
          */
-        function makeSingleInputControl(value, fieldSpec, events) {
+        function makeSingleInputControl(value, fieldSpec) {
             return resolver.loadViewControl(fieldSpec)
                 .then(function(widgetFactory) {
                     var id = html.genId(),
@@ -221,9 +218,9 @@ define([
                     });
             } else {
                 return Promise.all(
-                        Object.keys(structFields).map(function(fieldName) {
-                            return structFields[fieldName].instance.stop();
-                        }))
+                    Object.keys(structFields).map(function(fieldName) {
+                        return structFields[fieldName].instance.stop();
+                    }))
                     .then(function() {
                         ui.setContent('input-container.subcontrols', '');
                         structFields = {};
@@ -231,7 +228,7 @@ define([
             }
         }
 
-        function renderStruct(events) {
+        function renderStruct() {
             var layout = div({
                 style: {
                     'border-left': '5px silver solid',
@@ -262,17 +259,17 @@ define([
         function start(arg) {
             var events;
             return Promise.try(function() {
-                    parent = arg.node;
-                    container = parent.appendChild(document.createElement('div'));
-                    ui = UI.make({ node: container });
-                    events = Events.make({ node: container });
+                parent = arg.node;
+                container = parent.appendChild(document.createElement('div'));
+                ui = UI.make({ node: container });
+                events = Events.make({ node: container });
 
-                    viewModel.data = lang.copy(config.initialValue);
+                viewModel.data = lang.copy(config.initialValue);
 
-                    // return bus.request({}, {
-                    //     key: 'get-param-state'
-                    // });
-                })
+                // return bus.request({}, {
+                //     key: 'get-param-state'
+                // });
+            })
                 .then(function() {
                     return render(events);
                 })
@@ -323,12 +320,12 @@ define([
 
         function stop() {
             return Promise.try(function() {
-                    if (structFields) {
-                        return Promise.all(Object.keys(structFields).map(function(id) {
-                            return structFields[id].instance.stop();
-                        }));
-                    }
-                })
+                if (structFields) {
+                    return Promise.all(Object.keys(structFields).map(function(id) {
+                        return structFields[id].instance.stop();
+                    }));
+                }
+            })
                 .then(function() {
                     if (parent && container) {
                         parent.removeChild(container);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/subdataView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/subdataView.js
@@ -57,7 +57,6 @@ define([
         var spec = config.parameterSpec,
             parent,
             container,
-            runtime = Runtime.make(),
             workspaceId = config.workspaceId,
             bus = config.bus,
             model,
@@ -66,7 +65,7 @@ define([
             options = {
                 objectSelectionPageSize: 20
             },
-            
+            runtime = Runtime.make(),
             ui;
 
         // Validate configuration.
@@ -486,7 +485,7 @@ define([
             }
         }
 
-        function makeInputControl(events, bus) {
+        function makeInputControl() {
             // There is an input control, and a dropdown,
             // TODO select2 after we get a handle on this...
             var availableValues = model.getItem('availableValues');
@@ -560,17 +559,14 @@ define([
             switch (changedProperty) {
             case 'value':
                 // just change the selections.
-                var count = buildCount();
-                ui.setContent('input-control.count', count);
+                ui.setContent('input-control.count', buildCount());
 
                 break;
             case 'availableValues':
                 // rebuild the options
                 // re-apply the selections from the value
-                var options = buildOptions(),
-                    count = buildCount();
-                ui.setContent('input-control.input', options);
-                ui.setContent('input-control.count', count);
+                ui.setContent('input-control.input', buildOptions());
+                ui.setContent('input-control.count', buildCount());
 
                 break;
             case 'referenceObjectName':
@@ -718,7 +714,7 @@ define([
              * Issued when thre is a need to have all params reset to their
              * default value.
              */
-            bus.on('reset-to-defaults', function(message) {
+            bus.on('reset-to-defaults', function() {
                 resetModelValue();
                 // model.reset();
                 // TODO: this should really be set when the linked field is reset...
@@ -938,7 +934,7 @@ define([
                 showFrom: 0,
                 showTo: 5
             },
-            onUpdate: function(props) {
+            onUpdate: function() {
                 renderStats();
                 renderToolbar();
                 renderAvailableItems();

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/subdataView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/subdataView.js
@@ -54,10 +54,10 @@ define([
         button = t('button');
 
     function factory(config) {
-        var options = {},
-            spec = config.parameterSpec,
+        var spec = config.parameterSpec,
             parent,
             container,
+            runtime = Runtime.make(),
             workspaceId = config.workspaceId,
             bus = config.bus,
             model,
@@ -66,7 +66,7 @@ define([
             options = {
                 objectSelectionPageSize: 20
             },
-            runtime = Runtime.make(),
+            
             ui;
 
         // Validate configuration.
@@ -147,82 +147,82 @@ define([
                 content = div({ style: { textAlign: 'center' } }, 'no available values');
             } else {
                 content = itemsToShow.map(function(item, index) {
-                        var isSelected = selected.some(function(id) {
-                                return (item.id === id);
-                            }),
-                            disabled = isSelected;
-                        return div({ class: 'row', style: { border: '1px #CCC solid' } }, [
-                            div({
-                                class: 'col-md-2',
-                                style: {
-                                    verticalAlign: 'middle',
-                                    borderRadius: '3px',
-                                    padding: '2px',
-                                    backgroundColor: '#EEE',
-                                    color: '#444',
-                                    textAlign: 'right',
-                                    paddingRight: '6px',
-                                    fontFamily: 'monospace'
-                                }
-                            }, String(from + index + 1)),
-                            div({
-                                class: 'col-md-8',
-                                style: {
-                                    padding: '2px'
-                                }
-                            }, item.text),
-                            div({
-                                class: 'col-md-2',
-                                style: {
-                                    padding: '2px',
-                                    textAlign: 'right',
-                                    verticalAlign: 'top'
-                                }
-                            }, [
-                                (function() {
-                                    if (disabled) {
-                                        return span({
-                                            class: 'kb-btn-icon',
-                                            type: 'button',
-                                            dataToggle: 'tooltip',
-                                            title: 'Remove from selected'
-                                        }, [
-                                            span({
-                                                class: 'fa fa-minus-circle',
-                                                style: {
-                                                    color: 'red',
-                                                    fontSize: '200%'
-                                                }
-                                            })
-                                        ]);
-                                    }
-                                    if (allowSelection) {
-                                        return span({
-                                            class: 'kb-btn-icon',
-                                            type: 'button',
-                                            dataToggle: 'tooltip',
-                                            title: 'Add to selected',
-                                            dataItemId: item.id,
-                                        }, [span({
-                                            class: 'fa fa-plus-circle',
-                                            style: {
-                                                color: 'green',
-                                                fontSize: '200%'
-                                            }
-                                        })]);
-                                    }
+                    var isSelected = selected.some(function(id) {
+                            return (item.id === id);
+                        }),
+                        disabled = isSelected;
+                    return div({ class: 'row', style: { border: '1px #CCC solid' } }, [
+                        div({
+                            class: 'col-md-2',
+                            style: {
+                                verticalAlign: 'middle',
+                                borderRadius: '3px',
+                                padding: '2px',
+                                backgroundColor: '#EEE',
+                                color: '#444',
+                                textAlign: 'right',
+                                paddingRight: '6px',
+                                fontFamily: 'monospace'
+                            }
+                        }, String(from + index + 1)),
+                        div({
+                            class: 'col-md-8',
+                            style: {
+                                padding: '2px'
+                            }
+                        }, item.text),
+                        div({
+                            class: 'col-md-2',
+                            style: {
+                                padding: '2px',
+                                textAlign: 'right',
+                                verticalAlign: 'top'
+                            }
+                        }, [
+                            (function() {
+                                if (disabled) {
                                     return span({
                                         class: 'kb-btn-icon',
                                         type: 'button',
                                         dataToggle: 'tooltip',
-                                        title: 'Can\'t add - remove one first',
-                                        dataItemId: item.id
-                                    }, span({ class: 'fa fa-ban', style: { color: 'silver', fontSize: '200%' } }));
-                                }())
+                                        title: 'Remove from selected'
+                                    }, [
+                                        span({
+                                            class: 'fa fa-minus-circle',
+                                            style: {
+                                                color: 'red',
+                                                fontSize: '200%'
+                                            }
+                                        })
+                                    ]);
+                                }
+                                if (allowSelection) {
+                                    return span({
+                                        class: 'kb-btn-icon',
+                                        type: 'button',
+                                        dataToggle: 'tooltip',
+                                        title: 'Add to selected',
+                                        dataItemId: item.id,
+                                    }, [span({
+                                        class: 'fa fa-plus-circle',
+                                        style: {
+                                            color: 'green',
+                                            fontSize: '200%'
+                                        }
+                                    })]);
+                                }
+                                return span({
+                                    class: 'kb-btn-icon',
+                                    type: 'button',
+                                    dataToggle: 'tooltip',
+                                    title: 'Can\'t add - remove one first',
+                                    dataItemId: item.id
+                                }, span({ class: 'fa fa-ban', style: { color: 'silver', fontSize: '200%' } }));
+                            }())
 
-                            ])
-                        ]);
-                    })
+                        ])
+                    ]);
+                })
                     .join('\n');
             }
 
@@ -307,30 +307,30 @@ define([
                 value: model.getItem('filter') || '',
                 id: events.addEvents({
                     events: [{
-                            type: 'keyup',
-                            handler: function(e) {
-                                doSearchKeyUp(e);
-                            }
-                        },
-                        {
-                            type: 'focus',
-                            handler: function() {
-                                Jupyter.narrative.disableKeyboardManager();
-                            }
-                        },
-                        {
-                            type: 'blur',
-                            handler: function() {
-                                // console.log('SingleSubData Search BLUR');
-                                // Jupyter.narrative.enableKeyboardManager();
-                            }
-                        },
-                        {
-                            type: 'click',
-                            handler: function() {
-                                Jupyter.narrative.disableKeyboardManager();
-                            }
+                        type: 'keyup',
+                        handler: function(e) {
+                            doSearchKeyUp(e);
                         }
+                    },
+                    {
+                        type: 'focus',
+                        handler: function() {
+                            Jupyter.narrative.disableKeyboardManager();
+                        }
+                    },
+                    {
+                        type: 'blur',
+                        handler: function() {
+                            // console.log('SingleSubData Search BLUR');
+                            // Jupyter.narrative.enableKeyboardManager();
+                        }
+                    },
+                    {
+                        type: 'click',
+                        handler: function() {
+                            Jupyter.narrative.disableKeyboardManager();
+                        }
+                    }
                     ]
                 })
             });
@@ -558,22 +558,22 @@ define([
          */
         function updateInputControl(changedProperty) {
             switch (changedProperty) {
-                case 'value':
-                    // just change the selections.
-                    var count = buildCount();
-                    ui.setContent('input-control.count', count);
+            case 'value':
+                // just change the selections.
+                var count = buildCount();
+                ui.setContent('input-control.count', count);
 
-                    break;
-                case 'availableValues':
-                    // rebuild the options
-                    // re-apply the selections from the value
-                    var options = buildOptions(),
-                        count = buildCount();
-                    ui.setContent('input-control.input', options);
-                    ui.setContent('input-control.count', count);
+                break;
+            case 'availableValues':
+                // rebuild the options
+                // re-apply the selections from the value
+                var options = buildOptions(),
+                    count = buildCount();
+                ui.setContent('input-control.input', options);
+                ui.setContent('input-control.count', count);
 
-                    break;
-                case 'referenceObjectName':
+                break;
+            case 'referenceObjectName':
                     // refetch the available values
                     // set available values
                     // update input control for available values
@@ -617,8 +617,8 @@ define([
 
         function syncAvailableValues() {
             return Promise.try(function() {
-                    return fetchData();
-                })
+                return fetchData();
+            })
                 .then(function(data) {
                     isAvailableValuesInitialized = true;
                     if (!data) {
@@ -670,25 +670,25 @@ define([
          */
         function render() {
             return Promise.try(function() {
-                    // check to see if we have to render inputControl.
-                    var events = Events.make({ node: container }),
-                        inputControl = makeInputControl(events, bus),
-                        content = div({
-                            class: 'input-group',
-                            style: {
-                                width: '100%'
-                            }
-                        }, inputControl);
+                // check to see if we have to render inputControl.
+                var events = Events.make({ node: container }),
+                    inputControl = makeInputControl(events, bus),
+                    content = div({
+                        class: 'input-group',
+                        style: {
+                            width: '100%'
+                        }
+                    }, inputControl);
 
-                    ui.setContent('input-container', content);
-                    renderSearchBox();
-                    renderStats();
-                    renderToolbar();
-                    renderAvailableItems();
-                    renderSelectedItems();
+                ui.setContent('input-container', content);
+                renderSearchBox();
+                renderStats();
+                renderToolbar();
+                renderAvailableItems();
+                renderSelectedItems();
 
-                    events.attachEvents();
-                })
+                events.attachEvents();
+            })
                 .catch(function(err) {
                     console.error('ERROR in render', err);
                 });
@@ -870,21 +870,21 @@ define([
                 // Get initial data.
                 // Weird, but will make it look nicer.
                 Promise.all([
-                        bus.request({
-                            parameterName: spec.id
-                        }, {
-                            key: {
-                                type: 'get-parameter'
-                            }
-                        }),
-                        bus.request({
-                            parameterName: spec.data.constraints.subdataSelection.parameter_id
-                        }, {
-                            key: {
-                                type: 'get-parameter'
-                            }
-                        })
-                    ])
+                    bus.request({
+                        parameterName: spec.id
+                    }, {
+                        key: {
+                            type: 'get-parameter'
+                        }
+                    }),
+                    bus.request({
+                        parameterName: spec.data.constraints.subdataSelection.parameter_id
+                    }, {
+                        key: {
+                            type: 'get-parameter'
+                        }
+                    })
+                ])
                     .spread(function(paramValue, referencedParamValue) {
                         // hmm, the default value of a subdata is null, but that does
                         // not play nice with the model props defaulting mechanism which


### PR DESCRIPTION
Fixed the bug with the subdata view control not working when embedded within a repeating grouped parameter. The issue was the at the sequence control (responsible for repeated parameters) and was not passing along the "param channel id" which is required for parameters to be able to receive updates from other parameters. In addition the subdata view control itself would not have made use of the param channel for receiving these updates. For the view control, this only occurs during widget startup.

While working on this, the following bugs were discovered and fixed:
- required subdata controls were showing the red "required but incomplete" flag upon reloading a narrative, even if they were indeed populated. This was fixed by ensuring that the autoValidation method runs after data refresh.
- it was possible to double-tap the add-subdata-item button for large subdata collections -- the processing of a large subdata collection (e.g. sorghum features) is noticeable and there was no guard around the button event code.
- search was not case insensitive, but is supposed to be.

There was also a performance related issue with the subdata search. To prevent search over large collections from causing ui pauses, the search was enforcing 3 or more characters before the search would run. This was confusing because there was no messaging; and also unnecessary for small collections which can render at keypress speed. So now only collections with 4K or more items will invoke this behavior, and a message is displayed to the right of the control  to indicate more characters are required.

Also cleared the path with the first few commits by resolving code quality issues which triggered lint errors (and would prevent me from seeing real errors in modified code.)