### PR TITLE
addresses VERY LARGE HEAT MAPS [SCT-878]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
@@ -98,7 +98,6 @@ define ([
             var colW = rowH;
             var hmW = 150 + 110 + size * colW;
 
-console.log("ACTUAL SIZE IS : ", hmW, hmH, rowIds.length);
             var $heatmapDiv = $('<div style = \'width : '+hmW+'px; height : '+hmH+'px\'></div>');
 //            $containerDiv.append($heatmapDiv);
             $containerDiv.append('<div style = \'width : 5px; height : 5px\'></div>');

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
@@ -5,6 +5,8 @@
  * @public
  */
 
+ var MAGIC_DOWNLOAD_NUMBER = 50;
+
 define ([
     'kbwidget',
     'bootstrap',
@@ -19,7 +21,7 @@ define ([
     kbaseHeatmap
 ) {
     'use strict';
-    
+
     return KBWidget({
         name: 'kbaseExpressionPairwiseCorrelation',
         parent : kbaseExpressionGenesetBaseWidget,
@@ -73,9 +75,9 @@ define ([
                 var row = [];
                 for(var j = 0 ; j < rowDescriptors.length; j++){
                     row.push(values[i][j].toFixed(3));
-                }                
+                }
                 data.push(row);
-            }            
+            }
             var heatmap =
                 {
                     row_ids : rowIds,
@@ -86,20 +88,19 @@ define ([
                 };
 
             var size = rowIds.length;
-            var rowH = 35;
+            var rowH = 15;
             var hmH = 80 + 20 + size * rowH;
-            if (hmH > 700)
-                hmH = 700;
+
             if (hmH < 210) {
                 hmH = 210;
                 rowH = Math.round((hmH - 100) / size);
             }
             var colW = rowH;
             var hmW = 150 + 110 + size * colW;
-            if (hmW > 700)
-                hmW = 700;
+
+console.log("ACTUAL SIZE IS : ", hmW, hmH, rowIds.length);
             var $heatmapDiv = $('<div style = \'width : '+hmW+'px; height : '+hmH+'px\'></div>');
-            $containerDiv.append($heatmapDiv);
+//            $containerDiv.append($heatmapDiv);
             $containerDiv.append('<div style = \'width : 5px; height : 5px\'></div>');
 
             // TODO: heatmap values out of range still scale color instead of just the max/min color
@@ -109,7 +110,34 @@ define ([
                 minValue : self.minRange,
                 maxValue : self.maxRange
             });
-            
+
+            if (rowIds.length < MAGIC_DOWNLOAD_NUMBER) {
+              $containerDiv.append($heatmapDiv);
+            }
+            else {
+              var $svg = $heatmapDiv.find('svg');
+              var $dummy = $.jqElem('div').append($svg);
+
+              $containerDiv.append(
+                $.jqElem('button')
+                  .append("Please download the svg of this pairwise correlation")
+                  .addClass('btn btn-primary')
+                  .on('click', function(e) {
+                  var file = new Blob([$dummy.html()], {type : 'text'});
+                  var a = document.createElement("a"),
+                          url = URL.createObjectURL(file);
+                  a.href = url;
+                  a.download = 'pairwise.svg';
+                  document.body.appendChild(a);
+                  a.click();
+                  setTimeout(function() {
+                      document.body.removeChild(a);
+                      window.URL.revokeObjectURL(url);
+                  }, 0);
+                })
+              );
+            }
+
         }
     });
 });


### PR DESCRIPTION
This does three things -

1) It was rendering heat maps with a cell size of 35—dropped that to 15 instead.
2) If a heat map was > 700px, it'd just crunch it down to 700px and render as a smudge. Now it allows it to grow as necessary.
3) added the MAGIC_DOWNLOAD_NUMBER (which is arbitrarily set to 50). If a heat map has more than 50 columns/rows in it, it won't display it to the user. Instead, they'll get a button that says "Please download the svg of this pairwise correlation" where they can download it instead.

For sake of data, the gray heat map attached to the ticket came out of this narrative: https://ci.kbase.us/narrative/ws.31058.obj.1# as part of ecoli_K_5_clusters. Add that object, go to the clusters tab, and then "Explore Pairwise Correlations" for cluster_0. That's a heat map with 223 rows, and 5.1 megabytes to download. My iMac has 32 gigs of RAM in it and BOY it was not happy trying to display all of that in the browser, but it can do it. Eventually.

Confirmed that the downloaded svg can be opened up in Inkscape. Again, eventually.