### PR TITLE
SCT-908: Heatmap formatting issues

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseExpressionMatrixHeatmap.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/rna-seq/kbaseExpressionMatrixHeatmap.js
@@ -40,7 +40,7 @@ define ([
                     .addClass('alert alert-danger')
                     .html('Could not load object : ' + newDataset.description);
             } else {
-                var $heatElem = $.jqElem('div').css({width : 800, height : newDataset.data.row_ids.length * 10});
+                var $heatElem = $.jqElem('div').css({width : 800, height : newDataset.data.row_ids.length * 10 + 100});
 
                 var $heatmap = new kbaseHeatmap($heatElem, {
                     xPadding : 170,

--- a/kbase-extension/static/kbase/js/widgets/vis/kbaseHeatmap.js
+++ b/kbase-extension/static/kbase/js/widgets/vis/kbaseHeatmap.js
@@ -601,7 +601,7 @@ define (
 
                         $hm.showToolTip(
                             {
-                                label : d.label || 'Value for: ' + d.row + ' - ' + d.column + '<br>is ' + d.value,
+                                label : d.label || 'Value for: ' + d.row + ' - ' + d.column + '<br>is ' + d.value.toPrecision(4),
                             }
                         );
 


### PR DESCRIPTION
This PR addresses a couple of small issues requested by Sunita. It limits the precision of heatmap tooltips to 4 sig figs and addresses scrunched up heatmaps that occur when there are too few rows