### PR TITLE
SCT-962, SCT-975 batch backend

### DIFF
--- a/src/biokbase/narrative/app_util.py
+++ b/src/biokbase/narrative/app_util.py
@@ -25,6 +25,17 @@ def check_tag(tag, raise_exception=False):
         return tag_exists
 
 
+def strict_system_variable(var):
+    """
+    Returns a system variable.
+    If that variable isn't defined, or anything else happens, raises an exception.
+    """
+    result = system_variable(var)
+    if result is None:
+        raise ValueError('Unable to retrieve system variable: "{}"'.format(var))
+    return result
+
+
 def system_variable(var):
     """
     Returns a KBase system variable. Just a little wrapper.

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -271,7 +271,7 @@ class AppManager(object):
             return new_job
 
     def run_app(self, app_id, params, tag="release", version=None,
-                cell_id=None, run_id=None, dry_run=False, **kwargs):
+                cell_id=None, run_id=None, dry_run=False):
         """
         Attempts to run the app, returns a Job with the running app info.
         If this is given a cell_id, then returns None. If not, it returns the
@@ -304,7 +304,7 @@ class AppManager(object):
             if params is None:
                 params = dict()
             return self._run_app_internal(app_id, params, tag, version,
-                                          cell_id, run_id, dry_run, **kwargs)
+                                          cell_id, run_id, dry_run)
         except Exception as e:
             e_type = type(e).__name__
             e_message = str(e).replace('<', '&lt;').replace('>', '&gt;')
@@ -331,7 +331,7 @@ class AppManager(object):
             return
 
     def _run_app_internal(self, app_id, params, tag, version,
-                          cell_id, run_id, dry_run, **kwargs):
+                          cell_id, run_id, dry_run):
         """
         Attemps to run the app, returns a Job with the running app info.
         Should *hopefully* also inject that app into the Narrative's metadata.

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -152,6 +152,7 @@ class AppManager(object):
 
     def _run_batch_app_internal(self, app_id, params, tag, version, cell_id, run_id, dry_run):
         batch_method = "kb_BatchApp.run_batch"
+        batch_app_id = "kb_BatchApp/run_batch"
         batch_method_ver = "dev"
         ws_id = strict_system_variable('workspace_id')
         spec = self._get_validated_app_spec(app_id, tag, True, version=version)
@@ -218,8 +219,8 @@ class AppManager(object):
         job_runner_inputs = {
             'method': batch_method,
             'service_ver': batch_method_ver,
-            'params': batch_params,
-            'app_id': app_id,
+            'params': [batch_params],
+            'app_id': batch_app_id,
             'wsid': ws_id,
             'meta': job_meta
         }

--- a/src/biokbase/narrative/tests/test.cfg
+++ b/src/biokbase/narrative/tests/test.cfg
@@ -48,6 +48,7 @@ test_app_id=AssemblyRAST/run_arast
 test_app_tag=dev
 test_job_id=new_job_id
 test_input_ref=11635/19/4
+batch_app_id=kb_BatchApp.run_batch
 
 [logging]
 config=logproxy.conf

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -3,6 +3,7 @@ Tests for the app manager.
 """
 from biokbase.narrative.jobs.appmanager import AppManager
 from biokbase.narrative.jobs.specmanager import SpecManager
+import biokbase.narrative.app_util as app_util
 from biokbase.narrative.jobs.job import Job
 from IPython.display import HTML
 import unittest
@@ -191,10 +192,7 @@ class AppManagerTestCase(unittest.TestCase):
         os.environ['KB_WORKSPACE_ID'] = self.public_ws
         sm = SpecManager()
         spec = sm.get_spec(app_id, tag=tag)
-        (params, ws_inputs) = self.am._validate_parameters(app_id,
-                                                           tag,
-                                                           sm.app_params(spec),
-                                                           inputs)
+        (params, ws_inputs) = app_util.validate_parameters(app_id, tag, sm.app_params(spec), inputs)
         self.assertDictEqual(params, inputs)
         self.assertIn('11635/9/1', ws_inputs)
         self.assertIn('11635/10/1', ws_inputs)
@@ -260,7 +258,7 @@ class AppManagerTestCase(unittest.TestCase):
         }]
         self.assertDictEqual(expected[0], mapped_inputs[0])
         ref_path = ws_name + '/MyReadsSet; ' + ws_name + "/rhodobacterium.art.q10.PE.reads"
-        ret = self.am._transform_input("resolved-ref", ref_path, None)
+        ret = app_util.transform_param_value("resolved-ref", ref_path, None)
         self.assertEqual(ret, "wjriehl:1475006266615/MyReadsSet;11635/10/1")
         if prev_ws_id is None:
             del(os.environ['KB_WORKSPACE_ID'])
@@ -388,13 +386,13 @@ class AppManagerTestCase(unittest.TestCase):
         ]
         for test in test_data:
             spec = test.get('spec', None)
-            ret = self.am._transform_input(test['type'], test['value'], spec)
+            ret = app_util.transform_param_value(test['type'], test['value'], spec)
             self.assertEqual(ret, test['expected'])
         del(os.environ['KB_WORKSPACE_ID'])
 
     def test_transform_input_bad(self):
         with self.assertRaises(ValueError):
-            self.am._transform_input('foo', 'bar', None)
+            app_util.transform_param_value('foo', 'bar', None)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds a `run_app_batch` function to the appmanager. Instead of taking a single dictionary of inputs, it takes a list of dictionaries. These get built out (based on the app their calling), then bundled together in a call to the kb_BatchApp.run_batch app.

This all might change eventually, but it's a place to start from.