### PR TITLE
SCT-976 batch jobmanager

### DIFF
--- a/kbase-extension/static/kbase/js/util/timeFormat.js
+++ b/kbase-extension/static/kbase/js/util/timeFormat.js
@@ -336,6 +336,9 @@ define([], function() {
      * @return {string} a human readable timestamp
      */
     function readableTimestamp (timestamp) {
+        if (!timestamp) {
+            timestamp = 0;
+        }
         var format = function (x) {
             if (x < 10)
                 x = '0' + x;

--- a/src/biokbase/narrative/clients.py
+++ b/src/biokbase/narrative/clients.py
@@ -33,9 +33,21 @@ def __init_client(client_name):
         c = Catalog(URLS.catalog)
     elif client_name == 'service' or client_name == 'service_wizard':
         c = ServiceClient(URLS.service_wizard, use_url_lookup=True)
-
+    elif client_name == 'job_service_mock':
+        c = JobServiceMock()
     else:
         raise ValueError('Unknown client name "%s"' % client_name)
 
     __clients[client_name] = c
     return c
+
+
+class JobServiceMock():
+    def __init__(self):
+        self.client = get('service')
+
+    def check_job(self, job_id):
+        return self.client.sync_call('narrative_job_mock.check_job', [job_id])[0]
+
+    def check_jobs(self, params):
+        return self.client.sync_call('narrative_job_mock.check_jobs', [params])[0]

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -121,7 +121,7 @@ class Job(object):
         if self._last_state is not None and self._last_state.get('finished', 0) == 1:
             return self._last_state
         try:
-            state = clients.get("job_service").check_job(self.job_id)
+            state = clients.get("job_service_mock").check_job(self.job_id)
             if 'cancelled' in state:
                 state[u'canceled'] = state.get('cancelled', 0)
                 del state['cancelled']

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -86,7 +86,7 @@ class JobManager(object):
             raise new_e
 
         job_ids = [j[0] for j in nar_jobs]
-        job_states = clients.get('job_service').check_jobs({
+        job_states = clients.get('job_service_mock').check_jobs({
             'job_ids': job_ids, 'with_job_params': 1
         })
         job_param_info = job_states.get('job_params', {})
@@ -740,7 +740,7 @@ class JobManager(object):
                 jobs_to_lookup.append(job_id)
         # 3. Lookup those jobs what need it. Cache 'em as we go, if finished.
         try:
-            fetched_states = clients.get('job_service').check_jobs({'job_ids': jobs_to_lookup})
+            fetched_states = clients.get('job_service_mock').check_jobs({'job_ids': jobs_to_lookup})
         except Exception as e:
             kblogging.log_event(self._log, 'get_all_job_states_error', {'err': str(e)})
             return {}


### PR DESCRIPTION
There really isn't much to do for the batch jobmanager, as defined now. But this wires things together to use the mock job checking service. Also there's a couple minor fixes to some frontend things.

So it's temporary, but reasonably small. It does also depend on #1314 getting merged first, though.