### PR TITLE
disabled report viewer button is now disabled text file not ban [SCT-930]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1216,7 +1216,9 @@ define([
                 .then(function (result) {
                     if (result.length === 0) {
                         $reportButton.addClass('disabled');
-                        $reportButton.empty().append($('<span>').addClass('fa fa-ban').css('width', '0.75em'));
+                        $reportButton.empty().append($('<span>')
+                            .addClass('fa fa-file-text')
+                            .css('width', '0.75em'));
                         $reportButton
                             .tooltip({
                                 title: 'No report associated with this object',
@@ -1229,7 +1231,11 @@ define([
                         objData.reportRef = null;
                         return;
                     } else if (result.length === 1) {
-                        $reportButton.empty().append($('<span>').addClass('fa fa-file-text').css('width', '0.75em'));
+                        $reportButton
+                            .empty()
+                            .append($('<span>')
+                                .addClass('fa fa-file-text')
+                                .css('width', '0.75em'));
                         objData.reportRef = result[0].ref;
                         $reportButton
                             .tooltip({


### PR DESCRIPTION
Just a very minor change to have the icon for a non-functional disabled report viewer button be the same as the enabled button (the "file-text" font awesome font) but showing in a disabled state.
I was experimenting with icons for the states, and left the "ban" icon inadvertently.