### PR TITLE
fix problem when starting a batch app

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -185,7 +185,6 @@ class AppManager(object):
 
         # This is what calls the function in the back end - Module.method
         # This isn't the same as the app spec id.
-        function_name = service_name + '.' + service_method
         job_meta = {'tag': tag}
         if cell_id is not None:
             job_meta['cell_id'] = cell_id
@@ -194,8 +193,8 @@ class AppManager(object):
 
         # Now put these all together in a way that can be sent to the batch processing app.
         batch_params = {
-            "app_id": app_id,
-            "method": function_name,
+            "module_name": service_name,
+            "method_name": service_method,
             "service_ver": service_ver,
             "wsid": ws_id,
             "meta": job_meta,


### PR DESCRIPTION
The parameters being sent to the batch app weren't what was expected. Expected a string like "module.method" for app_id. Instead, app_id expected just the module name.

So this is the narrative side of two changes. The kb_BatchApp.run_batch now expects "module_name" and "method_name" to be separate, and this Narrative change updates to meet the right expectations.