### PR TITLE
font styles

### DIFF
--- a/kbase-extension/static/kbase/config/feature-config.json
+++ b/kbase-extension/static/kbase/config/feature-config.json
@@ -4,5 +4,5 @@
     "advanced": false,
     "developer": false,
     "lazyWidgetRender": true,
-    "batchAppMode": true
+    "batchAppMode": false
 }

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -74,7 +74,6 @@
 #kb-narr-name {
     font-family: Oxygen;
     font-weight: bold;
-    font-style: italic;
     font-size: 130%;
     padding-bottom: 7px;
     white-space: nowrap;

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -3177,7 +3177,6 @@ button.kb-data-obj {
 #kb-loading-blocker p {
     text-align: center;
     font-size: 24px;
-    font-family: Oxygen helvetica neue;
     font-weight: bold;
 }
 

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -210,7 +210,8 @@ define([
                             type: 'get-batch-mode'
                         },
                         handle: function() {
-                            return model.getItem('user-settings.batchMode') || false;
+                            var canDoBatch = Config.get('features').batchAppMode;
+                            return canDoBatch && (model.getItem('user-settings.batchMode') || false);
                         }
                     });
 
@@ -780,6 +781,9 @@ define([
         }
 
         function toggleBatchMode() {
+            if (!Config.get('features').batchAppMode) {
+                return;
+            }
             // var curState = fsm.getCurrentState();
             // var btn = ui.getButton('batch-toggle');
             // btn.classList.toggle('batch-active');
@@ -1268,7 +1272,7 @@ define([
             var runId = new Uuid(4).format(),
                 fixedApp = fixApp(app),
                 code;
-            if (model.getItem('user-settings.batchMode')) {
+            if (model.getItem('user-settings.batchMode') && Config.get('features').batchAppMode) {
                 code = PythonInterop.buildBatchAppRunner(cellId, runId, fixedApp, [params]);
             }
             else {

--- a/nbextensions/appCell2/widgets/appParamsWidget.js
+++ b/nbextensions/appCell2/widgets/appParamsWidget.js
@@ -15,7 +15,8 @@ define([
     'widgets/appWidgets2/fieldWidgetCompact',
     'widgets/appWidgets2/paramResolver',
 
-    'common/runtime'
+    'common/runtime',
+    'narrativeConfig'
     // All the input widgets
 
 ], function (
@@ -29,7 +30,8 @@ define([
     RowWidget,
     FieldWidget,
     ParamResolver,
-    Runtime
+    Runtime,
+    Config
 
     // Input widgets
 ) {
@@ -319,8 +321,8 @@ define([
 
         function renderLayout(batchMode) {
             var events = Events.make(),
-                batchToggleBtn = buildBatchToggleButton(batchMode, events),
-                formContent = [batchToggleBtn];
+                batchToggleBtn = Config.get('features').batchAppMode ? buildBatchToggleButton(batchMode, events) : null,
+                formContent = batchToggleBtn ? [batchToggleBtn] : [];
             if (batchMode) {
                 formContent.push(div('batch mode!'));
             }


### PR DESCRIPTION
Just tweaks a couple small things since the last update that cleaned up how fonts are made.
1. Changes the Narrative titles back to non-italicized.
2. Changes the font in the loading screen from just a plain serifed font (I think it was Times New Roman) back to Oxygen Bold.

Others could go here, too. I think a mix of the font sizes and bolding make them look squashed together in the data and app cards, as well as the headers to the data slideout, but those might take extra fiddling.