### PR TITLE
SCT 1082 - fix public data tab regressions

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCardLayout.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCardLayout.js
@@ -82,7 +82,6 @@ define ([
             })
             .click(function () {
                 $moreContent.slideToggle('fast');
-                console.log('here12', options);
                 if (options.onOpen) {
                     try {
                         options.onOpen();

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -374,7 +374,7 @@ define([
             if(this.writingLock) {
                 return;
             }
-            // Set the refresh timer on the first refresh. From  here, it'll refresh it_this
+            // Set the refresh timer on the first refresh. From  here, it'll refresh itself
             // every this.options.refresh_interval (30000) ms
             if (this.refreshTimer === null) {
                 this.refreshTimer = setInterval(function () {


### PR DESCRIPTION
couple of regressions in the data copy feature for the public data tab:
- genome names with html-entities needed additional scrubbing when translating to object name
- the public data tab's copy of the data list widget's data was populated at widget creation time, which occurs (at least now, or sometimes) before the data is loaded, so it was behaving (initially) as if the there were no objects in the narrative, which conflicted with the workspace calls which revealed that there were! A race condition. Moved the data loading into the first render of the widget, rather than the init method (aka, constructor).