### PR TITLE
enhanced expression matrix viewer [SCT-901]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -12,7 +12,7 @@ define ([
     'kbaseTabs',
     'narrativeConfig',
     'kb_common/jsonRpc/dynamicServiceClient',
-    'ExpressionUtils-client-api',
+		'kbase-generic-client-api',
     // For effect
     'bootstrap',
     'jquery-dataTables'
@@ -24,7 +24,7 @@ define ([
     kbaseTabs,
     Config,
     DynamicServiceClient,
-    ExpressionUtilsClient,
+		GenericClient
 ) {
     'use strict';
 
@@ -71,17 +71,22 @@ define ([
                 token: auth.token
             });
 
-            this.expressionUtils = new DynamicServiceClient({
-                module: 'ExpressionUtils',
+            /*this.expressionUtils = new DynamicServiceClient({
+                module: 'ExpressionAPI',
                 url: Config.url('service_wizard'),
                 token: auth.token,
                 version : 'dev',
-            });
+            });*/
 
-            /*this.expressionUtils = new ExpressionUtils(
+            this.genericClient = new GenericClient(
+              Config.url('service_wizard'),
+              { token: auth.token, version : 'dev' }
+            );
+
+            /*this.expressionAPI = new expressionAPI(
                 Config.url('service_wizard'),
                 {'token': this.authToken()});*/
-console.log("EU IS : ", this.expressionUtils);
+console.log("EU IS : ", this.genericClient, auth.token);
             // Let's go...
             this.loadAndRender();
 
@@ -98,15 +103,20 @@ console.log("EU IS : ", this.expressionUtils);
 
             self.loading(true);
             var expressionMatrixRef = '16162/40/2';//this.options.workspaceID + '/' + this.options.expressionMatrixID;
-            /*Promise.resolve(self.expressionUtils.get_enhancedFilteredExpressionMatrix({
+            /*Promise.resolve(self.expressionAPI.get_enhancedFilteredExpressionMatrix({
                 fem_objet_ref: expressionMatrixRef
             }))*/
-            self.expressionUtils.callFunc('get_enhancedFilteredExpressionMatrix', {
-              fem_objet_ref: expressionMatrixRef
-            } )
+            console.log("CALL ONE");
+            self.genericClient.sync_call('ExpressionAPI.get_enhancedFilteredExpressionMatrix', [{
+              fem_object_ref: expressionMatrixRef
+            }] )
             .then( function (data) {
               console.log("I HAVE ME DATA : ", data);
+              self.matrixStat = data[0].enhanced_FEM.data;
+              self.render();
+              self.loading(false);
             })
+
                 /*.spread(function (data) {
                     self.matrixStat = data;
                     self.render();
@@ -116,6 +126,18 @@ console.log("EU IS : ", this.expressionUtils);
                 console.log("FAILED WITH : ", error, expressionMatrixRef);
                     self.clientError(error);
                 });
+var oldStyleRef = this.options.workspaceID + '/' + this.options.expressionMatrixID;
+console.log("OLD CALL", self.featureValues, oldStyleRef);
+            self.featureValues.callFunc('get_matrix_stat', [{
+                input_data: oldStyleRef
+            }])
+                .spread(function (data) {
+console.log("OLD LOAD DATA : ", data);
+                })
+                .catch(function(error){
+console.log("OLD CALL FAILED : ", error);
+                });
+
         },
 
         render: function() {

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -106,12 +106,12 @@ console.log("EU IS : ", this.genericClient, auth.token);
             /*Promise.resolve(self.expressionAPI.get_enhancedFilteredExpressionMatrix({
                 fem_objet_ref: expressionMatrixRef
             }))*/
-            console.log("CALL ONE");
+            console.log("CALL ONE AGAINST ", expressionMatrixRef);
             self.genericClient.sync_call('ExpressionAPI.get_enhancedFilteredExpressionMatrix', [{
               fem_object_ref: expressionMatrixRef
             }] )
             .then( function (data) {
-              console.log("I HAVE ME DATA : ", data);
+              console.log("I HAVE ME DATA : ", expressionMatrixRef, data);
               self.matrixStat = data[0].enhanced_FEM.data;
               self.render();
               self.loading(false);
@@ -127,7 +127,8 @@ console.log("EU IS : ", this.genericClient, auth.token);
                     self.clientError(error);
                 });
 var oldStyleRef = this.options.workspaceID + '/' + this.options.expressionMatrixID;
-console.log("OLD CALL", self.featureValues, oldStyleRef);
+oldStyleRef = '16162/40/2';
+/*console.log("OLD CALL", self.featureValues, oldStyleRef);
             self.featureValues.callFunc('get_matrix_stat', [{
                 input_data: oldStyleRef
             }])
@@ -136,6 +137,17 @@ console.log("OLD LOAD DATA : ", data);
                 })
                 .catch(function(error){
 console.log("OLD CALL FAILED : ", error);
+                });*/
+
+console.log("GC OLD CALL", self.featureValues, oldStyleRef);
+            self.genericClient.sync_call('KBaseFeatureValues.get_matrix_stat', [{
+                input_data: oldStyleRef
+            }])
+                .spread(function (data) {
+console.log("GC OLD LOAD DATA : ", data);
+                })
+                .catch(function(error){
+console.log("GC OLD CALL FAILED : ", error);
                 });
 
         },

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -10,8 +10,9 @@ define ([
     'kbwidget',
     'kbaseAuthenticatedWidget',
     'kbaseTabs',
-    'narrativeConfig',    
+    'narrativeConfig',
     'kb_common/jsonRpc/dynamicServiceClient',
+    'ExpressionUtils-client-api',
     // For effect
     'bootstrap',
     'jquery-dataTables'
@@ -22,7 +23,8 @@ define ([
     kbaseAuthenticatedWidget,
     kbaseTabs,
     Config,
-    DynamicServiceClient
+    DynamicServiceClient,
+    ExpressionUtilsClient,
 ) {
     'use strict';
 
@@ -69,6 +71,16 @@ define ([
                 token: auth.token
             });
 
+            /*this.expressionUtils = new DynamicServiceClient({
+                module: 'ExpressionUtils',
+                url: Config.url('service_wizard'),
+                token: auth.token
+            });*/
+
+            this.expressionUtils = new ExpressionUtils(
+                Config.url('service_wizard'),
+                {'token': this.authToken()});
+console.log("EU IS : ", this.expressionUtils);
             // Let's go...
             this.loadAndRender();
 
@@ -85,15 +97,19 @@ define ([
 
             self.loading(true);
             var expressionMatrixRef = this.options.workspaceID + '/' + this.options.expressionMatrixID;
-            self.featureValues.callFunc('get_matrix_stat', [{
-                input_data: expressionMatrixRef
-            }])
-                .spread(function (data) {
+            Promise.resolve(self.expressionUtils.get_enhancedFilteredExpressionMatrix({
+                fem_objet_ref: expressionMatrixRef
+            }))
+            .then( function (data) {
+              console.log("I HAVE ME DATA : ", data);
+            })
+                /*.spread(function (data) {
                     self.matrixStat = data;
                     self.render();
                     self.loading(false);
-                })
+                })*/
                 .catch(function(error){
+                console.log("FAILED WITH : ", error);
                     self.clientError(error);
                 });
         },
@@ -299,7 +315,7 @@ define ([
 
         clientError: function(error){
             this.loading(false);
-            // TODO: Don't know that this is a service error; should 
+            // TODO: Don't know that this is a service error; should
             // inspect the error object.
             this.showMessage(error.message);
         }

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -71,15 +71,16 @@ define ([
                 token: auth.token
             });
 
-            /*this.expressionUtils = new DynamicServiceClient({
+            this.expressionUtils = new DynamicServiceClient({
                 module: 'ExpressionUtils',
                 url: Config.url('service_wizard'),
-                token: auth.token
-            });*/
+                token: auth.token,
+                version : 'dev',
+            });
 
-            this.expressionUtils = new ExpressionUtils(
+            /*this.expressionUtils = new ExpressionUtils(
                 Config.url('service_wizard'),
-                {'token': this.authToken()});
+                {'token': this.authToken()});*/
 console.log("EU IS : ", this.expressionUtils);
             // Let's go...
             this.loadAndRender();
@@ -96,10 +97,13 @@ console.log("EU IS : ", this.expressionUtils);
             var self = this;
 
             self.loading(true);
-            var expressionMatrixRef = this.options.workspaceID + '/' + this.options.expressionMatrixID;
-            Promise.resolve(self.expressionUtils.get_enhancedFilteredExpressionMatrix({
+            var expressionMatrixRef = '16162/40/2';//this.options.workspaceID + '/' + this.options.expressionMatrixID;
+            /*Promise.resolve(self.expressionUtils.get_enhancedFilteredExpressionMatrix({
                 fem_objet_ref: expressionMatrixRef
-            }))
+            }))*/
+            self.expressionUtils.callFunc('get_enhancedFilteredExpressionMatrix', {
+              fem_objet_ref: expressionMatrixRef
+            } )
             .then( function (data) {
               console.log("I HAVE ME DATA : ", data);
             })
@@ -109,7 +113,7 @@ console.log("EU IS : ", this.expressionUtils);
                     self.loading(false);
                 })*/
                 .catch(function(error){
-                console.log("FAILED WITH : ", error);
+                console.log("FAILED WITH : ", error, expressionMatrixRef);
                     self.clientError(error);
                 });
         },

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionMatrix.js
@@ -11,8 +11,8 @@ define ([
     'kbaseAuthenticatedWidget',
     'kbaseTabs',
     'narrativeConfig',
-    'kb_common/jsonRpc/dynamicServiceClient',
 		'kbase-generic-client-api',
+    'bluebird',
     // For effect
     'bootstrap',
     'jquery-dataTables'
@@ -23,8 +23,8 @@ define ([
     kbaseAuthenticatedWidget,
     kbaseTabs,
     Config,
-    DynamicServiceClient,
-		GenericClient
+    GenericClient,
+    Promise
 ) {
     'use strict';
 
@@ -65,28 +65,11 @@ define ([
                 return this;
             }
 
-            this.featureValues = new DynamicServiceClient({
-                module: 'KBaseFeatureValues',
-                url: Config.url('service_wizard'),
-                token: auth.token
-            });
-
-            /*this.expressionUtils = new DynamicServiceClient({
-                module: 'ExpressionAPI',
-                url: Config.url('service_wizard'),
-                token: auth.token,
-                version : 'dev',
-            });*/
-
             this.genericClient = new GenericClient(
               Config.url('service_wizard'),
-              { token: auth.token, version : 'dev' }
+              { token: auth.token }
             );
 
-            /*this.expressionAPI = new expressionAPI(
-                Config.url('service_wizard'),
-                {'token': this.authToken()});*/
-console.log("EU IS : ", this.genericClient, auth.token);
             // Let's go...
             this.loadAndRender();
 
@@ -102,54 +85,49 @@ console.log("EU IS : ", this.genericClient, auth.token);
             var self = this;
 
             self.loading(true);
-            var expressionMatrixRef = '16162/40/2';//this.options.workspaceID + '/' + this.options.expressionMatrixID;
-            /*Promise.resolve(self.expressionAPI.get_enhancedFilteredExpressionMatrix({
-                fem_objet_ref: expressionMatrixRef
-            }))*/
-            console.log("CALL ONE AGAINST ", expressionMatrixRef);
-            self.genericClient.sync_call('ExpressionAPI.get_enhancedFilteredExpressionMatrix', [{
+            var expressionMatrixRef = this.options.upas.expressionMatrixID;
+
+            // this is the "old" method that loads up the Conditions table and some of the values in the Overview table
+            var get_matrix_stat_promise = self.genericClient.sync_call('KBaseFeatureValues.get_matrix_stat', [{
+                input_data: expressionMatrixRef
+            }]);
+
+            // this is the "new" method that loads an enhanced filter expression matrix, with an enhanced feature table that also
+            // contains q-value and fold change columns. Unfortunately, at the time that this widget went out, the service was fairly
+            // twitchy and prone to falling over - there were auth token issues that were resolved, but 502 bad gateway errors are
+            // still cropping up fairly often, which diminishes user experience.
+            //
+            // so there are a couple of bandaids in here to fall back on the old table data if this widget is deployed and the expression api
+            // service goes down.
+            var enhancedFilter_promise = self.genericClient.sync_call('ExpressionAPI.get_enhancedFilteredExpressionMatrix', [{
               fem_object_ref: expressionMatrixRef
-            }] )
-            .then( function (data) {
-              console.log("I HAVE ME DATA : ", expressionMatrixRef, data);
-              self.matrixStat = data[0].enhanced_FEM.data;
-              self.render();
-              self.loading(false);
-            })
+            }] );
 
-                /*.spread(function (data) {
-                    self.matrixStat = data;
-                    self.render();
-                    self.loading(false);
-                })*/
-                .catch(function(error){
-                console.log("FAILED WITH : ", error, expressionMatrixRef);
-                    self.clientError(error);
-                });
-var oldStyleRef = this.options.workspaceID + '/' + this.options.expressionMatrixID;
-oldStyleRef = '16162/40/2';
-/*console.log("OLD CALL", self.featureValues, oldStyleRef);
-            self.featureValues.callFunc('get_matrix_stat', [{
-                input_data: oldStyleRef
-            }])
-                .spread(function (data) {
-console.log("OLD LOAD DATA : ", data);
+            // first thing we do is our old get_matrix_stat call, which we need for the conditions table.
+            get_matrix_stat_promise
+              .then( function (res) {
+
+                self.matrixStat     = res[0];
+                // the number of features was defined in the old method call.
+
+                self.numFeatures = self.matrixStat.mtx_descriptor.rows_count;
+
+                // now we see if our expression api enhanced filter call works. If it did, then we keep a
+                // record of that object and update our numFeatures. That number *should* always be the same, but better
+                // safe than sorry
+                enhancedFilter_promise.then(function(res) {
+                  self.enhancedFeatures = res[0].enhanced_FEM.data;
+                  self.numFeatures      = self.enhancedFeatures.values.length;
                 })
-                .catch(function(error){
-console.log("OLD CALL FAILED : ", error);
-                });*/
-
-console.log("GC OLD CALL", self.featureValues, oldStyleRef);
-            self.genericClient.sync_call('KBaseFeatureValues.get_matrix_stat', [{
-                input_data: oldStyleRef
-            }])
-                .spread(function (data) {
-console.log("GC OLD LOAD DATA : ", data);
+                // once we've checked that enhancedFilter_promise, then no matter what we render our widget and flag that we're no longer loading
+                .finally( function() {
+                  self.render();
+                  self.loading(false);
                 })
-                .catch(function(error){
-console.log("GC OLD CALL FAILED : ", error);
-                });
-
+              })
+              .catch(function(error){
+                self.clientError(error);
+              });
         },
 
         render: function() {
@@ -157,6 +135,7 @@ console.log("GC OLD CALL FAILED : ", error);
             var pref = this.pref;
             var container = this.$elem;
             var matrixStat = this.matrixStat;
+            var enhancedFeatures = this.enhancedFeatures;
 
             ///////////////////////////////////// Instantiating Tabs ////////////////////////////////////////////
             container.empty();
@@ -174,7 +153,7 @@ console.log("GC OLD CALL FAILED : ", error);
                 .append(self.makeRow('Genome', $('<span />').append(matrixStat.mtx_descriptor.genome_name).css('font-style', 'italic')))
                 .append(self.makeRow('Description', matrixStat.mtx_descriptor.description))
                 .append(self.makeRow('# Conditions', matrixStat.mtx_descriptor.columns_count))
-                .append(self.makeRow('# Features', matrixStat.mtx_descriptor.rows_count))
+                .append(self.makeRow('# Features', self.numFeatures))
                 .append(self.makeRow('Scale', matrixStat.mtx_descriptor.scale))
                 .append(self.makeRow('Value type', matrixStat.mtx_descriptor.type))
                 .append(self.makeRow('Row normalization', matrixStat.mtx_descriptor.row_normalization))
@@ -225,6 +204,44 @@ console.log("GC OLD CALL FAILED : ", error);
                 $('<div style="font-size: 1em; margin-top:0.2em; font-style: italic; width:100%; text-align: center;">Statistics calculated across all conditions for the feature</div>')
             );
 
+            /* XXX - due to the notes up above about the ExpressionAPI sometimes failing, we keep track of what the old columns were in the table, as well as
+                     the new columns from the new method. Then a smidge later, we look to see if we have an enhancedFeatures object. If we do, then we use
+                     the new columns, and if not then we fall back to the old columns, since we're using the old method.
+            */
+            var oldFeatureTableColumns =
+              [
+                  { sTitle: 'Feature ID', mData: 'id'},
+                  { sTitle: 'Function', mData: 'function'},
+                  { sTitle: 'Min', mData:'min' },
+                  { sTitle: 'Max', mData:'max' },
+                  { sTitle: 'Average', mData:'avg' },
+                  { sTitle: 'Std. Dev.', mData:'std'},
+                  { sTitle: 'Missing Values?', mData:'missing_values' },
+                  { sTitle: 'Fold Change', mData:'fold-change' },
+                  { sTitle: 'Q Value', mData:'q-value' },
+              ]
+            ;
+
+            var newFeatureTableColumns =
+              [
+                  { sTitle: 'Feature ID', mData: 'id'},
+                  { sTitle: 'Function', mData: 'description'},
+                  { sTitle: 'Min', mData:'min' },
+                  { sTitle: 'Max', mData:'max' },
+                  { sTitle: 'Average', mData:'mean' },
+                  { sTitle: 'Std. Dev.', mData:'std_dev'},
+                  { sTitle: 'Missing Values?', mData:'is_missing_values' },
+                  { sTitle: 'Fold Change', mData:'fold-change' },
+                  { sTitle: 'Q Value', mData:'q-value' },
+              ]
+            ;
+
+            var featureTableColumns = self.enhancedFeatures
+              ? newFeatureTableColumns
+              : oldFeatureTableColumns;
+
+
+
             $('<table id="'+pref+'genes-table" \
                 class="table table-bordered table-striped" style="width: 100%; margin-left: 0px; margin-right: 0px;">\
                 </table>')
@@ -232,15 +249,7 @@ console.log("GC OLD CALL FAILED : ", error);
                 .dataTable({
                     sDom: 'lftip',
                     aaData: self.buildGenesTableData(),
-                    aoColumns: [
-                        { sTitle: 'Feature ID', mData: 'id'},
-                        { sTitle: 'Function', mData: 'function'},
-                        { sTitle: 'Min', mData:'min' },
-                        { sTitle: 'Max', mData:'max' },
-                        { sTitle: 'Average', mData:'avg' },
-                        { sTitle: 'Std. Dev.', mData:'std'},
-                        { sTitle: 'Missing Values?', mData:'missing_values' }
-                    ]
+                    aoColumns: featureTableColumns
                 });
         },
 
@@ -265,6 +274,55 @@ console.log("GC OLD CALL FAILED : ", error);
         },
 
         buildGenesTableData: function(){
+
+            var enhancedFeatures = this.enhancedFeatures;
+
+            /* XXX - finally in here, we look to see if we have our enhancedFeatures object. If we don't then we're going to bow out
+                     and fall back to 'oldBuildGenesTableData', which was the old method accessing the old data, just renamed. If we
+                     *do* have data, then we just continue on and build our table.
+            */
+            if (enhancedFeatures === undefined) {
+              return this.oldBuildGenesTableData();
+            }
+
+            var tableData = [];
+
+            var key_to_idx_map = [];
+            for (var i = 0; i < enhancedFeatures.col_ids.length; i++) {
+              key_to_idx_map[ enhancedFeatures.col_ids[i] ] = i;
+            };
+
+            for (var i = 0; i < enhancedFeatures.values.length; i++) {
+
+              var fold_change = enhancedFeatures.values[i][ key_to_idx_map['fold-change'] ];
+              if ($.isNumeric(fold_change)) {
+                fold_change = fold_change.toFixed(2);
+              }
+              var q_value = enhancedFeatures.values[i][ key_to_idx_map['q-value'] ];
+              if ($.isNumeric(q_value)) {
+                q_value = q_value.toFixed(2);
+              }
+
+              tableData.push(
+                {
+                  index             : i,
+                  id                : enhancedFeatures.row_ids[i],
+                  description       : enhancedFeatures.values[i][ key_to_idx_map['description'] ],
+                  min               : enhancedFeatures.values[i][ key_to_idx_map['min'] ].toFixed(2),
+                  max               : enhancedFeatures.values[i][ key_to_idx_map['max'] ].toFixed(2),
+                  mean              : enhancedFeatures.values[i][ key_to_idx_map['mean'] ].toFixed(2),
+                  std_dev           : enhancedFeatures.values[i][ key_to_idx_map['std_dev'] ].toFixed(2),
+                  is_missing_values : enhancedFeatures.values[i][ key_to_idx_map['is_missing_values'] ],
+                  'fold-change'     : fold_change,
+                  'q-value'         : q_value,
+                }
+              )
+            };
+
+            return tableData;
+        },
+
+        oldBuildGenesTableData: function(){
             var matrixStat = this.matrixStat;
             var tableData = [];
 
@@ -282,7 +340,9 @@ console.log("GC OLD CALL FAILED : ", error);
                         max: stat.max ? stat.max.toFixed(2) : null,
                         avg: stat.avg ? stat.avg.toFixed(2) : null,
                         std: stat.std ? stat.std.toFixed(2) : null,
-                        missing_values: stat.missing_values ? 'Yes' : 'No'
+                        missing_values: stat.missing_values ? 'Yes' : 'No',
+                    'fold-change' : 'enhanced features not available right now',
+                    'q-value' : 'enhanced features not available right now',
                     }
                 );
             }

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -81,6 +81,7 @@ require.config({
         'TaxonAPI-client-api': 'kbase/js/api/TaxonAPIClient',
         'GenomeSearchUtil-client-api': 'kbase/js/api/GenomeSearchUtilClient',
         'SetAPI-client-api': 'kbase/js/api/SetAPIClient',
+        'ExpressionUtils-client-api': 'kbase/js/api/ExpressionUtilsClient',
         'Taxonomy-client-api': 'kbase/js/api/TaxonomyAPIClient',
         'RestAPIClient' : 'kbase/js/api/RestAPIClient',
         'StagingServiceClient' : 'kbase/js/api/StagingServiceClient',


### PR DESCRIPTION
Finally has the enhanced expression matrix viewer which adds the two new columns to the display.

The ExpressionAPI has been fairly twitchy over the last several weeks (most recently it tends to start throwing 502 bad gateway errors after a while), so the widget is built to be backwards compatible—it uses the new ExpressionAPI.get_enhancedFilteredExpressionMatrix method first. If it works, then we're good to go. If not, then it falls back on the old data from the old call and notes in the table that the extra columns aren't available.

At some point in the nebulous future, that should be cleaned up once the ExpressionAPI service is hardened a little more.