### PR TITLE
Fix bower version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /kb/dev_container/narrative
 RUN mkdir -p /kb/deployment/ui-common/ && ./src/scripts/kb-update-config -f src/config.json.templ -o /kb/deployment/ui-common/narrative_version
 
 # Install Javascript dependencies
-RUN npm install && bower install --allow-root --config.interactive=false
+RUN npm install && ./node_modules/.bin/bower install --allow-root --config.interactive=false
 
 # Compile Javascript down into an itty-bitty ball unless SKIP_MINIFY is non-empty
 # (commented out for now)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {
-    "bower": "1.7.9",
+    "bower": "1.8.4",
     "geckodriver": "1.6.1",
     "grunt": "1.0.1",
     "grunt-cli": "1.2.0",

--- a/scripts/local-dev-run.sh
+++ b/scripts/local-dev-run.sh
@@ -8,12 +8,13 @@ if [ -z $env ]; then
 	echo "The 'env' environment variable is required"
 	exit 1
 fi
+# use this below if you want to install and mount external components (bower packages) into the running container.
+# --mount type=bind,src=${root}/${ext_components_dir},dst=${container_root}/${ext_components_dir} \
 docker run \
 	--dns=8.8.8.8 \
 	-e "CONFIG_ENV=${env}" \
 	--network=kbase-dev \
 	--name=narrative  \
 	--mount type=bind,src=${root}/${static_dir},dst=${container_root}/${static_dir} \
-	--mount type=bind,src=${root}/${ext_components_dir},dst=${container_root}/${ext_components_dir} \
 	--mount type=bind,src=${root}/${nbextension_dir},dst=${container_root}/kbase-extension/static/${nbextension_dir} \
 	--rm kbase/narrative:dev


### PR DESCRIPTION
The bower version in the base image is 1.7.6; the current version is 1.8.4. 1.8.0, released in late 2016, deprecated the old package service hosted at heroku. The herokuapp service still works, sometimes, but is not reliable. This fix updates the narrative's locally installed bower, which was at 1.7.9, to 1.8.4, and the Dockerfile to use the locally installed bower.

A small fix to the local image run script removes the mapping of the ext_components directory, which breaks if ext_components is not installed locally, which for me is more often than not the case. It is also only rarely used for testing new dependency versions without needing to rebuild the image.