### PR TITLE
log values to fixed 2 decimals [SCT-380]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionVolcanoPlot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionVolcanoPlot.js
@@ -443,11 +443,13 @@ define([
             d.log_q_value = 'MIN';
           }
           else {
-            d.log_q_value = - Math.log10(parseFloat(d.q_value));
+            d.log_q_value = - Math.log10(parseFloat(d.q_value)).toFixed(2);
             if (d.log_q_value < min_log_q_value) {
               min_log_q_value = d.log_q_value;
             }
           }
+
+          d.log2fc_f = d.log2fc_f.toFixed(2);
         });
 
         data.forEach( function(d) {


### PR DESCRIPTION
Ensures that the displayed columns are fixed to at most 2 decimal places.