### PR TITLE
Pass along Env Vars at Narrative startup, fix problematic defaults for docker config

### DIFF
--- a/docker/docker.lua
+++ b/docker/docker.lua
@@ -10,6 +10,18 @@
 local M = {}
 local Spore = require('Spore')
 local json = require('json')
+local os = require("os")
+local narrEnvVars = os.getenv("NARR_ENV_VARS")
+
+-- Define a clientEnv variable that is passed as environment to the containers being
+-- started. The granularity of this kind of sucks, but it is only a stopgap until we
+-- eliminate this code from KBase.
+local clientEnv
+if narrEnvVars == nil then
+	clientEnv = json.util.null
+else
+	clientEnv = json.decode( narrEnvVars)
+end
 
 -- For creating new containers the config object must contain certain fields
 -- Example config contains:
@@ -26,7 +38,7 @@ local function config()
 		    Tty = false,
 		    OpenStdin = false,
 		    StdinOnce = false,
-		    Env = json.util.null,
+		    Env = clientEnv,
 		    Cmd = {'/bin/bash'},
 		    Dns = json.util.null,
 		    Image = "base",

--- a/docker/docker.lua
+++ b/docker/docker.lua
@@ -29,7 +29,6 @@ end
 -- Example config contains:
 local function config()
    local config = { Hostname = "",
-		    User = "nobody",
 		    Memory = 0,
 		    MemorySwap = 0,
 		    AttachStdin = false,

--- a/docker/docker.lua
+++ b/docker/docker.lua
@@ -22,7 +22,7 @@ if narrEnvVars == nil then
 	clientEnv = json.util.null
 else
 	clientEnv = json.decode( narrEnvVars)
-	ngx.log(ngx.INFO,string.format("Setting narrative container environment to: %s", narrEnvVars)
+	ngx.log(ngx.INFO,string.format("Setting narrative container environment to: %s", narrEnvVars))
 end
 
 -- For creating new containers the config object must contain certain fields

--- a/docker/docker.lua
+++ b/docker/docker.lua
@@ -11,6 +11,7 @@ local M = {}
 local Spore = require('Spore')
 local json = require('json')
 local os = require("os")
+local p = require('pl.pretty')
 local narrEnvVars = os.getenv("NARR_ENV_VARS")
 
 -- Define a clientEnv variable that is passed as environment to the containers being
@@ -21,6 +22,7 @@ if narrEnvVars == nil then
 	clientEnv = json.util.null
 else
 	clientEnv = json.decode( narrEnvVars)
+	ngx.log(ngx.INFO,string.format("Setting narrative container environment to: %s", narrEnvVars)
 end
 
 -- For creating new containers the config object must contain certain fields
@@ -39,7 +41,6 @@ local function config()
 		    OpenStdin = false,
 		    StdinOnce = false,
 		    Env = clientEnv,
-		    Cmd = {'/bin/bash'},
 		    Dns = json.util.null,
 		    Image = "base",
 		    Volumes = {},

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -151,8 +151,8 @@
         "ws_browser": "https://narrative.kbase.us/#ws"
     }, 
     "dev_mode": true, 
-    "git_commit_hash": "4aa6e0e", 
-    "git_commit_time": "Thu May 31 16:13:12 2018 -0700", 
+    "git_commit_hash": "72d46bb", 
+    "git_commit_time": "Wed Jun 13 11:19:31 2018 -0700", 
     "loading_gif": "/narrative/static/kbase/images/ajax-loader.gif", 
     "name": "KBase Narrative", 
     "next": {


### PR DESCRIPTION
These commits modify the Lua code to look for an environment variable called NARR_ENV_VARS which is then inserted into the default docker client config for environment variables passed to along at narrative container startup.

The value for NARR_ENV_VARS should an array of NAME=VALUE strings. For example, the following docker command will startup the nginx container and set the CONFIG_ENV variable to appdev for all narratives started by the Docker.lua module:
`docker run -it -v /var/run/docker.sock:/var/run/docker.sock -e 'NARR_ENV_VARS=["CONFIG_ENV=appdev"]' kbase/nginx:latest`

This commit also fixes the default docker configs for CMD and USER so that they don't clobber the settings built into the narrative image. The old defaults set CMD to /bin/bash, which stopped the narrative from starting up, and set the running user to nobody, making it impossible to update the config.json file