### PR TITLE
Change import button to 'Select format' PTV-1023

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -303,7 +303,7 @@ define([
                         }
                     });
                     $('td:eq(4)', nRow).find('select').select2({
-                        placeholder: 'Select a format'
+                        placeholder: 'Select format'
                     });
                     $('td:eq(4)', nRow).find('button[data-import]').off('click').on('click', function(e) {
                         var importType = $(e.currentTarget).prevAll('#import-type').val();


### PR DESCRIPTION
@scanon - This PR changes 'Select a format' to 'Select format' on the Import selection pane. The goal is to eliminate the ellipses that currently appear as "Select a for..." in PTV-1023.