### PR TITLE
fixed undefined object bug [SCT-380]

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionVolcanoPlot.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionVolcanoPlot.js
@@ -449,7 +449,9 @@ define([
             }
           }
 
-          d.log2fc_f = d.log2fc_f.toFixed(2);
+          if (!!d.log2fc_f) {
+            d.log2fc_f = d.log2fc_f.toFixed(2);
+          }
         });
 
         data.forEach( function(d) {


### PR DESCRIPTION
Apparently the log2fc_f value can sometimes be undefined/null. So just wraps it in a check to see if we can get a truthy value out of it, and if so make it toFixed(). 

Otherwise, just leave it as is, since I wasn't comfortable with making explicitly undefined values "0".