### PR TITLE
SCT-1199 hide the new run button

### DIFF
--- a/kbase-extension/static/kbase/custom/custom.css
+++ b/kbase-extension/static/kbase/custom/custom.css
@@ -377,3 +377,25 @@ p {
 .prompt {
     display: none !important;
 }
+
+/*
+ * Jupyter 5.6.0 introduced a "run this cell" button that appears on mouseover.
+ * Cool though this is, it's a problem on app cells.
+ * This hunk of CSS should remove it until we can better work it in to our design.
+ */
+div.code_cell:hover .run_this_cell {
+    visibility: hidden !important;
+}
+
+div.code_cell:hover div.input_prompt.run_this_cell {
+    visibility: hidden !important;
+}
+
+div.code_cell div.input_prompt {
+    min-width: 0;
+}
+
+.run_this_cell {
+    padding: 0 !important;
+    width: 0 !important;
+}


### PR DESCRIPTION
In Jupyter Notebook 5.6.0, there's a new run button that shows up on hover over any code cell. ( see this PR: https://github.com/jupyter/notebook/pull/3535/ Clicking it runs that cell. Pretty nifty, but it breaks a number of different design things we have, including how app cells are supposed to run.

This is the short term fix so we can use their security fixes - just hide the new thing.