### PR TITLE
Sct 1210

### DIFF
--- a/kbase-extension/static/kbase/js/common/data.js
+++ b/kbase-extension/static/kbase/js/common/data.js
@@ -7,7 +7,7 @@ define([
     function filterObjectInfoByType(objects, types) {
         return objects.map(function(objectInfo) {
                 var type = objectInfo.typeModule + '.' + objectInfo.typeName;
-                if (types.indexOf(type) >= 0) {
+                if (types.indexOf(type) >= 0 || types.indexOf(objectInfo.typeModule) >= 0) {
                     return objectInfo;
                 }
             })

--- a/src/biokbase/narrative/jobs/specmanager.py
+++ b/src/biokbase/narrative/jobs/specmanager.py
@@ -26,7 +26,10 @@ class SpecManager(object):
 
         return self.app_specs[tag][app_id]
 
-    def get_type_spec(self, type_id, raise_exception=True):
+    def get_type_spec(self, type_id, raise_exception=True, allow_module_match=True):
+        # if we can't find a full match for a type, try to match just the module
+        if (type_id not in self.type_specs) and allow_module_match:
+            type_id = type_id.split(".")[0]
         if (type_id not in self.type_specs) and raise_exception:
             raise ValueError('Unknown type id "{}"'.format(type_id))
         return self.type_specs.get(type_id)

--- a/src/biokbase/narrative/tests/data/type_specs.json
+++ b/src/biokbase/narrative/tests/data/type_specs.json
@@ -768,10 +768,26 @@
             "TSV": "FBAFileUtil/export_fba_as_tsv_file",
             "EXCEL": "FBAFileUtil/export_fba_as_excel_file"
         },
-        "view_method_ids": ["NarrativeViewers/view_fba_result_details"],
         "description": "<p>This type describes flux balance analysis.</p>\\n",
         "type_name": "KBaseFBA.FBA",
         "tooltip": "FBA object",
+        "landing_page_url_prefix": "ws/fbas",
+        "icon": {
+            "url": "img?type_name=KBaseFBA.FBA&image_name=none"
+        }
+    },
+    "KBaseFBA": {
+        "import_method_ids": [],
+        "subtitle": "FBA module",
+        "name": "FBA objects",
+        "export_functions": {
+            "TSV": "FBAFileUtil/export_fba_as_tsv_file",
+            "EXCEL": "FBAFileUtil/export_fba_as_excel_file"
+        },
+        "view_method_ids": ["NarrativeViewers/view_fba_result_details"],
+        "description": "<p>This type describes flux balance analysis.</p>\\n",
+        "type_name": "KBaseFBA",
+        "tooltip": "FBA types",
         "landing_page_url_prefix": "ws/fbas",
         "icon": {
             "url": "img?type_name=KBaseFBA.FBA&image_name=none"

--- a/src/biokbase/narrative/tests/data/type_specs.json
+++ b/src/biokbase/narrative/tests/data/type_specs.json
@@ -768,6 +768,7 @@
             "TSV": "FBAFileUtil/export_fba_as_tsv_file",
             "EXCEL": "FBAFileUtil/export_fba_as_excel_file"
         },
+        "view_method_ids": ["NarrativeViewers/view_fba_result_details"],
         "description": "<p>This type describes flux balance analysis.</p>\\n",
         "type_name": "KBaseFBA.FBA",
         "tooltip": "FBA object",

--- a/src/biokbase/narrative/tests/test_specmanager.py
+++ b/src/biokbase/narrative/tests/test_specmanager.py
@@ -8,12 +8,16 @@ from narrative_mock.mockclients import get_mock_client
 
 class SpecManagerTestCase(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
-        self.sm = SpecManager()
-        self.good_app_id = 'NarrativeTest/test_input_params'
-        self.good_tag = 'dev'
-        self.bad_app_id = 'NotARealApp'
-        self.bad_tag = 'NotARealTag'
+    def setUpClass(cls):
+        cls.sm = SpecManager()
+        cls.good_app_id = 'NarrativeTest/test_input_params'
+        cls.good_tag = 'dev'
+        cls.bad_app_id = 'NotARealApp'
+        cls.bad_tag = 'NotARealTag'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sm.reload()
 
     def test_apps_present(self):
         # on startup, should have app_specs
@@ -35,10 +39,11 @@ class SpecManagerTestCase(unittest.TestCase):
 
     @mock.patch('biokbase.narrative.jobs.specmanager.clients.get', get_mock_client)
     def test_get_type_spec(self):
-        self.assertIn("view_method_ids", self.sm.get_type_spec("KBaseFBA.FBA").keys())
-        self.assertIn("view_method_ids", self.sm.get_type_spec("KBaseFBA.NU_FBA").keys())
+        self.sm.reload()
+        self.assertIn("export_functions", self.sm.get_type_spec("KBaseFBA.FBA").keys())
+        self.assertIn("export_functions", self.sm.get_type_spec("KBaseFBA.NU_FBA").keys())
         with self.assertRaisesRegexp(ValueError, "Unknown type"):
-            self.assertIn("view_method_ids", self.sm.get_type_spec("KBaseExpression.NU_FBA").keys())
+            self.assertIn("export_functions", self.sm.get_type_spec("KBaseExpression.NU_FBA").keys())
 
 
 if __name__ == "__main__":

--- a/src/biokbase/narrative/tests/test_specmanager.py
+++ b/src/biokbase/narrative/tests/test_specmanager.py
@@ -1,5 +1,9 @@
-from biokbase.narrative.jobs.specmanager import SpecManager
 import unittest
+
+import mock
+
+from biokbase.narrative.jobs.specmanager import SpecManager
+from narrative_mock.mockclients import get_mock_client
 
 
 class SpecManagerTestCase(unittest.TestCase):
@@ -28,6 +32,13 @@ class SpecManagerTestCase(unittest.TestCase):
         # bad id with raise
         with self.assertRaises(ValueError):
             self.sm.check_app(self.bad_app_id, raise_exception=True)
+
+    @mock.patch('biokbase.narrative.jobs.specmanager.clients.get', get_mock_client)
+    def test_get_type_spec(self):
+        self.assertIn("view_method_ids", self.sm.get_type_spec("KBaseFBA.FBA").keys())
+        self.assertIn("view_method_ids", self.sm.get_type_spec("KBaseFBA.NU_FBA").keys())
+        with self.assertRaisesRegexp(ValueError, "Unknown type"):
+            self.assertIn("view_method_ids", self.sm.get_type_spec("KBaseExpression.NU_FBA").keys())
 
 
 if __name__ == "__main__":

--- a/src/biokbase/narrative/tests/test_updater.py
+++ b/src/biokbase/narrative/tests/test_updater.py
@@ -71,7 +71,7 @@ class UpdaterTestCase(unittest.TestCase):
         for cell in nar['cells']:
             self.validate_cell(cell)
         self.validate_metadata(nar['metadata'])
-        return True;
+        return True
 
     def validate_metadata(self, meta):
         req_keys = ['description', 'data_dependencies', 'creator', 'format', 'name', 'type', 'ws_name', 'kbase']

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -573,6 +573,7 @@ class WidgetManager(object):
         info_tuple = clients.get('workspace').get_object_info_new({'objects': [{'ref': upa}],
                                                                    'includeMetadata': 1})[0]
         bare_type = info_tuple[2].split('-')[0]
+        type_module = bare_type.split(".")[0]
 
         type_spec = self._sm.get_type_spec(bare_type, raise_exception=False)
 
@@ -609,7 +610,7 @@ class WidgetManager(object):
                 obj_param_value = upa if (is_ref_path or is_external) else info_tuple[1]
                 upa_params = list()
                 for param in spec_params:
-                    if any(t == bare_type for t in param['allowed_types']):
+                    if any((t == bare_type or t == type_module) for t in param['allowed_types']):
                         input_params[param['id']] = obj_param_value
                         upa_params.append(param['id'])
 


### PR DESCRIPTION
Allow a match to a module level type spec file if no more specific match is found allowing for the definition of more generic viewers and download functions
Allow the specification of only a type's parent modules as a "valid_ws_type" to allow any types from that class to be submitted