### PR TITLE
Changing the text in the drop zone to recommend Globus for large files. SCT-1370

### DIFF
--- a/kbase-extension/static/kbase/templates/data_staging/dropzone_area.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropzone_area.html
@@ -11,7 +11,16 @@
         </div>
     </div>
     <div class="dz-message">
-        <p>Drag and drop data files (or click) in this box to upload them to your staging area.<br><br>
+        <p>Three ways to add data to the staging area:</p>
+        <ul>
+          <li>Click in this box
+          <li>Drag and drop data files 
+          <li>For large files (over 20GB) or a large number of files use 
+               <a href="https://www.globus.org/app/transfer?destination_id=3aca022a-5e5b-11e6-8309-22000b97daec&destination_path=%2F"
+               target="_blank" class="globus_link">
+               <i class="fa fa-cloud-upload"></i> Globus Online
+               </a>
+        </ul>
         <p>Click the <i class="fa fa-question-circle"></i> below for help.
-    </div>
+     </div>
 </form>


### PR DESCRIPTION
@briehl  - Users need a clearer warning that Drag-n-drop stops working around 20GB and they need to switch to Globus. Roy suggested that we need to specify when and why Globus is offered as an option. The documentation is being updated for SCT-1370.

This PR is a revision to the text users will see in the drop zone of the Import panel.