### PR TITLE
SCT-1395: Convert object ref and IDs to common names for download

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
@@ -57,10 +57,20 @@ define (
             this.type = this.options.type;
             this.objId = this.options.objId;
             this.ref = this.options.ref;
+            console.log(options);
+            console.log(this);
             if (!this.objId) {
                 var refPathItems = this.ref.split(';');
                 this.objId = refPathItems[refPathItems.length - 1].trim().split('/')[1];
             }
+            this.ws = new Workspace(self.wsUrl, {token: this.token});
+            this.ws.get_object_info3({'objects':[{'ref':this.ref}]},
+                    (objectinfo) => {
+                this.objId = objectinfo.infos[0][1];
+                this.ref = this.ref.split("/").slice(0, -1).join("/") + "/" + this.objId;
+                console.log("ref" + this.ref);
+            }
+                );
             this.downloadSpecCache = options['downloadSpecCache'];
             var lastUpdateTime = this.downloadSpecCache['lastUpdateTime'];
             if (lastUpdateTime) {

--- a/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
@@ -4,11 +4,86 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 define([
-    'kbaseNarrativeDownloadPanel'
-], function(Widget) {
-    describe('Test the kbaseNarrativeDownloadPanel widget', function() {
-        it('Should do things', function() {
+    'jquery',
+    'kbaseNarrativeDownloadPanel',
+    'testUtil',
+    'common/runtime',
+    'base/js/namespace',
+    'kbaseNarrative'
+], (
+    $,
+    kbaseNarrativeDownloadPanel,
+    TestUtil,
+    Runtime,
+    Jupyter,
+    Narrative
+) => {
+    describe('Test the kbaseNarrativeDownloadPanel widget', () => {
+        let $div = null;
+        beforeEach(() => {
+            jasmine.Ajax.install();
+            $div = $('<div>');
+            Jupyter.narrative = new Narrative();
+            Jupyter.narrative.getAuthToken = () => { return 'NotARealToken!' };
+        });
 
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+            $div.remove();
+        });
+
+        it('Should properly load with a valid upa', (done) => {
+            let ws = 1111,
+                oid = 2222,
+                ver = 3333,
+                name = 'fake_test_object',
+                objType = 'FakeModule.FakeType-7.7',
+                saveDate = '2018-08-03T00:17:04+0000',
+                userId = 'fakeUser',
+                wsName = 'fakeWs',
+                checksum = '12345',
+                meta = {},
+                size = 1234567,
+                upa = String(ws) + '/' + String(oid) + '/' + String(ver);
+
+            jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
+                status: 200,
+                statusText: 'success',
+                contentType: 'application/json',
+                responseHeaders: '',
+                responseText: JSON.stringify({
+                    version: '1.1',
+                    result: [{
+                        infos: [[
+                            oid,
+                            name,
+                            objType,
+                            saveDate,
+                            ver,
+                            userId,
+                            ws,
+                            wsName,
+                            checksum,
+                            size,
+                            meta
+                        ]],
+                        paths: [[upa]]
+                    }]
+                })
+            });
+
+            let w = new kbaseNarrativeDownloadPanel($div, {
+                    token: null,
+                    type: objType,
+                    objId: oid,
+                    ref: upa,
+                    downloadSpecCache: {'lastUpdateTime': 100, 'types': {
+                        [objType]: {'export_functions': {"FAKE": "fake_method"}}}
+                    }
+            });
+            expect($div.html()).toContain("JSON");
+            expect($div.html()).toContain("FAKE");
+            done();
         });
     });
 });


### PR DESCRIPTION
I suspect some UPA/ref path work resulted in objectId becoming a numerical ID rather than an object name. I added in a WS call to fetch the common name and update the objectId and ref accordingly.

I also added what tests I could (but was not sure how to simulate this particular change)