### PR TITLE
Sct-1526

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/codeCellLauncher.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/codeCellLauncher.js
@@ -1,0 +1,136 @@
+/**
+ * Output widget to generate a code cell with vis output.
+ * @public
+ */
+
+define ([
+    'uuid',
+    'jquery',
+    'kbwidget',
+    'kbaseAuthenticatedWidget',
+    'kbaseTabs',
+    'narrativeConfig',
+    'base/js/namespace',
+    'common/utils',
+    // For effect
+    'bootstrap',
+    'jquery-dataTables',
+    'datatables.net-buttons',
+    'datatables.net-buttons-bs',
+    'datatables.net-buttons-html5',
+    'datatables.net-buttons-print'
+], function(
+    Uuid,
+    $,
+    KBWidget,
+    kbaseAuthenticatedWidget,
+    kbaseTabs,
+    Config,
+    Jupyter,
+    utils
+) {
+    'use strict';
+
+    return KBWidget({
+        name: 'codeCellLauncher',
+        parent : kbaseAuthenticatedWidget,
+        version: '1.0.2',
+        options: {
+            output: null,
+            workspaceID: null,
+            loadingImage: Config.get('loading_gif')
+        },
+
+        init: function(options) {
+            this._super(options);
+            // Create a message pane
+            this.$messagePane = $('<div/>').addClass('kbwidget-message-pane kbwidget-hide-message');
+            this.$elem.append(this.$messagePane);
+            return this;
+        },
+
+        launchCodeCell: function (code) {
+            const thisCell = this.$elem[0].parentElement.parentElement.kb_obj.cell,
+                cellId = utils.getMeta(thisCell, 'attributes', 'id'),
+                cellIndex = Jupyter.notebook.find_cell_index(thisCell),
+                newCellId = new Uuid(4).format(),
+                setupData = {
+                    type: 'code',
+                    cellId: newCellId,
+                    parentCellId: cellId,
+                };
+
+            let newCell = Jupyter.notebook.insert_cell_below('code', cellIndex, setupData);
+            newCell.set_text(code);
+            newCell.execute();
+
+            // Don't want duplicate child cells on load. This is the best way I can think to do it right now
+            Jupyter.notebook.delete_cell(cellIndex)
+        },
+
+        get_python_code: function (type, matrix_ref) {
+            let code;
+            if (type === 'dataframe') {
+                code = 'from biokbase.narrative.viewers import get_df\n' +
+                    `df = get_df('${matrix_ref}')\ndf`
+            } else if (type === 'clustergrammer') {
+                code = 'from biokbase.narrative.viewers import view_as_clustergrammer\n' +
+                    `view_as_clustergrammer('${matrix_ref}')`
+            } else if (type === 'seaborn box') {
+                code = 'import seaborn as sns\n' +
+                    'from biokbase.narrative.viewers import get_df\n' +
+                    `df = get_df('${matrix_ref}', None, None)\n` +
+                    'sns.boxplot(data=df).set(xlabel="Columns", ylabel="Row Values");'
+            } else if (type === 'plotly stackedbars') {
+                code = 'import plotly\n' +
+                    'import plotly.graph_objs as go\n' +
+                    'from biokbase.narrative.viewers import get_df\n\n' +
+                    `df = get_df('${matrix_ref}', None, None)\n` +
+                    'plotly.offline.init_notebook_mode(connected=True)\n' +
+                    'plotly.offline.iplot({\n' +
+                    '    "data": [go.Bar(x=df.columns, y=row, name=i) for i, row in df.iterrows()],\n' +
+                    '    "layout": go.Layout(title="Stacked bars" xaxis={"title": "Columns"}, yaxis={"title": "Row Values"}, barmode="stack")\n' +
+                    '})'
+
+            } else {
+                this.showMessage(`Unsupported output type ${type}`);
+            }
+            return code;
+        },
+
+        loggedInCallback: function(event, auth) {
+            console.log(this.options);
+            const type = this.options.output_type,
+                matrix_ref = this.options.matrix_ref;
+
+            const code = this.get_python_code(type, matrix_ref);
+            if (code) this.launchCodeCell(code);
+            return this;
+        },
+
+        loggedOutCallback: function() {
+            this.isLoggedIn = false;
+            return this;
+        },
+
+        loading: function(isLoading) {
+            if (isLoading) {
+                this.showMessage('<img src=\'' + this.options.loadingImage + '\'/>');
+            } else {
+                this.hideMessage();
+            }
+        },
+
+        showMessage: function(message) {
+            var span = $('<span/>').append(message);
+
+            this.$messagePane.append(span);
+            this.$messagePane.show();
+        },
+
+        hideMessage: function() {
+            this.$messagePane.hide();
+            this.$messagePane.empty();
+        }
+    });
+});

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -338,6 +338,7 @@ require.config({
         'kbaseDifferentialExpressionMatrixSetViewer': 'kbase/js/widgets/function_output/kbaseDifferentialExpressionMatrixSetViewer',
         'GenomeClassifierTrainingSet': 'kbase/js/widgets/function_output/GenomeClassifierTrainingSet',
         'GenomeCategorizer': 'kbase/js/widgets/function_output/GenomeCategorizer',
+        'code-cell': 'kbase/js/widgets/function_output/codeCellLauncher',
 
         /***
          * END CUSTOM OUTPUT WIDGETS

--- a/src/biokbase/narrative/tests/test_viewers.py
+++ b/src/biokbase/narrative/tests/test_viewers.py
@@ -78,16 +78,28 @@ class ViewersTestCase(unittest.TestCase):
                                                  mapping, {"test_attribute_1"}, clustergrammer=True))
 
     def test_get_df(self):
+        import pandas as pd
         from biokbase.narrative import viewers
+
         res = viewers.get_df(self.generic_ref)
-        self.assertEqual(str(type(res)), "<class 'pandas.core.frame.DataFrame'>")
+        self.assertIsInstance(res, pd.DataFrame)
         self.assertEqual(res.shape, (3, 4))
+        self.assertIsInstance(res.index, pd.MultiIndex)
+
+        res = viewers.get_df(self.generic_ref, None, None)
+        self.assertIsInstance(res, pd.DataFrame)
+        self.assertEqual(res.shape, (3, 4))
+        self.assertIsInstance(res.index, pd.Index)
+
         res = viewers.get_df(self.generic_ref, clustergrammer=True)
-        self.assertEqual(str(type(res)), "<class 'pandas.core.frame.DataFrame'>")
+        self.assertIsInstance(res, pd.DataFrame)
         self.assertEqual(res.shape, (3, 4))
+        self.assertIsInstance(res.index, pd.Index)
+
         res = viewers.get_df(self.expression_matrix_ref)
-        self.assertEqual(str(type(res)), "<class 'pandas.core.frame.DataFrame'>")
+        self.assertIsInstance(res, pd.DataFrame)
         self.assertEqual(res.shape, (4297, 16))
+        self.assertIsInstance(res.index, pd.Index)
 
     def test_view_as_clustergrammer(self):
         from biokbase.narrative import viewers


### PR DESCRIPTION
This new viewer widget accepts a few params (matrix_ref and output_type for now), generates some python code, launches and executes a Code Cell with that code and then removes itself (which ensures that a duplicate code cell is not inserted when the narrative is reloaded).

It's a working demo but have a few open issues:
Should the python code go into `pythonInterop.js` or should we keep that to just narrative functions?
I haven't decided how to test the widget correctly yet (I have an idea though).
Product Team will have some feedback on which visualizations should be supported and what parameters should be able to be set.