### PR TITLE
SCT-1602 Allow workspace id for Narrative URLs

### DIFF
--- a/kbase-extension/static/kbase/js/common/jupyter.js
+++ b/kbase-extension/static/kbase/js/common/jupyter.js
@@ -140,7 +140,6 @@ define([
         getCells: getCells,
         getCell: getCell,
         disableKeyListenersForCell: disableKeyListenersForCell,
-        // getWorkspaceRef: getWorkspaceRef,
         onEvent: onEvent,
         uiModeIs: uiModeIs,
         canEdit: canEdit,

--- a/kbase-extension/static/kbase/js/common/runtime.js
+++ b/kbase-extension/static/kbase/js/common/runtime.js
@@ -100,10 +100,7 @@ define([
          * The kbaseNarrative object does this, but it also does a lot more...
          */
         function workspaceId() {
-            var wsInfo = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-            if (wsInfo && wsInfo.length === 3) {
-                return wsInfo[1];
-            }
+            return narrativeConfig.getItem('workspaceId', null);
         }
 
         return {

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -294,10 +294,7 @@ define(
 
         function initializeRuntime() {
             var runtime = Runtime.make();
-            var wsInfo = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-            if (wsInfo && wsInfo.length === 3) {
-                runtime.setEnv('workspaceId', parseInt(wsInfo[1]));
-            }
+            runtime.setEnv('workspaceId', Config.workspaceId);
         }
 
         return {

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -20,12 +20,6 @@ define(
 
         function loadDomEvents() {
 
-            $(document).on('workspaceIdQuery.Narrative', function(e, callback) {
-                if (callback) {
-                    callback(window.workspaceId);
-                }
-            });
-
             // bind menubar buttons
             $('#kb-save-btn').click(function() {
                 if (Jupyter && Jupyter.notebook) {

--- a/kbase-extension/static/kbase/js/narrativeConfig.js
+++ b/kbase-extension/static/kbase/js/narrativeConfig.js
@@ -37,7 +37,6 @@ define([
     var config, debug;
 
     // Get the workspace id from the URL
-    console.log(window.location.href);
     var workspaceId = null,
         objectId = null,
         narrativeRef = null,

--- a/kbase-extension/static/kbase/js/narrativeConfig.js
+++ b/kbase-extension/static/kbase/js/narrativeConfig.js
@@ -37,10 +37,20 @@ define([
     var config, debug;
 
     // Get the workspace id from the URL
-    var workspaceId = null;
-    var m = window.location.href.match(/ws\.(\d+)\.obj\.(\d+)/);
-    if (m && m.length > 1) {
-        workspaceId = parseInt(m[1]);
+    console.log(window.location.href);
+    var workspaceId = null,
+        objectId = null,
+        narrativeRef = null,
+        m = window.location.href.match(/(ws\.)?(\d+)((\.obj\.(\d+))(\.ver\.(\d+))?)?/);
+    // 2 = wsid
+    // 5 = objid
+    // 7 = ver
+    if (m && m.length > 2) {
+        workspaceId = parseInt(m[2]);
+        if (m[5] != undefined) {
+            objectId = parseInt(m[5]);
+            narrativeRef = workspaceId + '/' + objectId;
+        }
     }
 
     // Build the config up from the configSet (from config.json)
@@ -57,6 +67,8 @@ define([
         tooltip: ConfigSet.tooltip,
         icons: IconsSet,
         workspaceId: workspaceId,
+        objectId: objectId,
+        narrativeRef: narrativeRef,
         loading_gif: ConfigSet.loading_gif,
         use_local_widgets: ConfigSet.use_local_widgets,
         features: FeatureSet,
@@ -200,7 +212,6 @@ define([
 
     return {
         updateConfig: updateConfig,
-        // loadConfig: loadConfig,
         config: config,
         getConfig: getConfig,
         url: url,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -55,10 +55,6 @@ define([
 ) {
     'use strict';
 
-    function objectInfoToRef(info) {
-        return [info[6], info[0], info[4]].join('/');
-    }
-
     return KBWidget({
         name: 'kbaseNarrativeDataList',
         parent: kbaseAuthenticatedWidget,
@@ -73,6 +69,7 @@ define([
             slideTime: 400
         },
         // private variables
+        runtime: Runtime.make(),
         mainListPanelHeight: '340px',
         refreshTimer: null,
         ws_name: null,
@@ -306,13 +303,11 @@ define([
                 _this.refresh();
             });
 
-            // _this.initDataListSets();
-
             if (this.options.ws_name) {
                 this.ws_name = this.options.ws_name;
             }
 
-            this.wsId = Number(Jupyter.narrative.workspaceId);
+            this.wsId = this.runtime.workspaceId();
 
             return this;
         },
@@ -448,8 +443,7 @@ define([
                         return info;
                     }.bind(this));
                     var data = JSON.parse(JSON.stringify(justInfo));
-                    var runtime = Runtime.make();
-                    runtime.bus().set({
+                    this.runtime.bus().set({
                         data: data,
                         timestamp: new Date().getTime(),
                         objectInfo: objectInfoPlus

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -30,7 +30,7 @@ define([
     ControlPanel,
     kbaseNarrativeSharePanel,
     KBaseClientAPI,
-    Workspace,    
+    Workspace,
     GenericClient,
     TimeFormat
 ) {
@@ -74,17 +74,6 @@ define([
 
             // the string name of the workspace.
             this.ws_name = Jupyter.narrative.getWorkspaceName();
-
-            // the workspace ref of this Narrative object. (w/o version)
-            this.workspaceRef = Jupyter.narrative.workspaceRef;
-            this.workspaceId = Jupyter.narrative.workspaceId;
-
-            // Doesn't appear to be used.
-            // $(document).on(
-            //     'copyThis.Narrative', function (e, panel, active, jump) {
-            //         this.copyThisNarrative(panel, active, jump);
-            //     }.bind(this)
-            // );
 
             $([Jupyter.events]).on(
                 'notebook_saved.Notebook', function () {
@@ -1021,7 +1010,10 @@ define([
                     $errorMessage.empty();
                     $doCopyBtn.prop('disabled', true);
                     $cancelBtn.prop('disabled', true);
-                    this.copyNarrative(this.workspaceRef, $newNameInput.val())
+                    Jupyter.narrative.getNarrativeRef()
+                        .then((narrativeRef) => {
+                            return this.copyNarrative(narrativeRef, $newNameInput.val());
+                        })
                         .then(function() {
                             $alertContainer.hide();
                             setButtonWorking(false);
@@ -1081,11 +1073,8 @@ define([
             if (!this.ws) {
                 preCheckError = 'Cannot copy - please sign in again.';
             }
-            else if (!this.workspaceRef) {
+            else if (!workspaceRef) {
                 preCheckError = 'Cannot copy - cannot find Narrative id. Please refresh the page and try again.';
-            }
-            else if (!this.workspaceId) {
-                preCheckError = 'Cannot copy - cannot find Narrative data id. Please refresh the page and try again.';
             }
             if (preCheckError) {
                 return Promise.reject(preCheckError);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -1126,14 +1126,6 @@ define([
             // console.debug("activate read-write mode");
         },
 
-
-        /**
-         * Object identifier of current narrative, extracted from page URL.
-         */
-        getNarrId: function () {
-            return window.location.pathname.split('/').pop();
-        },
-
         /**
          * Once the notebook is loaded, all code cells with generated code
          * (e.g. the placeholder, provenance cells) should be hidden.

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -368,9 +368,12 @@ define([
                     $doCopyBtn.prop('disabled', true);
                     $cancelBtn.prop('disabled', true);
                     $newNameInput.prop('disabled', true);
-                    Jupyter.narrative.sidePanel.$narrativesWidget.copyNarrative(
-                            Jupyter.narrative.workspaceRef, $newNameInput.val()
-                        )
+                    Jupyter.narrative.getNarrativeRef()
+                        .then((narrativeRef) => {
+                            return Jupyter.narrative.sidePanel.$narrativesWidget.copyNarrative(
+                                narrativeRef, $newNameInput.val()
+                            );
+                        })
                         .then(function (result) {
                             Jupyter.narrative.sidePanel.$narrativesWidget.refresh();
                             // show go-to button

--- a/kbase-extension/static/narrativeMain.js
+++ b/kbase-extension/static/narrativeMain.js
@@ -24,30 +24,29 @@
  * @class narrativeMain
  * @static
  */
-require(['./narrative_paths'], function (paths) {
+require([
+    './narrative_paths'
+], function () {
+    'use strict';
     require([
         'jquery',
-        'bluebird',
         'narrativeConfig',
-        'kbase-client-api',
         'narrativeLogin',
         'css!font-awesome'
     ], function ($,
-        Promise,
         Config,
-        ClientApi,
-        Login) {
-        'use strict';
+        Login
+    ) {
         console.log('Loading KBase Narrative setup routine.');
 
         Config.updateConfig()
-            .then(function (config) {
-                require(['kbaseNarrative'], function (Narrative) {
+            .then(function () {
+                require(['kbaseNarrative'], function () {
                     Login.init($('#signin-button'))
-                    .then(function() {
-                        console.log('Starting Jupyter main');
-                        require(['notebook/js/main']);
-                    });
+                        .then(function() {
+                            console.log('Starting Jupyter main');
+                            require(['notebook/js/main']);
+                        });
                 });
             });
     });

--- a/src/biokbase/narrative/common/exceptions.py
+++ b/src/biokbase/narrative/common/exceptions.py
@@ -1,0 +1,19 @@
+import re
+from biokbase.workspace.baseclient import ServerError
+
+class PermissionsError(ServerError):
+    """Raised if user does not have permission to
+    access the workspace.
+    """
+    @staticmethod
+    def is_permissions_error(err):
+        """Try to guess if the error string is a permission-denied error
+        for the narrative (i.e. the workspace the narrative is in).
+        """
+        pat = re.compile("(\s*[Uu]sers?\s*(\w+)?\s*may not \w+ workspace.*)|(\s*[Tt]oken validation failed)")
+        return pat.search(err) is not None
+
+    def __init__(self, name=None, code=None, message=None, **kw):
+        ServerError.__init__(self, name, code, message, **kw)
+
+

--- a/src/biokbase/narrative/common/narrative_ref.py
+++ b/src/biokbase/narrative/common/narrative_ref.py
@@ -1,0 +1,95 @@
+"""
+Describes a Narrative Ref and has utilities for dealing with it.
+"""
+import biokbase.narrative.clients as clients
+from biokbase.workspace.baseclient import ServerError
+from exceptions import PermissionsError
+
+class NarrativeRef(object):
+    def __init__(self, ref):
+        """
+        :param ref: dict with keys wsid, objid, ver (either present or None)
+        wsid is required, this will raise a ValueError if it is not present, or not a number
+        objid, while required, can be gathered from the wsid. If there are problems with
+        fetching the objid, this will raise a ValueError
+        ver is not required
+        """
+        (self.wsid, self.objid, self.ver) = (ref.get("wsid"), ref.get("objid"), ref.get("ver"))
+        try:
+            self.wsid = int(self.wsid)
+        except ValueError:
+            raise ValueError("A numerical Workspace id is required for a Narrative ref, not {}".format(self.wsid))
+
+        if self.ver is not None:
+            try:
+                self.ver = int(self.ver)
+            except ValueError:
+                raise ValueError("If ver is present in the ref, it must be numerical, not {}".format(self.ver))
+        if self.objid is not None:
+            try:
+                self.objid = int(self.objid)
+            except ValueError:
+                raise ValueError("objid must be numerical, not {}".format(self.objid))
+        else:
+            self.objid = self._get_narrative_objid(self.wsid)
+
+    def __str__(self):
+        ref_str = "{}/{}".format(self.wsid, self.objid)
+        if self.ver is not None:
+            ref_str = ref_str + "/{}".format(self.ver)
+        return ref_str
+
+    def __eq__(self, other):
+        return self.wsid == other.wsid and \
+               self.objid == other.objid and \
+               self.ver == other.ver
+
+    def _get_narrative_objid(self, wsid):
+        """
+        Attempts to find the Narrative object id given a workspace id.
+        Can raise:
+            - ValueError
+                - if wsid is not an int
+                - if the found objid from the workspace metadata is not an int
+            - RuntimeError
+                - if there's not exactly 1 Narrative in that Workspace
+            - PermissionsError
+                - if the current user doesn't have access to that workspace
+        """
+        objid = None
+        try:
+            wsid = int(wsid)
+            ws_meta = clients.get('workspace').get_workspace_info({"id": wsid})[8]
+            if "narrative" in ws_meta:
+                objid = int(ws_meta["narrative"])
+            else:
+                narr_list = clients.get('workspace').list_objects({
+                    'ids': [wsid],
+                    'type': 'KBaseNarrative.Narrative'
+                })
+                if len(narr_list) == 0:
+                    raise RuntimeError("No Narratives found in workspace {}".format(wsid))
+                elif len(narr_list) == 1:
+                    objid = narr_list[0][0]
+                else:
+                    raise RuntimeError(
+                        "Not enough information to open Narrative - there are "
+                        "{} Narratives available in workspace {}, and no object "
+                        "id was given".format(len(narr_list), wsid)
+                    )
+            return int(objid)
+        except ValueError as err:
+            msg = "Unable to open Narrative with workspace id {}".format(wsid)
+            if objid is not None:
+                msg = msg + " and object id {}".format(objid)
+            msg = msg + " -- not an integer!"
+            raise ValueError(msg)
+        except ServerError as err:
+            raise self._ws_err_to_perm_err(err)
+
+    def _ws_err_to_perm_err(self, err):
+        if PermissionsError.is_permissions_error(err.message):
+            return PermissionsError(name=err.name, code=err.code,
+                                    message=err.message, data=err.data)
+        else:
+            return err

--- a/src/biokbase/narrative/contents/kbasewsmanager.py
+++ b/src/biokbase/narrative/contents/kbasewsmanager.py
@@ -45,6 +45,7 @@ import biokbase.narrative.ws_util as ws_util
 from biokbase.narrative.common.url_config import URLS
 from biokbase.narrative.common import util
 from biokbase.narrative.common.kblogging import get_narrative_logger
+from biokbase.narrative.common.narrative_ref import NarrativeRef
 from biokbase.narrative.services.user import UserService
 
 # -----------------------------------------------------------------------------
@@ -101,13 +102,13 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
     # a "ws.{workspace}.{object}" string
     path_regex = re.compile('^(ws\.)?(?P<wsid>\d+)((\.obj\.(?P<objid>\d+))(\.ver\.(?P<ver>\d+))?)?$')
 
-    ws_regex = re.compile('^ws\.(?P<wsid>\d+)\.obj\.(?P<objid>\d+)(\.(?P<ver>\d+))?')
-    # regex for parsing out fully qualified workspace name and object name
-    ws_regex2 = re.compile('^(?P<wsname>[\w:]+)/(?P<objname>[\w]+)')
+    # ws_regex = re.compile('^ws\.(?P<wsid>\d+)\.obj\.(?P<objid>\d+)(\.(?P<ver>\d+))?')
+    # # regex for parsing out fully qualified workspace name and object name
+    # ws_regex2 = re.compile('^(?P<wsname>[\w:]+)/(?P<objname>[\w]+)')
     # regex for par
-    kbid_regex = re.compile('^(kb\|[a-zA-Z]+\..+)')
+    # kbid_regex = re.compile('^(kb\|[a-zA-Z]+\..+)')
     # regex from pretty name path
-    objid_regex = re.compile('^.*\s-\s(?P<obj_long_id>ws\.(?P<wsid>\d+)\.obj\.(?P<objid>\d+))\s-\s')
+    # objid_regex = re.compile('^.*\s-\s(?P<obj_long_id>ws\.(?P<wsid>\d+)\.obj\.(?P<objid>\d+))\s-\s')
 
     # This is a regular expression to make sure that the workspace ID
     # doesn't contain non-legit characters in the object ID field
@@ -124,12 +125,6 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
         if not self.kbasews_uri:
             raise HTTPError(412, u"Missing KBase workspace service endpoint URI.")
 
-        # Map Narrative ids to notebook names
-        mapping = Dict()
-        # Map notebook names to Narrative ids
-        rev_mapping = Dict()
-        # Setup empty hash for session object
-        self.kbase_session = {}
         # Init the session info we need.
         self.narrative_logger = get_narrative_logger()
         self.user_service = UserService()
@@ -166,15 +161,12 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
     def file_exists(self, path):
         """We only support narratives right now, so look up
            a narrative from that path."""
-        path = path.strip('/')
-        obj_ref = self._obj_ref_from_path(path)
-        if obj_ref is None:
-            raise HTTPError(404, u'Path "{}" is not a valid Narrative path'.format(path))
+        ref = self._parse_path(path)
         self.log.warn(u'looking up whether a narrative exists')
         try:
-            self.log.warn(u'trying to get narrative {}'.format(obj_ref))
-            return self.narrative_exists(obj_ref)
-        except PermissionsError as e:
+            self.log.warn(u'trying to get narrative {}'.format(ref))
+            return self.narrative_exists(ref)
+        except PermissionsError:
             self.log.warn(u'found a 403 error')
             raise HTTPError(403, u"You do not have permission to view the narrative with id {}".format(path))
 
@@ -192,31 +184,23 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
         model[u'format'] = u'json'
         model[u'last_modified'] = nar[u'save_date']
         model[u'type'] = u'notebook'
-
-        # model = base_model('%s/%s' % (nar['notebook_id'], nar['name']))
-        # model['format'] = 'v3'
         return model
 
-    def _obj_ref_from_path(self, path):
-        parsed = self._parse_path(path)
-        if parsed is None:
-            return None
-        if u'wsid' not in parsed or u'objid' not in parsed:
-            return None
-        ref = u'{}/{}'.format(parsed[u'wsid'], parsed[u'objid'])
-        if parsed[u'ver'] is not None:
-            ref = ref + u'/{}'.format(parsed[u'ver'])
-        return ref
-
     def _parse_path(self, path):
+        """
+        From the URL path for a Narrative, returns a NarrativeRef
+
+        if the path isn't parseable, this raises a 404 with the invalid path.
+        """
+        path = path.strip('/')
         m = self.path_regex.match(path)
         if m is None:
-            return None
-        return dict(
+            raise HTTPError(404, "Invalid Narrative path {}".format(path))
+        return NarrativeRef(dict(
             wsid=m.group(u'wsid'),
             objid=m.group(u'objid'),
             ver=m.group(u'ver')
-        )
+        ))
 
     def get(self, path, content=True, type=None, format=None):
         """Get the model of a file or directory with or without content."""
@@ -225,11 +209,12 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
         model = base_model(path, path)
         if self.exists(path) and type != u'directory':
             #It's a narrative object, so try to fetch it.
-            obj_ref = self._parse_path(path)
-            if not obj_ref:
+            ref = self._parse_path(path)
+            if not ref:
                 raise HTTPError(404, u'Unknown Narrative "{}"'.format(path))
             try:
-                nar_obj = self.read_narrative(u'{}/{}'.format(obj_ref[u'wsid'], obj_ref[u'objid']), content)
+                # nar_obj = self.read_narrative(u'{}/{}'.format(ref[u'wsid'], ref[u'objid']), content)
+                nar_obj = self.fetch_narrative(ref, content=content)  #ref['wsid'], objid=ref['objid'], ver=ref['ver'], content=content)
                 model[u'type'] = u'notebook'
                 user = self.get_userid()
                 if content:
@@ -239,11 +224,11 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
                     self.mark_trusted_cells(nb, nar_obj['info'][5], path)
                     model['content'] = nb
                     model['name'] = nar_obj['data']['metadata'].get('name', 'Untitled')
-                    util.kbase_env.narrative = 'ws.{}.obj.{}'.format(obj_ref['wsid'], obj_ref['objid'])
+                    util.kbase_env.narrative = 'ws.{}.obj.{}'.format(ref.wsid, ref.objid)
                     util.kbase_env.workspace = model['content'].metadata.ws_name
-                    self.narrative_logger.narrative_open(u'{}/{}'.format(obj_ref['wsid'], obj_ref['objid']), nar_obj['info'][4])
+                    self.narrative_logger.narrative_open(u'{}/{}'.format(ref.wsid, ref.objid), nar_obj['info'][4])
                 if user is not None:
-                    model['writable'] = self.narrative_writable(u'{}/{}'.format(obj_ref['wsid'], obj_ref['objid']), user)
+                    model['writable'] = self.narrative_writable(u'{}/{}'.format(ref.wsid, ref.objid), user)
                 self.log.info(u'Got narrative {}'.format(model['name']))
             except HTTPError:
                 raise
@@ -287,7 +272,8 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
         self.check_and_sign(nb, path)
 
         try:
-            result = self.write_narrative(self._obj_ref_from_path(path), nb, self.get_userid())
+            ref = self._parse_path(path)
+            result = self.write_narrative(ref, nb, self.get_userid())
 
             new_id = u"ws.%s.obj.%s" % (result[1], result[2])
             util.kbase_env.narrative = new_id
@@ -309,17 +295,15 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
 
     def delete_file(self, path):
         """Delete file or directory by path."""
-        raise HTTPError(501, u'Narrative deletion not implemented here. Deletion should be handled elsewhere.')
+        raise HTTPError(501, u'Narrative deletion not implemented here. Deletion is handled elsewhere.')
 
     def rename_file(self, path, new_name):
         """Rename a file from old_path to new_path.
         This gets tricky in KBase since we don't deal with paths, but with
         actual file names. For now, assume that 'old_path' won't actually
         change, but the 'new_path' is actually the new Narrative name."""
-        path = path.strip('/')
-
         try:
-            self.rename_narrative(self._obj_ref_from_path(path), self.get_userid(), new_name)
+            self.rename_narrative(self._parse_path(path), self.get_userid(), new_name)
         except PermissionsError as err:
             pass
             # raise HTTPError(403, err.message)

--- a/src/biokbase/narrative/contents/kbasewsmanager.py
+++ b/src/biokbase/narrative/contents/kbasewsmanager.py
@@ -99,6 +99,8 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
 
     # regex for parsing out workspace_id and object_id from
     # a "ws.{workspace}.{object}" string
+    path_regex = re.compile('^(ws\.)?(?P<wsid>\d+)((\.obj\.(?P<objid>\d+))(\.ver\.(?P<ver>\d+))?)?$')
+
     ws_regex = re.compile('^ws\.(?P<wsid>\d+)\.obj\.(?P<objid>\d+)(\.(?P<ver>\d+))?')
     # regex for parsing out fully qualified workspace name and object name
     ws_regex2 = re.compile('^(?P<wsname>[\w:]+)/(?P<objname>[\w]+)')
@@ -175,9 +177,6 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
         except PermissionsError as e:
             self.log.warn(u'found a 403 error')
             raise HTTPError(403, u"You do not have permission to view the narrative with id {}".format(path))
-        # except Exception as e:
-        #     self.log.debug('got a 500 error')
-        #     raise HTTPError(500, e)
 
     def exists(self, path):
         """Looks up whether a directory or file path (i.e. narrative)
@@ -210,7 +209,7 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
         return ref
 
     def _parse_path(self, path):
-        m = self.ws_regex.match(path)
+        m = self.path_regex.match(path)
         if m is None:
             return None
         return dict(

--- a/src/biokbase/narrative/contents/kbasewsmanager.py
+++ b/src/biokbase/narrative/contents/kbasewsmanager.py
@@ -100,15 +100,12 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
 
     # regex for parsing out workspace_id and object_id from
     # a "ws.{workspace}.{object}" string
+    # should accept any of the following formats (the numbers are just random):
+    # ws.123.obj.456.ver.789
+    # ws.123.obj.456
+    # ws.123
+    # 123
     path_regex = re.compile('^(ws\.)?(?P<wsid>\d+)((\.obj\.(?P<objid>\d+))(\.ver\.(?P<ver>\d+))?)?$')
-
-    # ws_regex = re.compile('^ws\.(?P<wsid>\d+)\.obj\.(?P<objid>\d+)(\.(?P<ver>\d+))?')
-    # # regex for parsing out fully qualified workspace name and object name
-    # ws_regex2 = re.compile('^(?P<wsname>[\w:]+)/(?P<objname>[\w]+)')
-    # regex for par
-    # kbid_regex = re.compile('^(kb\|[a-zA-Z]+\..+)')
-    # regex from pretty name path
-    # objid_regex = re.compile('^.*\s-\s(?P<obj_long_id>ws\.(?P<wsid>\d+)\.obj\.(?P<objid>\d+))\s-\s')
 
     # This is a regular expression to make sure that the workspace ID
     # doesn't contain non-legit characters in the object ID field
@@ -213,8 +210,7 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
             if not ref:
                 raise HTTPError(404, u'Unknown Narrative "{}"'.format(path))
             try:
-                # nar_obj = self.read_narrative(u'{}/{}'.format(ref[u'wsid'], ref[u'objid']), content)
-                nar_obj = self.read_narrative(ref, content=content)  #ref['wsid'], objid=ref['objid'], ver=ref['ver'], content=content)
+                nar_obj = self.read_narrative(ref, content=content)
                 model[u'type'] = u'notebook'
                 user = self.get_userid()
                 if content:
@@ -306,7 +302,6 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
             self.rename_narrative(self._parse_path(path), self.get_userid(), new_name)
         except PermissionsError as err:
             pass
-            # raise HTTPError(403, err.message)
         except Exception as err:
             raise HTTPError(500, u'An error occurred while renaming your Narrative: {}'.format(err))
 
@@ -537,7 +532,6 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
             if not trusted:
                 self.log.warn("Notebook %s is not trusted", path)
             self.notary.mark_cells(nb, trusted)
-
             # self.log.warn("Notebook %s is totally trusted", path)
             # # all notebooks are trustworthy, because KBase is Pollyanna.
 

--- a/src/biokbase/narrative/contents/kbasewsmanager.py
+++ b/src/biokbase/narrative/contents/kbasewsmanager.py
@@ -214,7 +214,7 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
                 raise HTTPError(404, u'Unknown Narrative "{}"'.format(path))
             try:
                 # nar_obj = self.read_narrative(u'{}/{}'.format(ref[u'wsid'], ref[u'objid']), content)
-                nar_obj = self.fetch_narrative(ref, content=content)  #ref['wsid'], objid=ref['objid'], ver=ref['ver'], content=content)
+                nar_obj = self.read_narrative(ref, content=content)  #ref['wsid'], objid=ref['objid'], ver=ref['ver'], content=content)
                 model[u'type'] = u'notebook'
                 user = self.get_userid()
                 if content:
@@ -228,7 +228,7 @@ class KBaseWSManager(KBaseWSManagerMixin, ContentsManager):
                     util.kbase_env.workspace = model['content'].metadata.ws_name
                     self.narrative_logger.narrative_open(u'{}/{}'.format(ref.wsid, ref.objid), nar_obj['info'][4])
                 if user is not None:
-                    model['writable'] = self.narrative_writable(u'{}/{}'.format(ref.wsid, ref.objid), user)
+                    model['writable'] = self.narrative_writable(ref, user)
                 self.log.info(u'Got narrative {}'.format(model['name']))
             except HTTPError:
                 raise

--- a/src/biokbase/narrative/contents/narrativeio.py
+++ b/src/biokbase/narrative/contents/narrativeio.py
@@ -125,11 +125,12 @@ class KBaseWSManagerMixin(object):
         containing a single key: 'info', with the object info and, optionally,
         metadata.
 
-        :param ref: a NarrativeRef:
+        :param ref: a NarrativeRef
         :param content: if True, returns the narrative document, otherwise just the metadata
         :param include_metadata: if True, includes the object metadata when returning
         """
-        assert isinstance(ref, NarrativeRef), "Must use a NarrativeRef as input!"
+        log_event(g_log, "reading narrative: {}", {'ref': str(ref)})
+        assert isinstance(ref, NarrativeRef), "read_narrative must use a NarrativeRef as input!"
         try:
             if content:
                 nar_data = self.ws_client().get_objects([{'ref': str(ref)}])
@@ -193,7 +194,7 @@ class KBaseWSManagerMixin(object):
            (narrative, ws_id, obj_id, ver)
         """
 
-        assert isinstance(ref, NarrativeRef), "Must use a NarrativeRef as input!"
+        assert isinstance(ref, NarrativeRef), "write_narrative must use a NarrativeRef as input!"
         if 'worksheets' in nb:
             # it's an old version. update it by replacing the 'worksheets' key with
             # the 'cells' subkey
@@ -528,7 +529,7 @@ class KBaseWSManagerMixin(object):
 
         If nobody is logged in, this throws a WorkspaceClient.ServerError.
         """
-        assert isinstance(ref, NarrativeRef), "Must use a NarrativeRef as input!"
+        assert isinstance(ref, NarrativeRef), "narrative_permissions must use a NarrativeRef as input!"
         perms = {}
         try:
             perms = self.ws_client().get_permissions({'id': ref.wsid})

--- a/src/biokbase/narrative/contents/narrativeio.py
+++ b/src/biokbase/narrative/contents/narrativeio.py
@@ -147,40 +147,6 @@ class KBaseWSManagerMixin(object):
         except ServerError as err:
             raise self._ws_err_to_perm_err(err)
 
-    # def read_narrative(self, obj_ref, content=True, include_metadata=True):
-    #     """
-    #     Fetches a Narrative and its object info from the Workspace
-    #     If content is False, this only returns the Narrative's info
-    #     and metadata, otherwise, it returns the whole workspace object.
-
-    #     This is mainly a wrapper around Workspace.get_objects(), except that
-    #     it always returns a dict. If content is False, it returns a dict
-    #     containing a single key: 'info', with the object info and, optionally,
-    #     metadata.
-
-    #     obj_ref: expected to be in the format "wsid/objid", e.g. "4337/1"
-    #     or even "4337/1/1" to include version.
-    #     """
-
-    #     self._test_obj_ref(obj_ref)
-    #     try:
-    #         if content:
-    #             nar_data = self.ws_client().get_objects([{'ref': obj_ref}])
-    #             if nar_data:
-    #                 nar = nar_data[0]
-    #                 nar['data'] = update_narrative(nar['data'])
-    #                 return nar
-    #         else:
-    #             log_event(g_log, 'read_narrative testing existence', {'ref': obj_ref})
-    #             nar_data = self.ws_client().get_object_info_new({
-    #                 u'objects': [{'ref': obj_ref}],
-    #                 u'includeMetadata': 1 if include_metadata else 0
-    #             })
-    #             if nar_data:
-    #                 return {'info': nar_data[0]}
-    #     except ServerError, err:
-    #         raise self._ws_err_to_perm_err(err)
-
     def write_narrative(self, ref, nb, cur_user):
         """
         :param ref: a NarrativeRef

--- a/src/biokbase/narrative/contents/narrativeio.py
+++ b/src/biokbase/narrative/contents/narrativeio.py
@@ -14,6 +14,7 @@ from notebook.utils import (
     to_api_path,
     to_os_path
 )
+from biokbase.narrative.common.exceptions import PermissionsError
 from traitlets import (
     Unicode,
     Dict,
@@ -28,6 +29,8 @@ import re
 import json
 from collections import Counter
 from updater import update_narrative
+from biokbase.narrative.common.narrative_ref import NarrativeRef
+
 
 # The list_workspace_objects method has been deprecated, the
 # list_objects method is the current primary method for fetching
@@ -43,22 +46,6 @@ MAX_METADATA_SIZE_BYTES = 16000
 WORKSPACE_TIMEOUT = 30  # seconds
 
 g_log = get_logger("biokbase.narrative")
-
-
-class PermissionsError(ServerError):
-    """Raised if user does not have permission to
-    access the workspace.
-    """
-    @staticmethod
-    def is_permissions_error(err):
-        """Try to guess if the error string is a permission-denied error
-        for the narrative (i.e. the workspace the narrative is in).
-        """
-        pat = re.compile("(\s*[Uu]sers?\s*(\w+)?\s*may not \w+ workspace.*)|(\s*[Tt]oken validation failed)")
-        return pat.search(err) is not None
-
-    def __init__(self, name=None, code=None, message=None, **kw):
-        ServerError.__init__(self, name, code, message, **kw)
 
 
 class KBaseWSManagerMixin(object):
@@ -113,20 +100,21 @@ class KBaseWSManagerMixin(object):
             ver=m.group('ver')
         )
 
-    def narrative_exists(self, obj_ref):
+    def narrative_exists(self, ref):
         """
         Test if a narrative exists.
         If we can fetch the narrative info (e.g. the get_object_info from the
             workspace), then it exists.
+        :param ref: a NarrativeRef object
         """
         try:
-            return self.read_narrative(obj_ref, content=False, include_metadata=False) is not None
+            return self.read_narrative(ref, content=False, include_metadata=False) is not None
         except PermissionsError:
             raise
         except ServerError:
             return False
 
-    def read_narrative(self, obj_ref, content=True, include_metadata=True):
+    def read_narrative(self, ref, content=True, include_metadata=True):
         """
         Fetches a Narrative and its object info from the Workspace
         If content is False, this only returns the Narrative's info
@@ -137,31 +125,66 @@ class KBaseWSManagerMixin(object):
         containing a single key: 'info', with the object info and, optionally,
         metadata.
 
-        obj_ref: expected to be in the format "wsid/objid", e.g. "4337/1"
-        or even "4337/1/1" to include version.
+        :param ref: a NarrativeRef:
+        :param content: if True, returns the narrative document, otherwise just the metadata
+        :param include_metadata: if True, includes the object metadata when returning
         """
-
-        self._test_obj_ref(obj_ref)
+        assert isinstance(ref, NarrativeRef), "Must use a NarrativeRef as input!"
         try:
             if content:
-                nar_data = self.ws_client().get_objects([{'ref': obj_ref}])
-                if nar_data:
-                    nar = nar_data[0]
-                    nar['data'] = update_narrative(nar['data'])
-                    return nar
+                nar_data = self.ws_client().get_objects([{'ref': str(ref)}])
+                nar = nar_data[0]
+                nar['data'] = update_narrative(nar['data'])
+                return nar
             else:
-                log_event(g_log, 'read_narrative testing existence', {'ref': obj_ref})
-                nar_data = self.ws_client().get_object_info_new({
-                    u'objects': [{'ref': obj_ref}],
-                    u'includeMetadata': 1 if include_metadata else 0
+                log_event(g_log, 'read_narrative testing existence', {'ref': str(ref)})
+                nar_data = self.ws_client().get_object_info3({
+                    'objects': [{'ref': str(ref)}],
+                    'includeMetadata': 1 if include_metadata else 0
                 })
-                if nar_data:
-                    return {'info': nar_data[0]}
-        except ServerError, err:
+                return {'info': nar_data['infos'][0]}
+        except ServerError as err:
             raise self._ws_err_to_perm_err(err)
 
-    def write_narrative(self, obj_ref, nb, cur_user):
+    # def read_narrative(self, obj_ref, content=True, include_metadata=True):
+    #     """
+    #     Fetches a Narrative and its object info from the Workspace
+    #     If content is False, this only returns the Narrative's info
+    #     and metadata, otherwise, it returns the whole workspace object.
+
+    #     This is mainly a wrapper around Workspace.get_objects(), except that
+    #     it always returns a dict. If content is False, it returns a dict
+    #     containing a single key: 'info', with the object info and, optionally,
+    #     metadata.
+
+    #     obj_ref: expected to be in the format "wsid/objid", e.g. "4337/1"
+    #     or even "4337/1/1" to include version.
+    #     """
+
+    #     self._test_obj_ref(obj_ref)
+    #     try:
+    #         if content:
+    #             nar_data = self.ws_client().get_objects([{'ref': obj_ref}])
+    #             if nar_data:
+    #                 nar = nar_data[0]
+    #                 nar['data'] = update_narrative(nar['data'])
+    #                 return nar
+    #         else:
+    #             log_event(g_log, 'read_narrative testing existence', {'ref': obj_ref})
+    #             nar_data = self.ws_client().get_object_info_new({
+    #                 u'objects': [{'ref': obj_ref}],
+    #                 u'includeMetadata': 1 if include_metadata else 0
+    #             })
+    #             if nar_data:
+    #                 return {'info': nar_data[0]}
+    #     except ServerError, err:
+    #         raise self._ws_err_to_perm_err(err)
+
+    def write_narrative(self, ref, nb, cur_user):
         """
+        :param ref: a NarrativeRef
+        :param nb: a notebook model
+        :cur_user: the current user id
         Given a notebook, break this down into a couple parts:
         1. Figure out what ws and obj to save to
         2. Build metadata object
@@ -170,6 +193,7 @@ class KBaseWSManagerMixin(object):
            (narrative, ws_id, obj_id, ver)
         """
 
+        assert isinstance(ref, NarrativeRef), "Must use a NarrativeRef as input!"
         if 'worksheets' in nb:
             # it's an old version. update it by replacing the 'worksheets' key with
             # the 'cells' subkey
@@ -182,11 +206,8 @@ class KBaseWSManagerMixin(object):
             del(nb['worksheets'])
             nb['nbformat'] = 4
 
-        parsed_ref = self._parse_obj_ref(obj_ref)
-        if parsed_ref is None:
-            raise HTTPError(500, u'Unable to parse incorrect obj_ref "{}"'.format(obj_ref))
-        ws_id = parsed_ref['wsid']
-        obj_id = parsed_ref['objid']
+        ws_id = ref.wsid
+        obj_id = ref.objid
 
         # make sure the metadata's up to date.
         try:
@@ -392,7 +413,7 @@ class KBaseWSManagerMixin(object):
             # otherwise, remove them all.
             if total_size - method_size + len(meth_overflow_key) + len(unicode(num_methods)) < MAX_METADATA_SIZE_BYTES:
                 # filter them.
-                method_info = _filter_app_methods(total_size, meth_overflow_key, method_info)
+                method_info = self._filter_app_methods(total_size, meth_overflow_key, method_info)
             else:
                 method_info = Counter({meth_overflow_key : num_methods})
             total_size -= method_size
@@ -405,7 +426,7 @@ class KBaseWSManagerMixin(object):
 
             # same for apps now.
             if total_size - app_size + len(app_overflow_key) + len(unicode(num_apps)) < MAX_METADATA_SIZE_BYTES:
-                app_info = _filter_app_methods(total_size, app_overflow_key, app_info)
+                app_info = self._filter_app_methods(total_size, app_overflow_key, app_info)
             else:
                 app_info = Counter({app_overflow_key : num_apps})
             total_size -= app_size
@@ -430,9 +451,9 @@ class KBaseWSManagerMixin(object):
         filter_dict[overflow_key] = overflow_count
         return filter_dict
 
-    def rename_narrative(self, obj_ref, cur_user, new_name):
+    def rename_narrative(self, ref, cur_user, new_name):
         """
-        Renames a Narrative. Requires an obj_ref
+        Renames a Narrative. Requires a ref (NarrativeRef)
         and the name to set for the Narrative. If the current name
         doesn't match the new name, nothing changes.
 
@@ -441,12 +462,12 @@ class KBaseWSManagerMixin(object):
 
         Any Exceptions that get thrown should just be auto-raised.
         """
-        nar = self.read_narrative(obj_ref)['data']
+        nar = self.read_narrative(ref)['data']
         # do stuff to set the new name
         if nar['metadata']['name'] == new_name:
             return
         nar['metadata']['name'] = new_name
-        self.write_narrative(obj_ref, nar, cur_user)
+        self.write_narrative(ref, nar, cur_user)
 
     def copy_narrative(self, obj_ref, content=True):
         pass
@@ -494,7 +515,7 @@ class KBaseWSManagerMixin(object):
 
         return my_narratives
 
-    def narrative_permissions(self, obj_ref, user=None):
+    def narrative_permissions(self, ref, user=None):
         """
         Returns permissions to a Narrative.
         This is returned as a dict, where each key is a user.
@@ -507,13 +528,10 @@ class KBaseWSManagerMixin(object):
 
         If nobody is logged in, this throws a WorkspaceClient.ServerError.
         """
-        m = obj_ref_regex.match(obj_ref)
-        if m is None:
-            raise ValueError('Narrative object references must be of the format wsid/objid/ver')
-        ws_id = m.group('wsid')
+        assert isinstance(ref, NarrativeRef), "Must use a NarrativeRef as input!"
         perms = {}
         try:
-            perms = self.ws_client().get_permissions({'id': ws_id})
+            perms = self.ws_client().get_permissions({'id': ref.wsid})
         except ServerError, err:
             raise self._ws_err_to_perm_err(err)
         if user is not None:
@@ -523,7 +541,7 @@ class KBaseWSManagerMixin(object):
                 perms = {user: 'n'}
         return perms
 
-    def narrative_writable(self, obj_ref, user):
+    def narrative_writable(self, ref, user):
         """
         Returns True if the logged in user can know if the given user can write to this narrative.
         E.g. user A is logged in. If A can see user B's permissions, and user B can write to this
@@ -537,10 +555,12 @@ class KBaseWSManagerMixin(object):
 
         Throws a WorkspaceClient.ServerError if not logged in, or
         if the narrative doesn't exist.
+        :param ref: a NarrativeRef
+        :param user: str - the user to check for permissions
         """
         if user is None:
             raise ValueError('A user must be given for testing whether a Narrative can be written')
-        perms = self.narrative_permissions(obj_ref, user)
+        perms = self.narrative_permissions(ref, user)
         if perms.has_key(user):
             return perms[user] == 'w' or perms[user] == 'a'
         else:

--- a/src/biokbase/narrative/handlers/narrativehandler.py
+++ b/src/biokbase/narrative/handlers/narrativehandler.py
@@ -85,7 +85,6 @@ class NarrativeMainHandler(IPythonHandler):
         if model['type'] != 'notebook':
             # not a notebook, redirect to files
             return FilesRedirectHandler.redirect_to_files(self, path)
-        name = url_escape(path.rsplit('/', 1)[-1])
         path = url_escape(path)
         self.write(
             self.render_template(

--- a/src/biokbase/narrative/handlers/narrativehandler.py
+++ b/src/biokbase/narrative/handlers/narrativehandler.py
@@ -49,26 +49,6 @@ class NarrativeMainHandler(IPythonHandler):
     """
     def get(self, path):
         _init_session(self.request, self.cookies)
-        # """
-        # Inject the user's KBase cookie before trying to look up a file.
-        # One of our big use cases bypasses the typical Jupyter login mechanism.
-        # """
-        # client_ip = self.request.remote_ip
-        # http_headers = self.request.headers
-        # ua = http_headers.get('User-Agent', 'unknown')
-
-        # auth_cookie = self.cookies.get(auth_cookie_name, None)
-        # if auth_cookie:
-        #     token = urllib.unquote(auth_cookie.value)
-        # else:
-        #     raise web.HTTPError(status_code=401,
-        #                         log_message='No auth cookie, denying access',
-        #                         reason='Authorization required for Narrative access')
-
-        # if token != kbase_env.auth_token:
-        #     init_session_env(get_user_info(token), client_ip)
-        #     log_event(g_log, 'session_start', {'user': kbase_env.user, 'user_agent': ua})
-
         """
         get renders the notebook template if a name is given, or
         redirects to the '/files/' handler if the name is not given.

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -1,5 +1,5 @@
 from ..util import TestConfig
-
+from biokbase.workspace.baseclient import ServerError
 
 class MockClients(object):
     """
@@ -62,9 +62,23 @@ class MockClients(object):
         return "0.0.0"
 
     def get_workspace_info(self, params):
+        """
+        Some magic workspace ids.
+        12345 - the standard one.
+        678 - doesn't have useful narrative info in its metadata
+        789 - raises a permissions error
+        890 - raises a deleted workspace error
+        otherwise, returns workspace info with narrative = 1, and narrative name = 'Fake'
+        """
         wsid = params.get('id', 12345)
         name = params.get('workspace', 'some_workspace')
-        if name != 'invalid_workspace' and wsid > 0:
+        if wsid == 678:
+            return [wsid, name, 'owner', 'moddate', 'largestid', 'a', 'n', 'unlocked', {}]
+        elif wsid == 789:
+            raise ServerError("JSONRPCError", -32500, "User you may not read workspace 789")
+        elif wsid == 890:
+            raise ServerError("JSONRPCError", -32500, "Workspace 890 is deleted")
+        elif name != 'invalid_workspace':
             return [wsid, name, 'owner', 'moddate', 'largestid', 'a', 'n', 'unlocked', {'is_temporary': 'false', 'narrative': '1', 'narrative_nice_name': 'Fake'}]
         else:
             raise Exception('not found')

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -56,9 +56,14 @@ class MockClients(object):
 
     # ----- Workspace functions -----
 
+    def ver(self):
+        return "0.0.0"
+
     def get_workspace_info(self, params):
-        if params.get('workspace', '') != 'invalid_workspace':
-            return [12345, 'foo', 'bar']
+        wsid = params.get('id', 12345)
+        name = params.get('workspace', 'some_workspace')
+        if name != 'invalid_workspace' and wsid > 0:
+            return [wsid, name, 'owner', 'moddate', 'largestid', 'a', 'n', 'unlocked', {'is_temporary': 'false', 'narrative': '1', 'narrative_nice_name': 'Fake'}]
         else:
             raise Exception('not found')
 

--- a/src/biokbase/narrative/tests/test_kbasewsmanager.py
+++ b/src/biokbase/narrative/tests/test_kbasewsmanager.py
@@ -1,0 +1,21 @@
+import unittest
+from biokbase.narrative.contents.kbasewsmanager import KBaseWSManager
+
+class KBWSManagerTestCase(unittest.TestCase):
+    def test__parse_path(self):
+        manager = KBaseWSManager()
+        cases = [
+            ("123", {"wsid": "123", "objid": None, "ver": None}),
+            ("ws.123", {"wsid": "123", "objid": None, "ver": None}),
+            ("foo", None),
+            ("ws.123.obj.456", {"wsid": "123", "objid": "456", "ver": None}),
+            ("ws.123.obj.456.ver.7", {"wsid": "123", "objid": "456", "ver": "7"}),
+            ("ws.asdf.obj.sdf.ver.1", None),
+            ("ws.123.obj.f", None),
+            ("ws.obj.ver", None),
+            ("ws.1.obj.ver", None),
+            ("ws.1.obj.a", None),
+            ("ws.1.2", None)
+        ]
+        for c in cases:
+            self.assertEqual(c[1], manager._parse_path(c[0]))

--- a/src/biokbase/narrative/tests/test_kbasewsmanager.py
+++ b/src/biokbase/narrative/tests/test_kbasewsmanager.py
@@ -1,21 +1,37 @@
 import unittest
+import mock
 from biokbase.narrative.contents.kbasewsmanager import KBaseWSManager
+from narrative_mock.mockclients import get_mock_client
+from biokbase.narrative.common.narrative_ref import NarrativeRef
+from tornado.web import HTTPError
+
 
 class KBWSManagerTestCase(unittest.TestCase):
+
+    @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
     def test__parse_path(self):
         manager = KBaseWSManager()
         cases = [
-            ("123", {"wsid": "123", "objid": None, "ver": None}),
-            ("ws.123", {"wsid": "123", "objid": None, "ver": None}),
-            ("foo", None),
-            ("ws.123.obj.456", {"wsid": "123", "objid": "456", "ver": None}),
-            ("ws.123.obj.456.ver.7", {"wsid": "123", "objid": "456", "ver": "7"}),
-            ("ws.asdf.obj.sdf.ver.1", None),
-            ("ws.123.obj.f", None),
-            ("ws.obj.ver", None),
-            ("ws.1.obj.ver", None),
-            ("ws.1.obj.a", None),
-            ("ws.1.2", None)
+            ("123", NarrativeRef({"wsid": "123", "objid": None, "ver": None})),
+            ("ws.123", NarrativeRef({"wsid": "123", "objid": None, "ver": None})),
+            ("ws.123.obj.456", NarrativeRef({"wsid": "123", "objid": "456", "ver": None})),
+            ("ws.123.obj.456.ver.7", NarrativeRef({"wsid": "123", "objid": "456", "ver": "7"}))
         ]
         for c in cases:
             self.assertEqual(c[1], manager._parse_path(c[0]))
+
+    def test__parse_path_bad(self):
+        manager = KBaseWSManager()
+        cases = [
+            "foo",
+            "ws.asdf.obj.sdf.ver.1",
+            "ws.123.obj.f",
+            "ws.obj.ver",
+            "ws.1.obj.ver",
+            "ws.1.obj.a",
+            "ws.1.2"
+        ]
+        for c in cases:
+            with self.assertRaises(HTTPError) as e:
+                manager._parse_path(c)
+            self.assertIn("Invalid Narrative path {}".format(c), str(e.exception))

--- a/src/biokbase/narrative/tests/test_narrative_ref.py
+++ b/src/biokbase/narrative/tests/test_narrative_ref.py
@@ -12,3 +12,10 @@ class NarrativeRefTestCase(unittest.TestCase):
         self.assertEqual(ref.wsid, 123)
         self.assertEqual(ref.objid, 1)
         self.assertIsNone(ref.ver)
+
+    def test_ok(self):
+        ref = NarrativeRef({"wsid": 123, "objid": 456, "ver": 7})
+        self.assertEqual(ref.wsid, 123)
+        self.assertEqual(ref.objid, 456)
+        self.assertEqual(ref.ver, 7)
+

--- a/src/biokbase/narrative/tests/test_narrative_ref.py
+++ b/src/biokbase/narrative/tests/test_narrative_ref.py
@@ -4,6 +4,7 @@ from biokbase.narrative.contents.kbasewsmanager import KBaseWSManager
 from narrative_mock.mockclients import get_mock_client
 from biokbase.narrative.common.narrative_ref import NarrativeRef
 from tornado.web import HTTPError
+from biokbase.narrative.common.exceptions import PermissionsError
 
 class NarrativeRefTestCase(unittest.TestCase):
     @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
@@ -19,3 +20,13 @@ class NarrativeRefTestCase(unittest.TestCase):
         self.assertEqual(ref.objid, 456)
         self.assertEqual(ref.ver, 7)
 
+    @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
+    def test_no_objid_fail(self):
+        with self.assertRaises(RuntimeError) as e:
+            NarrativeRef({"wsid": 678, "objid": None, "ver": None})
+        self.assertIn("Expected an integer while looking up the Narrative id", str(e.exception))
+
+    @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
+    def test_no_ws_perm(self):
+        with self.assertRaises(PermissionsError) as e:
+            NarrativeRef({"wsid": 789, "objid": None, "ver": None})

--- a/src/biokbase/narrative/tests/test_narrative_ref.py
+++ b/src/biokbase/narrative/tests/test_narrative_ref.py
@@ -1,0 +1,14 @@
+import unittest
+import mock
+from biokbase.narrative.contents.kbasewsmanager import KBaseWSManager
+from narrative_mock.mockclients import get_mock_client
+from biokbase.narrative.common.narrative_ref import NarrativeRef
+from tornado.web import HTTPError
+
+class NarrativeRefTestCase(unittest.TestCase):
+    @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
+    def test_no_objid_ok(self):
+        ref = NarrativeRef({"wsid": 123, "objid": None, "ver": None})
+        self.assertEqual(ref.wsid, 123)
+        self.assertEqual(ref.objid, 1)
+        self.assertIsNone(ref.ver)

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -12,6 +12,7 @@ import biokbase.auth
 from tornado.web import HTTPError
 import util
 from biokbase.narrative.common.url_config import URLS
+from biokbase.narrative.common.narrative_ref import NarrativeRef
 
 __author__ = 'Bill Riehl <wjriehl@lbl.gov>'
 
@@ -26,6 +27,16 @@ def skipUnlessToken():
     if not HAS_TEST_TOKEN:
         return unittest.skip("No auth token")
 
+def str_to_ref(s):
+    """ Takes a ref string, returns a NarrativeRef object """
+    vals = s.split("/")
+    ref = {
+        "wsid": vals[0],
+        "objid": vals[1]
+    }
+    if len(vals) == 3:
+        ref["ver"] = vals[2]
+    return NarrativeRef(ref)
 
 class NarrIOTestCase(unittest.TestCase):
     # Before test:
@@ -57,7 +68,8 @@ class NarrIOTestCase(unittest.TestCase):
 
         self.ws_uri = URLS.workspace
 
-        self.invalid_nar_ref = config.get('strings', 'invalid_nar_ref')
+        self.invalid_nar_ref_str = config.get('strings', 'invalid_nar_ref')
+        self.invalid_nar_ref = str_to_ref(self.invalid_nar_ref_str)
         self.bad_nar_ref = config.get('strings', 'bad_nar_ref')
         self.invalid_ws_id = config.get('strings', 'invalid_ws_id')
         self.bad_ws_id = config.get('strings', 'bad_ws_id')
@@ -128,9 +140,9 @@ class NarrIOTestCase(unittest.TestCase):
         self.assertFalse(self.mixin.narrative_exists(self.invalid_nar_ref))
 
     def test_narrative_exists_bad(self):
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(AssertionError) as err:
             self.mixin.narrative_exists(self.bad_nar_ref)
-        self.assertIsNotNone(err)
+        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
 
     def test_narrative_exists_noauth(self):
         if self.test_token is None:
@@ -226,9 +238,9 @@ class NarrIOTestCase(unittest.TestCase):
         self.assertIsNotNone(err)
 
     def test_read_narrative_bad(self):
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(AssertionError) as err:
             self.mixin.read_narrative(self.bad_nar_ref)
-        self.assertIsNotNone(err)
+        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
 
     ##### test KBaseWSManagerMixin.write_narrative #####
 
@@ -271,9 +283,9 @@ class NarrIOTestCase(unittest.TestCase):
             self.skipTest("No auth token")
         self.login()
         nar = self.mixin.read_narrative(self.public_nar['ref'])['data']
-        with self.assertRaises(HTTPError) as err:
+        with self.assertRaises(AssertionError) as err:
             self.mixin.write_narrative(self.bad_nar_ref, nar, self.test_user)
-        self.assertEquals(err.exception.status_code, 500)
+        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
         self.logout()
 
     def test_write_narrative_bad_file(self):
@@ -325,9 +337,9 @@ class NarrIOTestCase(unittest.TestCase):
         self.assertIsNotNone(err)
 
     def test_rename_narrative_bad(self):
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(AssertionError) as err:
             self.mixin.rename_narrative(self.bad_nar_ref, self.test_user, 'new_name')
-        self.assertIsNotNone(err)
+        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
 
     ##### test KBaseWSManagerMixin.copy_narrative #####
 
@@ -438,9 +450,9 @@ class NarrIOTestCase(unittest.TestCase):
         self.logout()
 
     def test_narrative_permissions_bad(self):
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(AssertionError) as err:
             self.mixin.narrative_permissions(self.bad_nar_ref)
-        self.assertIsNotNone(err)
+        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
 
 
     ##### test KBaseWSManagerMixin.narrative_writable #####
@@ -489,9 +501,9 @@ class NarrIOTestCase(unittest.TestCase):
         if self.test_token is None:
             self.skipTest("No auth token")
         self.login()
-        with self.assertRaises(ValueError) as err:
+        with self.assertRaises(AssertionError) as err:
             self.mixin.narrative_writable(self.bad_nar_ref, self.test_user)
-        self.assertIsNotNone(err)
+        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
         self.logout()
 
 if __name__ == '__main__':

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -142,7 +142,7 @@ class NarrIOTestCase(unittest.TestCase):
     def test_narrative_exists_bad(self):
         with self.assertRaises(AssertionError) as err:
             self.mixin.narrative_exists(self.bad_nar_ref)
-        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
+        self.assertEquals("read_narrative must use a NarrativeRef as input!", str(err.exception))
 
     def test_narrative_exists_noauth(self):
         if self.test_token is None:
@@ -240,7 +240,7 @@ class NarrIOTestCase(unittest.TestCase):
     def test_read_narrative_bad(self):
         with self.assertRaises(AssertionError) as err:
             self.mixin.read_narrative(self.bad_nar_ref)
-        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
+        self.assertEquals("read_narrative must use a NarrativeRef as input!", str(err.exception))
 
     ##### test KBaseWSManagerMixin.write_narrative #####
 
@@ -285,7 +285,7 @@ class NarrIOTestCase(unittest.TestCase):
         nar = self.mixin.read_narrative(self.public_nar['ref'])['data']
         with self.assertRaises(AssertionError) as err:
             self.mixin.write_narrative(self.bad_nar_ref, nar, self.test_user)
-        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
+        self.assertEquals("write_narrative must use a NarrativeRef as input!", str(err.exception))
         self.logout()
 
     def test_write_narrative_bad_file(self):
@@ -339,7 +339,7 @@ class NarrIOTestCase(unittest.TestCase):
     def test_rename_narrative_bad(self):
         with self.assertRaises(AssertionError) as err:
             self.mixin.rename_narrative(self.bad_nar_ref, self.test_user, 'new_name')
-        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
+        self.assertEquals("read_narrative must use a NarrativeRef as input!", str(err.exception))
 
     ##### test KBaseWSManagerMixin.copy_narrative #####
 
@@ -452,7 +452,7 @@ class NarrIOTestCase(unittest.TestCase):
     def test_narrative_permissions_bad(self):
         with self.assertRaises(AssertionError) as err:
             self.mixin.narrative_permissions(self.bad_nar_ref)
-        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
+        self.assertEquals("narrative_permissions must use a NarrativeRef as input!", str(err.exception))
 
 
     ##### test KBaseWSManagerMixin.narrative_writable #####
@@ -503,7 +503,7 @@ class NarrIOTestCase(unittest.TestCase):
         self.login()
         with self.assertRaises(AssertionError) as err:
             self.mixin.narrative_writable(self.bad_nar_ref, self.test_user)
-        self.assertEquals("Must use a NarrativeRef as input!", str(err.exception))
+        self.assertEquals("narrative_permissions must use a NarrativeRef as input!", str(err.exception))
         self.logout()
 
 if __name__ == '__main__':

--- a/src/biokbase/narrative/tests/util.py
+++ b/src/biokbase/narrative/tests/util.py
@@ -10,6 +10,7 @@ import unittest
 import SocketServer
 from biokbase.narrative.common import util
 from biokbase.workspace.client import Workspace
+from biokbase.narrative.common.narrative_ref import NarrativeRef
 import os
 import json
 import ConfigParser
@@ -149,7 +150,8 @@ def upload_narrative(nar_file, auth_token, user_id, url=ci_ws, set_public=False)
     return {
         'ws': ws_info[0],
         'obj': obj_info[0][0],
-        'ref': '{}/{}'.format(ws_info[0], obj_info[0][0])
+        'refstr': '{}/{}'.format(ws_info[0], obj_info[0][0]),
+        'ref': NarrativeRef({'wsid': ws_info[0], 'objid': obj_info[0][0]})
     }
 
 

--- a/test/unit/spec/api/upaApiSpec.js
+++ b/test/unit/spec/api/upaApiSpec.js
@@ -5,9 +5,11 @@
 /*jslint white: true*/
 
 define ([
-    'api/upa'
+    'api/upa',
+    'narrativeConfig'
 ], function(
-    UpaApi
+    UpaApi,
+    Config
 ) {
     'use strict';
     describe('Test the UPA API', function() {
@@ -89,6 +91,7 @@ define ([
 
         beforeEach(function () {
             history.pushState(null, null, '/narrative/ws.31.obj.1');
+            Config.config.workspaceId = 31;
         });
 
         it('Should properly serialize an UPA from this workspace', function () {
@@ -160,6 +163,7 @@ define ([
 
         it('Should fail if the workspace id cannot be found.', function () {
             history.pushState(null, null, '/narrative/');
+            Config.config.workspaceId = undefined;
             try {
                 upaApi.deserialize('[1]/2/3');
                 fail('Should have failed here!');

--- a/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
@@ -8,13 +8,15 @@ define([
     'kbaseNarrativeOutputCell',
     'base/js/namespace',
     'kbaseNarrative',
-    'common/runtime'
+    'common/runtime',
+    'narrativeConfig'
 ], function(
     $,
     Widget,
     Jupyter,
     Narrative,
-    Runtime
+    Runtime,
+    Config
 ) {
     'use strict';
     describe('Test the kbaseNarrativeOutputCell widget', function() {
@@ -53,6 +55,7 @@ define([
         beforeEach(function() {
             beforeEach(function () {
                 history.pushState(null, null, '/narrative/ws.10.obj.1');
+                Config.config.workspaceId = 10;
             });
             Jupyter.narrative = new Narrative();
             $('body').append($('<div id="notebook-container">').append($target));


### PR DESCRIPTION
Currently Narrative URLs all look like this: https://narrative.kbase.us/narrative/ws.###.obj.###

This will adjust to allow urls like this: https://narrative.kbase.us/narrative/xyz where xyz = a numerical workspace id. The changes in this PR handle the following cases:
1. workspace has a single narrative, set in the workspace metadata.
2. workspace has a single narrative, but NOT set in the ws metadata.
3. If the workspace has either 0 or > 1 narrative (and the ws metadata is not set), it will throw a 404 error.

This wound up requiring a refactor of some deep chunks of the ContentsManager that's plugged in to Jupyter, so there's a bunch of changes and more tests are needed before merging (but I want them tested in Travis-CI as well).

Also, there's some front end adapter work that needs to be done, still.