### PR TITLE
Fix agent token

### DIFF
--- a/src/biokbase/narrative/clients.py
+++ b/src/biokbase/narrative/clients.py
@@ -20,19 +20,19 @@ def reset():
     __clients = dict()
 
 
-def __init_client(client_name):
+def __init_client(client_name, token=None):
     if client_name == 'workspace':
-        c = Workspace(URLS.workspace)
+        c = Workspace(URLS.workspace, token=token)
     elif client_name == 'job_service':
-        c = NarrativeJobService(URLS.job_service)
+        c = NarrativeJobService(URLS.job_service, token=token)
     elif client_name == 'narrative_method_store':
-        c = NarrativeMethodStore(URLS.narrative_method_store)
+        c = NarrativeMethodStore(URLS.narrative_method_store, token=token)
     elif client_name == 'user_and_job_state':
-        c = UserAndJobState(URLS.user_and_job_state)
+        c = UserAndJobState(URLS.user_and_job_state, token=token)
     elif client_name == 'catalog':
-        c = Catalog(URLS.catalog)
+        c = Catalog(URLS.catalog, token=token)
     elif client_name == 'service' or client_name == 'service_wizard':
-        c = ServiceClient(URLS.service_wizard, use_url_lookup=True)
+        c = ServiceClient(URLS.service_wizard, use_url_lookup=True, token=token)
     elif client_name == 'job_service_mock':
         c = JobServiceMock()
     else:

--- a/src/biokbase/narrative/clients.py
+++ b/src/biokbase/narrative/clients.py
@@ -9,11 +9,11 @@ from biokbase.narrative.common.url_config import URLS
 __clients = dict()
 
 
-def get(client_name):
+def get(client_name, token=None):
     # if client_name in __clients:
     #     return __clients[client_name]
     # else:
-    return __init_client(client_name)
+    return __init_client(client_name, token=token)
 
 
 def reset():

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -247,7 +247,7 @@ class AppManager(object):
         kblogging.log_event(self._log, "run_batch_app", log_info)
 
         try:
-            job_id = clients.get("job_service").run_job(job_runner_inputs)
+            job_id = clients.get("job_service", token=agent_token['token']).run_job(job_runner_inputs)
         except Exception as e:
             log_info.update({'err': str(e)})
             kblogging.log_event(self._log, "run_batch_app_error", log_info)
@@ -424,7 +424,7 @@ class AppManager(object):
         kblogging.log_event(self._log, "run_app", log_info)
 
         try:
-            job_id = clients.get("job_service").run_job(job_runner_inputs)
+            job_id = clients.get("job_service", token=agent_token['token']).run_job(job_runner_inputs)
         except Exception as e:
             log_info.update({'err': str(e)})
             kblogging.log_event(self._log, "run_app_error", log_info)

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -29,7 +29,9 @@ class MockClients(object):
     Will likely be removed (or modified, at least), when a minified KBase deploy becomes available.
     Then we don't need to mock as much.
     """
-    def __init__(self):
+    def __init__(self, token=None):
+        if token is not None:
+            assert isinstance(token, basestring)
         self.config = TestConfig()
         self.job_info = self.config.load_json_file(self.config.get('jobs', 'job_info_file'))
         self.test_job_id = self.config.get('app_tests', 'test_job_id')
@@ -257,8 +259,8 @@ class MockClients(object):
         return [data]
 
 
-def get_mock_client(client_name):
-    return MockClients()
+def get_mock_client(client_name, token=None):
+    return MockClients(token=token)
 
 class MockStagingHelper():
     def list(self):


### PR DESCRIPTION
Agent token info was passed to a started job, but apparently the token itself must be used to create the Job Service client that starts the job.

This fixes that.