### PR TITLE
Fix multiple dynamic dropdown

### DIFF
--- a/kbase-extension/static/kbase/js/common/sdk.js
+++ b/kbase-extension/static/kbase/js/common/sdk.js
@@ -527,7 +527,8 @@ define([
                     required: required
                 },
                 defaultValue: null
-            }
+            },
+            original: spec,
         };
         updateNullValue(itemSpec, spec);
         updateDefaultValue(itemSpec, spec);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -99,7 +99,7 @@ define([
                 style: {
                     width: '100%'
                 },
-                multiple: dd_options.multiselection || false,
+                multiple: false,
                 id: html.genId()
             }, [option({ value: '' }, '')].concat(selectOptions));
 


### PR DESCRIPTION
Pass original spec to individual items when building sequences (allow_multiple == True). 

I'm also removing the multiselection option because from what I can tell, the individual items are validated as text not lists and `allow_multiple` already allows for specifying multiple items. (I think there should ideally be only one, obvious way to do things)