### PR TITLE
Better generic error handling

### DIFF
--- a/kbase-extension/kbase_templates/403.html
+++ b/kbase-extension/kbase_templates/403.html
@@ -35,7 +35,7 @@ div#header, div#site {
         </select>
         <button id="req-btn" type="button" class="btn btn-sm btn-primary">Request</button>
     </div>
-    <div id="loader" style="display:none; margin-top: 1em">
+    <div id="loader" style="display: none; margin-top: 1em">
         <i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i>
     </div>
     <div id="request-result" style="font-size: 125%; margin-top: 2em"></div>

--- a/kbase-extension/kbase_templates/403.html
+++ b/kbase-extension/kbase_templates/403.html
@@ -22,7 +22,7 @@ div#header, div#site {
 
 {% block site %}
 
-<div class="error">
+<div class="error" data-code={{status_code}}>
     <p style="font-weight: bold">You do not have permission to access this Narrative.</p>
     <p style="font-size: 150%">You can request access from the Narrative owners using the controls below.</p>
 
@@ -45,5 +45,5 @@ div#header, div#site {
 
 {% block script %}
 {{super()}}
-<script src="{{ static_url("permErrorMain.js") }}" charset="utf-8"></script>
+<script src="{{ static_url("errorMain.js") }}" charset="utf-8"></script>
 {% endblock %}

--- a/kbase-extension/kbase_templates/403.html
+++ b/kbase-extension/kbase_templates/403.html
@@ -23,8 +23,8 @@ div#header, div#site {
 {% block site %}
 
 <div class="error">
-    <div style="font-size: 200%; font-weight: bold">You do not have permission to access this Narrative.</div>
-    <div style="font-size: 125%; margin-top: 1em">You can request access from the Narrative owners using the controls below.</div>
+    <p style="font-weight: bold">You do not have permission to access this Narrative.</p>
+    <p style="font-size: 150%">You can request access from the Narrative owners using the controls below.</p>
 
     <div id="perm-request" class="form-group form-inline" style="margin-top: 2em">
         <label for="req-level">Access Level</label>

--- a/kbase-extension/kbase_templates/error.html
+++ b/kbase-extension/kbase_templates/error.html
@@ -33,3 +33,8 @@ div#header, div#site {
 </header>
 
 {% endblock %}
+
+{% block script %}
+{{super()}}
+<script src="{{ static_url("errorMain.js") }}" charset="utf-8"></script>
+{% endblock %}

--- a/kbase-extension/kbase_templates/generic_error.html
+++ b/kbase-extension/kbase_templates/generic_error.html
@@ -39,5 +39,5 @@ div#header, div#site {
 
 {% block script %}
 {{super()}}
-<!-- <script src="{{ static_url("errorMain.js") }}" charset="utf-8"></script> -->
+<script src="{{ static_url("errorMain.js") }}" charset="utf-8"></script>
 {% endblock %}

--- a/kbase-extension/kbase_templates/generic_error.html
+++ b/kbase-extension/kbase_templates/generic_error.html
@@ -39,5 +39,5 @@ div#header, div#site {
 
 {% block script %}
 {{super()}}
-<script src="{{ static_url("errorMain.js") }}" charset="utf-8"></script>
+<!-- <script src="{{ static_url("errorMain.js") }}" charset="utf-8"></script> -->
 {% endblock %}

--- a/kbase-extension/kbase_templates/generic_error.html
+++ b/kbase-extension/kbase_templates/generic_error.html
@@ -16,20 +16,26 @@ div#header, div#site {
 {% block loading_message %}
 {% endblock %}
 
+{% block narrative_menu %}
+{% include 'basic_header.html' %}
+{% endblock %}
+
 {% block site %}
 
 <div class="error">
     {% block h1_error %}
-    <h1>{{status_code}} : {{status_message}}</h1>
+    <p style="font-weight: bold">
+        An error occurred while loading this Narrative.
+    </p>
     {% endblock h1_error %}
     {% block error_detail %}
-    {% if message %}
-    <p>The error was:</p>
-    <div class="traceback-wrapper">
-    <pre class="traceback">{{message}}</pre>
-    </div>
-    {% endif %}
+        {% if message %}
+            <p>The error was:</p>
+            <div class="traceback-wrapper">
+                <pre class="traceback">{{message}}</pre>
+            </div>
+        {% endif %}
     {% endblock %}
-</header>
+</div>
 
 {% endblock %}

--- a/kbase-extension/kbase_templates/generic_error.html
+++ b/kbase-extension/kbase_templates/generic_error.html
@@ -22,20 +22,22 @@ div#header, div#site {
 
 {% block site %}
 
-<div class="error">
+<div class="error" data-code={{status_code}}>
     {% block h1_error %}
     <p style="font-weight: bold">
-        An error occurred while loading this Narrative.
+        An error occurred while loading this Narrative
     </p>
     {% endblock h1_error %}
     {% block error_detail %}
         {% if message %}
-            <p>The error was:</p>
-            <div class="traceback-wrapper">
-                <pre class="traceback">{{message}}</pre>
-            </div>
+            <p>{{message}}</p>
         {% endif %}
     {% endblock %}
 </div>
 
+{% endblock %}
+
+{% block script %}
+{{super()}}
+<script src="{{ static_url("errorMain.js") }}" charset="utf-8"></script>
 {% endblock %}

--- a/kbase-extension/static/errorMain.js
+++ b/kbase-extension/static/errorMain.js
@@ -18,7 +18,7 @@ require([
     ) {
     Config.updateConfig()
         .then(function () {
-            return Login.init($('#signin-button'));
+            return Login.init($('#signin-button'), true);
         })
         .then(function () {
             let statusCode = document.getElementsByClassName('error')[0].getAttribute('data-code');

--- a/kbase-extension/static/errorMain.js
+++ b/kbase-extension/static/errorMain.js
@@ -9,7 +9,8 @@ require([
         'narrativeConfig',
         'narrativeLogin',
         'css!font-awesome'
-    ], function ($,
+    ], function (
+        $,
         Promise,
         DynamicServiceClient,
         Config,
@@ -20,7 +21,10 @@ require([
             return Login.init($('#signin-button'));
         })
         .then(function () {
-            buildRequestControl();
+            let statusCode = document.getElementsByClassName('error')[0].getAttribute('data-code');
+            if (statusCode === 403) {
+                buildRequestControl();
+            }
         });
 
     function buildRequestControl() {

--- a/kbase-extension/static/errorMain.js
+++ b/kbase-extension/static/errorMain.js
@@ -22,13 +22,13 @@ require([
         })
         .then(function () {
             let statusCode = document.getElementsByClassName('error')[0].getAttribute('data-code');
-            if (statusCode === 403) {
+            if (statusCode === '403') {
                 buildRequestControl();
             }
         });
 
     function buildRequestControl() {
-        $('#req-btn').click(requestPermission);
+        document.getElementById('req-btn').onclick = requestPermission;
     }
 
     function requestPermission() {
@@ -43,10 +43,13 @@ require([
         toggleControls();
         toggleLoader(true);
         Promise.try(() => {
-            $('#request-result').empty();
+            let resultElem = document.getElementById('request-result');
+            while (resultElem.firstChild) {
+                resultElem.removeChild(resultElem.firstChild);
+            }
             let userId = Login.sessionInfo.user_id,
                 token = Login.sessionInfo.token,
-                reqLevel = $('#req-level').val(),
+                reqLevel = document.getElementById('req-level').value,
                 wsId = Config.get('workspaceId'),
                 params = {
                     'ws_id': wsId,
@@ -69,29 +72,33 @@ require([
     }
 
     function toggleLoader(on) {
+        let loader = document.getElementById('loader');
         if (on) {
-            $('#loader').show();
+            loader.style.display = 'inherit';
         } else {
-            $('#loader').hide();
+            loader.style.display = 'none';
         }
     }
 
     function toggleControls(on) {
+        let controls = document.getElementById('perm-request');
         if (on) {
-            $('#perm-request').show();
+            controls.style.display = 'inherit';
         } else {
-            $('#perm-request').hide();
+            controls.style.display = 'none';
         }
     }
 
     function showError(err) {
-        let msg = err.message ? err.message : err.originalError.name;
-        let errText = 'Sorry, an error occurred while processing your request: ' + msg;
-        $('#request-result').append(errText);
+        let msg = err.message ? err.message : err.originalError.name,
+            errText = 'Sorry, an error occurred while processing your request: ' + msg,
+            errElem = document.getElementById('request-result');
+        errElem.append(errText);
     }
 
     function showSuccess() {
-        $('#request-result').append('Access request sent successfully!')
+        let errElem = document.getElementById('request-result');
+        errElem.append('Access request sent successfully!');
     }
 });
 });

--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -228,12 +228,17 @@ define ([
         return authClient.getAuthToken();
     }
 
-    function init($elem) {
+    function init($elem, noServer) {
         /* Flow.
          * 1. Get cookie. If present and valid, yay. If not, dialog / redirect to login page.
          * 2. Setup event triggers. need loggedInQuery.kbase, promptForLogin.kbase, logout.kbase,
          * 3. events to trigger: loggedIn, loggedInFailure, loggedOut
          * 4. Set up user widget thing on #signin-button
+         *
+         * If noServer is present, then DO NOT try to log in to the ipython kernel. Because it
+         * won't be there - this is mainly done if there's an error page, and we still want to
+         * show that the user is logged in, and potentially provide a resource to do authenticated
+         * communication with other KBase resources.
          */
         clearTokenCheckTimers();
         var sessionToken = authClient.getAuthToken();
@@ -254,7 +259,9 @@ define ([
                     email: results[1].email,
                     displayName: results[1].display
                 });
-                ipythonLogin(sessionToken);
+                if (!noServer) {
+                    ipythonLogin(sessionToken);
+                }
                 $(document).trigger('loggedIn', this.sessionInfo);
                 $(document).trigger('loggedIn.kbase', this.sessionInfo);
             }.bind(this))

--- a/src/biokbase/narrative/common/exceptions.py
+++ b/src/biokbase/narrative/common/exceptions.py
@@ -29,13 +29,13 @@ class WorkspaceError(Exception):
         if message is not None:
             self.message = message
         elif "No workspace with id" in ws_server_err.message:
-            self.message = "No Narrative found with this id"
+            self.message = "No Narrative was found with this id."
             self.http_code = 404
         elif "is deleted" in ws_server_err.message:
-            self.message = "This Narrative was deleted and is no longer available"
+            self.message = "This Narrative was deleted and is no longer available."
             self.http_code = 410
         elif "may not read" in ws_server_err.message:
-            self.message = "You do not have access to this workspace"
+            self.message = "You do not have access to this workspace."
             self.http_code = 403
         else:
             self.message = ws_server_err.message

--- a/src/biokbase/narrative/common/exceptions.py
+++ b/src/biokbase/narrative/common/exceptions.py
@@ -20,6 +20,9 @@ class PermissionsError(ServerError):
 class WorkspaceError(Exception):
     def __init__(self, ws_server_err, ws_id, message=None, http_code=500):
         """
+        This wraps Workspace calls regarding Narratives into exceptions that are
+        easier to parse for logging, user communication, etc.
+
         ws_server_err should be the ServerError that comes back from a workspace
         response. This will still try to infer what happened and make it easier to get to,
         but it's best to use a ServerError.
@@ -41,6 +44,9 @@ class WorkspaceError(Exception):
         elif "may not read" in ws_server_err.message:
             self.message = "You do not have access to this workspace."
             self.http_code = 403
+        elif "No object with id" in ws_server_err.message:
+            self.message = "Unable to find this Narrative based on workspace information."
+            self.http_code = 404
         else:
             self.message = ws_server_err.message
 

--- a/src/biokbase/narrative/common/exceptions.py
+++ b/src/biokbase/narrative/common/exceptions.py
@@ -23,9 +23,13 @@ class WorkspaceError(Exception):
         ws_server_err should be the ServerError that comes back from a workspace
         response. This will still try to infer what happened and make it easier to get to,
         but it's best to use a ServerError.
+
+        If there's a useful message, then that will be used to set the http_code, and
+        can override the kwarg input.
         """
         self.err = ws_server_err
         self.ws_id = ws_id
+        self.http_code = http_code
         if message is not None:
             self.message = message
         elif "No workspace with id" in ws_server_err.message:
@@ -39,7 +43,6 @@ class WorkspaceError(Exception):
             self.http_code = 403
         else:
             self.message = ws_server_err.message
-            self.http_code = 500
 
     def __str__(self):
         return "WorkspaceError: {}: {}: {}".format(self.ws_id, self.http_code, self.message)

--- a/src/biokbase/narrative/common/exceptions.py
+++ b/src/biokbase/narrative/common/exceptions.py
@@ -17,3 +17,29 @@ class PermissionsError(ServerError):
         ServerError.__init__(self, name, code, message, **kw)
 
 
+class WorkspaceError(Exception):
+    def __init__(self, ws_server_err, ws_id, message=None, http_code=500):
+        """
+        ws_server_err should be the ServerError that comes back from a workspace
+        response. This will still try to infer what happened and make it easier to get to,
+        but it's best to use a ServerError.
+        """
+        self.err = ws_server_err
+        self.ws_id = ws_id
+        if message is not None:
+            self.message = message
+        elif "No workspace with id" in ws_server_err.message:
+            self.message = "No Narrative found with this id"
+            self.http_code = 404
+        elif "is deleted" in ws_server_err.message:
+            self.message = "This Narrative was deleted and is no longer available"
+            self.http_code = 410
+        elif "may not read" in ws_server_err.message:
+            self.message = "You do not have access to this workspace"
+            self.http_code = 403
+        else:
+            self.message = ws_server_err.message
+            self.http_code = 500
+
+    def __str__(self):
+        return "WorkspaceError: {}: {}: {}".format(self.ws_id, self.http_code, self.message)

--- a/src/biokbase/narrative/common/narrative_ref.py
+++ b/src/biokbase/narrative/common/narrative_ref.py
@@ -3,7 +3,7 @@ Describes a Narrative Ref and has utilities for dealing with it.
 """
 import biokbase.narrative.clients as clients
 from biokbase.workspace.baseclient import ServerError
-from exceptions import PermissionsError
+from exceptions import WorkspaceError
 
 class NarrativeRef(object):
     def __init__(self, ref):
@@ -68,11 +68,4 @@ class NarrativeRef(object):
                 "Expected an integer while looking up the Narrative id, "
                 "got '{}'".format(ws_meta.get("narrative")))
         except ServerError as err:
-            raise self._ws_err_to_perm_err(err)
-
-    def _ws_err_to_perm_err(self, err):
-        if PermissionsError.is_permissions_error(err.message):
-            return PermissionsError(name=err.name, code=err.code,
-                                    message=err.message, data=err.data)
-        else:
-            return err
+            raise WorkspaceError(err, self.wsid)

--- a/src/biokbase/narrative/handlers/narrativehandler.py
+++ b/src/biokbase/narrative/handlers/narrativehandler.py
@@ -63,10 +63,12 @@ class NarrativeMainHandler(IPythonHandler):
         except web.HTTPError as e:
             log_event(g_log, 'loading_error', {'error': str(e)})
             if e.status_code == 403:
-                self.write(self.render_template('403.html'))
+                self.write(self.render_template('403.html', status_code=403))
                 return
             else:
-                self.write(self.render_template('generic_error.html', message=e.log_message))
+                self.write(self.render_template(
+                    'generic_error.html', message=e.log_message, status_code=e.status_code
+                ))
                 return
         if model.get('type') != 'notebook':
             # not a notebook, redirect to files

--- a/src/biokbase/narrative/handlers/narrativehandler.py
+++ b/src/biokbase/narrative/handlers/narrativehandler.py
@@ -61,14 +61,13 @@ class NarrativeMainHandler(IPythonHandler):
         try:
             model = cm.get(path, content=False)
         except web.HTTPError as e:
-            if e.status_code == 500:
-                self.write(self.render_template('500.html'))
-                raise
-            elif e.status_code == 403:
+            log_event(g_log, 'loading_error', {'error': str(e)})
+            if e.status_code == 403:
                 self.write(self.render_template('403.html'))
-                raise
+                return
             else:
-                raise
+                self.write(self.render_template('generic_error.html', message=e.log_message))
+                return
         if model.get('type') != 'notebook':
             # not a notebook, redirect to files
             return FilesRedirectHandler.redirect_to_files(self, path)

--- a/src/biokbase/narrative/tests/test_narrative_ref.py
+++ b/src/biokbase/narrative/tests/test_narrative_ref.py
@@ -24,7 +24,22 @@ class NarrativeRefTestCase(unittest.TestCase):
     def test_no_objid_fail(self):
         with self.assertRaises(RuntimeError) as e:
             NarrativeRef({"wsid": 678, "objid": None, "ver": None})
-        self.assertIn("Expected an integer while looking up the Narrative id", str(e.exception))
+        self.assertIn("Couldn't find Narrative object id in Workspace metadata", str(e.exception))
+
+    @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
+    def test_ref_init_fail(self):
+        with self.assertRaises(ValueError) as e:
+            NarrativeRef({"wsid": "x", "objid": None, "ver": None})
+        self.assertIn("A numerical Workspace id is required for a Narrative ref, not x", str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            NarrativeRef({"wsid": 678, "objid": "x", "ver": None})
+        self.assertIn("objid must be numerical, not x", str(e.exception))
+
+        with self.assertRaises(ValueError) as e:
+            NarrativeRef({"wsid": 678, "objid": 1, "ver": "x"})
+        self.assertIn("If ver is present in the ref, it must be numerical, not x", str(e.exception))
+
 
     @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
     def test_no_ws_perm(self):

--- a/src/biokbase/narrative/tests/test_narrative_ref.py
+++ b/src/biokbase/narrative/tests/test_narrative_ref.py
@@ -4,7 +4,7 @@ from biokbase.narrative.contents.kbasewsmanager import KBaseWSManager
 from narrative_mock.mockclients import get_mock_client
 from biokbase.narrative.common.narrative_ref import NarrativeRef
 from tornado.web import HTTPError
-from biokbase.narrative.common.exceptions import PermissionsError
+from biokbase.narrative.common.exceptions import WorkspaceError
 
 class NarrativeRefTestCase(unittest.TestCase):
     @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
@@ -28,5 +28,7 @@ class NarrativeRefTestCase(unittest.TestCase):
 
     @mock.patch('biokbase.narrative.common.narrative_ref.clients.get', get_mock_client)
     def test_no_ws_perm(self):
-        with self.assertRaises(PermissionsError) as e:
+        with self.assertRaises(WorkspaceError) as e:
             NarrativeRef({"wsid": 789, "objid": None, "ver": None})
+        self.assertEqual(403, e.exception.http_code)
+        self.assertIn("You do not have access to this workspace", e.exception.message)

--- a/src/biokbase/narrative/tests/test_narrativeexporting.py
+++ b/src/biokbase/narrative/tests/test_narrativeexporting.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-from biokbase.narrative.contents.narrativeio import PermissionsError
+from biokbase.narrative.common.exceptions import WorkspaceError
+from biokbase.workspace.baseclient import ServerError
 from biokbase.narrative.exporter.exporter import NarrativeExporter
 import unittest
 import os
@@ -32,7 +33,7 @@ def mock_read_narrative(style):
     elif style == bad_narrative_ref:
         raise ValueError('Bad Narrative!')
     elif style == private_narrative_ref:
-        raise PermissionsError('Private Narrative!')
+        raise WorkspaceError(ServerError("Error", -32500, "Private workspace!"), private_narrative_ref)
 
 test_narrative_ref = config.get('narrative_refs', 'public')
 private_narrative_ref = config.get('narrative_refs', 'private')
@@ -62,7 +63,7 @@ class NarrativeExportTesting(unittest.TestCase):
             self.exporter.export_narrative(bad_narrative_ref, output_file)
 
     def test_export_private(self):
-        with self.assertRaises(PermissionsError):
+        with self.assertRaises(WorkspaceError):
             self.exporter.export_narrative(private_narrative_ref, output_file)
 
 

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -489,5 +489,21 @@ class NarrIOTestCase(unittest.TestCase):
         self.assertEquals("narrative_permissions must use a NarrativeRef as input!", str(err.exception))
         self.logout()
 
+    ##### test KBaseWSManagerMixin._validate_nar_type #####
+    def test__validate_nar_type_ok(self):
+        self.assertIsNone(self.mixin._validate_nar_type("KBaseNarrative.Narrative-123.45", None))
+        self.assertIsNone(self.mixin._validate_nar_type("KBaseNarrative.Narrative", None))
+
+    def test__validate_nar_type_fail(self):
+        bad_type = "NotANarrative"
+        ref = "123/45"
+        with self.assertRaises(HTTPError) as err:
+            self.mixin._validate_nar_type(bad_type, None)
+        self.assertIn("Expected a Narrative object, got a {}".format(bad_type), str(err.exception))
+
+        with self.assertRaises(HTTPError) as err:
+            self.mixin._validate_nar_type(bad_type, ref)
+        self.assertIn("Expected a Narrative object with reference {}, got a {}".format(ref, bad_type), str(err.exception))
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -151,8 +151,8 @@
         "ws_browser": "https://narrative.kbase.us/#ws"
     },
     "dev_mode": {{ if ne .Env.CONFIG_ENV "prod" }} true {{- else }} false {{- end }},
-    "git_commit_hash": "1a5344bcb",
-    "git_commit_time": "Tue Jan 22 17:35:43 2019 -0800",
+    "git_commit_hash": "21c2fdca3",
+    "git_commit_time": "Thu Jan 24 15:53:50 2019 -0800",
     "loading_gif": "/narrative/static/kbase/images/ajax-loader.gif",
     "name": "KBase Narrative",
     "next": {


### PR DESCRIPTION
All communication errors with workspace now raise a WorkspaceError (before was just either the standard ServerError, or a PermissionsError). WorkspaceErrors are aware of what http_code they should have, and parse the Workspace error message into something more fitting for the Narrative context.

These errors now show up a little more pretty on the front end, too, and include the same trimmed-down header as the permissions error.