### PR TITLE
improved google analytics support

### DIFF
--- a/docs/developer/local-docker.md
+++ b/docs/developer/local-docker.md
@@ -2,8 +2,6 @@
 
 It is useful to run the Narrative within a local docker container. E.g. this makes it easy to work on Narrative ui locally integrated with a local instance of kbase-ui.
 
-
-
 ## Narrative
 
 The following changes are required:
@@ -11,11 +9,15 @@ The following changes are required:
 - Build the docker image using the make target "dev_image", this builds the docker image without the "grunt minify" step.
   The image will be tagged kbase/narrative:dev instead of the current git branch
 
+  ```
+  make dev_image
+  ```
+
 - start the container using the `scripts/local-dev-run.sh` script. 
 
     This script starts the narrative image using features to integrate it with local kbase-ui.
 
-    ```bash
+    ```
     env=ci bash scripts/local-dev-run.sh
     ```
 
@@ -39,29 +41,16 @@ If you need to update or change dependencies (bower.json), you'll need to rebuil
 The Dockerfile runs 'src/scripts/kb-update-config' to generate '/kb/deployment/ui-common/narrative_version'. This script has the unfortunate side effect of overwriting the config file source in /src/config.json.
 This is a little frustrating because it means that a committer has to be very careful to omit this file when building the image for development or testing.
 
-
 ## kbase-ui
 
-The kbase-ui proxier needs to route narrative requests. In order to enable this, the proxier's nginx config needs to be modified:
+The kbase-ui proxier knows how to route to a local narrative container. To invoke this behavior add `local-narrative=t` to the start line as run from the kbase-ui repo:
 
-- in your kbase-ui repo
+```
+make dev-start env=ci build=dev build-image=f local-narrative=t
+```
 
-- edit tools/proxier/docker/src/conf/nginx.conf.tmpl
-
-- comment out the line `proxy_pass https://{{ .Env.deploy_ui_hostname }}/narrative;` and uncomment the line below it
-
-- comment out the line `proxy_pass https://{{ .Env.deploy_hostname }}/narrative;` and uncomment the line below it.
-
-- rebuild the proxier image: make proxier-image
-
-- launch the proxier image: make run-proxier-image env=ci
+> Use `build-image=t` if you haven't built the kbase-ui image yet.
 
 ## Done?
 
 You should now be able to navigate to https://ci.kbase.us, log in, and pull a Narrative from the Dashboard.
-
-## Full Recipe
-
-TODO: all steps to from zero to hero.
-
-TODO: copy version of this doc into kbase-ui docs.

--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -45,14 +45,17 @@
         }
         checkBrowser();
     </script>
+    
+    <!-- Global Site Tag (gtag.js) - Google Analytics -->
+    <!-- -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{google_analytics_id}}"></script>
     <script>
-        /* Google Analaytics */
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-38443357-1', 'narrative');
-        ga('send', 'pageview');
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', '{{google_analytics_id}}', {
+        'cookie_domain': 'kbase.us'
+      })
     </script>
 
     <script src="{{static_url('components/es6-promise/promise.min.js')}}" type="text/javascript" charset="utf-8"></script>

--- a/scripts/local-dev-run.sh
+++ b/scripts/local-dev-run.sh
@@ -8,13 +8,26 @@ if [ -z $env ]; then
 	echo "The 'env' environment variable is required"
 	exit 1
 fi
-# use this below if you want to install and mount external components (bower packages) into the running container.
-# --mount type=bind,src=${root}/${ext_components_dir},dst=${container_root}/${ext_components_dir} \
-docker run \
-	--dns=8.8.8.8 \
-	-e "CONFIG_ENV=${env}" \
-	--network=kbase-dev \
-	--name=narrative  \
-	--mount type=bind,src=${root}/${static_dir},dst=${container_root}/${static_dir} \
-	--mount type=bind,src=${root}/${nbextension_dir},dst=${container_root}/kbase-extension/static/${nbextension_dir} \
-	--rm kbase/narrative:dev
+echo "Starting Narrative for environment '${env}'"
+
+if [ "${mount}" == "t" ]; then
+	docker run \
+		--dns=8.8.8.8 \
+		-e "CONFIG_ENV=${env}" \
+		--network=kbase-dev \
+		--name=narrative  \
+		--mount type=bind,src=${root}/${static_dir},dst=${container_root}/${static_dir} \
+		--mount type=bind,src=${root}/${nbextension_dir},dst=${container_root}/kbase-extension/static/${nbextension_dir} \
+		--rm -it \
+		kbase/narrative:dev
+else
+	echo "Not mounting local dirs ${mount}"
+	docker run \
+		--dns=8.8.8.8 \
+		-e "CONFIG_ENV=${env}" \
+		--network=kbase-dev \
+		--name=narrative  \
+		--rm -it \
+		kbase/narrative:dev
+fi
+

--- a/src/biokbase/narrative/handlers/narrativehandler.py
+++ b/src/biokbase/narrative/handlers/narrativehandler.py
@@ -17,6 +17,7 @@ from biokbase.auth import (
     get_user_info,
     init_session_env
 )
+from biokbase.narrative.common.url_config import URLS
 
 HTTPError = web.HTTPError
 
@@ -80,7 +81,8 @@ class NarrativeMainHandler(IPythonHandler):
                 notebook_path=path,
                 notebook_name=path,
                 kill_kernel=False,
-                mathjax_url=self.mathjax_url
+                mathjax_url=self.mathjax_url,
+                google_analytics_id=URLS.google_analytics_id,
             )
         )
 

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -43,7 +43,8 @@
         "user_profile": "https://appdev.kbase.us/services/user_profile/rpc",
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://appdev.kbase.us/services/ws",
-        "ws_browser": "https://appdev.kbase.us/#ws"
+        "ws_browser": "https://appdev.kbase.us/#ws",
+        "google_analytics_id": "UA-74533556-1"
     },
     "auth_cookie": "kbase_session",
     "auth_sleep_recheck_ms": 60000,
@@ -90,7 +91,8 @@
         "user_profile": "https://ci.kbase.us/services/user_profile/rpc",
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://ci.kbase.us/services/ws",
-        "ws_browser": "https://narrative.kbase.us/#ws"
+        "ws_browser": "https://narrative.kbase.us/#ws",
+        "google_analytics_id": "UA-74532036-1"
     },
     "comm_wait_timeout": 600000,
     "config": "{{ .Env.CONFIG_ENV }}",
@@ -148,7 +150,8 @@
         "user_profile": "https://ci.kbase.us/services/user_profile/rpc",
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://ci.kbase.us/services/ws",
-        "ws_browser": "https://narrative.kbase.us/#ws"
+        "ws_browser": "https://narrative.kbase.us/#ws",
+        "google_analytics_id": "UA-74532036-1"
     },
     "dev_mode": {{ if ne .Env.CONFIG_ENV "prod" }} true {{- else }} false {{- end }},
     "git_commit_hash": "21c2fdca3",
@@ -199,7 +202,8 @@
         "user_profile": "https://next.kbase.us/services/user_profile/rpc",
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://next.kbase.us/services/ws",
-        "ws_browser": "https://narrative.kbase.us/#ws"
+        "ws_browser": "https://narrative.kbase.us/#ws",
+        "google_analytics_id": "UA-74530365-1"
     },
     "prod": {
         "KBaseSearchEngine": "https://kbase.us/services/searchapi",
@@ -245,7 +249,55 @@
         "user_profile": "https://kbase.us/services/user_profile/rpc",
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://kbase.us/services/ws",
-        "ws_browser": "https://narrative.kbase.us/#ws"
+        "ws_browser": "https://narrative.kbase.us/#ws",
+        "google_analytics_id": "UA-38443357-1"
+    },
+    "narrative-dev": {
+        "KBaseSearchEngine": "https://narrative-dev.kbase.us/services/searchapi",
+        "auth": "https://narrative-dev.kbase.us/services/auth",
+        "awe": "https://narrative-dev.kbase.us/services/awe-api",
+        "catalog": "https://narrative-dev.kbase.us/services/catalog",
+        "cdn": "https://narrative-dev.kbase.us/cdn/files",
+        "compound_img_url": "http://minedatabase.mcs.anl.gov/compound_images/ModelSEED/",
+        "data_import_export": "https://narrative-dev.kbase.us/services/data_import_export",
+        "data_panel_sources": "/data_source_config.json",
+        "fba": "https://narrative-dev.kbase.us/services/KBaseFBAModeling/",
+        "ftp_api_root": "/data/bulk",
+        "ftp_api_url": "https://narrative-dev.kbase.us/services/kb-ftp-api/v0",
+        "gene_families": "https://narrative-dev.kbase.us/services/gene_families",
+        "genomeCmp": "https://narrative-dev.kbase.us/services/genome_comparison/jsonrpc",
+        "job_service": "https://narrative-dev.kbase.us/services/njs_wrapper",
+        "landing_pages": "/#dataview/",
+        "log_host": "https://elasticsearch2.chicago.kbase.us",
+        "log_port": 9000,
+        "log_proxy_host": "172.17.42.1",
+        "log_proxy_port": 32001,
+        "login": "https://narrative-dev.kbase.us/services/authorization/Sessions/Login",
+        "narrative_job_proxy": "https://narrative-dev.kbase.us/services/narrativejobproxy/",
+        "narrative_method_store": "https://narrative-dev.kbase.us/services/narrative_method_store/rpc",
+        "narrative_method_store_image": "https://narrative-dev.kbase.us/services/narrative_method_store/",
+        "narrative_method_store_types": "https://narrative-dev.kbase.us/services/narrative_method_store/rpc",
+        "profile_page": "/#people/",
+        "protein_info": "",
+        "provenance_view": "/#objgraphview",
+        "reset_password": "https://gologin.kbase.us/ResetPassword",
+        "search": "https://narrative-dev.kbase.us/services/search/getResults",
+        "service_wizard": "https://narrative-dev.kbase.us/services/service_wizard",
+        "shock": "https://narrative-dev.kbase.us/services/shock-api",
+        "staging_api_url": "https://narrative-dev.kbase.us/services/staging_service",
+        "status_page": "http://kbase.us/internal/status/",
+        "submit_jira_ticket": "https://atlassian.kbase.us/secure/CreateIssueDetails!init.jspa?pid=10200&issuetype=1&description=Narrative%20version",
+        "transform": "https://narrative-dev.kbase.us/services/transform",
+        "trees": "https://narrative-dev.kbase.us/services/trees",
+        "ui_common_root": "https://narrative-dev.kbase.us/",
+        "update_profile": "https://gologin.kbase.us/account/UpdateProfile",
+        "uploader": "",
+        "user_and_job_state": "https://narrative-dev.kbase.us/services/userandjobstate",
+        "user_profile": "https://narrative-dev.kbase.us/services/user_profile/rpc",
+        "version_check": "{{ .Env.VERSION_CHECK }}",
+        "workspace": "https://narrative-dev.kbase.us/services/ws",
+        "ws_browser": "https://narrative-dev.kbase.us/#ws",
+        "google_analytics_id": "UA-131054609-1"
     },
     "release_notes": "https://github.com/kbase/narrative/blob/master/RELEASE_NOTES.md",
     "tooltip": {


### PR DESCRIPTION
- add per-deploy-env google analytics tracking id; previously was hardcoded to production
- update google analytics usage to use latest recommended google js lib
- improvements to local-dev-with-docker docs and script

This PR strives to improve google analytics usage, as part of the current effort to improve GA support at KBase. To wit:

1. Update the analytics library to the recommended google client. That is, since the Narrative already uses the GA client downloaded from google via the code snipped published by google, this replaces the current google client code snippet with the current release.  The previous client was "analytics.js", and the current one is "gtag/js". Usage is a bit different. This matches the new google analytics usage in the static app catalog.

2. Utilize unique a GA tracker id per KBase deployment environment. Previously the GA id was hardcoded into the page.html template. This caused all Narrative usage to send page hit stats to the production GA account. We have individual accounts for each KBase deployment environment, each with their own individual GA tracker id. 
This prevents development and testing usage from interfering with production stats, and enables real-time and historical monitoring of all kbase deployment environments. It also allows us to more easily test the usage of GA, as we can conduct tests in CI etc. without interference form other environments.
The PR also includes a config stanza for narrative-dev, since I needed to test this locally against each deployment environment.

I have assumed that the current deployment strategy for Narrative still uses config.json.templ. If this is not the case, please indicate the current deployment config in a comment and I'll adjust the PR accordingly.

Also included in this PR are some changes to the local developer tool and doc for dockerized local deployment.