### PR TITLE
Add lazy loading to reports

### DIFF
--- a/kbase-extension/static/kbase/js/util/display.js
+++ b/kbase-extension/static/kbase/js/util/display.js
@@ -254,12 +254,44 @@ define([
                .append($('<span>').addClass(iconClass));
     }
 
+    /* -------------------------------------------------------
+     * Code modified from:
+     * Lazy Load - jQuery plugin for lazy loading images
+     * Copyright (c) 2007-2015 Mika Tuupola
+     * Licensed under the MIT license
+     * Project home: http://www.appelsiini.net/projects/lazyload
+     */
+    /**
+     *
+     * @param {DOMElement} element
+     */
+    function verticalInViewport(element) {
+        if (!element) {
+            return true;
+        }
+        let rect = element.getBoundingClientRect();
+        if (rect.top === 0 && rect.bottom === 0) {
+            return false;
+        }
+        return (
+            (rect.top >= 0 && rect.top <= (window.innerHeight || document.documentElement.clientHeight)) ||
+            (rect.bottom >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight))
+        );
+        // if (!element || !settings) {
+        //     return true;
+        // }
+        // let fold = settings.container.offset().top + settings.container.height(),
+        //     elementTop = $(element).offset().top - settings.threshold;
+        // return elementTop <= fold;
+    }
+
     return {
         lookupUserProfile: lookupUserProfile,
         displayRealName: displayRealName,
         loadingDiv: loadingDiv,
         getAppIcon: getAppIcon,
         createError: createError,
-        simpleButton: simpleButton
+        simpleButton: simpleButton,
+        verticalInViewport: verticalInViewport
     };
 });

--- a/kbase-extension/static/kbase/js/util/display.js
+++ b/kbase-extension/static/kbase/js/util/display.js
@@ -254,13 +254,6 @@ define([
                .append($('<span>').addClass(iconClass));
     }
 
-    /* -------------------------------------------------------
-     * Code modified from:
-     * Lazy Load - jQuery plugin for lazy loading images
-     * Copyright (c) 2007-2015 Mika Tuupola
-     * Licensed under the MIT license
-     * Project home: http://www.appelsiini.net/projects/lazyload
-     */
     /**
      *
      * @param {DOMElement} element
@@ -277,12 +270,6 @@ define([
             (rect.top >= 0 && rect.top <= (window.innerHeight || document.documentElement.clientHeight)) ||
             (rect.bottom >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight))
         );
-        // if (!element || !settings) {
-        //     return true;
-        // }
-        // let fold = settings.container.offset().top + settings.container.height(),
-        //     elementTop = $(element).offset().top - settings.threshold;
-        // return elementTop <= fold;
     }
 
     return {


### PR DESCRIPTION
Similar to the lazy loading of viewers, this goes through the following cycle:

On AppCell report panel load, check if the panel is in the viewport. If so, render the KBaseReportView widget and be done. If not, attach a scroll listener to the `#notebook-container` element. On each scroll event fire, check if it's in view again. When the panel goes in view, render the widget and remove the listener.

There's one little hack in there where if the bounding box being tested has no height and is at top 0, bottom 0, treat it as not in view. It's probably not actually being rendered on the page yet, so this is safe.