### PR TITLE
Fix share saving

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v5.6.0 (more notes will follow).
 
+### Version 3.10.1
+- Fixed a critical bug where users with write access to a Narrative (but not share access) were unable to save changes to a Narrative or run Apps.
+
 ### Version 3.10.0
 - Fix tooltip for long object names in the data panel.
 - Add ability to prefix a part of path_to_subdata with WSREF to list options from other objects.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "homepage": "https://kbase.us",
   "dependencies": {
     "bluebird": "3.4.7",

--- a/kbase-extension/static/kbase/custom/custom.js
+++ b/kbase-extension/static/kbase/custom/custom.js
@@ -1007,61 +1007,67 @@ define([
         if (Jupyter.narrative.readonly) {
             return;
         }
-        options = options || {};
-        var that = this;
-        var dialog_body = $('<div>').append(
-            $('<p>').addClass('rename-message')
-                .text(options.message ? options.message : 'Enter a new Narrative name:')
-        ).append(
-            $('<br>')
-        ).append(
-            $('<input>').attr('type', 'text').attr('size', '25').addClass('form-control')
-                .val(options.notebook.get_notebook_name())
-        );
-        var d = dialog.modal({
-            title: 'Rename Narrative',
-            body: dialog_body,
-            notebook: options.notebook,
-            keyboard_manager: this.keyboard_manager,
-            buttons: {
-                'OK': {
-                    class: 'btn-primary',
-                    click: function () {
-                        var new_name = d.find('input').val();
-                        d.find('.rename-message').text('Renaming and saving...');
-                        d.find('input[type="text"]').prop('disabled', true);
-                        that.notebook.rename(new_name).then(
-                            function () {
-                                d.modal('hide');
-                                that.notebook.metadata.name = new_name;
-                                that.element.find('span.filename').text(new_name);
-                                Jupyter.narrative.saveNarrative();
-                                if (options.callback) {
-                                    options.callback();
-                                }
-                            },
-                            function (error) {
-                                d.find('.rename-message').text(error.message || 'Unknown error');
-                                d.find('input[type="text"]').prop('disabled', false).focus().select();
-                            }
-                        );
-                        return false;
-                    }
-                },
-                'Cancel': {}
-            },
-            open: function () {
-                /**
-                 * Upon ENTER, click the OK button.
-                 */
-                d.find('input[type="text"]').keydown(function (event) {
-                    if (event.which === keyboard.keycodes.enter) {
-                        d.find('.btn-primary').first().click();
-                        return false;
-                    }
-                });
-                d.find('input[type="text"]').focus().select();
+        Jupyter.narrative.getUserPermissions()
+        .then((perm) => {
+            if (perm !== 'a') {
+                return;
             }
+            options = options || {};
+            var that = this;
+            var dialog_body = $('<div>').append(
+                $('<p>').addClass('rename-message')
+                    .text(options.message ? options.message : 'Enter a new Narrative name:')
+            ).append(
+                $('<br>')
+            ).append(
+                $('<input>').attr('type', 'text').attr('size', '25').addClass('form-control')
+                    .val(options.notebook.get_notebook_name())
+            );
+            var d = dialog.modal({
+                title: 'Rename Narrative',
+                body: dialog_body,
+                notebook: options.notebook,
+                keyboard_manager: this.keyboard_manager,
+                buttons: {
+                    'OK': {
+                        class: 'btn-primary',
+                        click: function () {
+                            var new_name = d.find('input').val();
+                            d.find('.rename-message').text('Renaming and saving...');
+                            d.find('input[type="text"]').prop('disabled', true);
+                            that.notebook.rename(new_name).then(
+                                function () {
+                                    d.modal('hide');
+                                    that.notebook.metadata.name = new_name;
+                                    that.element.find('span.filename').text(new_name);
+                                    Jupyter.narrative.saveNarrative();
+                                    if (options.callback) {
+                                        options.callback();
+                                    }
+                                },
+                                function (error) {
+                                    d.find('.rename-message').text(error.message || 'Unknown error');
+                                    d.find('input[type="text"]').prop('disabled', false).focus().select();
+                                }
+                            );
+                            return false;
+                        }
+                    },
+                    'Cancel': {}
+                },
+                open: function () {
+                    /**
+                     * Upon ENTER, click the OK button.
+                     */
+                    d.find('input[type="text"]').keydown(function (event) {
+                        if (event.which === keyboard.keycodes.enter) {
+                            d.find('.btn-primary').first().click();
+                            return false;
+                        }
+                    });
+                    d.find('input[type="text"]').focus().select();
+                }
+            });
         });
     };
 });

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -182,6 +182,14 @@ define([
         });
     };
 
+    Narrative.prototype.getUserPermissions = function () {
+        return new Workspace(Config.url('workspace'), {token: this.getAuthToken()})
+            .get_workspace_info({id: this.workspaceId})
+            .then((wsInfo) => {
+                return wsInfo[5];
+            });
+    }
+
     /**
      * A wrapper around the Jupyter.notebook.kernel.execute() function.
      * If any KBase widget needs to make a kernel call, it should go through here.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbase-narrative-core",
   "description": "Core components for the KBase Narrative Interface",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -1,7 +1,7 @@
 __all__ = ['magics', 'ws_util', 'common', 'handlers', 'contents', 'services', 'widgetmanager'] #, 'viewers']
 
 from semantic_version import Version
-__version__ = Version("3.10.0")
+__version__ = Version("3.10.1")
 version = lambda: __version__
 
 # if run directly:

--- a/src/biokbase/narrative/contents/narrativeio.py
+++ b/src/biokbase/narrative/contents/narrativeio.py
@@ -203,14 +203,16 @@ class KBaseWSManagerMixin(object):
             raise HTTPError(400, u'Unexpected error setting Narrative attributes: %s' %e)
 
         # With that set, update the workspace metadata with the new info.
-        try:
-            updated_metadata = {
-                u'is_temporary': u'false',
-                u'narrative_nice_name': nb[u'metadata'][u'name']
-            }
-            self.ws_client().alter_workspace_metadata({u'wsi': {u'id': ws_id}, u'new':updated_metadata})
-        except ServerError as err:
-            raise WorkspaceError(err, ws_id, message="Error adjusting Narrative metadata", http_code=500)
+        perms = self.narrative_permissions(ref, user=cur_user)
+        if perms[cur_user] == 'a':
+            try:
+                updated_metadata = {
+                    u'is_temporary': u'false',
+                    u'narrative_nice_name': nb[u'metadata'][u'name']
+                }
+                self.ws_client().alter_workspace_metadata({u'wsi': {u'id': ws_id}, u'new':updated_metadata})
+            except ServerError as err:
+                raise WorkspaceError(err, ws_id, message="Error adjusting Narrative metadata", http_code=500)
 
         # Now we can save the Narrative object.
         try:

--- a/src/config.json
+++ b/src/config.json
@@ -253,5 +253,5 @@
         "showDelay": 750
     },
     "use_local_widgets": true,
-    "version": "3.10.0"
+    "version": "3.10.1"
 }

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -305,5 +305,5 @@
         "showDelay": 750
     },
     "use_local_widgets": true,
-    "version": "3.10.0"
+    "version": "3.10.1"
 }


### PR DESCRIPTION
**MASTER VERSION** - a PR is also set for develop

This bug crept in before GSP.
A user with "write" access (i.e. "w" in workspace) is unable to save a Narrative right now, as it requires a little poke at the workspace metadata. Only workspace admins can change that. Previously, the error that was thrown was just silently ignored, now it's propagated forward.

The solution here is in two parts.
1. Check if the user can edit the ws metadata before saving. If not, (they don't have 'a' perms on that ws), then don't even try.
2. The main way that ws metadata gets modified is with the narrative name. So prevent anyone who isn't an admin from changing the Narrative name through the browser (this checks and shows a polite error message now).