### PR TITLE
Lazy-load the Narratives tab

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeControlPanel.js
@@ -212,5 +212,15 @@ define ([
         body: function() {
             return this.$bodyDiv;
         },
+
+        /**
+         * Gets invoked whenever the user clicks over to the side panel tab where this control
+         * panel lives. For example, the current (5/29/2019) narrative starts on the Analyze tab.
+         * When a user clicks on the Narratives tab, each widget there (just the one, really) has
+         * this function called.
+         */
+        activate: function() {
+            // no op - meant to be extended by some functional widget.
+        }
     });
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -106,6 +106,7 @@ define([
             this.my_user_id = auth.user_id;
             if (this.options.autopopulate) {
                 this.refresh();
+                this.hasBeenActivated = true;
             }
             return this;
         },

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -67,6 +67,7 @@ define([
         nar_name: null,
         $mainPanel: null,
         $newNarrativeLink: null, // when a new narrative is created, gives a place to link to it
+        hasBeenActivated: false,
 
         init: function (options) {
             this._super(options);
@@ -90,13 +91,22 @@ define([
         },
 
         my_user_id: null,
+        activate: function () {
+            if (!this.hasBeenActivated) {
+                this.refresh();
+                this.hasBeenActivated = true;
+            }
+        },
+
         loggedInCallback: function (event, auth) {
             this.ws = new Workspace(this.options.ws_url, auth);
             this.manager = new NarrativeManager({ws_url: this.options.ws_url, nms_url: this.options.nms_url}, auth);
             this.serviceClient = new GenericClient(Config.url('service_wizard'), auth);
 
             this.my_user_id = auth.user_id;
-            this.refresh();
+            if (this.options.autopopulate) {
+                this.refresh();
+            }
             return this;
         },
         loggedOutCallback: function () {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -79,7 +79,7 @@ define(
 
                 var manageWidgets = this.buildPanelSet([{
                     name: 'kbaseNarrativeManagePanel',
-                    params: { autopopulate: true, showTitle: false }
+                    params: { autopopulate: false, showTitle: false }
                 }, ]);
 
                 this.$narrativesWidget = manageWidgets['kbaseNarrativeManagePanel'];
@@ -93,10 +93,12 @@ define(
 
                 this.$tabs = this.buildTabs([{
                     tabName: 'Analyze',
-                    content: $analysisPanel
+                    content: $analysisPanel,
+                    widgets: [this.$dataWidget, this.$methodsWidget]
                 }, {
                     tabName: 'Narratives',
-                    content: $managePanel
+                    content: $managePanel,
+                    widgets: [this.$narrativesWidget]
                 },
                 ], true);
 
@@ -197,6 +199,9 @@ define(
                         $body.find('div.kb-side-tab').removeClass('active');
                         // $body.find('div:nth-child(' + (idx+1) + ').kb-side-tab').addClass('active');
                         $body.find('[kb-data-id=' + idx + ']').addClass('active');
+                        tabs[idx].widgets.forEach(w => {
+                            w.activate();
+                        });
                         if (isOuter)
                             this.hideOverlay();
                     }
@@ -204,6 +209,9 @@ define(
 
                 $header.find('div:nth-child(2)').addClass('active');
                 $body.find('div:first-child.kb-side-tab').addClass('active');
+                tabs[0].widgets.forEach(w => {
+                    w.activate();
+                });
 
                 return {
                     header: $header,


### PR DESCRIPTION
Took a little tweaking to a few places.

In the parent widget class for the Narrative Manager widget, I added an `activate()` method. This gets invoked whenever that tab gets clicked on by the user. It's a no-op in the parent widget, so each child widget can extend it. Only the Narrative manager widget uses it to do its first rendering, then it doesn't do so again.