### PR TITLE
Bugfix for dynamic dropdown result processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ static/dist
 my_narrative_venv/
 narrative_venv/
 new_narrative_env_2/
+js-coverage
 
 # From https://github.com/github/gitignore/blob/master/Python.gitignore
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -188,7 +188,7 @@ define([
             searchTerm = searchTerm || '';
 
             if (!searchTerm && !dd_options.query_on_empty_input) {
-                return []
+                return [];
             }
             if (dataSource === 'ftp_staging') {
                 return Promise.resolve(stagingService.search({query: searchTerm}))
@@ -224,9 +224,9 @@ define([
                 } else {
                     return Promise.resolve(genericClientCall(call_params))
                         .then(function (results) {
-                            var index = dd_options.result_array_index
+                            var index = dd_options.result_array_index;
                             if (!index) {
-                                index = 0
+                                index = 0;
                             }
                             if (index >= results.length) {
                                 console.error(`Result array from ${dd_options.service_function} ` +
@@ -234,17 +234,17 @@ define([
                                     'was requested');
                                 return [];
                             }
-                            results = results[index]
-                            var path = dd_options.path_to_selection_items
+                            results = results[index];
+                            var path = dd_options.path_to_selection_items;
                             if (!path) {
-                                path = []
+                                path = [];
                             }
-                            results = Props.getDataItem(results, path)
+                            results = Props.getDataItem(results, path);
                             if (!Array.isArray(results)) {
                                 console.error('Selection items returned from ' +
                                     `${dd_options.service_function} at path /${path.join('/')} ` +
-                                    `in postion ${index} of the returned list are not an array`)
-                                return []
+                                    `in postion ${index} of the returned list are not an array`);
+                                return [];
                             } else {
                                 results.forEach(function(obj, index) {
                                     // could check here that each item is a map? YAGNI

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -35,7 +35,7 @@ define([
     TimeFormat,
     StringUtil,
     GenericClient,
-    Props,
+    Props
 ) {
     'use strict';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative-core",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixed two bugs:

The dynamic dropdown was hardcoded to only handle the case where the selection
items were in the first position of the return array and were at the first level
of the object at that position.
Now the position of the object in the return array and the path into the object
to the selection items can be specified.

Some dynamic service functions don't like empty input, but the DD will always
query the server regardless of the input contents. This behavior can now
be configured.

These changes require https://github.com/kbase/narrative_method_store/pull/74

There are no meaningful tests for the DD, and developing  a test harness
for the DD is way out of scope, so the changes were tested manually.