### PR TITLE
minor dynamic dropdown fixes

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -188,7 +188,7 @@ define([
             searchTerm = searchTerm || '';
 
             if (!searchTerm && !dd_options.query_on_empty_input) {
-                return [];
+                return Promise.resolve([]);
             }
             if (dataSource === 'ftp_staging') {
                 return Promise.resolve(stagingService.search({query: searchTerm}))
@@ -230,7 +230,7 @@ define([
                             }
                             if (index >= results.length) {
                                 console.error(`Result array from ${dd_options.service_function} ` +
-                                    `has length ${results.length} but index ${index} ` + 
+                                    `has length ${results.length} but index ${index} ` +
                                     'was requested');
                                 return [];
                             }
@@ -370,8 +370,6 @@ define([
                     }
                 }).on('change', function() {
                     doChange();
-                }).on('advanced-shown.kbase', function(e) {
-                    $(e.target).select2({ width: 'resolve' });
                 });
                 events.attachEvents(container);
             });


### PR DESCRIPTION
1. fetchData needs to always return a Promise (even on a no-op, empty array return)
2. Calling the select2 command again when showing a dynamic dropdown tagged as advanced would cause the dropdown to forget its ajax ability (should probably be double-checked in different browsers, but verified in Firefox and Chrome)