### PR TITLE
PTV-1214, PTV-1341, fix problems from previous update

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseBinnedContigs.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseBinnedContigs.js
@@ -105,7 +105,7 @@ define([
                     isSortable: true
                 }, {
                     id: 'cov',
-                    text: 'Read Coverage',
+                    text: 'Marker Completeness',
                     isSortable: true
                 }, {
                     id: 'gc',

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeComparisonViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseGenomeComparisonViewer.js
@@ -74,16 +74,20 @@ define (
         				'style="margin-left: auto; margin-right: auto;" id="'+self.pref+'overview-table"/>');
         		tabOverview.append(tableOver);
         		tableOver.append('<tr><td>Genome comparison object</td><td>'+info[1]+'</td></tr>');
-        		tableOver.append('<tr><td>Genome comparison workspace</td><td>'+info[7]+'</td></tr>');
-        		tableOver.append('<tr><td>Core functions</td><td>'+object.core_functions+'</td></tr>');
-        		tableOver.append('<tr><td>Core families</td><td>'+object.core_families+'</td></tr>');
-        		if (object.protcomp_ref) {
-        			tableOver.append('<tr><td>Protein Comparison</td><td>'+object.protcomp_ref+'</td></tr>');
+				if (object.protcomp_ref) {
+        			tableOver.append('<tr><td>Genome Comparison</td><td>'+object.protcomp_ref+'</td></tr>');
         		} else {
-        			tableOver.append('<tr><td>Protein Comparison</td><td>'+object.pangenome_ref+'</td></tr>');
+        			tableOver.append('<tr><td>Pangenome</td><td>'+object.pangenome_ref+'</td></tr>');
         		}
-        		tableOver.append('<tr><td>Owner</td><td>'+info[5]+'</td></tr>');
-        		tableOver.append('<tr><td>Creation</td><td>'+info[3]+'</td></tr>');
+				//tableOver.append('<tr><td>Genome comparison workspace</td><td>'+info[7]+'</td></tr>');
+        		tableOver.append('<tr><td>Core functions</td><td>'+object.core_functions+'</td></tr>');
+				tableOver.append('<tr><td>Total functions</td><td>'+object.functions.length+'</td></tr>');
+				tableOver.append('<tr><td>Core families</td><td>'+object.core_families+'</td></tr>');
+				tableOver.append('<tr><td>Total families</td><td>'+object.families.length+'</td></tr>');
+        		tableOver.append('<tr><td>Number of Genomes</td><td>'+info[10]["Number genomes"]+'</td></tr>');
+
+        		//tableOver.append('<tr><td>Owner</td><td>'+info[5]+'</td></tr>');
+        		//tableOver.append('<tr><td>Creation</td><td>'+info[3]+'</td></tr>');
         		///////////////////////////////////// Genomes table ////////////////////////////////////////////
         		var tabGenomes = $("<div/>");
     			tabObj.addTab({tab: 'Genome Comparison', content: tabGenomes, canDelete : false, show: false});
@@ -93,11 +97,12 @@ define (
         		var headings = [
 					"Genome","Legend"
 				];
-				for (var i in genomes) {
+				var numGenomes = genomes.length;
+				for (var i=0; i<numGenomes; i++) {
 					headings.push("G"+(i+1));
 				}
 				tableGenomes.append('<tr><th><b>'+headings.join('</b></th><th><b>')+'</b></th></tr>');
-				for (var i in genomes) {
+				for (var i=0; i<numGenomes; i++) {
             		var genome = genomes[i];
             		var row = [
             			"<b>G"+(i+1)+"</b>-"+genome.name,"# of families:<br># of functions:"

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
@@ -227,7 +227,7 @@ define([
                     return this.searchAndCacheOrthologs(query, sortBy, pageNum * this.options.pFamsPerPage, this.options.pFamsPerPage);
                 }.bind(this),
                 decoration: [{
-                    col: 1,
+                    col: 0,
                     type: 'link',
                     clickFunction: function(id) {
                         this.addFamilyTab(this.dataCache[id]);


### PR DESCRIPTION
@briehl 
PTV-1214 - Binned contig viewer - Make column heading change

PTV-1341 - GenomeComparison Viewer had information that wasn't needed and was missing some very useful information. The details are in the ticket.

Previous update - In the genome comparison viewer, the column and row heading should have been G1, G2, G3... but they came out G01, G11, G21 because I was adding a 1 as a string instead of a number.

Previous update - Last time I moved a column in the 'Families' table and the wrong column was getting a hotlink, which went nowhere. I just had to move the link to the first column instead of the second.

Unlike last time, this one has been tested because I now have narrative working locally. :)