### PR TITLE
PTV-966 fix float validator

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/float.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/float.js
@@ -29,10 +29,10 @@ define([
         if (!isFinite(value)) {
             return 'value must be a finite float';
         }
-        if (max && max < value) {
+        if (max !== null && !isNaN(max) && max < value) {
             return 'the maximum value for this parameter is ' + max;
         }
-        if (min && min > value) {
+        if (min !== null && !isNaN(min) && min > value) {
             return 'the minimum value for this parameter is ' + min;
         }
     }
@@ -68,7 +68,7 @@ define([
         });
     }
 
-    // For text values, there is 
+    // For text values, there is
     // function validate(value, spec) {
     //     try {
     //         var nativeValue = importString(value);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/float.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/float.js
@@ -23,16 +23,16 @@ define([
     }
 
     function validateFloat(value, min, max) {
-        if (isNaN(value)) {
+        if (typeof value !== 'number') {
             return 'value must be numeric';
         }
         if (!isFinite(value)) {
             return 'value must be a finite float';
         }
-        if (max !== null && !isNaN(max) && max < value) {
+        if (typeof max === 'number' && value > max) {
             return 'the maximum value for this parameter is ' + max;
         }
-        if (min !== null && !isNaN(min) && min > value) {
+        if (typeof min === 'number' && value < min) {
             return 'the minimum value for this parameter is ' + min;
         }
     }


### PR DESCRIPTION
`if (min && min > value)` was being ignored if `min` is 0. So that's treated as falsy.

And fun fact, `isNaN(null)` evaluates to `false`. So it'll catch `undefined` and strings and whatnot, but not null? I ❤️ Javascript.