### PR TITLE
make the default behavior to do empty input search in dyn dropdown

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -71,6 +71,10 @@ define([
             userId = runtime.userId(),
             eventListeners = [];
 
+        if (dd_options.query_on_empty_input === undefined) {
+            dd_options.query_on_empty_input = 1;
+        }
+
         /**
          * This function takes a nested return and returns a flat key-value pairing for use with
          * handlebar replacement for example {"foo":{"bar": "meh"}} becomes {"foo.bar": "meh"}
@@ -171,6 +175,13 @@ define([
                         max_length: spec.data.constraints.max_length,
                         required: spec.data.constraints.required
                     };
+                // selected item might be either a string or a number.
+                // if it's a number, we want it to be a string
+                // if it's something else, we should raise an error, since that's
+                // something fishy coming from the data-providing service
+                if (typeof selectedItem === 'number') {
+                    selectedItem = String(selectedItem);
+                }
                 return Validation.validateText(selectedItem, validationConstraints);
             });
         }

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -71,7 +71,7 @@ define([
             userId = runtime.userId(),
             eventListeners = [];
 
-        if (dd_options.query_on_empty_input === undefined) {
+        if (typeof dd_options.query_on_empty_input === 'undefined') {
             dd_options.query_on_empty_input = 1;
         }
 


### PR DESCRIPTION
DO NOT MERGE

Also pending in this PR is some looser validation, so if it gets a number or a string, it just stays as a number or a string. The idea here is that whatever the service provides should be passed along to the app. As long as its an atomic type (a number or string). Maybe booleans can be investigated in the future if we need, but expanding this to arrays or structures would just be ripe for abuse.