### PR TITLE
Minor error formatting fix

### DIFF
--- a/nbextensions/appCell2/widgets/tabs/errorTab.js
+++ b/nbextensions/appCell2/widgets/tabs/errorTab.js
@@ -74,7 +74,9 @@ define([
             pre({
                 dataElement: 'detail',
                 style: {
-                    border: '0px silver solid',
+                    border: '0px',
+                    maxHeight: '100rem',
+                    overflowY: 'auto',
                     padding: '4px',
                     xoverflowY: 'auto',
                     wordBreak: 'break-word'

--- a/nbextensions/appCell2/widgets/tabs/errorTab.js
+++ b/nbextensions/appCell2/widgets/tabs/errorTab.js
@@ -11,6 +11,7 @@ define([
 
     var t = html.tag,
         div = t('div'),
+        pre = t('pre'),
         ul = t('ul'),
         li = t('li');
 
@@ -70,7 +71,7 @@ define([
             div({ style: { fontWeight: 'bold', marginTop: '1em' } }, [
                 'Detail'
             ]),
-            div({
+            pre({
                 dataElement: 'detail',
                 style: {
                     border: '0px silver solid',


### PR DESCRIPTION
Make the "Details" section of the app widget's error output formatted with a `pre` tag so you can see the proper linebreaks and debug things more easily