### PR TITLE
Remove opacity reduction styles on unselected app cells

### DIFF
--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -279,10 +279,6 @@ control with padding, and then scooting the icon back into its column.
 
 /* tweaks to elemnts that should be dimmed when the cell is not selected */
 
-.unselected .kb-app-cell {
-    opacity: 0.5;
-}
-
 .kb-app-cell .advanced-parameter-showing {
     display: block;
 }

--- a/kbase-extension/static/kbase/custom/custom.css
+++ b/kbase-extension/static/kbase/custom/custom.css
@@ -339,18 +339,6 @@ span#notebook_name:hover {
     color: #000;
 }
 
-.cell.unselected .btn-default {
-    color: #CCC;
-}
-
-.cell.unselected .kb-cell-toolbar .title-container {
-    opacity: 0.5;
-}
-
-.cell.unselected .kb-cell-toolbar .buttons-container {
-    opacity: 0.2;
-}
-
 .kb-btn-icon {
     display: inline-block;
     padding: 4px;


### PR DESCRIPTION
Removes the opacity reduction on unselected app cells. This one is another annoyance for me, as I'd prefer app cells to be readable without having to click on them. But I understand this change may be more controversial and may not have consensus. Nevertheless, here's a PR for it. Feel free to close if we think users wouldn't like it. 