### PR TITLE
SCT-401 - fix issue where losing connection results in user being unable to save

### DIFF
--- a/kbase-extension/static/kbase/js/api/auth.js
+++ b/kbase-extension/static/kbase/js/api/auth.js
@@ -1,14 +1,14 @@
 define([
     'bluebird',
     'jquery',
-    'util/string',
     'jqueryCookie'
-], function(Promise, $, StringUtil) {
+], function(Promise, $) {
     'use strict';
 
     function factory(config) {
-        var url = config.url;
-        var cookieName = 'kbase_session';
+        const url = config.url,
+            cookieName = 'kbase_session',
+            cookieRegex = new RegExp('(^| )' + cookieName + '=([^;]+)');
 
         /**
          * Does a GET request to get the profile of the currently logged in user.
@@ -42,14 +42,19 @@ define([
             return null;
         }
 
+        function getTokenCookie() {
+            let match = document.cookie.match(cookieRegex);
+            if (match) {
+                return match[2];
+            }
+            return null;
+        }
+
         /* Returns the current auth token that's stuffed in a cookie.
          * Returns null if not logged in.
          */
         function getAuthToken() {
-            if (!$.cookie(cookieName)) {
-                return null;
-            }
-            return $.cookie(cookieName);
+            return getTokenCookie();
         }
 
         /* Sets the given auth token into the browser's cookie.

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -715,17 +715,17 @@ define([
             }
         };
 
-        $([Jupyter.events]).on('notebook_loaded.Notebook', function () {
+        $([Jupyter.events]).on('notebook_loaded.Notebook', () => {
             this.loadingWidget.updateProgress('narrative', true);
             $('#notification_area').find('div#notification_trusted').hide();
 
-            $(document).one('dataUpdated.Narrative', function () {
+            $(document).one('dataUpdated.Narrative', () => {
                 this.loadingWidget.updateProgress('data', true);
-            }.bind(this));
+            });
 
-            $(document).one('appListUpdated.Narrative', function () {
+            $(document).one('appListUpdated.Narrative', () => {
                 this.loadingWidget.updateProgress('apps', true);
-            }.bind(this));
+            });
 
             // Tricky with inter/intra-dependencies between kbaseNarrative and kbaseNarrativeWorkspace...
             this.sidePanel = new KBaseNarrativeSidePanel($('#kb-side-panel'), { autorender: false });
@@ -753,34 +753,36 @@ define([
             }
             this.initSharePanel();
             this.updateDocumentVersion()
-                .then(function() {
+                .then(() => {
                     // init the controller
                     return this.narrController.render();
-                }.bind(this))
-                .finally(function () {
+                })
+                .finally(() => {
                     this.sidePanel.render();
-                }.bind(this));
+                });
 
-            $([Jupyter.events]).trigger('loaded.Narrative');
-            $([Jupyter.events]).on('kernel_ready.Kernel',
-                function () {
-                    console.log('Kernel Ready! Initializing Job Channel...');
-                    this.loadingWidget.updateProgress('kernel', true);
-                    // TODO: This should be an event "kernel-ready", perhaps broadcast
-                    // on the default bus channel.
-                    this.sidePanel.$jobsWidget.initCommChannel()
-                        .then(function () {
-                            this.loadingWidget.updateProgress('jobs', true);
-                        }.bind(this))
-                        .catch(function (err) {
-                            // TODO: put the narrative into a terminal state
-                            console.error('ERROR initializing kbase comm channel', err);
-                            KBFatal('Narrative.ini', 'KBase communication channel could not be initiated with the back end. TODO');
-                            // this.loadingWidget.remove();
-                        }.bind(this));
-                }.bind(this)
-            );
-        }.bind(this));
+            $([Jupyter.events]).on('kernel_ready.Kernel', () => {
+                NarrativeLogin.restartSession();
+                Jupyter.notebook.kernel.execute(
+                    'import os;' +
+                    'os.environ["KB_AUTH_TOKEN"]="' + this.getAuthToken() + '";' +
+                    'os.environ["KB_WORKSPACE_ID"]="' + Jupyter.notebook.metadata.ws_name + '"'
+                );
+
+                console.log('Kernel Ready! Initializing Job Channel...');
+                this.loadingWidget.updateProgress('kernel', true);
+                // TODO: This should be an event "kernel-ready", perhaps broadcast
+                // on the default bus channel.
+                this.sidePanel.$jobsWidget.initCommChannel()
+                    .then(() => {
+                        this.loadingWidget.updateProgress('jobs', true);
+                    })
+                    .catch((err) => {
+                        console.error('ERROR initializing kbase comm channel', err);
+                        KBFatal('Narrative.ini', 'KBase communication channel could not be initiated with the back end.');
+                    });
+            });
+        });
     };
 
     /**

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -1,308 +1,305 @@
 /*global define,Jupyter,window*/
 /*jslint white: true,browser:true*/
 // Bind all page buttons right at startup.
-define(
-    [
-        'kbwidget',
-        'bootstrap',
-        'jquery',
-        'narrativeConfig',
-        'common/runtime',
-        'api/auth'
-    ],
-    function(
-        KBWidget,
-        bootstrap,
-        $,
-        Config,
-        Runtime,
-        Auth
-    ) {
-        'use strict';
+define([
+    'jquery',
+    'narrativeConfig',
+    'common/runtime',
+    'api/auth',
+    'narrativeLogin'
+], function(
+    $,
+    Config,
+    Runtime,
+    Auth,
+    NarrativeLogin
+) {
+    'use strict';
 
-        function loadDomEvents() {
+    function loadDomEvents() {
 
-            // bind menubar buttons
-            $('#kb-save-btn').click(function() {
-                if (Jupyter && Jupyter.notebook) {
-                    var narrName = Jupyter.notebook.notebook_name;
-                    // we do not allow users to leave their narratives untitled
-                    if (narrName.trim().toLowerCase() === 'untitled' || narrName.trim().length === 0) {
-                        Jupyter.save_widget.rename_notebook({ notebook: Jupyter.notebook }); //"Please name your Narrative before saving.", false);
-                    } else {
-                        Jupyter.narrative.saveNarrative();
-                    }
-                }
-            });
-            $('#kb-kernel-int-btn').click(function() {
-                if (Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
-                    Jupyter.notebook.kernel.interrupt();
-                }
-            });
-            $('#kb-kernel-ref-btn').click(function() {
-                if (Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
-                    Jupyter.notebook.kernel.restart();
-                }
-            });
-            $('#kb-kernel-rec-btn').click(function() {
-                if (Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
-                    Jupyter.notebook.kernel.reconnect();
-                }
-            });
-            $('#kb-del-btn').click(function() {
-                if (Jupyter && Jupyter.notebook) {
-                    Jupyter.notebook.delete_cell();
-                }
-            });
-            $('#kb-jira-btn').attr('href', Config.url('submit_jira_ticket') + '%20' + Config.get('version'));
-            $('#kb-status-btn').attr('href', Config.url('status_page'));
-
-            $('#kb-add-code-cell').click(function() {
-                    var data = {
-                        type: 'code',
-                        language: 'python'
-                    };
-                    Jupyter.narrative.insertAndSelectCellBelow('code', null, data);
-                })
-                .tooltip({
-                    delay: {
-                        show: Config.get('tooltip').showDelay,
-                        hide: Config.get('tooltip').hideDelay
-                    }
-                });
-
-            $('#kb-add-md-cell').click(function() {
-                    Jupyter.narrative.insertAndSelectCellBelow('markdown');
-                })
-                .tooltip({
-                    delay: {
-                        show: Config.get('tooltip').showDelay,
-                        hide: Config.get('tooltip').hideDelay
-                    }
-                });
-
-            $('#kb-side-toggle-in').click(function() {
-                Jupyter.narrative.toggleSidePanel();
-            });
-        }
-
-        function loadGlobals() {
-            /**
-             * Error logging for detectable failure conditions.
-             * Logs go through the kernel and thus are sent to the
-             * main KBase logging facility (Splunk, as of this writing).
-             *
-             * Usage:
-             *    KBFail(<is_it_fatal>, "what you were doing", "what happened");
-             * Returns: false if Jupyter not initialized yet, true otherwise
-             */
-            window._kb_failed_once = false;
-            window.KBFail = function(is_fatal, where, what) {
-                if (!Jupyter || !Jupyter.notebook || !Jupyter.notebook.kernel) {
-                    return false;
-                }
-                var code = "";
-                if (window._kb_failed_once === false) {
-                    code += "from biokbase.narrative.common import kblogging\n";
-                    window._kb_failed_once = true;
-                }
-                code += "kblogging.NarrativeUIError(";
-                if (is_fatal) {
-                    code += "True,";
+        // bind menubar buttons
+        $('#kb-save-btn').click(function() {
+            if (Jupyter && Jupyter.notebook) {
+                var narrName = Jupyter.notebook.notebook_name;
+                // we do not allow users to leave their narratives untitled
+                if (narrName.trim().toLowerCase() === 'untitled' || narrName.trim().length === 0) {
+                    Jupyter.save_widget.rename_notebook({ notebook: Jupyter.notebook }); //"Please name your Narrative before saving.", false);
                 } else {
-                    code += "False,";
+                    Jupyter.narrative.saveNarrative();
                 }
+            }
+        });
+        $('#kb-kernel-int-btn').click(function() {
+            if (Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
+                Jupyter.notebook.kernel.interrupt();
+            }
+        });
+        $('#kb-kernel-ref-btn').click(function() {
+            if (Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
+                Jupyter.notebook.kernel.restart();
+            }
+        });
+        $('#kb-kernel-rec-btn').click(function() {
+            if (Jupyter && Jupyter.notebook && Jupyter.notebook.kernel) {
+                Jupyter.notebook.kernel.reconnect();
+            }
+        });
+        $('#kb-del-btn').click(function() {
+            if (Jupyter && Jupyter.notebook) {
+                Jupyter.notebook.delete_cell();
+            }
+        });
+        $('#kb-jira-btn').attr('href', Config.url('submit_jira_ticket') + '%20' + Config.get('version'));
+        $('#kb-status-btn').attr('href', Config.url('status_page'));
+
+        $('#kb-add-code-cell').click(function() {
+                var data = {
+                    type: 'code',
+                    language: 'python'
+                };
+                Jupyter.narrative.insertAndSelectCellBelow('code', null, data);
+            })
+            .tooltip({
+                delay: {
+                    show: Config.get('tooltip').showDelay,
+                    hide: Config.get('tooltip').hideDelay
+                }
+            });
+
+        $('#kb-add-md-cell').click(function() {
+                Jupyter.narrative.insertAndSelectCellBelow('markdown');
+            })
+            .tooltip({
+                delay: {
+                    show: Config.get('tooltip').showDelay,
+                    hide: Config.get('tooltip').hideDelay
+                }
+            });
+
+        $('#kb-side-toggle-in').click(function() {
+            Jupyter.narrative.toggleSidePanel();
+        });
+    }
+
+    function loadGlobals() {
+        /**
+         * Error logging for detectable failure conditions.
+         * Logs go through the kernel and thus are sent to the
+         * main KBase logging facility (Splunk, as of this writing).
+         *
+         * Usage:
+         *    KBFail(<is_it_fatal>, "what you were doing", "what happened");
+         * Returns: false if Jupyter not initialized yet, true otherwise
+         */
+        window._kb_failed_once = false;
+        window.KBFail = function(is_fatal, where, what) {
+            if (!Jupyter || !Jupyter.notebook || !Jupyter.notebook.kernel) {
+                return false;
+            }
+            var code = "";
+            if (window._kb_failed_once === false) {
+                code += "from biokbase.narrative.common import kblogging\n";
+                window._kb_failed_once = true;
+            }
+            code += "kblogging.NarrativeUIError(";
+            if (is_fatal) {
+                code += "True,";
+            } else {
+                code += "False,";
+            }
+            if (where) {
+                code += 'where="' + where + '"';
+            }
+            if (what) {
                 if (where) {
-                    code += 'where="' + where + '"';
+                    code += ", ";
                 }
-                if (what) {
-                    if (where) {
-                        code += ", ";
-                    }
-                    code += 'what="' + what + '"';
-                }
-                code += ")\n";
-                // Log the failure
-                if (Jupyter.notebook.kernel.is_connected()) {
-                    Jupyter.notebook.kernel.execute(code, null, { store_history: false });
-                }
-                return true;
-            };
-            /**
-             * Syntactic sugar for logging error vs. fatal error.
-             *
-             * Same as KBFail() with boolean flag replaced by different names
-             * for the function.
-             */
-            window.KBError = function(where, what) {
-                return KBFail(false, where, what);
-            };
-
-            /**
-             * KBFatal will, in addition to calling KBFail(),
-             * put up a modal dialog showing the error
-             * and providing some advice to users on what to do next.
-             *
-             * @param where (string) Where the error occurred
-             * @param what  (string) What happened
-             */
-            window.KBFatal = function(where, what) {
-                var res = KBFail(true, where, what);
-
-                var version = Config.get('version') || 'unknown';
-                var hash = Config.get('git_commit_hash') || 'unknown';
-                var full_version = 'unknown';
-                if (version !== 'unknown') {
-                    if (hash === 'unknown') {
-                        full_version = version;
-                    } else {
-                        full_version = version + ' (hash=' + hash + ')';
-                    }
-                }
-                var $fatal =
-                    $('<div tabindex=-1 role="dialog" aria-labelledby="kb-fatal-error" aria-hidden="true">')
-                    .addClass('modal fade')
-                    .append($('<div>').addClass('modal-dialog')
-                        .append($('<div>').addClass('modal-content').addClass('kb-error-dialog')
-                            .append($('<div>').addClass('modal-header')
-                                .append($('<h4>').addClass('modal-title')
-                                    .append('KBase Narrative Error')))
-                            .append($('<div>').addClass('modal-body'))
-                            .append($('<p>').css({ 'margin': '-1em 0 0 1em' })
-                                .text('Hmmm, your narrative seemed to hit a fatal error.'))
-                            .append($('<p>').css({ 'margin-left': '1em' })
-                                .html('But, as a wise man once said, ' +
-                                    '<strong>"Don\'t Panic!"</strong>'))
-                            .append($('<p>').css({ 'margin': '1em 0 0 1em' })
-                                .text('Some errors are caused by the ' +
-                                    'way browsers cache information. Try manually clearing your ' +
-                                    'browser cache and reloading the page.')
-                                .append($('<span>')
-                                    .append($('<a>')
-                                        .attr({
-                                            href: "http://www.refreshyourcache.com/en/home/",
-                                            target: "_blank"
-                                        })
-                                        .text('This page'))
-                                    .append($('<span>')
-                                        .text(' has instructions on how to clear the cache on all major browsers.'))))
-                            .append($('<p>').css({ 'margin': '1em 0 0 1em' })
-                                .html('If that doesn\'t work, please ' +
-                                    'contact us at ' +
-                                    '<a href="http://kbase.us/contact-us/">http://kbase.us/contact-us/</a> ' +
-                                    'and include the following information:'))
-                            .append($('<p>').css({ margin: '1em 0 0 2em' }).addClass('kb-err-text')
-                                .text('Version: ' + full_version))
-                            .append($('<p>').css({ margin: '0 0 0 2em' }).addClass('kb-err-text')
-                                .text('Error location: ' + where))
-                            .append($('<p>').css({ margin: '0 0 0 2em' }).addClass('kb-err-text')
-                                .text('Error message: ' + what))
-                            .append($('<div>').addClass('modal-footer')
-                                .append($('<div>')
-                                    .append($('<span>').css({ float: 'left' }).addClass('kb-err-warn')
-                                        .text("Note: the Narrative may not work properly until this error is fixed"))
-                                    .append($('<button type="button" data-dismiss="modal">')
-                                        .addClass('btn btn-default')
-                                        .append('Close').click(function() {
-                                            $fatal.modal('close');
-                                        })
-                                    )))));
-                $fatal.modal('show');
-            };
-
-            // Seed the runtime module with narrative environment info.
-            initializeRuntime();
-
-        }
-
-        function loadJupyterEvents() {
-            // Kickstart the Narrative loading routine once the notebook is loaded.
-            $([Jupyter.events]).on('app_initialized.NotebookApp', function () {
-                require(['kbaseNarrative'], function (Narrative) {
-
-                    Jupyter.narrative = new Narrative();
-                    Jupyter.narrative.init();
-
-                    /*
-                     * Override the move-cursor-down-or-next-cell and
-                     * move-cursor-up-or-previous-cell actions.
-                     *
-                     * When editing a textcell (markdown or code), if a user uses
-                     * the arrow keys to move to another cell, it normally lands
-                     * there in edit mode.
-                     *
-                     * This is bad for KBase-ified markdown cells, since it shows
-                     * the div and script tags that are used to render them, and
-                     * screws up the state management. These overrides just
-                     * check if the next cell is a KBase cell, and doesn't enable
-                     * edit mode if so.
-                     */
-                    Jupyter.keyboard_manager.actions.register({
-                        handler: function (env, event) {
-                            var index = env.notebook.get_selected_index();
-                            var cell = env.notebook.get_cell(index);
-                            if (cell.at_bottom() && index !== (env.notebook.ncells() - 1)) {
-                                if (event) {
-                                    event.preventDefault();
-                                }
-                                env.notebook.command_mode();
-                                env.notebook.select_next(true);
-                                if (!env.notebook.get_selected_cell().metadata['kb-cell']) {
-                                    env.notebook.edit_mode();
-                                    var cm = env.notebook.get_selected_cell().code_mirror;
-                                    cm.setCursor(0, 0);
-                                }
-                            }
-                            return false;
-                        }
-                    },
-                    'move-cursor-down',
-                    'jupyter-notebook');
-
-                    Jupyter.keyboard_manager.actions.register({
-                        handler: function (env, event) {
-                            var index = env.notebook.get_selected_index(),
-                                cell = env.notebook.get_cell(index),
-                                cm = env.notebook.get_selected_cell().code_mirror,
-                                cur = cm.getCursor();
-                            if (cell && cell.at_top() && index !== 0 && cur.ch === 0) {
-                                if (event) {
-                                    event.preventDefault();
-                                }
-                                env.notebook.command_mode();
-                                env.notebook.select_prev(true);
-                                if (!env.notebook.get_selected_cell().metadata['kb-cell']) {
-                                    env.notebook.edit_mode();
-                                    cm = env.notebook.get_selected_cell().code_mirror;
-                                    cm.setCursor(cm.lastLine(), 0);
-                                }
-                            }
-                            return false;
-                        }
-                    },
-                    'move-cursor-up',
-                    'jupyter-notebook');
-                });
-            });
-
-            $([Jupyter.events]).on('kernel_ready.Kernel', function () {
-                let auth = Auth.make({url: Config.url('auth')});
-                Jupyter.notebook.kernel.execute(
-                    'import os;' +
-                    'os.environ["KB_AUTH_TOKEN"]="' + auth.getAuthToken() + '";' +
-                    'os.environ["KB_WORKSPACE_ID"]="' + Jupyter.notebook.metadata.ws_name + '"'
-                );
-            });
-        }
-
-        function initializeRuntime() {
-            var runtime = Runtime.make();
-            runtime.setEnv('workspaceId', Config.get('workspaceId'));
-        }
-
-        return {
-            loadDomEvents: loadDomEvents,
-            loadGlobals: loadGlobals,
-            loadJupyterEvents: loadJupyterEvents
+                code += 'what="' + what + '"';
+            }
+            code += ")\n";
+            // Log the failure
+            if (Jupyter.notebook.kernel.is_connected()) {
+                Jupyter.notebook.kernel.execute(code, null, { store_history: false });
+            }
+            return true;
         };
-    });
+        /**
+         * Syntactic sugar for logging error vs. fatal error.
+         *
+         * Same as KBFail() with boolean flag replaced by different names
+         * for the function.
+         */
+        window.KBError = function(where, what) {
+            return KBFail(false, where, what);
+        };
+
+        /**
+         * KBFatal will, in addition to calling KBFail(),
+         * put up a modal dialog showing the error
+         * and providing some advice to users on what to do next.
+         *
+         * @param where (string) Where the error occurred
+         * @param what  (string) What happened
+         */
+        window.KBFatal = function(where, what) {
+            var res = KBFail(true, where, what);
+
+            var version = Config.get('version') || 'unknown';
+            var hash = Config.get('git_commit_hash') || 'unknown';
+            var full_version = 'unknown';
+            if (version !== 'unknown') {
+                if (hash === 'unknown') {
+                    full_version = version;
+                } else {
+                    full_version = version + ' (hash=' + hash + ')';
+                }
+            }
+            var $fatal =
+                $('<div tabindex=-1 role="dialog" aria-labelledby="kb-fatal-error" aria-hidden="true">')
+                .addClass('modal fade')
+                .append($('<div>').addClass('modal-dialog')
+                    .append($('<div>').addClass('modal-content').addClass('kb-error-dialog')
+                        .append($('<div>').addClass('modal-header')
+                            .append($('<h4>').addClass('modal-title')
+                                .append('KBase Narrative Error')))
+                        .append($('<div>').addClass('modal-body'))
+                        .append($('<p>').css({ 'margin': '-1em 0 0 1em' })
+                            .text('Hmmm, your narrative seemed to hit a fatal error.'))
+                        .append($('<p>').css({ 'margin-left': '1em' })
+                            .html('But, as a wise man once said, ' +
+                                '<strong>"Don\'t Panic!"</strong>'))
+                        .append($('<p>').css({ 'margin': '1em 0 0 1em' })
+                            .text('Some errors are caused by the ' +
+                                'way browsers cache information. Try manually clearing your ' +
+                                'browser cache and reloading the page.')
+                            .append($('<span>')
+                                .append($('<a>')
+                                    .attr({
+                                        href: "http://www.refreshyourcache.com/en/home/",
+                                        target: "_blank"
+                                    })
+                                    .text('This page'))
+                                .append($('<span>')
+                                    .text(' has instructions on how to clear the cache on all major browsers.'))))
+                        .append($('<p>').css({ 'margin': '1em 0 0 1em' })
+                            .html('If that doesn\'t work, please ' +
+                                'contact us at ' +
+                                '<a href="http://kbase.us/contact-us/">http://kbase.us/contact-us/</a> ' +
+                                'and include the following information:'))
+                        .append($('<p>').css({ margin: '1em 0 0 2em' }).addClass('kb-err-text')
+                            .text('Version: ' + full_version))
+                        .append($('<p>').css({ margin: '0 0 0 2em' }).addClass('kb-err-text')
+                            .text('Error location: ' + where))
+                        .append($('<p>').css({ margin: '0 0 0 2em' }).addClass('kb-err-text')
+                            .text('Error message: ' + what))
+                        .append($('<div>').addClass('modal-footer')
+                            .append($('<div>')
+                                .append($('<span>').css({ float: 'left' }).addClass('kb-err-warn')
+                                    .text("Note: the Narrative may not work properly until this error is fixed"))
+                                .append($('<button type="button" data-dismiss="modal">')
+                                    .addClass('btn btn-default')
+                                    .append('Close').click(function() {
+                                        $fatal.modal('close');
+                                    })
+                                )))));
+            $fatal.modal('show');
+        };
+
+        // Seed the runtime module with narrative environment info.
+        initializeRuntime();
+
+    }
+
+    function loadJupyterEvents() {
+        // Kickstart the Narrative loading routine once the notebook is loaded.
+        $([Jupyter.events]).on('app_initialized.NotebookApp', function () {
+            require(['kbaseNarrative'], function (Narrative) {
+
+                Jupyter.narrative = new Narrative();
+                Jupyter.narrative.init();
+
+                /*
+                    * Override the move-cursor-down-or-next-cell and
+                    * move-cursor-up-or-previous-cell actions.
+                    *
+                    * When editing a textcell (markdown or code), if a user uses
+                    * the arrow keys to move to another cell, it normally lands
+                    * there in edit mode.
+                    *
+                    * This is bad for KBase-ified markdown cells, since it shows
+                    * the div and script tags that are used to render them, and
+                    * screws up the state management. These overrides just
+                    * check if the next cell is a KBase cell, and doesn't enable
+                    * edit mode if so.
+                    */
+                Jupyter.keyboard_manager.actions.register({
+                    handler: function (env, event) {
+                        var index = env.notebook.get_selected_index();
+                        var cell = env.notebook.get_cell(index);
+                        if (cell.at_bottom() && index !== (env.notebook.ncells() - 1)) {
+                            if (event) {
+                                event.preventDefault();
+                            }
+                            env.notebook.command_mode();
+                            env.notebook.select_next(true);
+                            if (!env.notebook.get_selected_cell().metadata['kb-cell']) {
+                                env.notebook.edit_mode();
+                                var cm = env.notebook.get_selected_cell().code_mirror;
+                                cm.setCursor(0, 0);
+                            }
+                        }
+                        return false;
+                    }
+                },
+                'move-cursor-down',
+                'jupyter-notebook');
+
+                Jupyter.keyboard_manager.actions.register({
+                    handler: function (env, event) {
+                        var index = env.notebook.get_selected_index(),
+                            cell = env.notebook.get_cell(index),
+                            cm = env.notebook.get_selected_cell().code_mirror,
+                            cur = cm.getCursor();
+                        if (cell && cell.at_top() && index !== 0 && cur.ch === 0) {
+                            if (event) {
+                                event.preventDefault();
+                            }
+                            env.notebook.command_mode();
+                            env.notebook.select_prev(true);
+                            if (!env.notebook.get_selected_cell().metadata['kb-cell']) {
+                                env.notebook.edit_mode();
+                                cm = env.notebook.get_selected_cell().code_mirror;
+                                cm.setCursor(cm.lastLine(), 0);
+                            }
+                        }
+                        return false;
+                    }
+                },
+                'move-cursor-up',
+                'jupyter-notebook');
+            });
+        });
+
+        $([Jupyter.events]).on('kernel_ready.Kernel', function () {
+            let auth = Auth.make({url: Config.url('auth')});
+            Jupyter.notebook.kernel.execute(
+                'import os;' +
+                'os.environ["KB_AUTH_TOKEN"]="' + auth.getAuthToken() + '";' +
+                'os.environ["KB_WORKSPACE_ID"]="' + Jupyter.notebook.metadata.ws_name + '"'
+            );
+            NarrativeLogin.restartSession();
+        });
+    }
+
+    function initializeRuntime() {
+        var runtime = Runtime.make();
+        runtime.setEnv('workspaceId', Config.get('workspaceId'));
+    }
+
+    return {
+        loadDomEvents: loadDomEvents,
+        loadGlobals: loadGlobals,
+        loadJupyterEvents: loadJupyterEvents
+    };
+});

--- a/test/unit/spec/narrativeLoginSpec.js
+++ b/test/unit/spec/narrativeLoginSpec.js
@@ -1,19 +1,201 @@
-define (
-	[
-		'jquery',
-		'narrativeLogin'
-	], function(
-		$,
-		Login
-	) {
-    describe('Test the kbaseNarrative module', function() {
-        it('Should do things', function() {
-            expect(Login.init).not.toBe(null);
+define([
+    'jquery',
+    'narrativeLogin',
+    'testUtil',
+    'narrativeConfig'
+], function(
+    $,
+    Login,
+    TestUtil,
+    Config
+) {
+    'use strict';
+
+    function insertTokenCookie(token) {
+        document.cookie = 'kbase_session=' + token;
+    }
+
+    function mockValidToken(token) {
+        insertTokenCookie(token);
+        // call to auth.getCurrentProfile
+        jasmine.Ajax.stubRequest(
+            Config.url('auth') + '/api/V2/me'
+        ).andReturn({
+            status: 200,
+            statusText: 'HTTP/1.1 200 OK',
+            contentType: 'application/json',
+            responseText: JSON.stringify({
+                created: 1490219221579,
+                lastlogin: 1578423051701,
+                display: 'Some User',
+                roles: [{
+                    id: 'DevToken',
+                    desc: 'Create developer tokens'
+                }],
+                'customroles':['goofypants'],
+                'policyids':[
+                    {'id':'data-policy.3','agreedon':1490285343224},
+                    {'id':'kbase-user.2','agreedon':1490285343222}
+                ],
+                user: 'some_user',
+                local: false,
+                email: 'some_user@somewhere.com',
+                idents: [{
+                    provusername: 'some_user@globusid.org',
+                    provider: 'Globus',
+                    id: 'some_globus_id'
+                }, {
+                    provusername: '1234-5678-9876-5432',
+                    provider: 'OrcID',
+                    id: 'some_OrcID_id'
+                }]
+            })
         });
 
-        it('Should instantiate on a DOM node', function() {
-            var $node = $("<div>");
-            Login.init($node);
+        jasmine.Ajax.stubRequest(
+            Config.url('auth') + '/api/V2/token'
+        ).andReturn({
+            status: 200,
+            statusText: 'HTTP/1.1 200 OK',
+            contentType: 'application/json',
+            responseText: JSON.stringify({
+                type: "Login",
+                id: 'some_token_id',
+                expires: new Date().getTime() + 100000,
+                created: 1578423051700,
+                name: null,
+                user: 'some_user',
+                custom: {},
+                cachefor: 300000
+            })
+        });
+    }
+
+    function mockInvalidToken(token) {
+        insertTokenCookie(token);
+        const error = JSON.stringify({
+            error: {
+                httpcode: 401,
+                httpstatus: 'Unauthorized',
+                appcode: 10020,
+                apperror: 'Invalid token',
+                message: '10020 Invalid token',
+                callid: '8296207964623217',
+                time: 1578600439463
+            }
+        });
+        jasmine.Ajax.stubRequest(
+            Config.url('auth') + '/api/V2/me'
+        ).andReturn({
+            status: 401,
+            statusText: 'Not allowed',
+            contentType: 'application/json',
+            responseText: error
+        });
+
+        jasmine.Ajax.stubRequest(
+            Config.url('auth') + 'api/V2/token'
+        ).andReturn({
+            status: 401,
+            statusText: 'Not allowed',
+            contentType: 'application/json',
+            responseText: error
+        });
+    }
+
+    function mockNoToken() {
+
+    }
+
+    describe('Test the kbaseNarrative module', () => {
+        beforeEach(() => {
+            document.cookie = 'kbase_session=; expires=' + new Date().setTime(1) + '; path=/';
+            Login.sessionInfo = null;
+            jasmine.Ajax.install();
+            jasmine.Ajax.stubRequest(
+                /\/login$/
+            ).andReturn({
+                status: 200
+            });
+        });
+
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+        });
+
+        it('Should load successfully', () => {
+            expect(Login.init).toBeDefined();
+            expect(Login.sessionInfo).toBeDefined();
+            expect(Login.getAuthToken).toBeDefined();
+            expect(Login.restartSession).toBeDefined();
+        });
+
+        it('Should instantiate on a DOM node with a valid token', (done) => {
+            mockValidToken('valid_token');
+            let $node = $("<div>"),
+                loggedIn = false,
+                loggedInKBase = false;
+
+            $(document).on('loggedIn', () => {
+                loggedIn = true;
+            });
+            $(document).on('loggedIn.kbase', () => {
+                loggedInKBase = true;
+            });
+
+            Login.init($node)
+                .then(() => {
+                    /* check the following from init:
+                    * 1. token check timer gets created
+                    * 2. authClient.getTokenInfo and
+                    * 3. authClient.getUserProfile get called
+                    * 4. "loggedIn.kbase" and "loggedIn" get triggered on document
+                    */
+                    expect(loggedIn).toBeTruthy();
+                    expect(loggedInKBase).toBeTruthy();
+                    done();
+                });
+
+        });
+
+        it('Should fail to instantiate without a valid auth token', (done) => {
+            mockInvalidToken('fake-token');
+            Login.init($('<div>'))
+                .then(done);
+        });
+
+        // it('Should fail to instantiate without any login token', (done) => {
+        //     Login.init($('<div>'))
+        //         .then(done);
+        // });
+
+        it('Should re-log in to Jupyter server on request', (done) => {
+            mockValidToken('valid_token');
+            Login.restartSession().then(done);
+        });
+
+        it('Should provide a null auth token if one is not present', () => {
+            const token = Login.getAuthToken();
+            expect(token).toBeNull();
+        });
+
+        it('Should provide an auth token straight from the cookie', () => {
+            const token = 'valid_token';
+            mockValidToken(token)
+            expect(Login.getAuthToken()).toBe(token);
+        });
+
+        it('Should provide session info on request after initing', (done) => {
+            mockValidToken('valid_token');
+            Login.init($('<div>'))
+                .then(() => {
+                    expect(Login.sessionInfo).not.toBeNull();
+                    done();
+                });
+        });
+
+        it('Should give a null session info before initing', () => {
+            expect(Login.sessionInfo).toBeNull();
         });
     });
 });

--- a/test/unit/spec/narrativeLoginSpec.js
+++ b/test/unit/spec/narrativeLoginSpec.js
@@ -104,7 +104,33 @@ define([
     }
 
     function mockNoToken() {
-
+        const error = JSON.stringify({
+            error: {
+                httpcode: 400,
+                httpstatus: 'Bad Request',
+                appcode: 10010,
+                apperror: 'No authentication token',
+                message: '10010 No authentication token: No user token provided',
+                callid: '5753458997874970',
+                time: 1578603882613
+            }
+        });
+        jasmine.Ajax.stubRequest(
+            Config.url('auth') + '/api/V2/me'
+        ).andReturn({
+            status: 401,
+            statusText: 'Bad Request',
+            contentType: 'application/json',
+            responseText: error
+        });
+        jasmine.Ajax.stubRequest(
+            Config.url('auth') + '/api/V2/token'
+        ).andReturn({
+            status: 401,
+            statusText: 'Bad Request',
+            contentType: 'application/json',
+            responseText: error
+        });
     }
 
     describe('Test the kbaseNarrative module', () => {
@@ -155,7 +181,17 @@ define([
                     expect(loggedInKBase).toBeTruthy();
                     done();
                 });
+        });
 
+        it('Should run a token validation timer when inited with a valid token', (done) => {
+            mockValidToken('valid_token');
+            let $node = $('<div>');
+            Login.init($node)
+                .then(() => {
+                    setTimeout(() => {
+                        done();
+                    }, 2000)
+                });
         });
 
         it('Should fail to instantiate without a valid auth token', (done) => {
@@ -164,10 +200,11 @@ define([
                 .then(done);
         });
 
-        // it('Should fail to instantiate without any login token', (done) => {
-        //     Login.init($('<div>'))
-        //         .then(done);
-        // });
+        it('Should fail to instantiate without any login token', (done) => {
+            mockNoToken();
+            Login.init($('<div>'))
+                .then(done);
+        });
 
         it('Should re-log in to Jupyter server on request', (done) => {
             mockValidToken('valid_token');


### PR DESCRIPTION
This scenario has been going on for years. A user logs in, does stuff, goes away for a while (or loses internet for a while), then returns to a disconnected kernel. After reconnecting or restarting the kernel, the user now can't save.

The reason for this was that there are two backend pieces that require their own state for KBase code to run. The kernel (where code gets executed, including app running and managing), and the server (where notebook/Narrative management gets done, including saving and loading). 

Restarting the kernel does nothing to modify the server state. This change updates that so that both the kernel and server state get updated at the same time.

The real change is in `kbaseNarrative.js`. Now, when the kernel signals that its ready (on page load, or after a restart), 3 things happen:
1. Push the current Narrative session info into the server.
2. Push the current Narrative session info into the kernel.
3. Forge the Jobs communication channel between the client and kernel, and have the kernel update its job state.

Previously, #2 and 3 were in separate responses to the same event, they're merged together to avoid a race condition (I'm not sure if that's ever been seen in the wild, but I think I've seen it once or twice if there's a very inconvenient network hiccup).