### PR TITLE
fix issues with narrative saving

### DIFF
--- a/src/biokbase/narrative/contents/narrativeio.py
+++ b/src/biokbase/narrative/contents/narrativeio.py
@@ -203,16 +203,17 @@ class KBaseWSManagerMixin(object):
             raise HTTPError(400, 'Unexpected error setting Narrative attributes: %s' %e)
 
         # With that set, update the workspace metadata with the new info.
-        try:
-            updated_metadata = {
-                u'is_temporary': u'false',
-                u'narrative_nice_name': nb[u'metadata'][u'name'],
-                u'cell_count': str(len(nb[u'cells'])),
-                u'searchtags': 'narrative'
-            }
-            self.ws_client().alter_workspace_metadata({u'wsi': {u'id': ws_id}, u'new':updated_metadata})
-        except ServerError as err:
-            raise WorkspaceError(err, ws_id, message="Error adjusting Narrative metadata", http_code=500)
+        perms = self.narrative_permissions(ref, user=cur_user)
+        if perms[cur_user] == 'a':
+            try:
+                updated_metadata = {
+                    'is_temporary': 'false',
+                    'narrative_nice_name': nb['metadata']['name'],
+                    'searchtags': 'narrative'
+                }
+                self.ws_client().alter_workspace_metadata({'wsi': {'id': ws_id}, 'new': updated_metadata})
+            except ServerError as err:
+                raise WorkspaceError(err, ws_id, message="Error adjusting Narrative metadata", http_code=500)
 
         # Now we can save the Narrative object.
         try:

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -241,10 +241,9 @@ class NarrIOTestCase(unittest.TestCase):
         self.assertTrue(result[1] == self.private_nar['ws'] and result[2] == self.private_nar['obj'])
         self.assertEquals(result[0]['metadata']['is_temporary'], 'false')
 
-        ws = Workspace(url=URLS.workspace, token=self.test_token)
+        ws = clients.get("workspace")
         ws_info = ws.get_workspace_info({'id': result[1]})
         self.assertEquals(ws_info[8]['searchtags'], 'narrative')
-        self.assertEquals(ws_info[8]['cell_count'], str(len(nar['cells'])))
         self.logout()
 
     def test_write_narrative_valid_anon(self):


### PR DESCRIPTION
Fails happen when a non-owner shared user saves.
This got fixed a while ago on this branch, but somehow regressed when extracting EE2 code.