### PR TITLE
Fix some app catalog links

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/app_card.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/app_card.js
@@ -193,7 +193,7 @@ define (
             $titleSpan.append($('<div>').addClass('kbcb-app-card-title').append(info.name));
             if(info['module_name']) {
                 $titleSpan.append($('<div>').addClass('kbcb-app-card-module').append(
-                                        $('<a href="/#appcatalog/module/'+info.module_name+'" target="_blank">')
+                                        $('<a href="/#catalog/modules/'+info.module_name+'" target="_blank">')
                                             .append(info.module_name)
                                             .on('click',function(event) {
                                                 // have to stop propagation so we don't go to the app page first

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/kbaseCatalogBrowser.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/catalog/kbaseCatalogBrowser.js
@@ -333,9 +333,9 @@ define ([
 
 
             // VERSION
-            /*var $verR = $('<a href="/#appcatalog/browse/release">').append('Released Modules');
-            var $verB = $('<a href="/#appcatalog/browse/beta">').append('Beta Modules');
-            var $verD = $('<a href="/#appcatalog/browse/dev">').append('Modules in Development');
+            /*var $verR = $('<a href="/#catalog/apps/release">').append('Released Modules');
+            var $verB = $('<a href="/#catalog/apps/beta">').append('Beta Modules');
+            var $verD = $('<a href="/#catalog/apps/dev">').append('Modules in Development');
 
             var $version = $('<li>').addClass('dropdown')
                                 .append('<a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Version<span class="caret"></span></a>')
@@ -355,7 +355,7 @@ define ([
             //var $statusLink = $('<li>').append($('<a href="/#appcatalog/status">').append('Status'));
             //var $registerLink = $('<li>').append($('<a href="/#appcatalog/register">').append('<i class="fa fa-plus-circle"></i> Add Module'));
 
-            var $viewAppCatalog = $('<li>').append($('<a href="/#appcatalog" target="_blank">').append('View App Catalog'));
+            var $viewAppCatalog = $('<li>').append($('<a href="/#catalog/apps" target="_blank">').append('View App Catalog'));
 
 
             // PLACE CONTENT ON CONTROL BAR
@@ -847,7 +847,7 @@ define ([
                         var $section = $('<div>').addClass('catalog-section');
                         $currentModuleDiv = $('<div>').addClass('kbcb-app-card-list-container');
                         $section.append($('<div>').css({'color':'#777'})
-                                .append($('<h4>').append('<a href="/#appcatalog/module/'+m+'" target="_blank">'+m+'</a>')));
+                                .append($('<h4>').append('<a href="/#catalog/modules/'+m+'" target="_blank">'+m+'</a>')));
                         $section.append($currentModuleDiv);
                         self.$appListPanel.append($section);
                     }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseAppCard.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseAppCard.js
@@ -67,7 +67,7 @@ define (
                 }
             }
             if (app.module_name && (entry.version === undefined)) {
-                type = '<a href="' + self.options.moduleLink + '/' + app.module_name + '" target="_blank">' +
+                type = '<a href="' + self.options.moduleLink + app.module_name + '" target="_blank">' +
                     app.namespace + '</a> ';
             }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -67,7 +67,7 @@ define([
             title: 'Apps',
             methodStoreURL: Config.url('narrative_method_store'),
             catalogURL: Config.url('catalog'),
-            moduleLink: '/#appcatalog/module/',
+            moduleLink: '/#catalog/modules/',
             methodHelpLink: '/#appcatalog/app/',
             appHelpLink: '/#appcatalog/app/l.a/'
         },


### PR DESCRIPTION
Before, the side panel app browser was generating links like `https://ci.kbase.us/#appcatalog/module//KBaseFeatureValues`

But they should be `https://ci.kbase.us/#catalog/modules/KBaseFeatureValues`