### PR TITLE
Small fix on the public data links for the sidebar

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/publicDataSources/searchDataSource.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/publicDataSources/searchDataSource.js
@@ -169,7 +169,7 @@ define([
                                     ws: this.config.workspaceName,
                                     type: this.config.type,
                                     attached: false,
-                                    workspaceReference: genomeRecord.ws_ref
+                                    workspaceReference: {ref: genomeRecord.ws_ref}
                                 };
                             }.bind(this));
                             // for now assume that all items before the page have been fetched


### PR DESCRIPTION
The links in the public data sidebar weren't working. It looks like `object.workspaceReference` needs to have a `ref`property. This should also fix the "Add" button, but I had a hard time testing that