### PR TITLE
bump jinja2 to version 2.11.1

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@ rsa==4.0
 pyasn1==0.4.5
 requests==2.22.0
 pyyaml==5.2
-jinja2==2.10
+jinja2==2.11.1
 sympy==1.3
 setuptools==40.8.0
 semantic_version==2.6.0


### PR DESCRIPTION
version 2.10 (previous one) has a security flaw.