### PR TITLE
JobManager cleanup

### DIFF
--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1479,16 +1479,13 @@ define([
                     'but the new one may include new features. Add a new "' +
                     model.getItem('newAppName') +
                     '" app cell for the update.');
-                // outdatedBtn.classList.remove('hidden');
             }
 
             var indicatorNode = ui.getElement('run-control-panel.status.indicator');
             var iconNode = ui.getElement('run-control-panel.status.indicator.icon');
             if (iconNode) {
                 // clear the classes
-
                 indicatorNode.className = state.ui.appStatus.classes.join(' ');
-
                 iconNode.className = '';
                 iconNode.classList.add('fa', 'fa-' + state.ui.appStatus.icon.type, 'fa-3x');
             }
@@ -1570,7 +1567,7 @@ define([
         /*
         setReadOnly is called to put the cell into read-only mode when it is loaded.
         This is different than view-only, which for read/write mode is toggleable.
-        Read-only does  imply view-only as well.!
+        Read-only does imply view-only as well!
          */
         function setReadOnly() {
             readOnly = true;
@@ -2669,11 +2666,13 @@ define([
                     case 'editing':
                         break;
                     case 'processing':
+                    case 'error':
                         startListeningForJobMessages(model.getItem('exec.jobState.job_id'));
                         requestJobStatus(model.getItem('exec.jobState.job_id'));
                         break;
                     case 'success':
-                    case 'error':
+                        break;
+                    // case 'error':
                             // do nothing for now
                     }
                 })

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -2,7 +2,7 @@ from ..util import TestConfig
 from biokbase.workspace.baseclient import ServerError
 
 
-class MockClients(object):
+class MockClients:
     """
     Mock KBase service clients as needed for Narrative backend tests.
     Use this with the Python mock library to mock the biokbase.narrative.clients.get call
@@ -273,7 +273,17 @@ class MockClients(object):
 def get_mock_client(client_name, token=None):
     return MockClients(token=token)
 
-class MockStagingHelper():
+def get_failing_mock_client(client_name, token=None):
+    return FailingMockClient(token=token)
+
+class FailingMockClient:
+    def __init__(self, token=None):
+        pass
+
+    def check_workspace_jobs(self, params):
+        raise ServerError("JSONRPCError", -32000, "Job lookup failed.")
+
+class MockStagingHelper:
     def list(self):
         """
         Mock the call to the staging service to get the "user's" files.

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -75,11 +75,6 @@ class JobManagerTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.jm.get_job('not_a_job_id')
 
-    def test_get_jobs_list(self):
-        running_jobs = self.jm.get_jobs_list()
-        self.assertIsInstance(running_jobs, list)
-        self.assertCountEqual(self.job_ids, [job.job_id for job in running_jobs])
-
     @mock.patch('biokbase.narrative.jobs.jobmanager.clients.get', get_mock_client)
     def test_list_jobs_html(self):
         jobs_html = self.jm.list_jobs()


### PR DESCRIPTION
NOTE that this is dependent on #1598 being accepted first.

1. Fixed a bug where looking up completed jobs could silently fail and respond with an empty job state, putting the app cell in an unrecoverable error state.
2. Cleaned up the JobManager initialization (removed an exception that can no longer happen).
3. Other cleanup