### PR TITLE
Fix narrative sort order

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeManagePanel.js
@@ -219,11 +219,7 @@ define([
             if (b.error) {
                 return -1;
             }
-            if (a.nar[3] > b.nar[3])
-                return -1; // sort by date
-            if (a.nar[3] < b[3])
-                return 1;  // sort by date
-            return 0;
+            return b.nar[3].localeCompare(a.nar[3]);
         },
 
         renderPanel: function () {

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@ rsa==4.0
 pyasn1==0.4.5
 requests==2.22.0
 pyyaml==5.2
-jinja2==2.10
+jinja2==2.11.1
 sympy==1.3
 setuptools==40.8.0
 semantic_version==2.6.0


### PR DESCRIPTION
This was mainly affecting firefox. Some how Chrome and Safari managed to get through, somehow. But it was a real bug.

The issue was that the list of Narratives in the Narrative panel was out of order, caused by referencing some key that didn't exist. So it was effectively comparing a string against `undefined`, which is weird.