### PR TITLE
Handle errors at job init better

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
@@ -495,9 +495,7 @@ define([
 
         getJobInitCode() {
             return [
-                'from biokbase.narrative.jobs.jobmanager import JobManager',
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
-                'JobManager().initialize_jobs()',
                 'JobComm().start_update_loop()'
             ].join('\n');
         }

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -61,6 +61,7 @@ class JobManager(object):
         4. start the status lookup loop.
         """
         ws_id = system_variable("workspace_id")
+        job_states = dict()
         try:
             job_states = clients.get('execution_engine2').check_workspace_jobs({
                 'workspace_id': ws_id, 'return_list': 0})
@@ -68,14 +69,6 @@ class JobManager(object):
         except Exception as e:
             kblogging.log_event(self._log, 'init_error', {'err': str(e)})
             new_e = transform_job_exception(e)
-            error = {
-                'error': 'Unable to get initial jobs list',
-                'message': getattr(new_e, 'message', 'Unknown reason'),
-                'code': getattr(new_e, 'code', -1),
-                'source': getattr(new_e, 'source', 'jobmanager'),
-                'name': getattr(new_e, 'name', type(e).__name__),
-                'service': 'execution_engine2'
-            }
             raise new_e
 
         for job_id, job_state in job_states.items():


### PR DESCRIPTION
The JobManager initialize_jobs call was not passing errors back to the browser. Now the flow goes:
1. Browser inits JobComm() with a kernel call.
2. JobComm (by default) tries to init JobManager.initialize_jobs
3. If that fails, JobComm sends the old `job_init_err` message across the channel.

It's that step 3 that wasn't there, so instead of sending a message (the front end registers a channel, the kernel response really creates it), nothing was happening. The semaphore that the app cells wait on never clears, and app cells never become more than just an empty header.

This fixes that with the initialization error prompt.

You can test by spoofing a bad EE2 endpoint in the config.