### PR TITLE
remove jquery from job log viewer, other minor fixes

### DIFF
--- a/kbase-extension/static/kbase/css/kbaseJobLog.css
+++ b/kbase-extension/static/kbase/css/kbaseJobLog.css
@@ -16,13 +16,11 @@
 .kblog-header {
     display: flex;
     font-family: monospace;
-    font-size: 85%;  
+    font-size: 85%;
 }
 
 .kblog-line {
-    display: flex;
     font-family: monospace;
-    font-size: 85%;
 }
 
 .kblog-line:hover {
@@ -31,11 +29,13 @@
 
 .kblog-num-wrapper {
     font-size: 85%;
+    display: flex;
+    flex-direction: row;
 }
 
 .kblog-line-num {
     flex-shrink: 0;
-    width: 9ex;
+    width: 3rem;
     text-align: right;
     color: #999;
     white-space: nowrap;

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -330,9 +330,13 @@ define([
         }
         ];
 
-    function factory(config) {
-        var config = config || {},
-            runtime = Runtime.make(),
+    /**
+     * The entrypoint to this widget. This creates the job log viewer and initializes it.
+     * Starting it is left as a lifecycle method for the calling object.
+     *
+     */
+    function factory() {
+        let runtime = Runtime.make(),
             bus = runtime.bus().makeChannelBus({ description: 'Log Viewer Bus' }),
             container,
             jobId,
@@ -606,20 +610,20 @@ define([
             const wrapperDiv = document.createElement('div');
             wrapperDiv.setAttribute('class', 'kblog-num-wrapper');
             // number
-            const numSpan = document.createElement('span');
-            numSpan.setAttribute('class', 'kblog-line-num');
+            const numDiv = document.createElement('div');
+            numDiv.setAttribute('class', 'kblog-line-num');
             const lineNumber = document.createTextNode(line.lineNumber);
-            numSpan.appendChild(lineNumber);
+            numDiv.appendChild(lineNumber);
             // text
-            const textSpan = document.createElement('span');
-            textSpan.setAttribute('class', 'kblog-text');
+            const textDiv = document.createElement('div');
+            textDiv.setAttribute('class', 'kblog-text');
             const lineText = document.createTextNode(line.text)
-            textSpan.appendChild(lineText);
+            textDiv.appendChild(lineText);
             // append line number and text
-            wrapperDiv.appendChild(numSpan);
-            wrapperDiv.appendChild(textSpan);
+            wrapperDiv.appendChild(numDiv);
+            wrapperDiv.appendChild(textDiv);
             // append wrapper to line div
-            kblogLine.appendChild(wrapperDiv)
+            kblogLine.appendChild(wrapperDiv);
 
             return kblogLine;
         }
@@ -1025,6 +1029,14 @@ define([
             return document.getElementById(panelId);
         }
 
+        /**
+         * The main lifecycle event, called when its container node exists, and we want to start
+         * running this widget.
+         * This detaches itself first, if it exists, then recreates itself in its host node.
+         * @param {object} arg - should have attributes:
+         *   - node - a DOM node where it will be hosted.
+         *   - jobId - string, a job id for this log
+         */
         function start(arg) {
             detach();  // if we're alive, remove ourselves before restarting
             var hostNode = arg.node;
@@ -1098,7 +1110,7 @@ define([
 
     return {
         make: function(config) {
-            return factory(config);
+            return factory();
         }
     };
 });

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -1,5 +1,13 @@
 /*global define*/
 /*jslint white:true,browser:true*/
+/**
+ * Usage:
+ * let viewer = JobLogViewer.make();
+ * viewer.start({
+ *     jobId: <some job id>,
+ *     node: <a DOM node>
+ * })
+ */
 define([
     'bluebird',
     'common/runtime',
@@ -1040,10 +1048,17 @@ define([
         function start(arg) {
             detach();  // if we're alive, remove ourselves before restarting
             var hostNode = arg.node;
+            if (!hostNode) {
+                throw new Error('Requires a node to start');
+            }
+            jobId = arg.jobId;
+            if (!jobId) {
+                throw new Error('Requires a job id to start');
+            }
+
             container = hostNode.appendChild(document.createElement('div'));
             ui = UI.make({ node: container });
 
-            jobId = arg.jobId;
             panelId = html.genId();
             var layout = renderLayout(panelId);
             container.innerHTML = layout.content;
@@ -1079,7 +1094,7 @@ define([
         function detach() {
             stop();
             if (container) {
-                container.innerHTML = '';
+                container.remove();
             }
         }
 

--- a/test/unit/spec/Util/jobLogViewerSpec.js
+++ b/test/unit/spec/Util/jobLogViewerSpec.js
@@ -1,0 +1,22 @@
+/*global define, describe, it, expect, jasmine, beforeEach, afterEach*/
+/*jslint white: true*/
+define([
+    'util/jobLogViewer'
+], (
+    JobLogViewer
+) => {
+    describe('Test the job log viewer module', () => {
+        beforeEach(() => {
+
+        });
+
+        it('Should load the module code successfully', () => {
+            expect(JobLogViewer).toBeDefined();
+        });
+
+        it('Should have the factory method', () => {
+            expect(JobLogViewer.make).toBeDefined();
+            expect(JobLogViewer.make).toEqual(jasmine.any(Function));
+        });
+    });
+})

--- a/test/unit/spec/Util/jobLogViewerSpec.js
+++ b/test/unit/spec/Util/jobLogViewerSpec.js
@@ -6,8 +6,14 @@ define([
     JobLogViewer
 ) => {
     describe('Test the job log viewer module', () => {
+        let hostNode = null;
         beforeEach(() => {
+            hostNode = document.createElement('div');
+            document.body.appendChild(hostNode);
+        });
 
+        afterEach(() => {
+            hostNode.remove();
         });
 
         it('Should load the module code successfully', () => {
@@ -17,6 +23,42 @@ define([
         it('Should have the factory method', () => {
             expect(JobLogViewer.make).toBeDefined();
             expect(JobLogViewer.make).toEqual(jasmine.any(Function));
+        });
+
+        it('Should be created', () => {
+            let viewer = JobLogViewer.make();
+            expect(viewer.start).toEqual(jasmine.any(Function));
+            expect(viewer.stop).toEqual(jasmine.any(Function));
+            expect(viewer.detach).toEqual(jasmine.any(Function));
+        });
+
+        it('Should fail to start without a node', () => {
+            let viewer = JobLogViewer.make();
+            const jobId = 'fakejob';
+            let arg = {
+                jobId: jobId
+            };
+            expect(() => {viewer.start(arg)}).toThrow(new Error('Requires a node to start'));
+        });
+
+        it('Should fail to start without a jobId', () => {
+            let viewer = JobLogViewer.make();
+            let arg = {
+                node: hostNode
+            };
+            expect(() => {viewer.start(arg)}).toThrow(new Error('Requires a job id to start'));
+        });
+
+        it('Should start as expected with inputs, and be stoppable and detachable', () => {
+            let viewer = JobLogViewer.make();
+            let arg = {
+                node: hostNode,
+                jobId: 'someFakeJob'
+            };
+            viewer.start(arg);
+            expect(hostNode.querySelector('div[data-element="kb-log"]')).toBeDefined();
+            viewer.detach();
+            expect(hostNode.innerHTML).toBe('');
         });
     });
 })


### PR DESCRIPTION
Addresses #1621 
* Make unique element id for viewer with `html.genId()` (see line 1042 - fetching the panel element)
  * set id = the generated id
* Remove most/all references to jquery and jquery as a dependency
  * There was just one remaining - an animate step. Swapped this out with a simple CSS transition.
* Rename warpperDiv -> wrapperDiv
  * just a typo, fixed
* Redundant if statements around line 663.
  * Also fixed.