### PR TITLE
fix autoscrolling the log viewer dragging the page around

### DIFF
--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -446,11 +446,7 @@ define([
          */
         function doFetchFirstLogChunk() {
             doStopPlayLogs();
-            panel.scrollTo({
-                top: 0,
-                left: 0,
-                behavior: 'smooth'
-              })
+            panel.scrollTo(0, 0);
         }
 
         /**
@@ -458,12 +454,7 @@ define([
          */
         function doFetchLastLogChunk() {
             doStopPlayLogs();
-            const lastChildElement = panel.lastChild
-            lastChildElement.scrollIntoView({
-                alignToTop: false,
-                behavior: 'smooth',
-                block: 'center'
-            })
+            panel.scrollTo(0, panel.lastChild.offsetTop);
         }
 
         function toggleViewerSize() {
@@ -673,11 +664,7 @@ define([
 
                 makeLogChunkDiv(viewLines);
                 if (fsm.getCurrentState().state.auto) {
-                    panel.lastElementChild.scrollIntoView({
-                        alignToTop: false,
-                        behavior: 'smooth',
-                        block: 'center'
-                    });
+                    panel.scrollTo(0, panel.lastChild.offsetTop);
                 }
             } else {
                 ui.setContent('panel', 'Sorry, no log yet...');

--- a/test/unit/spec/Util/jobLogViewerSpec.js
+++ b/test/unit/spec/Util/jobLogViewerSpec.js
@@ -124,6 +124,7 @@ define([
             btns.forEach(btn => {
                 expect(btn.classList.contains('disabled')).toBeTruthy();
             });
+            viewer.detach();
         });
     });
 })


### PR DESCRIPTION
It was using `scrollIntoView` instead of `parent.scrollTo`. 

Easy to let get through when you're only running a single app on a page. Also the `scrollTo(options)` form doesn't work on Safari.