### PR TITLE
redirect to load-narrative.html after deleting session

### DIFF
--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -811,7 +811,7 @@ define([
      * If it can't, or if this is being run locally, it pops up an alert saying so.
      */
     Narrative.prototype.updateVersion = function () {
-        var user = NarrativeLogin.sessionInfo.user; //.loginWidget($('#signin-button')).session('user_id');
+        var user = NarrativeLogin.sessionInfo.user;
         Promise.resolve(
             $.ajax({
                 contentType: 'application/json',
@@ -819,12 +819,12 @@ define([
                 type: 'DELETE',
                 crossDomain: true
             }))
-            .then(function () {
-                setTimeout(function () {
-                    location.reload(true);
+            .then(() => {
+                setTimeout(() => {
+                    location.replace(`/load-narrative.html?n=${this.workspaceId}&check=true`);
                 }, 200);
             })
-            .catch(function (error) {
+            .catch((error) => {
                 window.alert('Unable to update your Narrative session\nError: ' + error.status + ': ' + error.statusText);
                 console.error(error);
             });


### PR DESCRIPTION
Resolves #1630 

Instead of refreshing the page (and getting a plain 502 error from traefik), this now redirects to the load-narrative.html page which will then poke the loading container until 502 resolves into something useful.