### PR TITLE
remove toggle to job status before job launches

### DIFF
--- a/nbextensions/appCell2/widgets/appCellWidget-fsm.js
+++ b/nbextensions/appCell2/widgets/appCellWidget-fsm.js
@@ -526,7 +526,7 @@ define([], function() {
                         selected: false
                     },
                     logs: {
-                        enabled: true,
+                        enabled: false,
                         selected: false
                     },
                     results: {
@@ -617,7 +617,7 @@ define([], function() {
                         enabled: true
                     },
                     logs: {
-                        enabled: true
+                        enabled: false
                     },
                     results: {
                         enabled: false

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -2690,18 +2690,18 @@ define([
 
                     // Initial job state listening.
                     switch (fsm.getCurrentState().state.mode) {
-                    case 'execute-requested':
-                        // alert('started in "sending" state?');
-                        break;
-                    case 'editing':
-                        break;
-                    case 'processing':
-                    case 'error':
-                        startListeningForJobMessages(model.getItem('exec.jobState.job_id'));
-                        requestJobStatus(model.getItem('exec.jobState.job_id'));
-                        break;
-                    case 'success':
-                        break;
+                        case 'execute-requested':
+                            // alert('started in "sending" state?');
+                            break;
+                        case 'editing':
+                            break;
+                        case 'processing':
+                        case 'error':
+                            startListeningForJobMessages(model.getItem('exec.jobState.job_id'));
+                            requestJobStatus(model.getItem('exec.jobState.job_id'));
+                            break;
+                        case 'success':
+                            break;
                     }
                 })
                 .catch(function(err) {


### PR DESCRIPTION
fixes #1617

Job status is unavailable before the job starts, so disable that tab until the job actually starts (not in the Sending or Launching stages).