### PR TITLE
Fix cookies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ build-narrative-container:
 docker_image: build-narrative-container
 
 # Per PR #1328, adding an option to skip minification
-dev_image:
+dev-image:
 	SKIP_MINIFY=1 DOCKER_TAG=dev sh $(DOCKER_INSTALLER)
+
+run-dev-image:
+	ENV=$(ENV) bash scripts/local-dev-run.sh
 
 install:
 	bash $(INSTALLER)

--- a/kbase-extension/static/kbase/js/api/auth.js
+++ b/kbase-extension/static/kbase/js/api/auth.js
@@ -1,17 +1,36 @@
 define([
     'bluebird',
-    'jquery'
-], function(Promise, $) {
+    'jquery',
+    'narrativeConfig'
+], function (
+    Promise,
+    $,
+    Config
+) {
     'use strict';
 
     function factory(config) {
-        const url = config.url,
-            cookieNames = {
-                auth: 'kbase_session',                  // main auth token, use this
-                narrativeSession: 'narrative_session',  // session token - used by the router, not set, but should be deleted
-                backup: 'kbase_session_backup'          // used by the reports HTML server, should get deleted
+        const url = config.url;
+        const secureCookies = typeof config.secureCookies === 'undefined' ? true : config.secureCookies;
+
+        /*
+            Each cookie is defined
+        */
+        const cookieConfig = {
+            auth: {
+                name: 'kbase_session'
             },
-            tokenAge = 14; // days
+            backup: {
+                name: 'kbase_session_backup',
+                domain: 'kbase.us',
+                enableIn: ['prod']
+            },
+            narrativeSession: {
+                name: 'narrative_session'
+            }
+        };
+
+        const TOKEN_AGE = 14; // days
 
         /**
          * Meant for managing auth or session cookies (mainly auth cookies as set by
@@ -23,7 +42,7 @@ define([
          * expires is expected to be in days
          * auto set fields are:
          *  - path = '/'
-         *  - expires = tokenAge (default 14) days
+         *  - expires = TOKEN_AGE (default 14) days
          * @param {object} cookie
          *  - has the cookie keys: name, value, path, expires, max-age, domain
          *  - adds secure=true, samesite=none for KBase use.
@@ -32,29 +51,43 @@ define([
             if (!cookie.name) {
                 return;
             }
-            let name = encodeURIComponent(cookie.name);
-            let value = encodeURIComponent(cookie.value || '');
-            let props = {
-                expires: tokenAge,        // gets translated to GMT string
+            const name = encodeURIComponent(cookie.name);
+            const value = encodeURIComponent(cookie.value || '');
+            const props = {
+                expires: TOKEN_AGE,        // gets translated to GMT string
                 path: '/',
                 samesite: 'none'
             };
             if (Number.isInteger(cookie.expires)) {
                 props.expires = cookie.expires;
             }
+
+            // Default to secure cookies global setting if not specified.
+            if (typeof cookie.secure === 'undefined') {
+                cookie.secure = secureCookies;
+            }
+
             if (cookie.domain) {
                 props.domain = cookie.domain;
-                props.secure = 'true';
             }
             props['max-age'] = 86400 * props.expires;
             if (props.expires === 0) {
                 props.expires = new Date(0).toUTCString();
-            }
-            else {
+            } else {
                 props.expires = new Date(new Date().getTime() + (86400000*props.expires)).toUTCString();
             }
-            let propStr = Object.keys(props).map(key => `${key}=${props[key]}`).join('; ');
-            let newCookie = `${name}=${value}; ${propStr}`;
+
+            const fields = Object.keys(props).map((key) => {
+                return `${key}=${props[key]}`;
+            });
+
+            if (cookie.secure) {
+                fields.push('secure');
+            }
+
+            const propStr = fields.join(';');
+
+            const newCookie = `${name}=${value}; ${propStr}`;
             document.cookie=newCookie;
         }
 
@@ -63,12 +96,12 @@ define([
          * @param {string} name
          */
         function getCookie(name) {
-            let allCookies = {};
-            document.cookie.split(';').forEach(cookie => {
+            const allCookies = {};
+            document.cookie.split(';').forEach((cookie) => {
                 const parts = cookie.trim().split('=');
                 allCookies[parts[0]] = parts[1];
             });
-            return allCookies[name];
+            return allCookies[name] || null;
         }
 
         /**
@@ -79,16 +112,16 @@ define([
          * @param {string || undefined} domain
          */
         function removeCookie(name, path, domain) {
-            let removedCookie = {
-                name: name,
+            const cookieToRemove = {
+                name,
                 value: '',
-                path: path,
+                path,
                 expires: 0
             };
             if (domain) {
-                removedCookie.domain = domain;
+                cookieToRemove.domain = domain;
             }
-            setCookie(removedCookie);
+            setCookie(cookieToRemove);
         }
 
         /**
@@ -127,38 +160,57 @@ define([
          * Returns null if not logged in.
          */
         function getAuthToken() {
-            const token = getCookie(cookieNames.auth);
-            if (token) {
-                return token;
-            }
-            return null;
+            return getCookie(cookieConfig.auth.name);
         }
 
         /* Sets the given auth token into the browser's cookie.
          * Does nothing if the token is null.
          */
         function setAuthToken(token) {
-            if (token) {
-                ['auth', 'backup'].forEach((name) => {
-                    let cookie = {
-                        name: cookieNames[name],
-                        value: token
+            const deployEnv = Config.get('environment');
+
+            function setToken(config) {
+                // Honor cookie host whitelist if present.
+                if (config.enableIn) {
+                    if (config.enableIn.indexOf(deployEnv) === -1) {
+                        return;
                     }
-                    setCookie(cookie);
-                    cookie.domain='.kbase.us';
-                    setCookie(cookie);
-                });
+                }
+                const cookieField = {
+                    name: config.name,
+                    value: token
+                };
+                if (config.domain) {
+                    cookieField.domain = config.domain;
+                }
+                setCookie(cookieField);
             }
+
+            setToken(cookieConfig.auth);
+            setToken(cookieConfig.backup);
         }
 
         /* Deletes the auth cookies */
         function clearAuthToken() {
-            Object.keys(cookieNames).forEach(name => removeCookie(cookieNames[name], '/', '.kbase.us'));
-            Object.keys(cookieNames).forEach(name => removeCookie(cookieNames[name], '/'));
+            const deployEnv = Config.get('environment');
+
+            function removeToken(config) {
+                // Honor the cookie host whitelist if present.
+                if (config.enableIn) {
+                    if (config.enableIn.indexOf(deployEnv) === -1) {
+                        return;
+                    }
+                }
+                removeCookie(config.name, '/', config.domain);
+            }
+
+            Object.keys(cookieConfig).forEach((name) => {
+                removeToken(cookieConfig[name]);
+            });
         }
 
         function revokeAuthToken(token, id) {
-            var operation = '/tokens/revoke/' + id;
+            const operation = '/tokens/revoke/' + id;
             return makeAuthCall(token, {
                 operation: operation,
                 method: 'DELETE'
@@ -171,8 +223,8 @@ define([
             if (!token) {
                 token = getAuthToken();
             }
-            let encodedUsers = users.map(u => encodeURIComponent(u));
-            var operation = '/users/?list=' + encodedUsers.join(',');
+            const encodedUsers = users.map((u) => encodeURIComponent(u));
+            const operation = '/users/?list=' + encodedUsers.join(',');
             return makeAuthCall(token, {
                 operation: operation,
                 method: 'GET'
@@ -183,7 +235,7 @@ define([
             if (!token) {
                 token = getAuthToken();
             }
-            var operation = '/users/search/' + query;
+            let operation = '/users/search/' + query;
             if (options) {
                 operation += '/?fields=' + options.join(',');
             }
@@ -218,13 +270,13 @@ define([
          * parameters as expected.
          */
         function makeAuthCall(token, callParams) {
-            var version = callParams.version || 'V2',
-                callString = [
-                    url,
-                    '/api/',
-                    version,
-                    callParams.operation
-                ].join('');
+            const version = callParams.version || 'V2';
+            const callString = [
+                url,
+                '/api/',
+                version,
+                callParams.operation
+            ].join('');
 
             return Promise.resolve($.ajax({
                 url: callString,
@@ -255,36 +307,37 @@ define([
                 retries = 3;
             }
             return getTokenInfo(token)
-            .then(function(info) {
-                if (info.expires && info.expires > new Date().getTime()) {
-                    return true;
-                }
-                return false;
-            })
-            .catch(function(error) {
-                if (error.status === 401 || error.status === 403 || retries < 0) {
+                .then(function (info) {
+                    if (info.expires && info.expires > new Date().getTime()) {
+                        return true;
+                    }
                     return false;
-                }
-                else {
-                    throw error;
-                }
-            });
+                })
+                .catch(function (error) {
+                    if (error.status === 401 || error.status === 403 || retries < 0) {
+                        return false;
+                    }
+                    else {
+                        throw error;
+                    }
+                });
         }
 
         return {
-            putCurrentProfile: putCurrentProfile,
-            getCurrentProfile: getCurrentProfile,
+            putCurrentProfile,
+            getCurrentProfile,
             getUserProfile: getCurrentProfile,
-            getAuthToken: getAuthToken,
-            setAuthToken: setAuthToken,
-            clearAuthToken: clearAuthToken,
-            revokeAuthToken: revokeAuthToken,
-            getTokenInfo: getTokenInfo,
-            getUserNames: getUserNames,
-            searchUserNames: searchUserNames,
-            validateToken: validateToken
+            getAuthToken,
+            setAuthToken,
+            clearAuthToken,
+            revokeAuthToken,
+            getTokenInfo,
+            getUserNames,
+            searchUserNames,
+            validateToken,
+            setCookie,
+            getCookie
         };
-
     }
 
     return {

--- a/scripts/local-dev-run.sh
+++ b/scripts/local-dev-run.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
 root=$(git rev-parse --show-toplevel)
 static_dir=kbase-extension/static/kbase
+src_dir=src
+test_dir=test
 ext_components_dir=kbase-extension/static/ext_components
 nbextension_dir=nbextensions
 container_root=/kb/dev_container/narrative/
-if [ -z $env ]; then
-	echo "The 'env' environment variable is required"
+if [ -z "$ENV" ]; then
+	echo "The 'ENV' environment variable is required, set to either ci, next, appdev, or prod"
 	exit 1
 fi
-echo "Starting Narrative for environment '${env}'"
+echo "Starting Narrative for environment '${ENV}'"
 
-if [ "${mount}" == "t" ]; then
+mount_local_dirs="${mount:-t}"
+
+if [ "${mount_local_dirs}" == "t" ]; then
+    echo "Mounting local dirs ${mount_local_dirs}"
 	docker run \
 		--dns=8.8.8.8 \
-		-e "CONFIG_ENV=${env}" \
+		-e "CONFIG_ENV=${ENV}" \
 		--network=kbase-dev \
 		--name=narrative  \
+        --mount type=bind,src=${root}/${test_dir},dst=${container_root}/${test_dir} \
 		--mount type=bind,src=${root}/${static_dir},dst=${container_root}/${static_dir} \
+        --mount type=bind,src=${root}/${src_dir},dst=${container_root}/${src_dir} \
 		--mount type=bind,src=${root}/${nbextension_dir},dst=${container_root}/kbase-extension/static/${nbextension_dir} \
 		--rm -it \
 		kbase/narrative:dev
@@ -24,7 +31,7 @@ else
 	echo "Not mounting local dirs ${mount}"
 	docker run \
 		--dns=8.8.8.8 \
-		-e "CONFIG_ENV=${env}" \
+		-e "CONFIG_ENV=${ENV}" \
 		--network=kbase-dev \
 		--name=narrative  \
 		--rm -it \

--- a/test/unit/spec/api/authSpec.js
+++ b/test/unit/spec/api/authSpec.js
@@ -4,33 +4,58 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
+define([
     'api/auth',
     'narrativeConfig',
-    'testUtil'
-], function(
+    'testUtil',
+    'uuid'
+], function (
     Auth,
     Config,
-    TestUtil
+    TestUtil,
+    Uuid
 ) {
     'use strict';
 
-    var authClient,
+    let authClient,
         token;
-    const cookieKeys = ['kbase_session', 'kbase_session_backup', 'narrative_session'];
+
+    // The following functions ensure that the token for the "user" configured
+    // in test/unit/testConfig.json is set in the standard session cookie field
+    // before each test, and removed afterwards.
+    //
+    // This is for the convenience of testing "auth" functions which assume
+    // existing authentication, yet because it doesn't use the auth cookie functions,
+    // which is arguably beneficial here as it does keeps the scope of test setup
+    // more limited in scope.
+    //
+    // Note that for tests which test the auth cookie functions, clearToken()
+    // must be called first to clear out the session cookie.
+    //
+    // Also note that this does not deal with the backup or narrative session cookies,
+    // since those are
+    const cookieKeys = ['kbase_session'];
 
     function setToken(token) {
-        cookieKeys.forEach(key => document.cookie = `${key}=${token}`);
+        cookieKeys.forEach((key) => {
+            document.cookie = `${key}=${token}`;
+        });
     }
 
     function clearToken() {
-        cookieKeys.forEach(key => document.cookie = `${key}=`);
+        cookieKeys.forEach((key) => {
+            document.cookie = `${key}=`;
+        });
     }
 
     beforeEach(() => {
         token = TestUtil.getAuthToken();
         setToken(token);
-        authClient = Auth.make({url: Config.url('auth')});
+        authClient = Auth.make({
+            url: Config.url('auth'),
+            // Can't use secure cookies for testing.
+            secureCookies: false
+        });
     });
 
     afterEach(() => {
@@ -90,10 +115,10 @@ define ([
         it('Should fail to get profile with a missing token', (done) => {
             clearToken();
             authClient.getCurrentProfile()
-                .then((profile) => {
+                .then(() => {
                     done.fail('Should have failed!');
                 })
-                .catch((error) => {
+                .catch(() => {
                     done();
                 });
         });
@@ -211,33 +236,131 @@ define ([
 
         it('Should validate an auth token on request', (done) => {
             let doneCount = 0;
-            let trials = [{
+            const trials = [{
                 token: null,
                 isValid: true  // should get it from cookie
             }, {
                 token: 'someRandomToken',
                 isValid: false
-            }]
-            trials.forEach(trial => {
+            }];
+            trials.forEach((trial) => {
                 authClient.validateToken(trial.token)
-                    .then(isValid => {
+                    .then((isValid) => {
                         expect(isValid).toBe(trial.isValid);
                         doneCount++;
                         if (doneCount === trials.length) {
                             done();
                         }
                     })
-                    .catch(error => {
+                    .catch(() => {
                         done();
                     });
             });
         });
 
-        it('Should clear all auth token cookies on request', () => {
-            setToken('someToken');
-            expect(authClient.getAuthToken()).toEqual('someToken');
+        it('Should clear auth token cookie on request', () => {
+            // Ensure that the token automagically set is removed first.
+            clearToken();
+
+            // Setting an arbitrary token should work.
+            const cookieValue = new Uuid(4).format();
+            authClient.setAuthToken(cookieValue);
+            expect(authClient.getAuthToken()).toEqual(cookieValue);
+
+            // Clearing an auth token should also work.
             authClient.clearAuthToken();
             expect(authClient.getAuthToken()).toBeNull();
+
+            // Just to be totally sure.
+            expect(authClient.getCookie('kbase_session')).toBeNull();
+        });
+
+        it('Should properly handle backup cookie in non-prod environment', () => {
+            const env = Config.get('environment');
+            const backupCookieName = 'kbase_session_backup';
+            if (env === 'prod') {
+                pending('This test is not valid for a prod config');
+                return;
+            }
+
+            // Ensure that the token automagically set is removed first.
+            clearToken();
+
+            // Get a unique fake token, to ensure we don't conflict with
+            // another cookie value.
+            const cookieValue = new Uuid(4).format();
+
+            authClient.setAuthToken(cookieValue);
+            expect(authClient.getAuthToken()).toEqual(cookieValue);
+
+            // There should not be a backup cookie set yet
+            expect(authClient.getCookie(backupCookieName)).toBeNull();
+
+            // Since the backup cookie is only set in prod, we simulate the backup
+            // cookie having been set in prod in another session.
+            const backupCookieValue = new Uuid(4).format();
+
+            // Note the domain of localhost -- we can't use the real kbase.us domain.
+            authClient.setCookie({
+                name: backupCookieName,
+                value: backupCookieValue,
+                domain: 'localhost'
+            });
+
+            // The backup cookie should be set.
+            expect(authClient.getCookie(backupCookieName)).toEqual(backupCookieValue);
+
+            // Clearing an auth token should also work.
+            authClient.clearAuthToken();
+            expect(authClient.getAuthToken()).toBeNull();
+            expect(authClient.getCookie('kbase_session')).toBeNull();
+            expect(authClient.getCookie(backupCookieName)).toEqual(backupCookieValue);
+        });
+
+        it('Should set and clear backup cookie in prod', () => {
+            const env = Config.get('environment');
+            const backupCookieName = 'kbase_session_backup';
+            if (env !== 'prod') {
+                pending('This test is only valid for a prod config');
+                return;
+            }
+
+            // Ensure that the token automagically set is removed first.
+            clearToken();
+
+            // Setting an arbitrary token should work.
+            const cookieValue = new Uuid(4).format();
+            authClient.setAuthToken(cookieValue);
+            expect(authClient.getAuthToken()).toEqual(cookieValue);
+            expect(authClient.getCookie(backupCookieName)).toEqual(cookieValue);
+
+            // Clearing an auth token should also work.
+            authClient.clearAuthToken();
+            expect(authClient.getAuthToken()).toBeNull();
+            expect(authClient.getCookie('kbase_session')).toBeNull();
+            expect(authClient.getCookie(backupCookieName)).toBeNull();
+        });
+
+        it('Should clear the narrative_session cookie when the auth cookie is cleared', () => {
+            // Ensure that the token automagically set is removed first.
+            clearToken();
+
+            // We'll simulate the narrative_session token.
+            // This token is not set by the Narrative, but Traefik.
+            const cookieValue = new Uuid(4).format();
+            authClient.setCookie({
+                name: 'narrative_session',
+                value: cookieValue,
+                expires: 14
+            });
+
+            // Okay, it should be set.
+            expect(authClient.getCookie('narrative_session')).toEqual(cookieValue);
+
+            // Clearing the auth token should zap the narrative_session cookie too.
+            authClient.clearAuthToken();
+            expect(authClient.getAuthToken()).toBeNull();
+            expect(authClient.getCookie('narrative_session')).toBeNull();
         });
 
         it('Should revoke an auth token on request', () => {


### PR DESCRIPTION
Here are the changes to improve the cookie support.
The primary functional change is to make the configuration of cookies in auth.js carry specific cookie config info, separated test specs for zapping the narrative_session cookie and the backup cookie. The backup cookie testing also needs a spec targeting prod behavior, but that would require more changes since the testing is against localhost and the backup cookie is set for kbase.us.
Some minor changes to the tools I use for local narrative development in a container.
Since I couldn't fully test this, I performed manual confirmation using local kbase-ui and narrative proxied to respective kbase environments. 
Special setup was required:
- for narrative_session confirmation, the cookie is generated in next and narrative-dev; I chose next to test on. This required accessing the kbase next narrative, in order to generate the narrative_session cookie on the next.kbase.us host; then switch next.kbase.us to point to localhost via the local /etc/hosts; then, without closing the browser window (Chrome), access a narrative again, ensuring that the local narrative is called, then log out from the narrative. The narrative_session cookie is removed.
- for kbase_session_backup confirmation, a similar process is conducted, but against production.

Although it may be moot if we get narrative.kbase.us proxying to kbase.us services, this whole mechanism would be better engineered if the cookie configuration where folded into the per-environment configuration. I'm not too comfortable with either "kbase.us" hardcoded in auth.js, nor the special handling if the environment tag matches "prod". I don't know enough about the Narrative configuration administration to be able to make that change (if it is a change only to the local config.json, no problem :)) Feel free to bounce the 

One fix I will make outside of this ticket is that it appears that whoever set up the narrative-dev configuration for kbase-ui just copied the prod configuration, which sets the backup cookie. This could be problematic for staff who use narrative-dev, but kbase-ui will remove a backup cookie in prod if it finds one, but no accompanying kbase_session cookie.