### PR TITLE
Adding basic unit tests for app cell info tab.

### DIFF
--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -10,7 +10,9 @@ module.exports = function (config) {
             jasmine: {
                 failFast: false,
                 DEFAULT_TIMEOUT_INTERVAL: 20000
-            }
+            },
+            requireJsShowNoTimestampsError: '^(?!.*(^/narrative/static/))',
+            clearContext: false
         },
         plugins: [
             'karma-jasmine',
@@ -25,7 +27,8 @@ module.exports = function (config) {
         preprocessors: {
             'kbase-extension/static/kbase/js/**/!(api)/*.js': ['coverage'],
             'kbase-extension/static/kbase/js/api/!(*[Cc]lient*|Catalog|KBaseFeatureValues|NarrativeJobServiceWrapper|NewWorkspace)*.js': ['coverage'],
-            'kbase-extension/static/kbase/js/api/RestAPIClient.js': ['coverage']
+            'kbase-extension/static/kbase/js/api/RestAPIClient.js': ['coverage'],
+            'nbextensions/appcell2/widgets/tabs/*.js': ['coverage'],
         },
         files: [
             'kbase-extension/static/narrative_paths.js',
@@ -40,6 +43,7 @@ module.exports = function (config) {
             {pattern: 'kbase-extension/static/kbase/config/**/*.yaml', included: false, served: true},
             {pattern: 'kbase-extension/static/**/*.js', included: false, served: true},
             {pattern: 'kbase-extension/static/**/*.gif', included: false, served: true},
+            {pattern: 'nbextensions/appcell2/widgets/tabs/*.js', included: false},
             {pattern: 'test/unit/testConfig.json', included: false, served: true, nocache: true},
             {pattern: 'test/*.tok', included: false, served: true, nocache: true},
             {pattern: 'test/data/**/*', included: false, served: true},
@@ -66,6 +70,9 @@ module.exports = function (config) {
                 subdir: 'lcov'
             }],
             includeAllSources: true
+        },
+        mochaReporter: {
+            ignoreSkipped: true,
         },
         // web server port
         port: 9876,
@@ -98,6 +105,7 @@ module.exports = function (config) {
         browserNoActivityTimeout: 30000,
         singleRun: true,
         proxies: {
+            '/narrative/nbextensions': 'http://localhost:32323/narrative/nbextensions',
             '/narrative/static/': '/base/kbase-extension/static/',
             '/narrative/static/base': 'http://localhost:32323/narrative/static/base',
             '/narrative/static/notebook': 'http://localhost:32323/narrative/static/notebook',
@@ -106,10 +114,6 @@ module.exports = function (config) {
             '/narrative/static/bidi': 'http://localhost:32323/narrative/static/bidi',
             '/static/kbase/config': '/base/kbase-extension/static/kbase/config',
             '/test/': '/base/test/'
-        },
-        client: {
-          requireJsShowNoTimestampsError: '^(?!.*(^/narrative/static/))',
-          clearContext: false
         },
         concurrency: Infinity
 

--- a/test/unit/spec/appWidgets/infoTabSpec.js
+++ b/test/unit/spec/appWidgets/infoTabSpec.js
@@ -1,0 +1,90 @@
+/*global define*/
+/*global describe, expect, it*/
+/*global beforeEach */
+/*jslint white: true*/
+
+define([
+    '../../../../../narrative/nbextensions/appCell2/widgets/tabs/infoTab',
+], function(
+    infoTabWidget
+) {
+    'use strict';
+
+    describe('The App Info Tab module', function() {
+        it('loads', function() {
+            expect(infoTabWidget).not.toBe(null);
+        });
+
+        it('has expected functions', function() {
+            expect(infoTabWidget.make).toBeDefined();
+        });
+
+    });
+
+    describe('The App Info Tab instance', function() {
+        let node;
+        const model = {
+            getItem: (item) => model[item],
+            'app': {'tag': 'Mock App'},
+            'app.spec': {
+                'info': {
+                    'authors': ['Abraham', 'Martin', 'John'],
+                    'id': 0,
+                    'subtitle': 'A mock app for testing purposes',
+                    'ver': '1.0.1',
+                },
+                'parameters': [{
+                    'text_options': {
+                        'valid_ws_types': ['genome']},
+                    'ui_name': 'Genome',
+                }],
+            },
+            'executionStats': {
+                'number_of_calls': 1729,
+                'total_exec_time': 9001,
+            }
+        };
+        const mockInfoTab = infoTabWidget.make({model});
+
+        beforeEach(function () {
+            node = document.createElement('div');
+        });
+
+        it('has a factory which can be invoked', function() {
+            expect(mockInfoTab).not.toBe(null);
+        });
+
+        it('has the required methods', function() {
+            expect(mockInfoTab.start).toBeDefined();
+            expect(mockInfoTab.stop).toBeDefined();
+        });
+
+        it('has a method "start" which returns a Promise',
+            async function() {
+                const result = await mockInfoTab.start({node});
+                expect(result).toBe(node);
+            }
+        );
+
+        it('has a method "stop" which returns a Promise',
+            async function() {
+                await mockInfoTab.start({node});
+                const result = await mockInfoTab.stop();
+                expect(result).toBeUndefined();
+            }
+        );
+
+        it('returns the defined description', async function() {
+            const infoTab = await mockInfoTab.start({node});
+            expect(infoTab.firstChild.textContent).toBe(
+                model['app.spec']['info']['subtitle']
+            );
+        });
+
+        it('returns an item for each parameter', async function() {
+            const infoTab = await mockInfoTab.start({node});
+            const listItems = Array.from(infoTab.querySelectorAll('li li'));
+            expect(listItems.length).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
This pull request is to demonstrate tests running on code within the `nbextensions` directory without radically changing the current configuration within the repo. Most of the tests currently are configured to evaluate code under the `kbase-extension/static` directory. There is a sizable amount of code which lives under the `nbextensions` directory, but it does not seem to be configured to be tested at present. This comprises about 7% of the codebase by lines of code, so it might make sense to move all the code from here into the other folder. Before I would seriously suggest that, however, I would like a little more context on why there is a split in the first place and make sure that the move is possible and desirable.

The coverage report from karma also does not seem to properly count lines of code covered by the tests in this PR, so that should be addressed in the future.

The tests themselves also use slightly different syntax than the rest of the codebase, although this is internally consistent within this file. It would be worthwhile to adopt a convention to guide these sorts of syntax choices. In this case, the `await` syntax seems more maintainable to me than the equivalent `.then` approaches used elsewhere in the codebase. My main concern is that a convention be chosen and programmatically enforced through IDE tooling and perhaps a post commit hook, but I am flexible when it comes to the nature of that convention.