### PR TITLE
Updating Dependabot config to only check weekly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,18 @@ updates:
 - package-ecosystem: pip
   directory: "/src"
   schedule:
-    interval: daily
+    interval: weekly
     time: '11:00'
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: '11:00'
   open-pull-requests-limit: 10
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: '11:00'
   open-pull-requests-limit: 10


### PR DESCRIPTION
Daily updates are a bit excessive starting out.