### PR TITLE
SCT-1822 bump dropzone to 5.7.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "corejs-typeahead": "1.0.1",
     "d3": "3.5.6",
     "datatables": "1.10.9",
-    "dropzone": "4.3.0",
+    "dropzone": "5.7.0",
     "font-awesome": "4.7.0",
     "google-code-prettify": "1.0.5",
     "handlebars": "4.0.5",

--- a/kbase-extension/static/kbase/custom/custom.css
+++ b/kbase-extension/static/kbase/custom/custom.css
@@ -77,11 +77,6 @@ div.text_cell_input {
     border-radius: 0px;
 }
 
-
-/*div.text_cell_render {
-    margin-bottom: -10px;
-}*/
-
 div.cell {
     margin: 8px 0 8px 0px;
     padding: 0;
@@ -124,16 +119,12 @@ div.cell.selected.kb-error {
     border-left: 5px solid #d9534f;
 }
 
-input.raw_input {
-    /*height:auto;*/
-}
-
 div#notebook {
-    overflow-y: auto;
+    /* overflow-y: auto;
     min-width: 460px;
     min-height: 0;
-    height: 0;
-    padding-top: 0;
+    height: 0; */
+    padding: 0;
 }
 
 span#notebook_name {


### PR DESCRIPTION
An older version of dropzone would add a `null=null` header to upload POST requests to the staging service. When uploading >100 files, this was either overwriting or masking the body of the upload and causing a crash bug.

The latest version fixes it.

This also sneaks in a minor styling fix that was letting the Jupyter notebook pane invisibly overshadow the "Analyze" and "Data" tab toggle.