### PR TITLE
fix typo

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseVariation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseVariation.js
@@ -1,25 +1,25 @@
 /**
- * Output widget for genome variation in Jbrowse 
+ * Output widget for genome variation in Jbrowse
  * @author  Priya Ranjan <pranjan77@gmail.com>
  * @public
  */
 
- define (
-	[
-		'kbwidget',
-		'bootstrap',
-		'jquery',
+define (
+    [
+        'kbwidget',
+        'bootstrap',
+        'jquery',
         'narrativeConfig',
-		'kbaseAuthenticatedWidget',
-		'kb_common/jsonRpc/dynamicServiceClient'
-	], function(
-		KBWidget,
-		bootstrap,
-		$,
+        'kbaseAuthenticatedWidget',
+        'kb_common/jsonRpc/dynamicServiceClient'
+    ], function(
+        KBWidget,
+        bootstrap,
+        $,
         Config,
-		kbaseAuthenticatedWidget,
-		DynamicServiceClient,
-	) {
+        kbaseAuthenticatedWidget,
+        DynamicServiceClient
+) {
     return KBWidget({
         name: "kbaseVariation",
         parent : kbaseAuthenticatedWidget,


### PR DESCRIPTION
Aside from the tabs -> spaces change (for consistency), the `function` call at the top of the file had a trailing comma.