### PR TITLE
Removes sorting from two columns in the pangenome viewer - PTV-1527 #resolve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dev-image:
 	SKIP_MINIFY=1 DOCKER_TAG=dev sh $(DOCKER_INSTALLER)
 
 run-dev-image:
-	ENV=$(ENV) bash scripts/local-dev-run.sh
+	ENV=$(ENV) sh scripts/local-dev-run.sh
 
 install:
 	bash $(INSTALLER)

--- a/docs/developer/local-docker.md
+++ b/docs/developer/local-docker.md
@@ -9,19 +9,17 @@ The following changes are required:
 - Build the docker image using the make target "dev_image", this builds the docker image without the "grunt minify" step.
   The image will be tagged kbase/narrative:dev instead of the current git branch
 
+  ```bash
+  make dev-image
   ```
-  make dev_image
-  ```
 
-- start the container using the `scripts/local-dev-run.sh` script. 
+- start the container:
 
-    This script starts the narrative image using features to integrate it with local kbase-ui.
-
-    ```
-    env=ci bash scripts/local-dev-run.sh
+    ```bash
+    ENV={ci/next/prod} make run-dev-image
     ```
 
-    where env sets the CONFIG_ENV environment variable for the Docker container; ci is the environment in which you are working (needs to be same as the ui is running on.)
+    where ENV sets the CONFIG_ENV environment variable for the Docker container; ci is the environment in which you are working (needs to be same as the ui is running on.)
 
     - uses the config set $env; makes it easy to test different environments alongside ui
     - uses kbase-dev network; allows interoperation with the kbase-ui proxier 

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
@@ -208,11 +208,11 @@ define([
                 }, {
                     id: 'pcgCount',
                     text: 'Protein Coding Gene Count',
-                    isSortable: true
+                    isSortable: false
                 }, {
                     id: 'gCount',
                     text: 'Genome Count',
-                    isSortable: true
+                    isSortable: false
                 }],
                 rowsPerPage: this.options.pFamsPerPage,
                 searchPlaceholder: 'Search Families',

--- a/scripts/local-dev-run.sh
+++ b/scripts/local-dev-run.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 root=$(git rev-parse --show-toplevel)
 static_dir=kbase-extension/static/kbase
 src_dir=src


### PR DESCRIPTION
Actually sorting by these columns triggers an error in the backend api -- they are simply not sortable.
This resolves PTV-1527, which is linked to several public tickets.
Also included in this PR are some minor changes to the local docker developer support.

PTV-1527 #comment fixes table sorting, removes sorting from affected columns