### PR TITLE
Incorporated feedback on app cell info tab.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,9 +1,12 @@
 env:
-  browser: true
   amd: true
+  browser: true
+  es6: true
+  node: true
 extends: 'eslint:recommended'
 parserOptions:
-    ecmaVersion: 6
+    ecmaVersion: 2018
+root: true
 rules:
   strict:
     - error
@@ -11,8 +14,7 @@ rules:
   indent:
     - error
     - 4
-    - SwitchCase:
-      - 1
+    - SwitchCase: 1
   linebreak-style:
     - error
     - unix
@@ -27,3 +29,5 @@ rules:
     - allow:
       - warn
       - error
+  require-await:
+    - error

--- a/nbextensions/appCell2/widgets/tabs/infoTab.js
+++ b/nbextensions/appCell2/widgets/tabs/infoTab.js
@@ -1,10 +1,8 @@
 /*global define*/ // eslint-disable-line no-redeclare
 define([
-    'bluebird',
     'common/format',
     'common/utils',
 ], function(
-    Promise,
     format,
     utils
 ) {
@@ -60,10 +58,13 @@ define([
                 model.getItem('app').tag
             ].filter(toBoolean).join('/');
 
-            // DESCRIPTION
-            const description = document.createTextNode(appSpec.info.subtitle);
+            const methodFullInfo = appSpec.full_info;
 
-            // AVERAGE RUNTIME
+            // DESCRIPTION
+            const description = document.createElement('div');
+            description.innerHTML = methodFullInfo.description;
+
+            // RUN COUNT AND AVERAGE RUNTIME
             const execStats = model.getItem('executionStats');
             let avgRuntime;
             if( execStats
@@ -76,8 +77,9 @@ define([
             }
             let runtimeAvgListItem = document.createTextNode('');
             if(avgRuntime) {
-                runtimeAvgListItem = DOMTagLI(
-                    `The average execution time for this app is ${avgRuntime}.`
+                runtimeAvgListItem = DOMTagLI(''
+                    + `This app has been run ${execStats.number_of_calls}`
+                    + ` times and its average execution time is ${avgRuntime}.`
                 );
             }
 
@@ -102,7 +104,9 @@ define([
                     }
                 }
                 const li = document.createElement('li');
-                li.appendChild(document.createTextNode(param.ui_name));
+                const paramUIName = document.createElement('span');
+                paramUIName.innerHTML = param.ui_name;
+                li.appendChild(paramUIName);
                 if(types.length) {
                     li.appendChild(document.createTextNode(': '));
                 }
@@ -137,7 +141,7 @@ define([
 
             // CATALOG LINK
             const linkCatalog = DOMTagA(
-                'View in App Catalog',
+                'View Full Documentation',
                 { href: '/#appcatalog/app/' + appRef, target: '_blank' }
             );
             const linkCatalogListItem = document.createElement('li');

--- a/test/unit/spec/appWidgets/infoTabSpec.js
+++ b/test/unit/spec/appWidgets/infoTabSpec.js
@@ -1,6 +1,6 @@
-/*global define*/
-/*global describe, expect, it*/
 /*global beforeEach */
+/*global define*/ // eslint-disable-line no-redeclare
+/*global describe, expect, it*/
 /*jslint white: true*/
 
 define([
@@ -22,11 +22,13 @@ define([
     });
 
     describe('The App Info Tab instance', function() {
-        let node;
         const model = {
             getItem: (item) => model[item],
             'app': {'tag': 'Mock App'},
             'app.spec': {
+                'full_info' : {
+                    'description': 'Details about this mock app'
+                },
                 'info': {
                     'authors': ['Abraham', 'Martin', 'John'],
                     'id': 0,
@@ -35,19 +37,26 @@ define([
                 },
                 'parameters': [{
                     'text_options': {
-                        'valid_ws_types': ['genome']},
-                    'ui_name': 'Genome',
+                        'valid_ws_types': ['KBaseRNASeq.RNASeqSampleSet']},
+                    'ui_name': 'RNA sequence object <font color=red>*</font>',
+                }, {
+                    'ui_name': 'Adapters',
                 }],
             },
             'executionStats': {
                 'number_of_calls': 1729,
                 'total_exec_time': 9001,
-            }
+            },
         };
+        const appSpec = model.getItem('app.spec');
         const mockInfoTab = infoTabWidget.make({model});
+        let node, infoTabPromise, infoTab;
 
-        beforeEach(function () {
+        beforeEach(async function () {
             node = document.createElement('div');
+            infoTabPromise = mockInfoTab.start({node});
+            infoTab = await infoTabPromise;
+            return infoTab; // to use infoTab for linter
         });
 
         it('has a factory which can be invoked', function() {
@@ -60,31 +69,43 @@ define([
         });
 
         it('has a method "start" which returns a Promise',
-            async function() {
-                const result = await mockInfoTab.start({node});
-                expect(result).toBe(node);
+            function() {
+                expect(infoTabPromise instanceof Promise).toBeTrue();
             }
         );
 
         it('has a method "stop" which returns a Promise',
-            async function() {
-                await mockInfoTab.start({node});
-                const result = await mockInfoTab.stop();
-                expect(result).toBeUndefined();
+            function() {
+                const result = mockInfoTab.stop();
+                expect(result instanceof Promise).toBeTrue();
             }
         );
 
-        it('returns the defined description', async function() {
-            const infoTab = await mockInfoTab.start({node});
+        it('returns the defined description', function() {
             expect(infoTab.firstChild.textContent).toBe(
-                model['app.spec']['info']['subtitle']
+                appSpec.full_info.description
             );
         });
 
-        it('returns an item for each parameter', async function() {
-            const infoTab = await mockInfoTab.start({node});
+        it('returns an item for each parameter', function() {
             const listItems = Array.from(infoTab.querySelectorAll('li li'));
-            expect(listItems.length).toBe(1);
+            expect(listItems.length).toBe(appSpec.parameters.length);
+        });
+
+        it('renders parameter with formatting correctly', function() {
+            const RNASeqFormat = infoTab.querySelectorAll(
+                'li li:nth-child(1) font'
+            );
+            expect(RNASeqFormat.length).toBeGreaterThan(0);
+        });
+
+        it('renders parameter with no formatting correctly', function() {
+            const AdaptersFormat = infoTab.querySelectorAll(
+                'li li:nth-child(2)'
+            )[0];
+            expect(AdaptersFormat.innerText).toBe(
+                appSpec.parameters[1].ui_name
+            );
         });
     });
 });


### PR DESCRIPTION
This commit adjusts the app cell info tab according to user feedback related to #1652. It fixes some unit tests to test for what their spec says they are testing for, and includes some new tests. It updates some linter settings. Note that this PR changes the order of the info tab among other app cell tabs. This is not immediately obvious as JS did not always guarantee key order in objects, but now it does. Finally, it removes some instances of Bluebird in favor of the global built in Promise object.