### PR TITLE
Incorporated feedback on minimized cell status

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
@@ -329,6 +329,25 @@ define([
             });
         }
 
+        function minimizedStatus(mode, stage) {
+            if(mode === 'error' || mode === 'internal-error') {
+                return '<span style="color: red">Error</span>';
+            }
+            if(mode === 'canceled' || mode === 'canceling') {
+                return '<span style="color: orange">Canceled</span>';
+            }
+            if(mode ==='processing' && stage === 'running') {
+                return 'Running';
+            }
+            if(mode ==='processing' && stage === 'queued') {
+                return 'Queued';
+            }
+            if(mode === 'success') {
+                return '<span style="color: green">Success</span>';
+            }
+            return '';
+        }
+
         function render(cell) {
             /*
             The cell metadata 'kbase.cellState.toggleMinMax' is the
@@ -337,12 +356,14 @@ define([
             const cellCollapsed = utils.getCellMeta(
                 cell, 'kbase.cellState.toggleMinMax', 'maximized'
             ) !== 'maximized';
-            const execMessage = cell.element[0].querySelectorAll(
-                '[data-element="execMessage"]'
-            )[0];
-            const collapsedCellStatus = cellCollapsed ? (
-                execMessage && execMessage.innerHTML
-            ) : '';
+            const fsmMode = utils.getCellMeta(
+                cell, 'kbase.appCell.fsm.currentState.mode', ''
+            );
+            const fsmStage = utils.getCellMeta(
+                cell, 'kbase.appCell.fsm.currentState.stage', ''
+            );
+            const appStatePretty = minimizedStatus(fsmMode, fsmStage);
+            const collapsedCellStatus = cellCollapsed ? appStatePretty : '';
 
             var events = Events.make({ node: container }),
                 buttons = [
@@ -406,10 +427,20 @@ define([
                         utils.getCellMeta(cell, 'kbase.cellState.message')
                     ])
                 ]),
-                content = div({ class: 'kb-cell-toolbar container-fluid' }, [
-                    div({ class: 'row', style: { height: '56px' } }, [
-                        div({ class: 'col-sm-9 title-container' }, [
-                            div({ class: 'title', style: { display: 'flex', height: '56px' } }, [
+                content = div({ class: 'kb-cell-toolbar' }, [
+                    div({ class: '', style: {
+                        display: 'flex',
+                        flexDirection: 'row',
+                        height: '56px',
+                        justifyContent: 'space-between',
+                    } }, [
+                        div({
+                            class: 'title-container',
+                            style: {flexGrow: '1'}
+                        }, [
+                            div({ class: 'title', style: {
+                                display: 'flex', height: '56px'
+                            } }, [
                                 div({
                                     dataElement: 'icon',
                                     class: 'icon',
@@ -447,12 +478,18 @@ define([
                                     }, [getCellSubtitle(cell)])
                                 ]),
                                 div(
-                                    { style: { margin: '0px 0px 0px auto' } },
+                                    { style: {
+                                        margin: '0px 0px 0px auto',
+                                        minWidth: '65px'
+                                    }},
                                     [collapsedCellStatus]
                                 )
                             ])
                         ]),
-                        div({ class: 'col-sm-3 buttons-container' }, [
+                        div({
+                            class: 'buttons-container',
+                            style: { minWidth: '110px' }
+                        }, [
                             buttons,
                             message
                         ])

--- a/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
@@ -1,23 +1,29 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
+/*global describe, it, expect */
 /*jslint white: true*/
 define([
     'kbaseCellToolbarMenu'
-], function(Widget) {
+], function(
+    Widget,
+) {
     'use strict';
     describe('Test the kbaseCellToolbarMenu widget', function() {
-        const mockParentCell = (message, collapsedState) => {
+        const mockParentCell = (mode, stage, collapsedState) => {
             const messageContainer = document.createElement('div');
-            const execMessage = document.createElement('div');
-            execMessage.setAttribute('data-element', 'execMessage');
-            execMessage.innerHTML = message;
-            messageContainer.appendChild(execMessage);
+            const currentState = {
+                mode: mode,
+                stage: stage
+            };
+            const fsm = {
+                currentState: currentState,
+                getCurrentState: () => currentState,
+            };
             return {
                 element: [messageContainer],
                 metadata: {
                     kbase: {
+                        appCell: {
+                            fsm: fsm
+                        },
                         cellState: {
                             toggleMinMax: collapsedState
                         },
@@ -26,32 +32,64 @@ define([
                 }
             };
         };
-        const message = 'When in the course of human events...';
+        const mockToolbar = (mode, stage, collapsedState) => {
+            const instance = Widget.make();
+            const parentCell = mockParentCell(mode, stage, collapsedState);
+            const toolbarDiv = document.createElement('div');
+            instance.register_callback([toolbarDiv], parentCell);
+            return toolbarDiv.querySelectorAll(
+                'div.title div:nth-child(3)'
+            )[0].innerText;
+        };
 
         it('Should do things', function() {
         });
 
-        it('Should show the status message when collapsed', function() {
-            const instance = Widget.make();
-            const parentCell = mockParentCell(message, 'minimized');
-            const toolbarDiv = document.createElement('div');
-            instance.register_callback([toolbarDiv], parentCell);
+        it('Should say Error when minimized and mode is error', function() {
             expect(
-                toolbarDiv.querySelectorAll(
-                    'div.title div:nth-child(3)'
-                )[0].innerHTML
-            ).toBe(message);
+                mockToolbar('error', '', 'minimized')
+            ).toBe('Error');
         });
 
-        it('Should suppress the status message if not collapsed', function() {
-            const instance = Widget.make();
-            const parentCell = mockParentCell(message, 'maximized');
-            const toolbarDiv = document.createElement('div');
-            instance.register_callback([toolbarDiv], parentCell);
+        it('Should say Error when minimized and mode is internal-error', function() {
             expect(
-                toolbarDiv.querySelectorAll(
-                    'div.title div:nth-child(3)'
-                )[0].innerHTML
+                mockToolbar('internal-error', '', 'minimized')
+            ).toBe('Error');
+        });
+
+        it('Should say Canceled when minimized and canceling', function() {
+            expect(
+                mockToolbar('canceling', '', 'minimized')
+            ).toBe('Canceled');
+        });
+
+        it('Should say Canceled when minimized and canceled', function() {
+            expect(
+                mockToolbar('canceled', '', 'minimized')
+            ).toBe('Canceled');
+        });
+
+        it('Should say Running when minimized and running', function() {
+            expect(
+                mockToolbar('processing', 'running', 'minimized')
+            ).toBe('Running');
+        });
+
+        it('Should say Running when minimized and queued', function() {
+            expect(
+                mockToolbar('processing', 'queued', 'minimized')
+            ).toBe('Queued');
+        });
+
+        it('Should say Success when minimized and mode is success', function() {
+            expect(
+                mockToolbar('success', '', 'minimized')
+            ).toBe('Success');
+        });
+
+        it('Should suppress the status message if maximized', function() {
+            expect(
+                mockToolbar('processing', 'running', 'maximized')
             ).toBe('');
         });
     });


### PR DESCRIPTION
This PR relates to #1758 and takes a "less is more" attitude to the app cell status when minimized. Instead of using the long, and possibly dynamic, status message, it restricts statuses to Canceled, Error, Queued, Running, Success. This simplified approach allows the status messages to be styled more uniformly, increasing readability.