### PR TITLE
better handling for quotes in spec editor

### DIFF
--- a/src/biokbase/narrative/appeditor.py
+++ b/src/biokbase/narrative/appeditor.py
@@ -28,6 +28,18 @@ def generate_app_cell(validated_spec=None, spec_tuple=None):
         elif "errors" in validated and validated['errors']:
             raise Exception(validated['errors'])
 
+    # Each of the values of the validated spec needs to be escaped for JS.
+    # Specifically we turn " -> &quot; and ' -> &apos;
+    # This isn't done so much on the frontend because of how it's already interpreted and
+    # injected into the cell metadata,
+    # but it's necessary for this little function.
+
+    for i in range(len(validated_spec["parameters"])):
+        p = validated_spec["parameters"][i]
+        for key in ["ui_name", "short_hint", "description"]:
+            p[key] = p.get(key, '').replace('"', "&quot;")
+            p[key] = p.get(key, '').replace("'", "&apos;")
+
     js_template = """
         var outputArea = this,
             cellElement = outputArea.element.parents('.cell'),

--- a/src/biokbase/narrative/appeditor.py
+++ b/src/biokbase/narrative/appeditor.py
@@ -34,11 +34,15 @@ def generate_app_cell(validated_spec=None, spec_tuple=None):
     # injected into the cell metadata,
     # but it's necessary for this little function.
 
-    for i in range(len(validated_spec["parameters"])):
-        p = validated_spec["parameters"][i]
-        for key in ["ui_name", "short_hint", "description"]:
-            p[key] = p.get(key, '').replace('"', "&quot;")
-            p[key] = p.get(key, '').replace("'", "&apos;")
+    if "info" in validated_spec:
+        for key in ["name", "subtitle", "tooltip"]:
+            validated_spec["info"][key] = _fix_quotes(validated_spec["info"].get(key, ""))
+
+    if "parameters" in validated_spec:
+        for i in range(len(validated_spec["parameters"])):
+            p = validated_spec["parameters"][i]
+            for key in ["ui_name", "short_hint", "description"]:
+                p[key] = _fix_quotes(p.get(key, ""))
 
     js_template = """
         var outputArea = this,
@@ -56,3 +60,6 @@ def generate_app_cell(validated_spec=None, spec_tuple=None):
     js_code = Template(js_template).render(spec=json.dumps(validated_spec))
 
     return Javascript(data=js_code, lib=None, css=None)
+
+def _fix_quotes(s: str) -> str:
+    return s.replace('"', "&quot;").replace("'", "&apos;")

--- a/src/biokbase/narrative/tests/data/simple_display.yaml
+++ b/src/biokbase/narrative/tests/data/simple_display.yaml
@@ -31,6 +31,6 @@ parameters :
         ui-name : |
             A String
         short-hint : |
-            A description string.
+            A description string, with "quoted" values, shouldn't fail.
 description : |
     <p>This is a tiny, simple method intended for testing the Narrative's ability to parse and display specs.</p>

--- a/src/biokbase/narrative/tests/data/simple_display.yaml
+++ b/src/biokbase/narrative/tests/data/simple_display.yaml
@@ -1,9 +1,9 @@
 #
 # define display information
 #
-name: Test Simple Inputs
+name: Test Simple Inputs with "quotes"
 tooltip: |
-    A simple test spec with a single input.
+    A simple test spec with a single 'input'.
 screenshots: []
 
 icon: icon.png

--- a/src/biokbase/narrative/tests/test_appeditor.py
+++ b/src/biokbase/narrative/tests/test_appeditor.py
@@ -11,12 +11,12 @@ from .util import TestConfig
 
 class AppEditorTestCase(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
         config = TestConfig()
-        self.specs_list = config.load_json_file(config.get('specs', 'app_specs_file'))
-        self.spec_json = config.load_json_file(config.get('specs', 'simple_spec_json'))
+        cls.specs_list = config.load_json_file(config.get('specs', 'app_specs_file'))
+        cls.spec_json = config.load_json_file(config.get('specs', 'simple_spec_json'))
         with open(config.file_path(config.get('specs', 'simple_display_yaml'))) as f:
-            self.display_yaml = f.read()
+            cls.display_yaml = f.read()
             f.close()
 
     def test_gen_app_cell_post_validation(self):
@@ -28,6 +28,8 @@ class AppEditorTestCase(unittest.TestCase):
         self.assertIsNotNone(js)
         self.assertIsNotNone(js.data)
         self.assertIn("A description string, with &quot;quoted&quot; values, shouldn&apos;t fail.", js.data)
+        self.assertIn("Test Simple Inputs with &quot;quotes&quot;", js.data)
+        self.assertIn("A simple test spec with a single &apos;input&apos;.", js.data)
 
     def test_gen_app_cell_fail_validation(self):
         with self.assertRaises(Exception):

--- a/src/biokbase/narrative/tests/test_appeditor.py
+++ b/src/biokbase/narrative/tests/test_appeditor.py
@@ -26,6 +26,8 @@ class AppEditorTestCase(unittest.TestCase):
     def test_gen_app_cell_pre_valid(self):
         js = generate_app_cell(spec_tuple=(json.dumps(self.spec_json), self.display_yaml))
         self.assertIsNotNone(js)
+        self.assertIsNotNone(js.data)
+        self.assertIn("A description string, with &quot;quoted&quot; values, shouldn&apos;t fail.", js.data)
 
     def test_gen_app_cell_fail_validation(self):
         with self.assertRaises(Exception):


### PR DESCRIPTION
A long-standing issue with the in-narrative app spec editor is how it handles quotes in parameter descriptions. Or, more accurately, how it doesn't.

This was causing problems with how the cells are being generated. In the standard Narrative workflow, the app spec is directly put into the cell metadata, so as long as it's valid JSON, there's no problem. In the `generate_app_cell` function, the spec is "printed" into the Javascript parser directly, which causes some string parsing to be done. The result of this is that potentially invalid JSON (with the standard `\"` escaping of quotes) can be emitted, which causes the Javascript interpreter to fail.

This patch explicitly converts any double-quote `"` to `&quot;` and any single-quote `'` to `&apos;`, in parameter fields which is more html and JSON friendly.