### PR TITLE
Added clipboard functionality to select2 inputs.

### DIFF
--- a/kbase-extension/static/kbase/css/appCell.css
+++ b/kbase-extension/static/kbase/css/appCell.css
@@ -38,6 +38,34 @@
     border: 0;
 }
 
+.kb-app-row-clip-btn-addon {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    padding-right: 10px;
+    height: 100%;
+}
+
+.kb-app-row-clip-btn-addon:active:after {
+    background-color: #fff;
+    border-radius: 3px;
+    border: 1px solid gray;
+    content: 'copied!';
+    margin-top: -5px;
+    padding: 7px;
+    position: absolute;
+}
+
+.kb-input-group-wide {
+    width: 100%;
+}
+
+.kb-input-row-flex {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
 .cell.selected .btn-default.kb-app-row-close-btn {
     color: gray;
 }
@@ -47,7 +75,7 @@
     color: red;
 } */
 
-.kb-app-row-close-btn {
+.kb-app-row-clip-btn, .kb-app-row-close-btn {
     height: 100%;
     margin-left: 1px;
     /* border-left: 3px solid transparent; */
@@ -128,7 +156,7 @@
 .kb-input-group-addon {
     background: transparent;
     border: 0;
-    padding: 0px 4px 0px 4px;
+    padding: 0px 0px 0px 10px;
 }
 
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/common.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/common.js
@@ -1,0 +1,53 @@
+/*global define*/ //eslint-disable-line no-redeclare
+/*jslint white:true,browser:true*/
+
+define([
+], function () {
+    'use strict';
+
+    /*
+     * A clipboard button for copying data from select boxes.
+     */
+    function clipboardButton(div, button, events, ui, node) {
+        return div({
+            class: 'input-group-addon kb-app-row-clip-btn-addon',
+        }, button({
+            class: 'btn btn-xs kb-app-row-clip-btn',
+            type: 'button',
+            id: events.addEvent({
+                type: 'click',
+                handler: async function() {
+                    const text = (node
+                        .querySelectorAll('[role=textbox]')[0]
+                        .innerText
+                    );
+                    await navigator.clipboard.writeText(text);
+                }
+            })
+        }, ui.buildIcon({
+            name: 'clipboard'
+        })));
+    }
+
+    function containerContent(div, button, events, ui, container, input){
+        const clipboard = clipboardButton(
+            div, button, events, ui, container
+        );
+        const content = div({
+            dataElement: 'input-row',
+            class: 'kb-input-row-flex',
+        }, [
+            div({
+                class: 'input-group kb-input-group-wide',
+            }, input),
+            clipboard
+        ]);
+        return content;
+    }
+
+    return {
+        clipboardButton: clipboardButton,
+        containerContent: containerContent,
+    };
+
+});

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
@@ -7,12 +7,13 @@ define([
     'kb_common/utils',
     'kb_service/client/workspace',
     'kb_service/utils',
-    'common/validation',
+    'common/data',
     'common/events',
     'common/runtime',
     'common/ui',
-    'common/data',
+    'common/validation',
     'util/timeFormat',
+    'widgets/appWidgets2/common',
     'kb_sdk_clients/genericClient',
 
     'select2',
@@ -25,17 +26,19 @@ define([
     utils,
     Workspace,
     serviceUtils,
-    Validation,
+    Data,
     Events,
     Runtime,
     UI,
-    Data,
+    Validation,
     TimeFormat,
-    GenericClient) {
+    WidgetCommon,
+    GenericClient) { //eslint-disable-line no-unused-vars
     'use strict';
 
     // Constants
     var t = html.tag,
+        button = t('button'),
         div = t('div'),
         span = t('span'),
         b = t('b'),
@@ -82,7 +85,6 @@ define([
                         if (model.blacklistValues) {
                             return !model.blacklistValues.some(function(value) {
                                 if (objectInfoHasRef(objectInfo, value)) {
-                                    // if (value === getObjectRef(objectInfo)) {
                                     filteredOptions.push(idx);
                                     return true;
                                 }
@@ -94,7 +96,6 @@ define([
                         var selected = false,
                             ref = idx; //getObjectRef(objectInfo);
                         if (objectInfoHasRef(objectInfo, model.value)) {
-                            // if (getObjectRef(objectInfo) === model.value) {
                             selected = true;
                         }
                         return option({
@@ -295,9 +296,13 @@ define([
         function render() {
             return Promise.try(function() {
                 var events = Events.make(),
-                    inputControl = makeInputControl(events),
-                    content = div({ class: 'input-group', style: { width: '100%' } }, inputControl);
+                    inputControl = makeInputControl(events);
 
+                ui.setContent('input-container', '');
+                const container = ui.getElement('input-container');
+                const content = WidgetCommon.containerContent(
+                    div, button, events, ui, container, inputControl
+                );
                 ui.setContent('input-container', content);
 
                 $(ui.getElement('input-container.input')).select2({

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/select2ObjectView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/select2ObjectView.js
@@ -13,7 +13,7 @@ define([
     'common/ui',
     'common/data',
     'util/timeFormat',
-
+    'widgets/appWidgets2/common',
     'select2',
     'bootstrap',
     'css!font-awesome'
@@ -29,11 +29,14 @@ define([
     Runtime,
     UI,
     Data,
-    TimeFormat) {
+    TimeFormat,
+    WidgetCommon,
+) {
     'use strict';
 
     // Constants
     var t = html.tag,
+        button = t('button'),
         div = t('div'),
         span = t('span'),
         b = t('b'),
@@ -254,9 +257,13 @@ define([
         function render() {
             return Promise.try(function() {
                 var events = Events.make(),
-                    inputControl = makeInputControl(events),
-                    content = div({ class: 'input-group', style: { width: '100%' } }, inputControl);
+                    inputControl = makeInputControl(events);
 
+                ui.setContent('input-container', '');
+                const container = ui.getElement('input-container');
+                const content = WidgetCommon.containerContent(
+                    div, button, events, ui, container, inputControl
+                );
                 ui.setContent('input-container', content);
 
                 $(ui.getElement('input-container.input')).select2({

--- a/test/unit/spec/appWidgets/commonSpec.js
+++ b/test/unit/spec/appWidgets/commonSpec.js
@@ -1,0 +1,52 @@
+/*global define*/ // eslint-disable-line no-redeclare
+/*global describe, expect, it*/
+/*jslint white: true*/
+
+define([
+    'common/events',
+    'common/ui',
+    'kb_common/html',
+    'widgets/appWidgets2/common',
+], (
+    Events,
+    UI,
+    html,
+    WidgetCommon,
+) => {
+    'use strict';
+    const div = html.tag('div');
+    const button = html.tag('button');
+    const container = document.createElement('div');
+    const events = Events.make({ node: container });
+    const ui = UI.make({ node: container });
+    describe('Test WidgetCommon module', () => {
+        it('Should be loaded with the right functions', () => {
+            expect(WidgetCommon).toBeDefined();
+            expect(WidgetCommon.clipboardButton).toBeDefined();
+            expect(WidgetCommon.containerContent).toBeDefined();
+        });
+
+        it('Should be able to produce content with a clipboard icon', () => {
+            const input = document.createElement('div');
+            const content = WidgetCommon.containerContent(
+                div, button, events, ui, container, input
+            );
+            container.innerHTML = content;
+            expect(container
+                .querySelectorAll('[data-element=icon]')[0]
+                .classList.contains('fa-clipboard')
+            ).toBeTrue();
+        });
+
+        it('Should be able to create the clipboard icon', () => {
+            const clipboardButton = WidgetCommon.clipboardButton(
+                div, button, events, ui, container
+            );
+            container.innerHTML = clipboardButton;
+            expect(container
+                .querySelectorAll('[data-element=icon]')[0]
+                .classList.contains('fa-clipboard')
+            ).toBeTrue();
+        });
+    });
+});


### PR DESCRIPTION
Certain values are not as easy to copy and paste from within KBase app cells, and this PR trials a clipboard button to sequence input and view elements.

For select2 object inputs and views, this PR adds a clipboard icon to enable copying and pasting the value selected within the select2 widget.

