### PR TITLE
Adjust how authentication cookies are set

### DIFF
--- a/kbase-extension/static/kbase/js/api/auth.js
+++ b/kbase-extension/static/kbase/js/api/auth.js
@@ -56,7 +56,7 @@ define([
             const props = {
                 expires: TOKEN_AGE,        // gets translated to GMT string
                 path: '/',
-                samesite: 'none'
+                samesite: 'Lax'
             };
             if (Number.isInteger(cookie.expires)) {
                 props.expires = cookie.expires;

--- a/kbase-extension/static/kbase/js/api/auth.js
+++ b/kbase-extension/static/kbase/js/api/auth.js
@@ -45,7 +45,9 @@ define([
          *  - expires = TOKEN_AGE (default 14) days
          * @param {object} cookie
          *  - has the cookie keys: name, value, path, expires, max-age, domain
-         *  - adds secure=true, samesite=none for KBase use.
+         *  - adds secure=true, samesite=Lax for KBase use.
+         *  - When used in a localhost dev environment samesite=Lax and secure=false
+         *    should be sufficient for browsers.
          */
         function setCookie(cookie) {
             if (!cookie.name) {


### PR DESCRIPTION
# Description of PR purpose/changes

Auth tests (and local dev environment behavior) were failing due to auth tokens being unable to be set in the headless Chrome environment. Auth tokens are set as cookies in the browser, and there was a recent Chrome update that requires that `samesite=none` and `secure` are both set. This allows cross-origin cookies to work.

However, the only case where cookies need to be cross-origin is in a development environment that's configured to run on localhost (i.e. the narrative URL is something like http://localhost:8888). This is also running unsecure (not https), so a `secure` cookie cannot be set. So, when running a test that tries to make an auth token, that would always fail. But since we only need to have cookies like that on localhost, and they'll only communicate at the top level, we can use `samesite=Lax` and get all of the desired behavior. 

# Jira Ticket / Issue #

fixes https://kbase-jira.atlassian.net/browse/DATAUP-127

related to https://kbase-jira.atlassian.net/browse/DATAUP-116 (see also #1805 - tests are failing there because of this issue)

# Testing Instructions
Check the following:
- [x] Tests pass in travis and locally 

Can also be tested by including either Firefox or FirefoxHeadless in the list of browsers that karma uses.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
-  I have added tests that prove my fix is effective or that my feature works (N/A - the existing tests that were failing should be sufficient)
- [x] New and existing unit tests pass locally with my changes
- (N/A) Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

N/A