### PR TITLE
Update gitworkflow doc DATAUP-63

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ This is the repository for the KBase Narrative Interface.
 
 ***Table of Contents***
 
-- [About](#about)
-- [Installation](#installation)
-    - [Local Installation for Developers](#local-installation-for-developers)
-        - [Using a Conda Environment](#using-a-conda-environment)
-        - [Without Conda](#without-conda)
-- [Architecture](#architecture)
-- [Testing](#testing)
+  - [About](#branches-tags)
+  - [Installation](#local-installation-for-developers)
+    - [Local Installation for Developers](#pull-requests)
+      - [Using a Conda Environment](#using-a-conda-environment)
+      - [Without Conda](#without-conda)
+  - [Architecture](#realease-flow)
+  - [Testing](#testing)
     - [Manual Testing](#manual-testing)
-- [Submitting Code](#submitting-code)
+  - [Production Releases](#production-releases)
+    - [Submitting Code](#submitting-code)
 
 ## About
 
@@ -36,10 +37,10 @@ If you want to use the KBase Narrative Interface, just point your browser at htt
 Short version:
 Requires the following:
 
-- Python 3.6+
-- Anaconda/Miniconda as an environment manager (https://www.anaconda.com/)
-- Node.js (latest LTS recommended)
-- Bower 1.8.8+
+  - Python 3.6+
+  - Anaconda/Miniconda as an environment manager (<https://www.anaconda.com/>)
+  - Node.js (latest LTS recommended)
+  - Bower 1.8.8+
 
 ### *Using a Conda Environment*
 
@@ -104,9 +105,9 @@ Note: **DO NOT CHECK YOUR TOKEN FILE IN TO GITHUB**. You'll be shamed without me
 
 ### Manual Testing
 
-- It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
+  - It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
 
-- For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with `kbase-narrative`. You can print messages to the terminal using
+  - For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with `kbase-narrative`. You can print messages to the terminal using
 
 ```
 log = logging.getLogger("tornado.application")

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ If you want to use the KBase Narrative Interface, just point your browser at htt
 Short version:
 Requires the following:
 
-  - Python 3.6+
-  - Anaconda/Miniconda as an environment manager (<https://www.anaconda.com/>)
-  - Node.js (latest LTS recommended)
-  - Bower 1.8.8+
+- Python 3.6+
+- Anaconda/Miniconda as an environment manager (<https://www.anaconda.com/>)
+- Node.js (latest LTS recommended)
+- Bower 1.8.8+
 
 ### *Using a Conda Environment*
 
@@ -105,9 +105,9 @@ Note: **DO NOT CHECK YOUR TOKEN FILE IN TO GITHUB**. You'll be shamed without me
 
 ### Manual Testing
 
-  - It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
+- It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
 
-  - For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with `kbase-narrative`. You can print messages to the terminal using
+- For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with `kbase-narrative`. You can print messages to the terminal using
 
 ```
 log = logging.getLogger("tornado.application")

--- a/README.md
+++ b/README.md
@@ -10,14 +10,23 @@
 ***Table of Contents***
 
 - [About](#branches-tags)
+
 - [Installation](#local-installation-for-developers)
+
   - [Local Installation for Developers](#pull-requests)
+
     - [Using a Conda Environment](#using-a-conda-environment)
+
     - [Without Conda](#without-conda)
+
 - [Architecture](#realease-flow)
+
 - [Testing](#testing)
+
   - [Manual Testing](#manual-testing)
+
 - [Production Releases](#production-releases)
+
   - [Submitting Code](#submitting-code)
 
 ## About

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ This is the repository for the KBase Narrative Interface.
 
 - [About](#about)
 - [Installation](#installation)
-  - [Local Installation for Developers](#local-installation-for-developers)
-    - [Using a Conda Environment](#using-a-conda-environment)
-    - [Without Conda](#without-conda)
+    - [Local Installation for Developers](#local-installation-for-developers)
+        - [Using a Conda Environment](#using-a-conda-environment)
+        - [Without Conda](#without-conda)
 - [Architecture](#architecture)
 - [Testing](#testing)
-  - [Manual Testing](#manual-testing)
+    - [Manual Testing](#manual-testing)
 - [Submitting Code](#submitting-code)
 
 ## About
@@ -36,12 +36,12 @@ If you want to use the KBase Narrative Interface, just point your browser at htt
 Short version:
 Requires the following:
 
-* Python 3.6+
-* Anaconda/Miniconda as an environment manager (https://www.anaconda.com/)
-* Node.js (latest LTS recommended)
-* Bower 1.8.8+
+- Python 3.6+
+- Anaconda/Miniconda as an environment manager (https://www.anaconda.com/)
+- Node.js (latest LTS recommended)
+- Bower 1.8.8+
 
-### _Using a Conda Environment_
+### *Using a Conda Environment*
 
 This is the recommended method of installation!
 
@@ -65,7 +65,7 @@ sh scripts/install_narrative.sh
 kbase-narrative
 ```
 
-### _Without conda_
+### *Without conda*
 
 This process installs lots of requirements of specific versions and may clobber things on your PYTHONPATH.
 
@@ -92,9 +92,9 @@ When deployed in production, the Narrative Interface is compiled into a [Docker]
 
 Testing is composed of three components:
 
-* a `make test` directive that runs through a batch of unit-testing of the Narrative, both the front-end Javascript-based components, and the back-end IPython modifications
-* a `travis.yml` file for Travis-CI testing
-* a set of Selenium-based end-to-end tests that simulate browser interactions
+- a `make test` directive that runs through a batch of unit-testing of the Narrative, both the front-end Javascript-based components, and the back-end IPython modifications
+- a `travis.yml` file for Travis-CI testing
+- a set of Selenium-based end-to-end tests that simulate browser interactions
 
 Testing locally (i.e. not through Travis-CI) requires a local Narrative installation, with active virtualenv (if installed that way). Then just run `make test` or `make test-frontend-unit` or `make test-backend`. If you haven't changed any configuration, this will run unauthenticated tests and skip any tests that require authentication.
 
@@ -104,9 +104,9 @@ Note: **DO NOT CHECK YOUR TOKEN FILE IN TO GITHUB**. You'll be shamed without me
 
 ### Manual Testing
 
-* It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
+- It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
 
-* For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with kbase-narrative. You can print messages to the terminal using
+- For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with `kbase-narrative`. You can print messages to the terminal using
 
 ```
 log = logging.getLogger("tornado.application")

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - [About](#about)
 - [Installation](#installation)
-  - [Local Installation for Developers](#local-installation-for-developers)
+  - [Local Installation](#local-installation)
     - [Using a Conda Environment](#using-a-conda-environment)
     - [Without Conda](#without-conda)
 - [Architecture](#architecture)
@@ -30,7 +30,7 @@ This document contains links to various documentation in the [docs](docs) direct
 
 If you want to use the KBase Narrative Interface, just point your browser at https://narrative.kbase.us, make a free account, and jump in. This repo is only for people who wish to contribute to the development of the interface.
 
-### Local Installation for Developers
+### Local Installation
 
 Short version:
 Requires the following:

--- a/README.md
+++ b/README.md
@@ -7,24 +7,23 @@
 | master | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=master)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=master)](https://coveralls.io/r/kbase/narrative?branch=master) |
 | develop | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=develop)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=develop)](https://coveralls.io/r/kbase/narrative?branch=develop)|
 
-This is the repository for the KBase Narrative Interface.
-
 ***Table of Contents***
 
-  - [About](#branches-tags)
-  - [Installation](#local-installation-for-developers)
-    - [Local Installation for Developers](#pull-requests)
-      - [Using a Conda Environment](#using-a-conda-environment)
-      - [Without Conda](#without-conda)
-  - [Architecture](#realease-flow)
-  - [Testing](#testing)
-    - [Manual Testing](#manual-testing)
-  - [Production Releases](#production-releases)
-    - [Submitting Code](#submitting-code)
+- [About](#branches-tags)
+- [Installation](#local-installation-for-developers)
+  - [Local Installation for Developers](#pull-requests)
+    - [Using a Conda Environment](#using-a-conda-environment)
+    - [Without Conda](#without-conda)
+- [Architecture](#realease-flow)
+- [Testing](#testing)
+  - [Manual Testing](#manual-testing)
+- [Production Releases](#production-releases)
+  - [Submitting Code](#submitting-code)
 
 ## About
 
-The KBase Narrative Interface builds on the [Jupyter Notebook](http://jupyter.org) and contains elements to interact with various KBase tools and data stores.
+This is the repository for the KBase Narrative Interface.
+. The KBase Narrative Interface builds on the [Jupyter Notebook](http://jupyter.org) and contains elements to interact with various KBase tools and data stores.
 
 This document contains links to various documentation in the [docs](docs) directory, with a brief description of each.
 

--- a/README.md
+++ b/README.md
@@ -9,25 +9,16 @@
 
 ***Table of Contents***
 
--   [About](#branches-tags)
-
--   [Installation](#local-installation-for-developers)
-
-  -   [Local Installation for Developers](#pull-requests)
-
-    -   [Using a Conda Environment](#using-a-conda-environment)
-
-    -   [Without Conda](#without-conda)
-
--   [Architecture](#realease-flow)
-
--   [Testing](#testing)
-
-  -   [Manual Testing](#manual-testing)
-
--   [Production Releases](#production-releases)
-
-  -   [Submitting Code](#submitting-code)
+- [About](#branches-tags)
+- [Installation](#local-installation-for-developers)
+  - [Local Installation for Developers](#pull-requests)
+    - [Using a Conda Environment](#using-a-conda-environment)
+    - [Without Conda](#without-conda)
+- [Architecture](#realease-flow)
+- [Testing](#testing)
+  - [Manual Testing](#manual-testing)
+- [Production Releases](#production-releases)
+  - [Submitting Code](#submitting-code)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ***Table of Contents***
 
-- [About](#branches-tags)
+-   [About](#branches-tags)
 
 - [Installation](#local-installation-for-developers)
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@
 
 ***Table of Contents***
 
-- [About](#branches-tags)
-- [Installation](#local-installation-for-developers)
-  - [Local Installation for Developers](#pull-requests)
+- [About](#about)
+- [Installation](#installation)
+  - [Local Installation for Developers](#local-installation-for-developers)
     - [Using a Conda Environment](#using-a-conda-environment)
     - [Without Conda](#without-conda)
-- [Architecture](#realease-flow)
+- [Architecture](#architecture)
 - [Testing](#testing)
   - [Manual Testing](#manual-testing)
-- [Production Releases](#production-releases)
-  - [Submitting Code](#submitting-code)
+- [Submitting Code](#submitting-code)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -11,23 +11,23 @@
 
 -   [About](#branches-tags)
 
-- [Installation](#local-installation-for-developers)
+-   [Installation](#local-installation-for-developers)
 
-  - [Local Installation for Developers](#pull-requests)
+  -   [Local Installation for Developers](#pull-requests)
 
-    - [Using a Conda Environment](#using-a-conda-environment)
+    -   [Using a Conda Environment](#using-a-conda-environment)
 
-    - [Without Conda](#without-conda)
+    -   [Without Conda](#without-conda)
 
-- [Architecture](#realease-flow)
+-   [Architecture](#realease-flow)
 
-- [Testing](#testing)
+-   [Testing](#testing)
 
-  - [Manual Testing](#manual-testing)
+  -   [Manual Testing](#manual-testing)
 
-- [Production Releases](#production-releases)
+-   [Production Releases](#production-releases)
 
-  - [Submitting Code](#submitting-code)
+  -   [Submitting Code](#submitting-code)
 
 ## About
 
@@ -45,10 +45,10 @@ If you want to use the KBase Narrative Interface, just point your browser at htt
 Short version:
 Requires the following:
 
-- Python 3.6+
-- Anaconda/Miniconda as an environment manager (<https://www.anaconda.com/>)
-- Node.js (latest LTS recommended)
-- Bower 1.8.8+
+-   Python 3.6+
+-   Anaconda/Miniconda as an environment manager (<https://www.anaconda.com/>)
+-   Node.js (latest LTS recommended)
+-   Bower 1.8.8+
 
 ### *Using a Conda Environment*
 
@@ -113,9 +113,9 @@ Note: **DO NOT CHECK YOUR TOKEN FILE IN TO GITHUB**. You'll be shamed without me
 
 ### Manual Testing
 
-- It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
+-   It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
 
-- For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with `kbase-narrative`. You can print messages to the terminal using
+-   For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with `kbase-narrative`. You can print messages to the terminal using
 
 ```
 log = logging.getLogger("tornado.application")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@
 
 This is the repository for the KBase Narrative Interface.
 
+***Table of Contents***
+
+- [About](#about)
+- [Installation](#installation)
+  - [Local Installation for Developers](#local-installation-for-developers)
+    - [Using a Conda Environment](#using-a-conda-environment)
+    - [Without Conda](#without-conda)
+- [Architecture](#architecture)
+- [Testing](#testing)
+  - [Manual Testing](#manual-testing)
+- [Submitting Code](#submitting-code)
+
 ## About
 
 The KBase Narrative Interface builds on the [Jupyter Notebook](http://jupyter.org) and contains elements to interact with various KBase tools and data stores.
@@ -16,17 +28,23 @@ The KBase Narrative Interface builds on the [Jupyter Notebook](http://jupyter.or
 This document contains links to various documentation in the [docs](docs) directory, with a brief description of each.
 
 ## Installation
+
 If you want to use the KBase Narrative Interface, just point your browser at https://narrative.kbase.us, make a free account, and jump in. This repo is only for people who wish to contribute to the development of the interface.
 
-## Local Installation (for developers)
+### Local Installation for Developers
+
 Short version:
 Requires the following:
+
 * Python 3.6+
 * Anaconda/Miniconda as an environment manager (https://www.anaconda.com/)
 * Node.js (latest LTS recommended)
 * Bower 1.8.8+
 
-### Using a conda environment (recommended!)
+### _Using a Conda Environment_
+
+This is the recommended method of installation!
+
 ```
 git clone https://github.com/kbase/narrative
 cd narrative
@@ -35,19 +53,22 @@ conda activate my_narrative_environment
 ./scripts/install_narrative.sh
 kbase-narrative
 ```
+
 If the previous instructions do not work, try
+
 ```
 # source ~/anaconda3/bin/activate or wherever you have python installed
-conda create -n my_narrative_environment 
+conda create -n my_narrative_environment
 conda activate my_narrative_environment
 sh scripts/install_narrative.sh
 # scripts/install_narrative.sh
 kbase-narrative
 ```
 
+### _Without conda_
 
+This process installs lots of requirements of specific versions and may clobber things on your PYTHONPATH.
 
-### Or, without conda - this installs lots of requirements of specific versions and may clobber things on your PYTHONPATH.
 ```
 git clone https://github.com/kbase/narrative
 cd narrative
@@ -59,7 +80,7 @@ Long version: [Local Narrative setup](docs/install/local_install.md)
 
 ## Architecture
 
-### In progress!
+***In progress!***
 
 The Narrative sits on top of the Jupyter Notebook, so most of its architecture is a mirror of that. However, the Narrative's interaction with other KBase elements - namely the data stores and job running services - merits its own description. This will be ongoing (and evolving!), but a brief description of how a job gets run and registered is available here:
 
@@ -71,9 +92,9 @@ When deployed in production, the Narrative Interface is compiled into a [Docker]
 
 Testing is composed of three components:
 
-- a `make test` directive that runs through a batch of unit-testing of the Narrative, both the front-end Javascript-based components, and the back-end IPython modifications
-- a `travis.yml` file for Travis-CI testing
-- a set of Selenium-based end-to-end tests that simulate browser interactions
+* a `make test` directive that runs through a batch of unit-testing of the Narrative, both the front-end Javascript-based components, and the back-end IPython modifications
+* a `travis.yml` file for Travis-CI testing
+* a set of Selenium-based end-to-end tests that simulate browser interactions
 
 Testing locally (i.e. not through Travis-CI) requires a local Narrative installation, with active virtualenv (if installed that way). Then just run `make test` or `make test-frontend-unit` or `make test-backend`. If you haven't changed any configuration, this will run unauthenticated tests and skip any tests that require authentication.
 
@@ -81,11 +102,11 @@ To run authenticated tests, you'll need to get an auth token from KBase servers,
 
 Note: **DO NOT CHECK YOUR TOKEN FILE IN TO GITHUB**. You'll be shamed without mercy.
 
-## Manual Testing
+### Manual Testing
 
 * It can be useful to immediately see your changes in the narrative. For javascript changes, you will just have to reload the page. You can print messages to the console with `console.log`
 
-* For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with kbase-narrative. You can print messages to the terminal using 
+* For python changes, it will require shutting down the notebook, running `scripts/install_narrative.sh -u` and then starting the notebook server up again with kbase-narrative. You can print messages to the terminal using
 
 ```
 log = logging.getLogger("tornado.application")
@@ -94,6 +115,4 @@ log.info("Your Logs Go Here")
 
 ## Submitting code
 
-Ensure that tests pass (and add some for your changes), then submit a PR to the `develop` branch.
-
-This branch will eventually get merged to `master` where it is tagged and released to production.
+Follow the gitflow directions located at [docs/git-workflow.md](docs/git-workflow.md) to submit code to this repository.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # The KBase Narrative Interface
 
-<!-- [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kbase/narrative?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kbase/narrative?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 | Branch | Status |
 | :--- | :--- |
 | master | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=master)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=master)](https://coveralls.io/r/kbase/narrative?branch=master) |
-| develop | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=develop)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=develop)](https://coveralls.io/r/kbase/narrative?branch=develop)| -->
+| develop | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=develop)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=develop)](https://coveralls.io/r/kbase/narrative?branch=develop)|
 
 ***Table of Contents***
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # The KBase Narrative Interface
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kbase/narrative?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+<!-- [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kbase/narrative?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 | Branch | Status |
 | :--- | :--- |
 | master | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=master)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=master)](https://coveralls.io/r/kbase/narrative?branch=master) |
-| develop | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=develop)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=develop)](https://coveralls.io/r/kbase/narrative?branch=develop)|
+| develop | [![Build Status](https://travis-ci.org/kbase/narrative.svg?branch=develop)](https://travis-ci.org/kbase/narrative) [![Coverage Status](https://coveralls.io/repos/kbase/narrative/badge.svg?branch=develop)](https://coveralls.io/r/kbase/narrative?branch=develop)| -->
 
 ***Table of Contents***
 

--- a/docs/adrs/0001-git-workflow.md
+++ b/docs/adrs/0001-git-workflow.md
@@ -11,7 +11,7 @@ Developers on the narrative repository need to come into alignment on the git wo
 
 ## Status
 
-Pending
+Accepted
 
 ## Alternatives Considered
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -9,10 +9,10 @@ This document describes the git workflow that *all* developers of the narrative 
 - [Branches and Tags](#branches-tags)
 - [Contributing](#Contributing)
   - [Pull Requests](#pull-requests)
-- [Release Flows](#realease-flow)
+- [Release Flows](#release-flow)
   - [Development Releases](#development-releases)
   - [Production Releases](#production-releases)
-  - [Hotfix Releases](#hotfixes-releases)
+  - [Hotfix Releases](#hotfix-releases)
 
 ## Branches and Tags
 

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,36 +1,67 @@
 # Git branching workflow for narrative
 
-- Based on: http://drewfradette.ca/a-simpler-successful-git-branching-model/
-- Last modified: Dec. 11, 2014
+This document describes the git workflow that *all- developers of the narrative code must follow. It also describes the release procedure, which only an unlucky few should have to worry about.
 
-This document describes the git workflow that *all* developers of the narrative code must follow. It also describes the release procedure, which only an unlucky few should have to worry about.
+- Last modified: Aug. 31, 2020
+
+***Table of Contents***
+
+- [Branches and Tags](#branches-tags)
+- [Contributing](#Contributing)
+  - [Pull Requests](#pull-requests)
+- [Release Flows](#realease-flow)
+  - [Development Releases](#development-releases)
+  - [Production Releases](#production-releases)
+  - [Hotfix Releases](#hotfixes-releases)
 
 ## Branches and Tags
 
 There are 3 branches:
 
-* `develop` – Development branch. New features are added off this branch.
-* `staging` – Staging or "release candidate" branch. The branch deployed `narrative-dev`.
-* `master` – Production branch. The branch deployed on `narrative-next` and `narrative`. This branch is used for hotfixes.
+- `develop` – Development branch. New features are added off this branch.
+- `staging` – Staging or "release candidate" branch. The branch deployed `narrative-dev`.
+- `master` – Production branch. The branch deployed on `narrative-next` and `narrative`. This branch is used for hotfixes.
 
 Tags on master are used for indicating releases (see "Production releases", below).
 
-## Workflow
+## Contributing
+
+To contribute to this repository create a pull request for a new feature or issue.
+
+### Pull Requests
+
+#### _Internal Developers_
+
+To begin working on a feature or story, make sure you've assigned yourself to the story/issue in JIRA and marked it as "In Progress". If there isn't an story/issue yet for what you want to work on, please create one.
+
+Create a new branch off `develop` using the naming convention:
+
+`{your initials or username}-{summary}-{JIRA #}`
+
+For example: `jd-data-panel-button-112`
+
+When your branch is ready for review, open a PR into `develop` and request reviews from relevant team members. Address any failing tests, lint errors, PR feedback, etc. Once the work is approved, it will be merged.
+
+More detailed directions for the feature branch workflow are located on [Github](https://guides.github.com/introduction/flow/)
+
+#### _External 3rd Party Developers_
+
+External developers do not have write access to the repository. To create a pull request, fork the repository and submit a pull request from the fork. Instructions for how to fork a repository are located on [GitHub](https://guides.github.com/activities/forking/).
+
+## Release Flows
 
 There are three main workflows: development, production releases, and hotfixes.
 
-### Development
-
-To add a feature or fix a bug in development, work from the develop branch, i.e. create a new branch off develop and do a pull request when done (or directly push it back).
+### Development Releases
 
 Development "releases" to narrative-dev are done as follows:
 
-* Merge `develop` into `staging`
+- Merge `develop` into `staging`
 
         git pull origin develop staging
         git checkout staging; git merge develop
-        
-* Deploy new `staging` on narrative-dev
+
+- Deploy new `staging` on narrative-dev
 
 Because features should only be merged into develop after testing, and changes should not, in this mode, be made directly on `staging`, this can eventually be automated (e.g., run once per hour out of cron).
 
@@ -45,15 +76,15 @@ If the development mode is automated, turn off the automatic "merge", since you 
 
 Perform the final round of testing on `narrative-dev`:
 
-* Work in the `staging` branch, making bugfixes directly on this branch
+- Work in the `staging` branch, making bugfixes directly on this branch
 
         git checkout staging
         # bugfixes and testing
 
-* Test it.
-* Seriously, test it. This includes "stress" and "acceptance" tests.
- 
-Once you are satisfied that the `staging` branch is fit for production, you should commit any 
+- Test it.
+- Seriously, test it. This includes "stress" and "acceptance" tests.
+
+Once you are satisfied that the `staging` branch is fit for production, you should commit any
 changes you made:
 
     git commit -a # .. or whatever
@@ -61,32 +92,32 @@ changes you made:
 
 Now you will create the new release in `master`.
 
-* Merge the staging branch into the master branch.
+- Merge the staging branch into the master branch.
 
         git checkout master; git merge staging
 
-* Tag the master branch (using current version number).
+- Tag the master branch (using current version number).
 
         ver=`python -m biokbase.narrative.__init__`
         git tag -a "v$ver" -m "release version $ver"
 
-* Push the `master` branch, with tags, up to github
+- Push the `master` branch, with tags, up to github
 
         git push origin "v$ver"
 
-* Switch to the production host. Deploy on `narrative` using the newly created tag.
+- Switch to the production host. Deploy on `narrative` using the newly created tag.
 
         git checkout master
         # .. deploy ..
 
-### Hotfixes
+### Hotfix Releases
 
 Just in case something goes wrong, even after all that testing you did (cough!),
 here is how you "hotfix" the production release.
 
-* Create a hotfix branch based on the `master` branch
-* Commit your changes to the hotfix branch as necessary.
-* Merge the hotfix branch back into the master branch.
-* Create a new tag on the master branch. We use letters to signify a hotfix.
-* Build the production environment again with new hotfix tag.
-* Merge the master branch back into the develop branch.
+- Create a hotfix branch based on the `master` branch
+- Commit your changes to the hotfix branch as necessary.
+- Merge the hotfix branch back into the master branch.
+- Create a new tag on the master branch. We use letters to signify a hotfix.
+- Build the production environment again with new hotfix tag.
+- Merge the master branch back into the develop branch.

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -6,10 +6,10 @@ This document describes the git workflow that *all* developers of the narrative 
 
 ***Table of Contents***
 
-- [Branches and Tags](#branches-tags)
-- [Contributing](#Contributing)
+- [Branches and Tags](#branches-and-tags)
+- [Contributing](#contributing)
   - [Pull Requests](#pull-requests)
-- [Release Flows](#release-flow)
+- [Release Flows](#release-flows)
   - [Development Releases](#development-releases)
   - [Production Releases](#production-releases)
   - [Hotfix Releases](#hotfix-releases)

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,6 +1,6 @@
 # Git branching workflow for narrative
 
-This document describes the git workflow that *all- developers of the narrative code must follow. It also describes the release procedure, which only an unlucky few should have to worry about.
+This document describes the git workflow that *all* developers of the narrative code must follow. It also describes the release procedure, which only an unlucky few should have to worry about.
 
 - Last modified: Aug. 31, 2020
 
@@ -36,11 +36,11 @@ To begin working on a feature or story, make sure you've assigned yourself to th
 
 Create a new branch off `develop` using the naming convention:
 
-`{your initials or username}-{summary}-{JIRA #}`
+`{JIRA #}-{summary}`
 
-For example: `jd-data-panel-button-112`
+For example: `DATAUP-63-data_panel_button`
 
-When your branch is ready for review, open a PR into `develop` and request reviews from relevant team members. Address any failing tests, lint errors, PR feedback, etc. Once the work is approved, it will be merged.
+When your branch is ready for review, open a PR into develop. Address any lint errors or failing tests. Request reviews from relevant team members. Respond to PR feedback promptly, and request re-review once all issues have been resolved.
 
 More detailed directions for the feature branch workflow are located on [Github](https://guides.github.com/introduction/flow/)
 
@@ -84,8 +84,7 @@ Perform the final round of testing on `narrative-dev`:
 - Test it.
 - Seriously, test it. This includes "stress" and "acceptance" tests.
 
-Once you are satisfied that the `staging` branch is fit for production, you should commit any
-changes you made:
+Once you are satisfied that the `staging` branch is fit for production, you should commit any changes you made:
 
     git commit -a # .. or whatever
     git push


### PR DESCRIPTION
# Description of PR purpose/changes

This PR updates the narrative repo documentation to reflect the recent git workflow ADR. I also added a table of contents to the readme. This required editing some of the readme headers to work properly with markdown.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-63
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
