### PR TITLE
DATAUP-164 DATAUP-165 Update pull_request_template to reflect lint/black/precommit and add git precommit config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)
 
 # Updating Version and Release Notes (if applicable)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+      exclude: '.+Impl.py'
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: ''
+    hooks:
+    - id: flake8

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Requires the following:
 -   Node.js (latest LTS recommended)
 -   Bower 1.8.8+
 
+### Git Pre-commit installation
+
+Our git [pre-commit](https://pre-commit.com/#install) [hooks](/.pre-commit-config.yaml) allow you to run flake8 and black upon `git commit` and save you from having to run these linters manually.
+
+- change into the base directory
+- `pip install pre-commit`
+- `pre-commit install` to set up the git hook scripts
+- `pre-commit run --all-files` to test it out
+
+
 ### *Using a Conda Environment*
 
 This is the recommended method of installation!

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Our git [pre-commit](https://pre-commit.com/#install) [hooks](/.pre-commit-confi
 - change into the base directory
 - `pip install pre-commit`
 - `pre-commit install` to set up the git hook scripts
-- `pre-commit run --all-files` to test it out
+- edit a python file and `git commit -m <comment>` it in to test out the installation
 
 
 ### *Using a Conda Environment*

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -48,6 +48,12 @@ More detailed directions for the feature branch workflow are located on [Github]
 
 External developers do not have write access to the repository. To create a pull request, fork the repository and submit a pull request from the fork. Instructions for how to fork a repository are located on [GitHub](https://guides.github.com/activities/forking/).
 
+
+#### _Passing Flake8 and Black_
+
+In order to pass the build, flake8 and black must be run on the code. In order to avoid having to do so manually, use [git pre-commit](README.md#git-pre-commit-installation)
+
+
 ## Release Flows
 
 There are three main workflows: development, production releases, and hotfixes.


### PR DESCRIPTION
# Description of PR purpose/changes
In order to ease the burden on devs to run flake8 and black on each commit, we have instructions on how to automatically run these linters now added into the readme, as well as a dev checklist item

* List any dependencies that are required for this change.
It's possible we might need to update travis file if black changes it standards, and then the builds mysteriously start failing because of a new rule

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-164
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR:
``` 
* Install git precommit as per the instructions
* Attempt to check a file in
```
- [ ] Tests pass in travis and locally 

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
