### PR TITLE
DATAUP-128: First pass at adding support for a Truss tagged image build, based on branch named "truss"

### DIFF
--- a/.github/workflows/build_truss_pr.yaml
+++ b/.github/workflows/build_truss_pr.yaml
@@ -1,0 +1,27 @@
+---
+name: Build Truss Branch Image
+'on':
+  pull_request:
+    branches:
+    - truss
+    types:
+    - opened
+    - synchronize
+    - ready_for_review
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out GitHub Repo
+      if: github.event.pull_request.draft == false
+      with:
+        ref: "${{ github.event.pull_request.head.sha }}"
+      uses: actions/checkout@v2
+    - name: Build and Push to Packages
+      if: github.event.pull_request.draft == false
+      env:
+        PR: "${{ github.event.pull_request.number }}"
+        SHA: "${{ github.event.pull_request.head.sha }}"
+        DOCKER_ACTOR: "jsfillman"
+        DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
+      run: "./.github/workflows/scripts/build_truss_pr.sh\n"

--- a/.github/workflows/scripts/build_truss_pr.sh
+++ b/.github/workflows/scripts/build_truss_pr.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+export MY_ORG=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $1}')
+export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-truss")
+export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+export COMMIT=$(echo "$SHA" | cut -c -7)
+
+echo $DOCKER_TOKEN | docker login ghcr.io -u $DOCKER_ACTOR --password-stdin
+docker build --build-arg BUILD_DATE="$DATE" \
+             --build-arg COMMIT="$COMMIT" \
+             --build-arg BRANCH="$GITHUB_HEAD_REF" \
+             --build-arg PULL_REQUEST="$PR" \
+             --label us.kbase.vcs-pull-req="$PR" \
+             -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+	

--- a/.github/workflows/scripts/tag_truss_latest.sh
+++ b/.github/workflows/scripts/tag_truss_latest.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+export MY_ORG=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $1}')
+export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-truss")
+export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+export COMMIT=$(echo "$SHA" | cut -c -7)
+
+docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
+docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"

--- a/.github/workflows/tag_truss_latest.yaml
+++ b/.github/workflows/tag_truss_latest.yaml
@@ -1,0 +1,26 @@
+---
+name: Tag Latest Test Image
+'on':
+  pull_request:
+    branches:
+    - truss
+    types:
+    - closed
+jobs:
+  docker_tag:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out GitHub Repo
+      if: github.event_name == 'pull_request' && github.event.action == 'closed' &&
+        github.event.pull_request.merged == true
+      with:
+        ref: "${{ github.event.pull_request.head.sha }}"
+      uses: actions/checkout@v2
+    - name: Build and Push to Packages
+      if: github.event.pull_request.draft == false
+      env:
+        PR: "${{ github.event.pull_request.number }}"
+        SHA: "${{ github.event.pull_request.head.sha }}"
+        DOCKER_ACTOR: "jsfillman"
+        DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
+      run: "./.github/workflows/scripts/tag_truss_latest.sh\n"

--- a/docs/deploy_narrative.md
+++ b/docs/deploy_narrative.md
@@ -2,7 +2,7 @@
 
 This document describes how to release and deploy the Narrative Interface app onto the different KBase environments. It's intended for KBase developers and admins.
 
-- Last modified: Sep. 25, 2020
+- Last modified: Oct. 2, 2020
 
 **_Table of Contents_**
 
@@ -73,6 +73,10 @@ To see your changes once the new image is created, simply open a narrative on CI
 
 The [next](https://next.kbase.us), [appdev](https://appdev.kbase.us), and [prod](https://narrative.kbase.us) environments are all deployed using a production image. 
 
+### Deploying Narrative-Refactor
+
+The [narrative-refactor](https://narrative-refactor.kbase.us) image is built against the "truss" branch of the repo and is called narrative-truss:pr### when still in a PR state or narrative-truss:latest after merge
+
 #### Create Release Image
 
 1.  Create a new [pull request](https://github.com/kbase/narrative/compare) to merge the `develop` branch into `master`.
@@ -105,6 +109,7 @@ Once a pull request is merged from `develop` to `master` a new _production_ imag
 | Environment | Image URL                                                      |
 | ----------- | -------------------------------------------------------------- |
 | CI          | ghcr.io/kbase/narrative-develop:latest |
+| Narrative-refactor| ghcr.io/kbase/narrative-truss:latest |
 | Appdev      | ghcr.io/kbase/narrative:appdev         |
 | Next        | ghcr.io/kbase/narrative:next           |
 | Production  | ghcr.io/kbase/narrative:prod           |


### PR DESCRIPTION
# Description of PR purpose/changes

* Adds several new configs and shell scripts that run via github actions to support a new narrative-truss image that is build from a branch named "truss". This is intended for testing on narrative-refactor.kbase.us
* We want to keep a parallel test/integration environment for the Truss bulk import/analysis work, instead of having to deploy into CI for testing.
* We may need some help from Jason Fillman for setting permissions in case we missed something. These edits were tested in the narrative-traefiker repo and worked properly.

# Jira Ticket / Issue #
- [x] https://kbase-jira.atlassian.net/browse/DATAUP-128

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_ (N/A)
- [ ] Will need to see if the github actions complete without error after the merge (must merge first)
- [ ] Create a new branch called "truss" and make a trivial PR against it, this should result in a new narrative-truss:PR-### being built and visible at https://github.com/orgs/kbase/packages. Upon merge, a narrative-truss:latest should be available

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
