### PR TITLE
DATAUP-231 webdriverio example

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,13 @@
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {
+    "@wdio/cli": "^6.6.0",
+    "@wdio/local-runner": "^6.6.0",
+    "@wdio/mocha-framework": "^6.6.0",
+    "@wdio/spec-reporter": "^6.6.0",
+    "@wdio/sync": "^6.6.0",
     "bower": "^1.8.8",
-    "geckodriver": "^1.20.0",
+    "chromedriver": "^86.0.0",
     "grunt": "1.3.0",
     "grunt-cli": "1.3.2",
     "grunt-contrib-copy": "1.0.0",
@@ -34,14 +39,18 @@
     "puppeteer": "5.3.0",
     "requirejs": "2.3.6",
     "selenium-standalone": "6.20.0",
-    "selenium-webdriver": "3.6.0",
+    "selenium-webdriver": "^3.6.0",
     "string.prototype.endswith": "1.0.0",
-    "string.prototype.startswith": "1.0.0"
+    "string.prototype.startswith": "1.0.0",
+    "wdio-chromedriver-service": "^6.0.4",
+    "webdriverio": "^6.6.0"
   },
   "scripts": {
     "bower": "bower install",
     "test": "grunt test",
     "build": "grunt build"
   },
-  "dependencies": {}
+  "dependencies": {
+    "chrome-launcher": "^0.13.4"
+  }
 }

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,10 @@
+# Quick webdriverio overview and instructions.
+
+1. `npm install` to get webdriverio (wdio) dependencies installed
+2. Add your CI token to `test/integration/wdio.conf.js` under the `kbaseToken` key at the top of the file.
+3. From the root of the repo, run `npx wdio test/integration/wdio.conf.js` (if this is accepted, we can move that to a make target, a la `make test-integration`)
+
+## For more reading:
+* https://webdriver.io/ - overview of the project
+* https://webdriver.io/docs/browserobject.html - how to use the browser object
+* https://github.com/kbase/kbase-ui/tree/develop/src/test/integration-tests/specs - for wdio usage in kbase-ui. specifically, `theSpec.js` is the entrypoint (and invoked by the Makefile, which in turn calls grunt). This is somewhat more complicated as all tests are defined in yaml files, mostly provided by kbase-ui plugins. But it's wdio underneath.

--- a/test/integration/specs/narrative_basic_test.js
+++ b/test/integration/specs/narrative_basic_test.js
@@ -1,0 +1,35 @@
+/*global describe, it, browser, expect, $, afterEach*/
+describe('Narrative tree page with login', () => {
+    'use strict';
+    const userToken = browser.config.kbaseToken;
+
+    afterEach(() => {
+        browser.deleteCookies();
+    });
+
+    // async version
+    it('should open the narrative tree page', async () => {
+        await browser.url('http://localhost:8888/narrative/tree');
+        await expect(browser).toHaveTitle('KBase Narrative');
+    });
+
+    // sync version
+    it('sets the user token', () => {
+        browser.url('http://localhost:8888/narrative/tree');
+        $('.form-control').setValue(userToken);
+
+        // find an anchor element with text = OK and click on it
+        $('=OK').click();
+        expect(browser.getCookies(['kbase_session'])[0].value).toBe(userToken);
+    });
+
+    it('opens a narrative', () => {
+        browser.url('http://localhost:8888/narrative/tree');
+        $('.form-control').setValue(userToken);
+        $('=OK').click();
+        browser.pause(1000);
+        $('span*=ProkkaTest').click();
+        browser.switchWindow('http://localhost:8888/narrative/notebooks/ws.31932.obj.1');
+        expect($('nav[id="header"]').isDisplayed()).toBeTruthy();
+    });
+});

--- a/test/integration/wdio.conf.js
+++ b/test/integration/wdio.conf.js
@@ -1,0 +1,272 @@
+exports.config = {
+    kbaseToken: 'your-token-here',
+    //
+    // ====================
+    // Runner Configuration
+    // ====================
+    //
+    // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
+    // on a remote machine).
+    runner: 'local',
+    //
+    // ==================
+    // Specify Test Files
+    // ==================
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
+    //
+    specs: [
+        './test/integration/specs/**/*.js'
+    ],
+    // Patterns to exclude.
+    exclude: [
+        // 'path/to/excluded/files'
+    ],
+    //
+    // ============
+    // Capabilities
+    // ============
+    // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+    // time. Depending on the number of capabilities, WebdriverIO launches several test
+    // sessions. Within your capabilities you can overwrite the spec and exclude options in
+    // order to group specific specs to a specific capability.
+    //
+    // First, you can define how many instances should be started at the same time. Let's
+    // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+    // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+    // files and you set maxInstances to 10, all spec files will get tested at the same time
+    // and 30 processes will get spawned. The property handles how many capabilities
+    // from the same test should run tests.
+    //
+    maxInstances: 10,
+    //
+    // If you have trouble getting all important capabilities together, check out the
+    // Sauce Labs platform configurator - a great tool to configure your capabilities:
+    // https://docs.saucelabs.com/reference/platforms-configurator
+    //
+    capabilities: [{
+
+        // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+        // grid with only 5 firefox instances available you can make sure that not more than
+        // 5 instances get started at a time.
+        maxInstances: 5,
+        //
+        browserName: 'chrome',
+        acceptInsecureCerts: true
+        // If outputDir is provided WebdriverIO can capture driver session logs
+        // it is possible to configure which logTypes to include/exclude.
+        // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+        // excludeDriverLogs: ['bugreport', 'server'],
+    }],
+    //
+    // ===================
+    // Test Configurations
+    // ===================
+    // Define all options that are relevant for the WebdriverIO instance here
+    //
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    logLevel: 'info',
+    //
+    // Set specific log levels per logger
+    // loggers:
+    // - webdriver, webdriverio
+    // - @wdio/applitools-service, @wdio/browserstack-service, @wdio/devtools-service, @wdio/sauce-service
+    // - @wdio/mocha-framework, @wdio/jasmine-framework
+    // - @wdio/local-runner, @wdio/lambda-runner
+    // - @wdio/sumologic-reporter
+    // - @wdio/cli, @wdio/config, @wdio/sync, @wdio/utils
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    // logLevels: {
+    //     webdriver: 'info',
+    //     '@wdio/applitools-service': 'info'
+    // },
+    //
+    // If you only want to run your tests until a specific amount of tests have failed use
+    // bail (default is 0 - don't bail, run all tests).
+    bail: 0,
+    //
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
+    baseUrl: 'http://localhost',
+    //
+    // Default timeout for all waitFor* commands.
+    waitforTimeout: 10000,
+    //
+    // Default timeout in milliseconds for request
+    // if browser driver or grid doesn't send response
+    connectionRetryTimeout: 120000,
+    //
+    // Default request retries count
+    connectionRetryCount: 3,
+    //
+    // Test runner services
+    // Services take over a specific job you don't want to take care of. They enhance
+    // your test setup with almost no effort. Unlike plugins, they don't add new
+    // commands. Instead, they hook themselves up into the test process.
+    services: ['chromedriver'],
+
+    // Framework you want to run your specs with.
+    // The following are supported: Mocha, Jasmine, and Cucumber
+    // see also: https://webdriver.io/docs/frameworks.html
+    //
+    // Make sure you have the wdio adapter package for the specific framework installed
+    // before running any tests.
+    framework: 'mocha',
+    //
+    // The number of times to retry the entire specfile when it fails as a whole
+    // specFileRetries: 1,
+    //
+    // Delay in seconds between the spec file retry attempts
+    // specFileRetriesDelay: 0,
+    //
+    // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
+    // specFileRetriesDeferred: false,
+    //
+    // Test reporter for stdout.
+    // The only one supported by default is 'dot'
+    // see also: https://webdriver.io/docs/dot-reporter.html
+    reporters: ['spec'],
+
+
+
+    //
+    // Options to be passed to Mocha.
+    // See the full list at http://mochajs.org/
+    mochaOpts: {
+        ui: 'bdd',
+        timeout: 60000
+    },
+    //
+    // =====
+    // Hooks
+    // =====
+    // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+    // it and to build services around it. You can either apply a single function or an array of
+    // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+    // resolved to continue.
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
+    // onPrepare: function (config, capabilities) {
+    // },
+    /**
+     * Gets executed before a worker process is spawned and can be used to initialise specific service
+     * for that worker as well as modify runtime environments in an async fashion.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    // onWorkerStart: function (cid, caps, specs, args, execArgv) {
+    // },
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // beforeSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // before: function (capabilities, specs) {
+    // },
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
+    // beforeCommand: function (commandName, args) {
+    // },
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
+    // beforeSuite: function (suite) {
+    // },
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) starts.
+     */
+    // beforeTest: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
+    // beforeHook: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
+    // afterHook: function (test, context, { error, result, duration, passed, retries }) {
+    // },
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine).
+     */
+    // afterTest: function(test, context, { error, result, duration, passed, retries }) {
+    // },
+
+
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
+    // afterSuite: function (suite) {
+    // },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
+    // afterCommand: function (commandName, args, result, error) {
+    // },
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // after: function (result, capabilities, specs) {
+    // },
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // afterSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. An error
+     * thrown in the onComplete hook will result in the test run failing.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {<Object>} results object containing test results
+     */
+    // onComplete: function(exitCode, config, capabilities, results) {
+    // },
+    /**
+    * Gets executed when a refresh happens.
+    * @param {String} oldSessionId session ID of the old session
+    * @param {String} newSessionId session ID of the new session
+    */
+    //onReload: function(oldSessionId, newSessionId) {
+    //}
+}


### PR DESCRIPTION
# Description of PR purpose/changes

In contrast with #1830 , this PR gives an example of using [webdriverio](https://webdriver.io) to run tests. This is built on Selenium and uses the WebDriver control mechanisms. Selenium was a bear to set up and make consistent with other things in the narrative repo. Also, wdio is currently used in the https://github.com/kbase/kbase-ui repo.

To set up:
* `npm install` to get dependencies
* edit `test/integration/wdio.conf.js` to add a CI auth token to the `kbaseToken` key
* run tests with `npx wdio test/integration/wdio.conf.js`. The drivers are very very version specific and will want Chrome v86.

This isn't necessarily meant to be merged, but as a discussion to contrast with #1830 that @eamahanna kindly provided. The goal here is to finish up the integration test framework ADR from #1832.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: see above
- (n/a) Tests pass in travis and locally 
- (n/a) Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
