### PR TITLE
DATAUP-187 Review edits

### DIFF
--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -3270,6 +3270,11 @@ button.kb-data-obj {
   border: none;
 }
 
+.ftp-file-header {
+  margin-bottom: 5px;
+  margin-top: 8px;
+}
+
 .kb-import-content .upload-options button {
   background: #fff;
   border: 1px solid #c4c4c4;

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -3275,6 +3275,10 @@ button.kb-data-obj {
   margin-top: 8px;
 }
 
+.globus-link:hover {
+  text-decoration: none;
+}
+
 .kb-import-content .upload-options button {
   background: #fff;
   border: 1px solid #c4c4c4;

--- a/kbase-extension/static/kbase/templates/data_staging/ftp_file_header.html
+++ b/kbase-extension/static/kbase/templates/data_staging/ftp_file_header.html
@@ -3,11 +3,11 @@
         <div class="upload-options">
             Other ways to upload:
             {{#if userInfo.globusLinked}}
-                <a id="globusLinked" class="globus_acl_link" href="{{globusUrl}}" target="_blank" aria-label="opens new window to upload via globus">
+                <a id="globusLinked" class="globus_acl_link globus-link" href="{{globusUrl}}" target="_blank" aria-label="opens new window to upload via globus">
                     <button tabindex="-1" class="globus_linked">Upload with Globus</button>
                 </a>
             {{else}}
-                <a id="globusNotLinked" href="https://docs.kbase.us/data/globus" rel="noopener noreferrer" target="_blank"  aria-label="opens new window to kbase globus upload docs">
+                <a id="globusNotLinked" class="globus-link" href="https://docs.kbase.us/data/globus" rel="noopener noreferrer" target="_blank"  aria-label="opens new window to kbase globus upload docs">
                     <button tabindex="-1" class="globus_not_linked">Upload with Globus</button>
                 </a>
             {{/if}}

--- a/kbase-extension/static/kbase/templates/data_staging/ftp_file_header.html
+++ b/kbase-extension/static/kbase/templates/data_staging/ftp_file_header.html
@@ -1,15 +1,15 @@
-<div class="row" style="margin-bottom: 5px">
+<div class="row ftp-file-header">
     <div class="pull-left">
         <div class="upload-options">
             Other ways to upload:
             {{#if userInfo.globusLinked}}
-            <button class="globus_linked">
-                <a class="globus_acl_link" href="{{globusUrl}}" target="_blank" aria-label="opens new window to upload via globus">Upload with Globus</a>
-            </button>
+                <a id="globusLinked" class="globus_acl_link" href="{{globusUrl}}" target="_blank" aria-label="opens new window to upload via globus">
+                    <button tabindex="-1" class="globus_linked">Upload with Globus</button>
+                </a>
             {{else}}
-            <button class="globus_not_linked">
-                <a href="https://docs.kbase.us/data/globus" rel="noopener noreferrer" target="_blank"  aria-label="opens new window to kbase globus upload docs">Upload with Globus</a>
-            </button>
+                <a id="globusNotLinked" href="https://docs.kbase.us/data/globus" rel="noopener noreferrer" target="_blank"  aria-label="opens new window to kbase globus upload docs">
+                    <button tabindex="-1" class="globus_not_linked">Upload with Globus</button>
+                </a>
             {{/if}}
             <button class="web_upload_div">Upload with URL</button>
         </div>

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -100,27 +100,28 @@ define ([
                 });
             await linkedStagingViewer.render()
                 .then(() => {
-                    var $globusButton = $node.find('.globus_linked');
+                    var $globusButton = $node.find('#globusLinkedLink');
+                    console.log("LINKED BUTTON HTML: ", $globusButton.html())
                     expect($globusButton).toBeDefined();
                     expect($globusButton.html()).toContain('Upload with Globus');
-                    expect($globusButton.html()).toContain('https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&amp;destination_path=' + fakeUser);
+                    expect($globusButton).toContain('https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&amp;destination_path=' + fakeUser);
                     done();
                 });
         });
 
         it('Should render properly without a Globus linked account', async () => {
             await stagingViewer.render();
-            var $globusButton = $targetNode.find('.globus_not_linked');
+            var $globusButton = $targetNode.find('.globusNotLinkedLink');
             expect($globusButton).toBeDefined();
             expect($globusButton.html()).toContain('Upload with Globus');
-            expect($globusButton.html()).toContain('https://docs.kbase.us/data/globus');
+            expect($globusButton).toContain('https://docs.kbase.us/data/globus');
         });
 
         it('Should render a url button', async () => {
             await stagingViewer.render();
             var $urlButton = $targetNode.find('.web_upload_div');
             expect($urlButton).toBeDefined();
-            expect($urlButton.html()).toContain('Upload with URL');
+            expect($urlButton.html().toContain('Upload with URL');
         });
 
 

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -103,7 +103,7 @@ define ([
                     var $globusButton = $node.find('#globusLinked');
                     expect($globusButton).toBeDefined();
                     expect($globusButton.html()).toContain('Upload with Globus');
-                    expect($globusButton).toContain('https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&amp;destination_path=' + fakeUser);
+                    expect($globusButton.attr('href')).toEqual('https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&destination_path=' + fakeUser);
                     done();
                 });
         });
@@ -113,7 +113,7 @@ define ([
             var $globusButton = $targetNode.find('#globusNotLinked');
             expect($globusButton).toBeDefined();
             expect($globusButton.html()).toContain('Upload with Globus');
-            expect($globusButton).toContain('https://docs.kbase.us/data/globus');
+            expect($globusButton.attr('href')).toEqual('https://docs.kbase.us/data/globus');
         });
 
         it('Should render a url button', async () => {

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -100,8 +100,7 @@ define ([
                 });
             await linkedStagingViewer.render()
                 .then(() => {
-                    var $globusButton = $node.find('#globusLinkedLink');
-                    console.log("LINKED BUTTON HTML: ", $globusButton.html())
+                    var $globusButton = $node.find('#globusLinked');
                     expect($globusButton).toBeDefined();
                     expect($globusButton.html()).toContain('Upload with Globus');
                     expect($globusButton).toContain('https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&amp;destination_path=' + fakeUser);
@@ -111,7 +110,7 @@ define ([
 
         it('Should render properly without a Globus linked account', async () => {
             await stagingViewer.render();
-            var $globusButton = $targetNode.find('.globusNotLinkedLink');
+            var $globusButton = $targetNode.find('#globusNotLinked');
             expect($globusButton).toBeDefined();
             expect($globusButton.html()).toContain('Upload with Globus');
             expect($globusButton).toContain('https://docs.kbase.us/data/globus');
@@ -121,7 +120,7 @@ define ([
             await stagingViewer.render();
             var $urlButton = $targetNode.find('.web_upload_div');
             expect($urlButton).toBeDefined();
-            expect($urlButton.html().toContain('Upload with URL');
+            expect($urlButton.html()).toContain('Upload with URL');
         });
 
 


### PR DESCRIPTION
# Description of PR purpose/changes

This PR is to address the comments from Mallory: 
_"Was making the globus button text blue and underline on hover intentional? Was this to combat the a11y issue? If it was not intentional, can we style it so it matches the other button?

Can we add an 8px margin to this row so it has just a little bit more breathing room?"_

To address accessibility, I wrapped the button with an anchor tag and made the button non-keyboard navigable. This provides the benefit of the globus button looking correct while also maintaining typical link functionality with keyboard navigation and screen readers.  

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-187
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Execute `make test-frontend-unit`
* To view the changes locally, execute `kbase-narrative`, open a new narrative, and navigate to the import panel. The row for the buttons now has a top margin of 8px and the buttons are keyboard (click in the import area first then use keyboard to navigate) and screen reader accessible.

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
