### PR TITLE
Dataup 209 fix error msg cutoff

### DIFF
--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -102,15 +102,22 @@
   margin-left: 5px;
 }
 
-.dz-file__icon {
-  margin: 0 2px 0 2px;
+.dz-file__status {
   display: none;
   font-weight: bold;
   align-items: center;
 }
 
-.dz-file__icon__success {
+.dz-file__status__icon {
+  margin: 0 4px 0 8px;
+}
+
+.dz-file__status__success {
   color: #4BAF4F;
+}
+
+.dz-file__status__error {
+  color: #DF0002;
 }
 
 #kb-data-staging-table_wrapper {

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -65,13 +65,15 @@
 }
 
 .dz-file {
-  width:100%;
+  width: 100%;
   border: 1px solid #EEEEEE;
-  margin: 2px 0px;
-  padding: 5px 0px;
-  font-family: Oxygen, Arial, sans-serif;
-  font-style: normal;
-  font-size: 16px;
+  margin: 2px 0;
+  padding: 5px 0;
+  font: normal, 16px, Oxygen, Arial, sans-serif;
+}
+
+.dz-file__progress__bar {
+  width: 0;
 }
 
 .dz-file__row {

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -17,7 +17,7 @@
   margin: 2em 4.5em;
 }
 
-.text-button {
+.btn__text {
     background: #FFFFFF;
     box-sizing: border-box;
     border-radius: 4px;
@@ -35,26 +35,26 @@
     height: 34px;
 }
 
-.text-button:hover {
+.btn__text:hover {
     color: #36618E;
     border: 1px solid #ECF2F7;
     background-color: #ECF2F7;
     cursor: pointer;
 }
 
-.text-button:focus {
+.btn__text:focus {
     color: #36618E;
     border: 1px solid #E3EBF3;
     background-color: #E3EBF3;
 }
 
-.text-button:active {
+.btn__text:active {
     color: #36618E;
     border: 1px solid #D9E4EF;
     background-color: #D9E4EF;
 }
 
-.text-button:disabled {
+.btn__text:disabled {
     color: #929292;
     border: 1px solid #FAFAFA;
     background-color: #FAFAFA;
@@ -62,6 +62,50 @@
 
 .clear-all-dropzone {
     margin: 6px;
+}
+
+.dz-file {
+  width:100%;
+  border: 1px solid #EEEEEE;
+  margin: 2px 0px;
+  padding: 5px 0px;
+  font-family: Oxygen, Arial, sans-serif;
+  font-style: normal;
+  font-size: 16px;
+}
+
+
+.dz-file__name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 20px;
+}
+
+.dz-file__msg {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 14px;
+}
+
+.dz-file__msg__success {
+  display:none;
+  color: #4BAF4F;
+}
+
+.dz-file__progress__bar {
+  margin-bottom: inherit;
+  margin-left: 5px;
+}
+
+.dz-file__icon {
+  margin: 5px;
+  display: none;
+  font-weight: bold;
+}
+
+.dz-file__icon__success {
+  color: #4BAF4F;
 }
 
 #kb-data-staging-table_wrapper {

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -74,6 +74,10 @@
   font-size: 16px;
 }
 
+.dz-file__row {
+  display: flex;
+  align-items: center;
+}
 
 .dz-file__name {
   white-space: nowrap;
@@ -99,9 +103,10 @@
 }
 
 .dz-file__icon {
-  margin: 5px;
+  margin: 0 2px 0 2px;
   display: none;
   font-weight: bold;
+  align-items: center;
 }
 
 .dz-file__icon__success {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -95,7 +95,7 @@ define([
                 })
                 .on('success', (file, serverResponse) => {
                     var $successElem = $(file.previewElement);
-                    $successElem.find('#upload_progress_and_cancel').remove();
+                    $successElem.find('#upload_progress_and_cancel').hide();
                     $successElem.find('#dz_file_row_1').css({"display": "flex", "align-items": "center"});
                     $successElem.find('#success_icon').css('display', 'flex');
                     $successElem.find('#success_message').css('display', 'inline');
@@ -129,7 +129,7 @@ define([
                 })
                 .on('error', (erroredFile) => {
                     var $errorElem = $(erroredFile.previewElement);
-                    $errorElem.find('#upload_progress_and_cancel').remove();
+                    $errorElem.find('#upload_progress_and_cancel').hide();
                     $errorElem.find('#dz_file_row_1').css({"display": "flex", "align-items": "center"});
                     $errorElem.css('color', '#DF0002');
                     $errorElem.find('#error_icon').css('display', 'flex');

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -96,7 +96,7 @@ define([
                 .on('success', (file, serverResponse) => {
                     var $successElem = $(file.previewElement);
                     $successElem.find('#upload_progress_and_cancel').hide();
-                    $successElem.find('#dz_file_row_1').css({"display": "flex", "align-items": "center"});
+                    $successElem.find('#dz_file_row_1').css({'display': 'flex', 'align-items': 'center'});
                     $successElem.find('#success_icon').css('display', 'flex');
                     $successElem.find('#success_message').css('display', 'inline');
                     $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -173,8 +173,8 @@ define([
         },
 
         removeProgressBar: function($dropzoneElem) {
-            if (this.dropzone.getQueuedFiles().length === 0 &&
-            this.dropzone.getUploadingFiles().length === 0) {
+            if (!this.dropzone.getQueuedFiles().length &&
+            !this.dropzone.getUploadingFiles().length) {
                 $($dropzoneElem.find('#total-progress')).fadeOut(1000, function() {
                     $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0'});
                 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -125,7 +125,7 @@ define([
                     $('#clear-all-btn-container').remove();
                     $('#clear-all-btn').remove();
                     $dropzoneElem.find('#global-info').css({'display': 'none'});
-                    $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0%'});
+                    $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0'});
                 })
                 .on('error', (erroredFile) => {
                     var $errorElem = $(erroredFile.previewElement);
@@ -176,7 +176,7 @@ define([
             if (this.dropzone.getQueuedFiles().length === 0 &&
             this.dropzone.getUploadingFiles().length === 0) {
                 $($dropzoneElem.find('#total-progress')).fadeOut(1000, function() {
-                    $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0%'});
+                    $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0'});
                 });
             }
         },

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -130,7 +130,7 @@ define([
                 .on('error', (erroredFile) => {
                     var $errorElem = $(erroredFile.previewElement);
                     $errorElem.find('#upload_progress_and_cancel').hide();
-                    $errorElem.find('#dz_file_row_1').css({"display": "flex", "align-items": "center"});
+                    $errorElem.find('#dz_file_row_1').css({'display': 'flex', 'align-items': 'center'});
                     $errorElem.css('color', '#DF0002');
                     $errorElem.find('#error_icon').css('display', 'flex');
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -85,6 +85,13 @@ define([
                     $dropzoneElem.find('#global-info').css({'display': 'inline'});
                     $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());
 
+                    // If there is a button already in the area, it has to be removed,
+                    // and appened to the new document when additional errored files are added.
+                    if ($dropzoneElem.find('#clear-all-btn').length){
+                        this.deleteClearAllButton();
+                        $dropzoneElem.append(this.makeClearAllButton());
+                    }
+
                 })
                 .on('success', (file, serverResponse) => {
                     $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());
@@ -93,12 +100,8 @@ define([
                     file.previewElement.querySelector('#status-message').style.display = 'inline';
                     $(file.previewElement.querySelector('.fa-ban')).removeClass('fa-ban').addClass('fa-check');
                     $(file.previewElement.querySelector('.btn-danger')).removeClass('btn-danger').addClass('btn-success');
-                    if (this.dropzone.getQueuedFiles().length === 0 &&
-                        this.dropzone.getUploadingFiles().length === 0) {
-                        $($dropzoneElem.find('#total-progress')).fadeOut(1000, function() {
-                            $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0%'});
-                        });
-                    }
+
+                    this.removeProgressBar($dropzoneElem);
                     $(file.previewElement).fadeOut(1000, function() {
                         $(file.previewElement.querySelector('.btn')).trigger('click');
                     });
@@ -124,21 +127,17 @@ define([
                     $dropzoneElem.find('#global-info').css({'display': 'none'});
                     $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0%'});
                 })
-                .on('error', (err) => {
+                .on('error', (erroredFile) => {
+                    this.removeProgressBar($dropzoneElem);
                     let errorText = 'unable to upload file!';
-                    if (err && err.xhr && err.xhr.responseText) {
-                        errorText = err.xhr.responseText;
+                    if (erroredFile && erroredFile.xhr && erroredFile.xhr.responseText) {
+                        errorText = erroredFile.xhr.responseText;
                     }
                     $dropzoneElem.find('.error.text-danger').text('Error: ' + errorText);
+                    $dropzoneElem.find('#upload_progress_and_cancel').remove();
 
                     // Check to see if there already a button in the dropzone area
                     if (!$dropzoneElem.find('#clear-all-btn').length){
-                        $dropzoneElem.append(this.makeClearAllButton());
-
-                    } else {
-                        // If there is a button already in the area, it has to be removed,
-                        // and appened to the new document when additional errored files are added.
-                        this.deleteClearAllButton();
                         $dropzoneElem.append(this.makeClearAllButton());
                     }
                 });
@@ -166,6 +165,15 @@ define([
         deleteClearAllButton: function() {
             $('#clear-all-btn-container').remove();
             $('#clear-all-btn').remove();
+        },
+
+        removeProgressBar: function($dropzoneElem) {
+            if (this.dropzone.getQueuedFiles().length === 0 &&
+            this.dropzone.getUploadingFiles().length === 0) {
+                $($dropzoneElem.find('#total-progress')).fadeOut(1000, function() {
+                    $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0%'});
+                });
+            }
         },
 
         makeUploadMessage: function() {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -96,7 +96,7 @@ define([
                 .on('success', (file, serverResponse) => {
                     var $successElem = $(file.previewElement);
                     $successElem.find('#upload_progress_and_cancel').remove();
-                    $successElem.find('#dz_file_row_1'.css({"display": "flex", "align-items": "center"}));
+                    $successElem.find('#dz_file_row_1').css({"display": "flex", "align-items": "center"});
                     $successElem.find('#success_icon').css('display', 'flex');
                     $successElem.find('#success_message').css('display', 'inline');
                     $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());
@@ -130,7 +130,7 @@ define([
                 .on('error', (erroredFile) => {
                     var $errorElem = $(erroredFile.previewElement);
                     $errorElem.find('#upload_progress_and_cancel').remove();
-                    $errorElem.find('#dz_file_row_1'.css({"display": "flex", "align-items": "center"}));
+                    $errorElem.find('#dz_file_row_1').css({"display": "flex", "align-items": "center"});
                     $errorElem.css('color', '#DF0002');
                     $errorElem.find('#error_icon').css('display', 'flex');
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -94,11 +94,12 @@ define([
 
                 })
                 .on('success', (file, serverResponse) => {
-                    $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());
                     var $successElem = $(file.previewElement);
                     $successElem.find('#upload_progress_and_cancel').remove();
-                    $successElem.find('#success_icon').css('display', 'inline');
+                    $successElem.find('#dz_file_row_1'.css({"display": "flex", "align-items": "center"}));
+                    $successElem.find('#success_icon').css('display', 'flex');
                     $successElem.find('#success_message').css('display', 'inline');
+                    $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());
 
                     this.removeProgressBar($dropzoneElem);
                     $(file.previewElement).fadeOut(1000, function() {
@@ -128,9 +129,10 @@ define([
                 })
                 .on('error', (erroredFile) => {
                     var $errorElem = $(erroredFile.previewElement);
-                    $errorElem.css('color', '#DF0002');
                     $errorElem.find('#upload_progress_and_cancel').remove();
-                    $errorElem.find('#error_icon').css('display', 'inline');
+                    $errorElem.find('#dz_file_row_1'.css({"display": "flex", "align-items": "center"}));
+                    $errorElem.css('color', '#DF0002');
+                    $errorElem.find('#error_icon').css('display', 'flex');
 
                     this.removeProgressBar($dropzoneElem);
                     let errorText = 'unable to upload file!';

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -95,11 +95,10 @@ define([
                 })
                 .on('success', (file, serverResponse) => {
                     $dropzoneElem.find('#upload-message').text(this.makeUploadMessage());
-                    file.previewElement.querySelector('#status-message').textContent = 'Completed';
-                    file.previewElement.querySelector('.progress').style.display = 'none';
-                    file.previewElement.querySelector('#status-message').style.display = 'inline';
-                    $(file.previewElement.querySelector('.fa-ban')).removeClass('fa-ban').addClass('fa-check');
-                    $(file.previewElement.querySelector('.btn-danger')).removeClass('btn-danger').addClass('btn-success');
+                    var $successElem = $(file.previewElement);
+                    $successElem.find('#upload_progress_and_cancel').remove();
+                    $successElem.find('#success_icon').css('display', 'inline');
+                    $successElem.find('#success_message').css('display', 'inline');
 
                     this.removeProgressBar($dropzoneElem);
                     $(file.previewElement).fadeOut(1000, function() {
@@ -128,13 +127,17 @@ define([
                     $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0%'});
                 })
                 .on('error', (erroredFile) => {
+                    var $errorElem = $(erroredFile.previewElement);
+                    $errorElem.css('color', '#DF0002');
+                    $errorElem.find('#upload_progress_and_cancel').remove();
+                    $errorElem.find('#error_icon').css('display', 'inline');
+
                     this.removeProgressBar($dropzoneElem);
                     let errorText = 'unable to upload file!';
                     if (erroredFile && erroredFile.xhr && erroredFile.xhr.responseText) {
                         errorText = erroredFile.xhr.responseText;
                     }
-                    $dropzoneElem.find('.error.text-danger').text('Error: ' + errorText);
-                    $dropzoneElem.find('#upload_progress_and_cancel').remove();
+                    $dropzoneElem.find('#error_message').text('Error: ' + errorText);
 
                     // Check to see if there already a button in the dropzone area
                     if (!$dropzoneElem.find('#clear-all-btn').length){
@@ -146,7 +149,7 @@ define([
         makeClearAllButton: function() {
             var $clearAllBtn = $('<button>')
                 .text('Clear All')
-                .addClass('text-button clear-all-dropzone')
+                .addClass('btn__text clear-all-dropzone')
                 .attr('aria-label', 'clear all errored files from the dropzone')
                 .attr('id', 'clear-all-btn')
                 .click(function(){

--- a/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
@@ -23,11 +23,11 @@
         <div class="col-md-4">
             <div id="error_icon" class="pull-right dz-file__icon">
                 <span>Error</span>
-                <i class="fa fa-2x fa-exclamation-triangle"></i>
+                <i class="fa fa-2x fa-exclamation-triangle" aria-hidden="true"></i>
             </div>
             <div id="success_icon" class="pull-right dz-file__icon dz-file__icon__success">
                 <span>Completed</span>
-                <i class="fa fa-2x fa-check-circle"></i>
+                <i class="fa fa-2x fa-check-circle" aria-hidden="true"></i>
             </div>
         </div>
     </div>

--- a/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
@@ -21,20 +21,20 @@
             </div>
         </div>
         <div class="col-md-4">
-            <div id="error_icon" class="pull-right dz-file__icon">
+            <div id="error_icon" class="pull-right dz-file__status dz-file__status__error">
                 <span>Error</span>
-                <i class="fa fa-2x fa-exclamation-triangle" aria-hidden="true"></i>
+                <i class="fa fa-2x fa-exclamation-triangle dz-file__status__icon" aria-hidden="true"></i>
             </div>
-            <div id="success_icon" class="pull-right dz-file__icon dz-file__icon__success">
+            <div id="success_icon" class="pull-right dz-file__status dz-file__status__success">
                 <span>Completed</span>
-                <i class="fa fa-2x fa-check-circle" aria-hidden="true"></i>
+                <i class="fa fa-2x fa-check-circle dz-file__status__icon" aria-hidden="true"></i>
             </div>
         </div>
     </div>
     <div class="row">
         <div class="col-md-7">
             <div id="error_message" class="dz-file__msg" data-dz-errormessage></div>
-            <div id="success_message" class="dz-file__msg dz-file__msg__success">Successfully moved to stagin area!</div>
+            <div id="success_message" class="dz-file__msg dz-file__msg__success">Successfully moved to staging area!</div>
         </div>
     </div>
 </div>

--- a/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
@@ -9,7 +9,7 @@
         <div id="upload_progress_and_cancel" style="display: inline;">
             <div class="col-md-3 text-center">
                 <div class="progress progress-striped active dz-file__progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-                    <div class="progress-bar progress-bar-success" style="width:0%;" data-dz-uploadprogress></div>
+                    <div class="progress-bar progress-bar-success dz-file__progress__bar" data-dz-uploadprogress></div>
                 </div>
             </div>
             <div class="col-md-1">

--- a/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
@@ -1,33 +1,40 @@
 <div class="row file-row dz-file">
-    <div class="col-md-7">
-        <div class="dz-file__name" data-dz-name></div>
-        <div id="error_message" class="dz-file__msg" data-dz-errormessage></div>
-        <div id="success_message" class="dz-file__msg dz-file__msg__success">Successfully moved to stagin area!</div>
-    </div>
-    <div class="col-md-1">
-        <span class="size pull-right" data-dz-size></span>
-    </div>
-
-    <div id="upload_progress_and_cancel">
-        <div class="col-md-3 text-center">
-            <div class="progress progress-striped active dz-file__progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-                <div class="progress-bar progress-bar-success" style="width:0%;" data-dz-uploadprogress></div>
+    <div id="dz_file_row_1" class="row">
+        <div class="col-md-7">
+            <div class="dz-file__name" data-dz-name></div>
+        </div>
+        <div class="col-md-1 ">
+            <span class="size pull-right" data-dz-size></span>
+        </div>
+        <div id="upload_progress_and_cancel" style="display: inline;">
+            <div class="col-md-3 text-center">
+                <div class="progress progress-striped active dz-file__progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                    <div class="progress-bar progress-bar-success" style="width:0%;" data-dz-uploadprogress></div>
+                </div>
+            </div>
+            <div class="col-md-1">
+                <div class="pull-right">
+                    <button data-dz-remove class="btn btn-xs btn-danger cancel">
+                        <i class="fa fa-lg fa-fw fa-ban"></i>
+                    </button>
+                </div>
             </div>
         </div>
-        <div class="col-md-1">
-            <div class="pull-right">
-                <button data-dz-remove class="btn btn-xs btn-danger cancel">
-                    <i class="fa fa-lg fa-fw fa-ban"></i>
-                </button>
+        <div class="col-md-4">
+            <div id="error_icon" class="pull-right dz-file__icon">
+                <span>Error</span>
+                <i class="fa fa-2x fa-exclamation-triangle"></i>
+            </div>
+            <div id="success_icon" class="pull-right dz-file__icon dz-file__icon__success">
+                <span>Completed</span>
+                <i class="fa fa-2x fa-check-circle"></i>
             </div>
         </div>
     </div>
-    <div id="error_icon" class="pull-right dz-file__icon">
-        <span>Error</span>
-        <i class="fa fa-2x fa-exclamation-triangle"></i>
-    </div>
-    <div id="success_icon" class="pull-right dz-file__icon dz-file__icon__success">
-        <span>Completed</span>
-        <i class="fa fa-2x fa-check-circle"></i>
+    <div class="row">
+        <div class="col-md-7">
+            <div id="error_message" class="dz-file__msg" data-dz-errormessage></div>
+            <div id="success_message" class="dz-file__msg dz-file__msg__success">Successfully moved to stagin area!</div>
+        </div>
     </div>
 </div>

--- a/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
@@ -1,22 +1,29 @@
 <div class="row file-row" style="width:100%; border: 1px solid #EEE; margin: 2px 0; padding: 5px 0">
     <div class="col-md-7" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-        <span class="name" data-dz-name></span>
-        <strong class="error text-danger" data-dz-errormessage></strong>
+        <div class="name" data-dz-name></div>
+        <strong class="error text-danger" style="white-space: normal;" data-dz-errormessage></strong>
     </div>
     <div class="col-md-1">
         <span class="size pull-right" data-dz-size></span>
     </div>
-    <div class="col-md-3 text-center">
-        <div id="status-message" style="display:none"></div>
-        <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" style="margin-bottom: inherit; margin-left: 5px">
-            <div class="progress-bar progress-bar-success" style="width:0%;" data-dz-uploadprogress></div>
+
+    <div id="upload_progress_and_cancel">
+        <div class="col-md-3 text-center">
+            <div id="status-message" style="display:none"></div>
+            <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" style="margin-bottom: inherit; margin-left: 5px">
+                <div class="progress-bar progress-bar-success" style="width:0%;" data-dz-uploadprogress></div>
+            </div>
+        </div>
+        <div class="col-md-1">
+            <div class="pull-right">
+                <button data-dz-remove class="btn btn-xs btn-danger cancel">
+                    <i class="fa fa-lg fa-fw fa-ban"></i>
+                </button>
+            </div>
         </div>
     </div>
-    <div class="col-md-1">
-        <div class="pull-right">
-            <button data-dz-remove class="btn btn-xs btn-danger cancel">
-                <i class="fa fa-lg fa-fw fa-ban"></i>
-            </button>
-        </div>
+    <div id="error_icon" class="pull-right" style="margin: 5px;">
+        <span style="font-size: 16px;">Error</span>
+        <i class="fa fa-1.5x fa-exclamation-triangle"></i>
     </div>
 </div>

--- a/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
+++ b/kbase-extension/static/kbase/templates/data_staging/dropped_file.html
@@ -1,7 +1,8 @@
-<div class="row file-row" style="width:100%; border: 1px solid #EEE; margin: 2px 0; padding: 5px 0">
-    <div class="col-md-7" style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-        <div class="name" data-dz-name></div>
-        <strong class="error text-danger" style="white-space: normal;" data-dz-errormessage></strong>
+<div class="row file-row dz-file">
+    <div class="col-md-7">
+        <div class="dz-file__name" data-dz-name></div>
+        <div id="error_message" class="dz-file__msg" data-dz-errormessage></div>
+        <div id="success_message" class="dz-file__msg dz-file__msg__success">Successfully moved to stagin area!</div>
     </div>
     <div class="col-md-1">
         <span class="size pull-right" data-dz-size></span>
@@ -9,8 +10,7 @@
 
     <div id="upload_progress_and_cancel">
         <div class="col-md-3 text-center">
-            <div id="status-message" style="display:none"></div>
-            <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" style="margin-bottom: inherit; margin-left: 5px">
+            <div class="progress progress-striped active dz-file__progress__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
                 <div class="progress-bar progress-bar-success" style="width:0%;" data-dz-uploadprogress></div>
             </div>
         </div>
@@ -22,8 +22,12 @@
             </div>
         </div>
     </div>
-    <div id="error_icon" class="pull-right" style="margin: 5px;">
-        <span style="font-size: 16px;">Error</span>
-        <i class="fa fa-1.5x fa-exclamation-triangle"></i>
+    <div id="error_icon" class="pull-right dz-file__icon">
+        <span>Error</span>
+        <i class="fa fa-2x fa-exclamation-triangle"></i>
+    </div>
+    <div id="success_icon" class="pull-right dz-file__icon dz-file__icon__success">
+        <span>Completed</span>
+        <i class="fa fa-2x fa-check-circle"></i>
     </div>
 </div>

--- a/src/config.json
+++ b/src/config.json
@@ -379,7 +379,7 @@
     "upload": {
         "timeout": 0,
         "parallel_uploads": 10,
-        "max_file_size": 20480,
+        "max_file_size": 1,
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,

--- a/src/config.json
+++ b/src/config.json
@@ -103,7 +103,7 @@
         "google_ad_conversion": "kR9OCLas4JgBEOy2pucC"
     },
     "comm_wait_timeout": 600000,
-    "config": "dev",
+    "config": "narrative-refactor",
     "data_panel": {
         "initial_sort_limit": 10000,
         "max_name_length": 33,
@@ -379,7 +379,7 @@
     "upload": {
         "timeout": 0,
         "parallel_uploads": 10,
-        "max_file_size": 1,
+        "max_file_size": 20480,
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,

--- a/src/config.json
+++ b/src/config.json
@@ -103,7 +103,7 @@
         "google_ad_conversion": "kR9OCLas4JgBEOy2pucC"
     },
     "comm_wait_timeout": 600000,
-    "config": "narrative-refactor",
+    "config": "dev",
     "data_panel": {
         "initial_sort_limit": 10000,
         "max_name_length": 33,
@@ -379,7 +379,7 @@
     "upload": {
         "timeout": 0,
         "parallel_uploads": 10,
-        "max_file_size": 20480,
+        "max_file_size": 1,
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,

--- a/src/config.json
+++ b/src/config.json
@@ -379,7 +379,7 @@
     "upload": {
         "timeout": 0,
         "parallel_uploads": 10,
-        "max_file_size": 1,
+        "max_file_size": 20480,
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -145,7 +145,7 @@ define([
             });
         });
 
-        it('Should create a clear all button when a file upload error occurs', (done) => {
+        it('Should render properly when a file upload error occurs', (done) => {
             // Set the file max size to 0
             fuWidget.dropzone.options.maxFilesize = 1;
 
@@ -164,30 +164,7 @@ define([
             fuWidget.dropzone.addFile(mockFile);
             setTimeout(() => {
                 expect(adderMock).toHaveBeenCalled();
-                var clearAllButton = document.getElementById('clear-all-btn');
-                expect(clearAllButton).toBeDefined();
-                done();
-            });
-        });
-
-        it('Should display an error icon and hide the progress bar and cancel button when an error occurs', (done) => {
-            fuWidget.dropzone.options.maxFilesize = 1;
-
-            // Create file
-            const filename='foo.txt';
-            mockUploadEndpoint(filename, fakeUser, false);
-            var mockFile = createMockFile(filename);
-            Object.defineProperty(mockFile, 'size', {value: Math.pow(1024, 4), writable: false});
-
-            // Create mock calls
-            const adderMock = jasmine.createSpy('adderMock');
-            fuWidget.dropzone.on('addedfile', () => {
-                adderMock();
-            });
-
-            fuWidget.dropzone.addFile(mockFile);
-            setTimeout(() => {
-                expect(adderMock).toHaveBeenCalled();
+                expect(document.getElementById('clear-all-btn')).toBeDefined();
                 expect(document.getElementById('upload_progress_and_cancel')).toBeNull();
                 expect(document.getElementById('error_icon')).toBeDefined();
                 done();

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -192,7 +192,7 @@ define([
                 expect(document.getElementById('error_icon')).toBeDefined();
                 done();
             });
-        })
+        });
 
     });
 });

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -170,5 +170,29 @@ define([
             });
         });
 
+        it('Should display an error icon and hide the progress bar and cancel button when an error occurs', (done) => {
+            fuWidget.dropzone.options.maxFilesize = 1;
+
+            // Create file
+            const filename='foo.txt';
+            mockUploadEndpoint(filename, fakeUser, false);
+            var mockFile = createMockFile(filename);
+            Object.defineProperty(mockFile, 'size', {value: Math.pow(1024, 4), writable: false});
+
+            // Create mock calls
+            const adderMock = jasmine.createSpy('adderMock');
+            fuWidget.dropzone.on('addedfile', () => {
+                adderMock();
+            });
+
+            fuWidget.dropzone.addFile(mockFile);
+            setTimeout(() => {
+                expect(adderMock).toHaveBeenCalled();
+                expect(document.getElementById('upload_progress_and_cancel')).toBeNull();
+                expect(document.getElementById('error_icon')).toBeDefined();
+                done();
+            });
+        })
+
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes
This PR alters the file row UI in the dropzone area. On success and error, the file row has been updated to reflect this figma mock: https://www.figma.com/file/zBQcHiLV4FlIkD3Y1ogNcy/concept-sketches2?node-id=13%3A153

<img width="649" alt="Screen Shot 2020-10-23 at 7 09 28 AM" src="https://user-images.githubusercontent.com/56279459/97021270-1830cf00-14ff-11eb-83e3-f96e4ad83365.png">
<img width="694" alt="Screen Shot 2020-10-23 at 7 11 39 AM" src="https://user-images.githubusercontent.com/56279459/97021295-2121a080-14ff-11eb-8a7c-46f08c063933.png">


# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-209
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 

To test this PR, run the narrative locally and navigate to the staging area. Drop a file that is larger than the max file size (20). This will cause the file to error and you will be able to see the changes.

To view the successful file upload, you should see it flash briefly upon success. If you would like to view it for a longer period, open devtools and put a break point on line `108` in file `fileUploadWidget.js`.

A question I am currently asking Mallory: If the successful files are cleared immediately, do we need the brief flash of the success styling? Does it make sense to leave those files in the dropzone or should we just remove it immediately?

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
