### PR TITLE
DATAUP-269: fix add new cell buttons

### DIFF
--- a/kbase-extension/kbase_templates/notebook.html
+++ b/kbase-extension/kbase_templates/notebook.html
@@ -96,17 +96,15 @@ data-notebook-path="{{notebook_path | urlencode}}"
     </div>
     <div id="content-column">
         <span id="kb-add-code-cell"
-              class="kb-data-list-add-data-button fa fa-terminal fa-2x"
-              style="position:fixed; bottom:15px; right:75px; z-index:5"
+              class="fa fa-terminal fa-2x"
               data-toggle="tooltip" data-placement="top" Title="Add Code Cell"></span>
         <span id="kb-add-md-cell"
-              class="kb-data-list-add-data-button fa fa-paragraph fa-2x"
-              style="position:fixed; bottom:15px; right:10px; z-index:5"
+              class="fa fa-paragraph fa-2x"
               data-toggle="tooltip" data-placement="top" Title="Add Markdown Cell"></span>
 
         <div id="ipython-main-app">
             <div id="notebook_panel">
-                <div id="notebook"></div>
+                <div id="notebook" class="notebook__container"></div>
                 <div id='tooltip' class='ipython_tooltip' style='display:none'></div>
                 <div id="kb-ws-progress"></div>
             </div>
@@ -140,8 +138,4 @@ data-notebook-path="{{notebook_path | urlencode}}"
 <!-- Because the narrative (in this version) requires that some Javascript is loaded before
     running the main IPython stack, a little wrapper script had to be written. More details there. -->
 <script src="{{ static_url("narrativeMain.js") }}" charset="utf-8"></script>
-
-<!-- not used in this version, but left behind for posterity.
-    <script src="{{ static_url("notebook/js/main.js") }}" charset="utf-8"></script>
--->
 {% endblock %}

--- a/kbase-extension/static/kbase/css/kbaseNarrative.css
+++ b/kbase-extension/static/kbase/css/kbaseNarrative.css
@@ -2701,22 +2701,35 @@ button.kb-data-obj {
 /* specialize buttons that hover over narrative */
 #kb-add-code-cell,
 #kb-add-md-cell {
-  box-shadow: #cecece 2px 2px 1px;
-  height: 40px;
-  width: 40px;
   background-color: #2196f3;
+  border-radius: 50%;
+  bottom: 15px;
+  box-shadow: #cecece 2px 2px 1px;
+  cursor: pointer;
+  color: #fff;
+  height: 40px;
   opacity: 0.5;
+  padding-top: 5px;
+  position: fixed;
+  width: 40px;
+  z-index: 5;
 }
 
 #kb-add-code-cell {
-  right: 100px;
+  right: 75px;
+  padding-left: 7px;
 }
 
 #kb-add-md-cell {
   margin-right: 20px;
+  right: 10px;
+  padding-left: 8px;
 }
 
+#kb-add-code-cell:hover,
+#kb-add-md-cell:hover,
 .kb-data-list-add-data-button:hover {
+  opacity: 1;
   cursor: pointer;
   background-color: #36618e;
 }

--- a/kbase-extension/static/kbase/custom/custom.css
+++ b/kbase-extension/static/kbase/custom/custom.css
@@ -122,7 +122,7 @@ div.cell.selected.kb-error {
   border-left: 5px solid #d9534f;
 }
 
-#notebook {
+div#notebook {
   padding: 0;
 }
 


### PR DESCRIPTION
# Description of PR purpose/changes

Fixing the placement of the icons for the "Add new cell" buttons.

Beautiful buttons now:

<img width="165" alt="Screenshot 2020-10-23 at 11 46 17" src="https://user-images.githubusercontent.com/556057/97043348-33173980-1527-11eb-96b5-b9e7cf3cb700.png">
<img width="163" alt="Screenshot 2020-10-23 at 11 46 32" src="https://user-images.githubusercontent.com/556057/97043350-34486680-1527-11eb-9fb0-7149fe14bb5d.png">

Looking good, huh?

Also fixed a padding problem was accidentally unleashed due to selector precedence and the ****** styles in the underlying jupyter notebook. Doh!

Note: base branch is set to DATAUP-246_css_to_css-error_pages (#1887) as it assumes the presence of changes in that PR.

# Jira Ticket / Issue #

https://kbase-jira.atlassian.net/browse/DATAUP-269

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local narrative and navigating to any narrative page (non-error page, that is) and checkin' out them cool lil buttons in the bottom right corner. They're awesome!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas - N/A
- [ ] I have made corresponding changes to the documentation - N/A
- [x] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules - N/A
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes) - N/A
