### PR TITLE
DATAUP-301 simple fix for loading staging

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -68,6 +68,8 @@ define([
             this.userInfo = options.userInfo;
 
             // Get this party started.
+            //setting first load so setPath doesn't call updateView() as that will happen via narrativeStagingDataTab
+            this.firstLoad = true;
             this.setPath(options.path);
             this.openFileInfo = {};
 
@@ -149,7 +151,13 @@ define([
                 subpathTokens--;
             }
             this.subpath = subpath.slice(subpath.length - subpathTokens).join('/');
-            return this.updateView();
+            
+            //we don't need to call to update the view if it's the first time as narrative staging data tab will do the rendering for us
+            if (this.firstLoad) {
+                this.firstLoad = false;
+            } else {
+                return this.updateView();
+            }
         },
 
         renderFileHeader: function () {


### PR DESCRIPTION
# Description of PR purpose/changes
Came across a bug while working on another ticket, but I noticed that the stagingAreaViewer updateView() method gets called twice on our first load of the narrative. 

This is because it's being called via setPath in the init function on line 75 (of stagingAreaViewer), and then again via the narrativeStagingDataTab module when it first gets rendered and calls updateView() on line 97. 

It occurred to me that this could impact load times negatively so I put in a simple fix. Open to feedback on approach, just wanted to get something in. 

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-301

# Testing Instructions
* Details for how to test the PR: 
You can set breakpoints or console statements where stagingArea.updateView is being called. 

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

