### PR TITLE
bump version to 4.3.1, add release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,24 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Version 4.3.1
+- Fixed problem where code cells could forget their toggled state after saving.
+- Fixed setting up local authentication for developers.
+- DATAUP-69 - added a pull request template to the narrative repo.
+- DATAUP-120 - improve testing documentation
+- DATAUP-164, DATAUP-165 - add automatic linting configuration with flake8 and black for the Python layer.
+- DATAUP-176 - refactored the startup process to be more robust with respect to kernel activity.
+- DATAUP-178 - changed "Add Data" and "+" icon color in the data panel.
+- DATAUP-187 - repositioned Globus link in the staging area.
+- DATAUP-188, DATAUP-228 - adds text and refresh button to the staging area, and stabilized the trash can icon.
+- DATAUP-197 - fixed problem where canceling an app cell could cause it to freeze.
+- DATAUP-204 - made folder names clickable in the staging area.
+- DATAUP-210 - adds a "file too large" error to the staging area when a file is too large to upload.
+- DATAUP-213 - added a "clear all" button that removes all staging area errors.
+- DATAUP-246 - dramatic cleanup and refactor done globally throughout the Narrative stylesheets.
+- DATAUP-266 - fixed a problem where the staging area didn't automatically refresh when a file finishes uploading.
+- DATAUP-301 - fixed a problem where the staging area rendered twice in a row on page load.
+
 ### Version 4.3.0
 - SCT-2664 - Show the app cell status when in a collapsed state.
 - Added an "Info" tab to all app cells with app information.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "homepage": "https://kbase.us",
   "dependencies": {
     "bluebird": "3.4.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative-core",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kbase-narrative-core",
   "description": "Core components for the KBase Narrative Interface",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "private": true,
   "repository": "github.com/kbase/narrative",
   "devDependencies": {

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -2,7 +2,7 @@ __all__ = ["magics", "common", "handlers", "contents", "services", "widgetmanage
 
 from semantic_version import Version
 
-__version__ = Version("4.3.0")
+__version__ = Version("4.3.1")
 
 
 def version():

--- a/src/config.json
+++ b/src/config.json
@@ -383,5 +383,5 @@
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,
-    "version": "4.3.0"
+    "version": "4.3.1"
 }

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -383,5 +383,5 @@
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,
-    "version": "4.3.0"
+    "version": "4.3.1"
 }


### PR DESCRIPTION
Just updates the release notes to encompass all of the user-facing changes, and a few of the more major non-user-facing ones.

There's no real new features here (unless I'm forgetting something?), so this seems like a patch version change to me.