### PR TITLE
DATAUP-295 cancel upload bug

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -122,11 +122,16 @@ define([
                     $($dropzoneElem.find('#total-progress .progress-bar')).css({'width': '0'});
                 })
                 .on('canceled', (file) => {
-                    Promise.resolve(this.stagingServiceClient.delete({
-                        path: file.fullPath ? file.fullPath : file.name
-                    })).catch(xhr => {
-                        throw new Error(xhr.responseText ? xhr.responseText : 'Unknown error - unable to delete file from staging area');
-                    });
+                    let path = file.fullPath ? file.fullPath : file.name;
+                    if (path){
+                        Promise.resolve(this.stagingServiceClient.delete({
+                            path: path
+                        })).catch(xhr => {
+                            throw new Error(xhr.responseText ? xhr.responseText : 'Unknown error - unable to delete file from staging area');
+                        });
+                    } else {
+                        throw new Error('Unable to locate path for file to delete');
+                    }
                 })
                 .on('error', (erroredFile) => {
                     var $errorElem = $(erroredFile.previewElement);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -166,13 +166,9 @@ define([
             e.preventDefault();
 
             if(e.target.href === globusUrlLinked) {
-                let stagingServiceClient = new StagingServiceClient({
-                    root: this.stagingUrl,
-                    token: Runtime.make().authToken()
-                });
                 var globusWindow = window.open('', 'dz-globus');
                 globusWindow.document.write('<html><body><h2 style="text-align:center; font-family:\'Oxygen\', arial, sans-serif;">Loading Globus...</h2></body></html>');
-                stagingServiceClient.addAcl()
+                this.stagingServiceClient.addAcl()
                     .done(() => {
                         window.open($(e.target).attr('href'), 'dz-globus');
                         return true;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -124,11 +124,9 @@ define([
                 .on('canceled', (file) => {
                     Promise.resolve(this.stagingServiceClient.delete({
                         path: file.fullPath ? file.fullPath : file.name
-                    }))
-                    .catch(xhr => {
+                    })).catch(xhr => {
                         throw new Error(xhr.responseText ? xhr.responseText : 'Unknown error - unable to delete file from staging area');
-                    })
-
+                    });
                 })
                 .on('error', (erroredFile) => {
                     var $errorElem = $(erroredFile.previewElement);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js
@@ -126,7 +126,6 @@ define([
                         path: file.fullPath ? file.fullPath : file.name
                     }))
                     .catch(xhr => {
-                        //TODO ask design how to alert a user that their file could not be deleted
                         throw new Error(xhr.responseText ? xhr.responseText : 'Unknown error - unable to delete file from staging area');
                     })
 

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -205,7 +205,7 @@ define([
             });
         });
 
-        it('Should cancel a file when warning button clicked', (done) => {
+        it('Should contain a cancel warning button', () => {
             $targetNode = $('<div>');
             let uploadWidget = new FileUploadWidget($targetNode, {
                 path: '/',
@@ -215,23 +215,21 @@ define([
                 }
             });
 
+            // Create file
             const filename='foo.txt';
             mockUploadEndpoint(filename, fakeUser, false);
-            const mockFile = createMockFile(filename);
-            const cancelMock = jasmine.createSpy('cancelMock');
+            var mockFile = createMockFile(filename);
 
-            uploadWidget.dropzone.on('canceled', () => {
-                cancelMock();
+            const adderMock = jasmine.createSpy('adderMock');
+            uploadWidget.dropzone.on('addedfile', () => {
+                adderMock();
             });
 
             uploadWidget.dropzone.addFile(mockFile);
             let $cancelButton = uploadWidget.$elem.find('.cancel');
-            $cancelButton.click();
-
-            setTimeout(() => {
-                expect(cancelMock).toHaveBeenCalled();
-                done();
-            });
+            expect($cancelButton).toBeDefined();
+            console.log($cancelButton);
+            expect($cancelButton.attr('data-dz-remove')).toBeDefined();
         });
 
     });

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -228,7 +228,6 @@ define([
             uploadWidget.dropzone.addFile(mockFile);
             let $cancelButton = uploadWidget.$elem.find('.cancel');
             expect($cancelButton).toBeDefined();
-            console.log($cancelButton);
             expect($cancelButton.attr('data-dz-remove')).toBeDefined();
         });
 

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -174,7 +174,7 @@ define([
 
         it('Should provide a link to a globus accout when file upload maxfile size error occurs', (done) => {
             $targetNode = $('<div>');
-            var uploadWidget = new FileUploadWidget($targetNode, {
+            let uploadWidget = new FileUploadWidget($targetNode, {
                 path: '/',
                 userInfo: {
                     user: fakeUser,
@@ -204,6 +204,41 @@ define([
                 done();
             });
         });
+
+        it('Should cancel a file when warning button clicked', () => {
+            $targetNode = $('<div>');
+            let uploadWidget = new FileUploadWidget($targetNode, {
+                path: '/',
+                userInfo: {
+                    user: fakeUser,
+                    globusLinked: false
+                }
+            });
+
+            const filename='foo.txt';
+            mockUploadEndpoint(filename, fakeUser, false);
+            const mockFile = createMockFile(filename);
+            const cancelMock = jasmine.createSpy('cancelMock');
+            const sendingMock = jasmine.createSpy('sendingMock');
+
+            uploadWidget.dropzone.on('canceled', () => {
+                cancelMock();
+            });
+
+            uploadWidget.dropzone.on('sending', () => {
+                sendingMock();
+            });
+
+            uploadWidget.dropzone.addFile(mockFile);
+            let $cancelButton = uploadWidget.$elem.find('.cancel');
+            $cancelButton.click();
+
+            setTimeout(() => {
+                expect(sendingMock).toHaveBeenCalled();
+                expect(cancelMock).toHaveBeenCalled();
+                done();
+            });
+        })
 
     });
 });

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -205,7 +205,7 @@ define([
             });
         });
 
-        it('Should cancel a file when warning button clicked', () => {
+        it('Should cancel a file when warning button clicked', (done) => {
             $targetNode = $('<div>');
             let uploadWidget = new FileUploadWidget($targetNode, {
                 path: '/',
@@ -219,14 +219,9 @@ define([
             mockUploadEndpoint(filename, fakeUser, false);
             const mockFile = createMockFile(filename);
             const cancelMock = jasmine.createSpy('cancelMock');
-            const sendingMock = jasmine.createSpy('sendingMock');
 
             uploadWidget.dropzone.on('canceled', () => {
                 cancelMock();
-            });
-
-            uploadWidget.dropzone.on('sending', () => {
-                sendingMock();
             });
 
             uploadWidget.dropzone.addFile(mockFile);
@@ -234,11 +229,10 @@ define([
             $cancelButton.click();
 
             setTimeout(() => {
-                expect(sendingMock).toHaveBeenCalled();
                 expect(cancelMock).toHaveBeenCalled();
                 done();
             });
-        })
+        });
 
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

This PR includes the following changes:
* Adds an on `canceled` event handler to the upload widget. When an upload is canceled, the file is deleted from the server. Before this change, canceled files would appear partially upload in the staging area. 

* Added a test to verify the `canceled` event was being emitted when a user clicks on the cancel button for a file


# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-295
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions

Execute `make test-frontend-unit`

Navigate to the import tab, drop a file in the dropzone, cancel the file upload. You will not see the file appear in the staging area below.

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
