### PR TITLE
DATAUP-246: css to scss: single file, please

### DIFF
--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -13,7 +13,7 @@
     {% block stylesheet %}
     <link rel="stylesheet" href="{{ static_url("style/style.min.css") }}" type="text/css"/>
     {% endblock %}
-    <link rel="stylesheet" href="{{ static_url("kbase/css/page_concat.css") }}" type="text/css" />
+    <link rel="stylesheet" href="{{ static_url("kbase/css/all_concat.css") }}" type="text/css" />
 
     <script src="{{ static_url("ext_components/bowser/bowser.min.js") }}" type="text/javascript" charset="utf-8"></script>
     <script>

--- a/kbase-extension/static/kbase/js/tour.js
+++ b/kbase-extension/static/kbase/js/tour.js
@@ -5,8 +5,7 @@ define([
     'jquery',
     'bootstraptour',
     'handlebars',
-    'text!kbase/templates/tour/tour_panel.html',
-    'css!kbase/css/kbaseTour.css'
+    'text!kbase/templates/tour/tour_panel.html'
 ], function($, Tour, Handlebars, TourTmpl) {
     "use strict";
 

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -15,8 +15,7 @@ define([
     'common/ui',
     'common/events',
     'common/fsm',
-    'kb_common/html',
-    'css!kbase/css/kbaseJobLog.css'
+    'kb_common/html'
 ], function(
     Promise,
     Runtime,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -26,7 +26,6 @@ define([
     'text!kbase/templates/job_status/log_panel.html',
     'text!kbase/templates/job_status/log_line.html',
     'text!kbase/templates/job_status/new_objects.html',
-    'css!kbase/css/kbaseJobLog.css',
     'bootstrap'
 ], function (
     Promise,

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/uploadTour.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/uploadTour.js
@@ -6,8 +6,7 @@ define([
     'base/js/namespace',
     'bootstraptour',
     'handlebars',
-    'text!kbase/templates/tour/tour_panel.html',
-    'css!kbase/css/kbaseTour.css'
+    'text!kbase/templates/tour/tour_panel.html'
 ], function($, Jupyter, Tour, Handlebars, TourTmpl) {
     'use strict';
 

--- a/nbextensions/advancedViewCell/main.js
+++ b/nbextensions/advancedViewCell/main.js
@@ -33,8 +33,6 @@ define([
     'common/spec',
     'kb_service/utils',
     'kb_service/client/workspace',
-    'css!kbase/css/appCell.css',
-    'css!kbase/css/advancedViewCell.css',
     'bootstrap',
     'custom/custom'
 ], function(

--- a/nbextensions/appCell2/main.js
+++ b/nbextensions/appCell2/main.js
@@ -25,7 +25,6 @@ define([
     'kb_service/utils',
     'kb_service/client/workspace',
     './appCell',
-    'css!kbase/css/appCell.css',
     'bootstrap',
     'custom/custom'
 ], function(

--- a/nbextensions/appCell2/widgets/tabs/status/logTab.js
+++ b/nbextensions/appCell2/widgets/tabs/status/logTab.js
@@ -12,8 +12,7 @@ define([
     'util/jobLogViewer',
     './jobStateViewer',
     './jobStateList',
-    './jobInputParams',
-    'css!kbase/css/batchMode'
+    './jobInputParams'
 ], function (
     Promise,
     html,

--- a/nbextensions/editorCell/main.js
+++ b/nbextensions/editorCell/main.js
@@ -32,8 +32,6 @@ define([
     'common/jupyter',
     'kb_service/utils',
     'kb_service/client/workspace',
-    'css!kbase/css/appCell.css',
-    'css!kbase/css/editorCell.css',
     'bootstrap',
     'custom/custom'
 ], function(

--- a/nbextensions/viewCell/main.js
+++ b/nbextensions/viewCell/main.js
@@ -33,9 +33,6 @@ define([
     'kb_service/utils',
     'kb_service/client/workspace',
     './widgets/appInfoDialog',
-
-    // for effect
-    'css!kbase/css/appCell.css',
     'bootstrap',
     'custom/custom'
 ], function(


### PR DESCRIPTION
# Description of PR purpose/changes

Use a single file for all kbase css.

Removes dynamically-loaded kbase css from various widgets, and serves the `all_concat.css` file by default.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-246

# Testing Instructions
* Details for how to test the PR: 
- [ ] Tests pass in travis and locally 
- [ ] Changes available by spinning up a local narrative and clicking around.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes