### PR TITLE
DATAUP-215 file temporarily shows in staging area

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
@@ -84,8 +84,10 @@ define([
                         userId: Jupyter.narrative.userId
                     });
 
-                    this.uploadWidget.dropzone.on('complete', () => {
-                        this.updateView();
+                    this.uploadWidget.dropzone.on('complete', (file) => {
+                        if(file.status !== 'canceled') {
+                            this.updateView();
+                        }
                     });
 
                     this.stagingAreaViewer = new StagingAreaViewer(this.$myFiles, {


### PR DESCRIPTION
# Description of PR purpose/changes

This fixes the issue of deleted file showing up temporarily in the staging area after the upload has been cancelled. Dropzone.js emits the 'complete' event when an upload is completed or stopped. This triggered the staging area to be refreshed before the canceled file was deleted; therefore it could be temporarily seen (if you refreshed again, the deleted file would no longer be in the staging area.). 

Now, refresh is not called when a file is canceled because there is no file being added to the staging area. 

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-215
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
To test, navigate to the import tab. Upload a file, and cancel the upload before it completes. You should not see a file in the staging area. 

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
