### PR TITLE
DATAUP-288 left column prep - factory pattern

### DIFF
--- a/nbextensions/bulkImportCell/cellControlPanel.js
+++ b/nbextensions/bulkImportCell/cellControlPanel.js
@@ -17,19 +17,7 @@ define([
      * options -
      * - bus - the message bus
      * - ui - the UI controller
-     * - tabs: an object with the following properties:
-     *   - toggleAction - a function that should be run when toggling tabs, takes
-     *      the tab name as a single parameter
-     *   - tabs: also an object:
-     *     - selectedTab - string, one of the keys under "tabs"
-     *     - tabs - an object where each key is a tab key, and has a display label:
-     *       {
-     *          configure: {
-     *              label: "Configure"
-     *          }
-     *          , etc.
-     *       }
-     * - actions: object that defines the action buttons:
+     * - action: object that defines the action buttons:
      *   - current: which is the current button, and its state:
      *     - name - string, one of the action keys
      *     - disabled - if truthy, then should not be clickable
@@ -46,14 +34,6 @@ define([
     function CellControlPanel(options) {
         let bus = options.bus;
         let ui = options.ui;
-
-        // this.cellTabs = new CellTabs({
-        //     ui: this.ui,
-        //     bus: this.bus,
-        //     toggleAction: options.tabs.toggleAction,
-        //     tabs: options.tabs.tabs
-        // });
-
         let actionButton = new ActionButton({
             ui: ui,
             bus: bus,
@@ -66,12 +46,7 @@ define([
         }
 
         function stop() {
-            // this.cellTabs.stop();
             actionButton.stop();
-        }
-
-        function setTabState(newState) {
-            // this.cellTabs.setState(newState);
         }
 
         function setActionState(newState) {

--- a/nbextensions/bulkImportCell/cellTabs.js
+++ b/nbextensions/bulkImportCell/cellTabs.js
@@ -16,24 +16,23 @@ define([
         a = html.tag('a'),
         cssCellType = 'kb-bulk-import';
 
+    /**
+     * This is the factory function for the CellTabs component.
+     * @param {object} options
+     * - bus - the message bus
+     * - toggleAction - a function that should be run when toggling tabs, takes
+     *     the tab name as a single parameter
+     * - tabs: also an object:
+     *   - selectedTab - string, one of the keys under "tabs"
+     *   - tabs - an object where each key is a tab key, and has a display label:
+     *     {
+     *        configure: {
+     *            label: "Configure"
+     *        }
+     *        , etc.
+     *     }
+     */
     function CellTabs(options) {
-        /**
-         *
-         * @param {object} options
-         * - bus - the message bus
-         * - ui - the ui controller
-         *   - toggleAction - a function that should be run when toggling tabs, takes
-         *      the tab name as a single parameter
-         *   - tabs: also an object:
-         *     - selectedTab - string, one of the keys under "tabs"
-         *     - tabs - an object where each key is a tab key, and has a display label:
-         *       {
-         *          configure: {
-         *              label: "Configure"
-         *          }
-         *          , etc.
-         *       }
-         */
         let bus = options.bus,
             ui,
             tabToggleAction = options.toggleAction,

--- a/nbextensions/bulkImportCell/main.js
+++ b/nbextensions/bulkImportCell/main.js
@@ -37,7 +37,7 @@ define([
         return Promise.all(Jupyter.notebook.get_cells().map((cell) => {
             if (BulkImportCell.isBulkImportCell(cell)) {
                 try {
-                    new BulkImportCell(cell);
+                    BulkImportCell.make({cell});
                 }
                 catch(error) {
                     // If we have an error here, there is a serious problem setting up the cell and it is not usable.
@@ -75,7 +75,11 @@ define([
                     const importData = setupData.typesToFiles || {};
 
                     try {
-                        new BulkImportCell(cell, true, importData);
+                        BulkImportCell.make({
+                            cell,
+                            importData,
+                            initialize: true
+                        });
                     }
                     catch(error) {
                         Jupyter.notebook.delete_cell(Jupyter.notebook.find_cell_index(cell));

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -17,7 +17,7 @@ define([
             const cell = Mocks.buildMockCell('code');
             expect(cell.getIcon).not.toBeDefined();
             expect(cell.renderIcon).not.toBeDefined();
-            const cellWidget = new BulkImportCell(cell, true);
+            const cellWidget = BulkImportCell.make({cell, initialize: true});
             expect(cellWidget).toBeDefined();
             expect(cell.getIcon).toBeDefined();
             expect(cell.renderIcon).toBeDefined();
@@ -31,7 +31,7 @@ define([
 
         it('should have a cell that can render its icon', () => {
             const cell = Mocks.buildMockCell('code');
-            const cellWidget = new BulkImportCell(cell, true);
+            const cellWidget = BulkImportCell.make({cell, initialize: true});
             expect(cell).toBe(cellWidget.cell);
             expect(cell.getIcon()).toContain('fa-stack');
             cell.renderIcon();
@@ -40,26 +40,26 @@ define([
 
         it('should fail to make a bulk import cell if the cell is not a code cell', () => {
             const cell = Mocks.buildMockCell('markdown');
-            expect(() => new BulkImportCell(cell)).toThrow();
+            expect(() => BulkImportCell.make({cell})).toThrow();
         });
 
         it('can tell whether a cell is bulk import cell with a static function', () => {
             const codeCell = Mocks.buildMockCell('code');
             expect(BulkImportCell.isBulkImportCell(codeCell)).toBeFalsy();
-            new BulkImportCell(codeCell, true);
+            BulkImportCell.make({cell: codeCell, initialize: true});
             expect(BulkImportCell.isBulkImportCell(codeCell)).toBeTruthy();
         });
 
         it('should fail to set up a cell that is not a bulk import cell (has been initialized)', () => {
             const cell = Mocks.buildMockCell('code');
-            expect(() => new BulkImportCell(cell, false)).toThrow();
+            expect(() => BulkImportCell({cell, initialize: false})).toThrow();
         });
 
         it('should be able to delete its cell', () => {
             const cell = Mocks.buildMockCell('code');
             Jupyter.notebook = Mocks.buildMockNotebook();
             spyOn(Jupyter.notebook, 'delete_cell');
-            const cellWidget = new BulkImportCell(cell, true);
+            const cellWidget = BulkImportCell.make({cell, initialize: true});
 
             cellWidget.deleteCell();
             expect(Jupyter.notebook.delete_cell).toHaveBeenCalled();
@@ -72,7 +72,7 @@ define([
                 deleteCallback: () => done()
             });
             spyOn(Jupyter.notebook, 'delete_cell').and.callThrough();
-            new BulkImportCell(cell, true);
+            BulkImportCell.make({cell, initialize: true});
             runtime.bus().send({}, {
                 channel: {
                     cell: cell.metadata.kbase.attributes.id


### PR DESCRIPTION
# Description of PR purpose/changes

Convert the base `bulkImportCell` module to use the factory pattern.

It really only needs to expose the `make` function, other items are added to the factory result for help with testing and cell deletion if needed later.

This is on the same branch as other changes to #1954 , so there's some overlap until that gets merged, but I wanted to get this out there.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
Really there should be no change - fire up the narrative and try out a bulk import cell, and run tests. Tests should all have been updated accordingly.
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules