### PR TITLE
DATAUP-322: Adding cell minimize / maximize controls

### DIFF
--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -204,7 +204,7 @@ define([
          *     'fastq_reads': ['file1.fq', 'file2.fq']
          * }
          */
-        function initialize(typesToFiles) {
+        function initialize(_typesToFiles) {
             const meta = {
                 kbase: {
                     attributes: {
@@ -219,7 +219,7 @@ define([
                         'user-settings': {
                             showCodeInputArea: false
                         },
-                        inputs: typesToFiles
+                        inputs: _typesToFiles
                     }
                 }
             };
@@ -231,6 +231,38 @@ define([
          * extra functions that the Narrative can call.
          */
         function specializeCell() {
+
+            // minimizes the cell
+            cell.minimize = function() {
+                const inputArea = this.input.find('.input_area').get(0),
+                    outputArea = this.element.find('.output_wrapper'),
+                    viewInputArea = this.element.find('[data-subarea-type="bulk-import-cell-input"]'),
+                    showCode = Utils.getCellMeta(cell, 'kbase.bulkImportCell.user-settings.showCodeInputArea');
+
+                if (showCode) {
+                    inputArea.classList.remove('-show');
+                }
+                outputArea.addClass('hidden');
+                viewInputArea.addClass('hidden');
+            };
+
+            // maximizes the cell
+            cell.maximize = function() {
+                const inputArea = this.input.find('.input_area').get(0),
+                    outputArea = this.element.find('.output_wrapper'),
+                    viewInputArea = this.element.find('[data-subarea-type="bulk-import-cell-input"]'),
+                    showCode = Utils.getCellMeta(cell, 'kbase.bulkImportCell.user-settings.showCodeInputArea');
+
+                if (showCode) {
+                    if (!inputArea.classList.contains('-show')) {
+                        inputArea.classList.add('-show');
+                        cell.code_mirror.refresh();
+                    }
+                }
+                outputArea.removeClass('hidden');
+                viewInputArea.removeClass('hidden');
+            };
+
             // returns a DOM node with an icon to be rendered elsewhere
             cell.getIcon = function() {
                 return AppUtils.makeGenericIcon('upload', '#bf6c97');
@@ -264,6 +296,7 @@ define([
         function setupDomNode() {
             kbaseNode = document.createElement('div');
             kbaseNode.classList.add(`${cssCellType}__base-node`);
+            kbaseNode.setAttribute('data-subarea-type', 'bulk-import-cell-input');
             // inserting after, with raw dom, means telling the parent node
             // to insert a node before the node following the one we are
             // referencing. If there is no next sibling, the null value

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -19,8 +19,9 @@ define([
             expect(cell.renderIcon).not.toBeDefined();
             const cellWidget = BulkImportCell.make({cell, initialize: true});
             expect(cellWidget).toBeDefined();
-            expect(cell.getIcon).toBeDefined();
-            expect(cell.renderIcon).toBeDefined();
+            ['getIcon', 'renderIcon', 'maximize', 'minimize'].forEach( (method) => {
+                expect(cell[method]).toBeDefined();
+            });
             expect(cell.metadata.kbase).toBeDefined();
             for(const prop of ['id', 'status', 'created', 'title', 'subtitle']) {
                 expect(cell.metadata.kbase.attributes[prop]).toBeDefined();


### PR DESCRIPTION
# Description of PR purpose/changes

Adds in the maximise / minimise JS for showing and hiding the bulk import cell contents.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-322
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local narrative, creating a new bulk import cell, and then clicking on the min/max component.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
