### PR TITLE
Use script to install extensions in dockerfile

### DIFF
--- a/scripts/install_narrative_docker.sh
+++ b/scripts/install_narrative_docker.sh
@@ -81,29 +81,5 @@ HOME=/tmp
 console "Installing nbextensions"
 cp -r nbextensions kbase-extension/static
 cd kbase-extension/static/nbextensions
-
-jupyter nbextension install $(pwd)/viewCell --symlink --sys-prefix
-jupyter nbextension enable viewCell/main --sys-prefix
-
-jupyter nbextension install $(pwd)/outputCell --symlink --sys-prefix
-jupyter nbextension enable outputCell/main --sys-prefix
-
-jupyter nbextension install $(pwd)/dataCell --symlink --sys-prefix
-jupyter nbextension enable dataCell/main --sys-prefix
-
-jupyter nbextension install $(pwd)/editorCell --symlink --sys-prefix
-jupyter nbextension enable editorCell/main --sys-prefix
-
-jupyter nbextension install $(pwd)/appCell2 --symlink --sys-prefix
-jupyter nbextension enable appCell2/main --sys-prefix
-
-jupyter nbextension install $(pwd)/advancedViewCell --symlink --sys-prefix
-jupyter nbextension enable advancedViewCell/main --sys-prefix
-
-jupyter nbextension install $(pwd)/codeCell --symlink --sys-prefix
-jupyter nbextension enable codeCell/main --sys-prefix
-
-jupyter nbextension enable --py --sys-prefix widgetsnbextension
-jupyter nbextension enable --py --sys-prefix clustergrammer_widget
-
-console "Done installing nbextension"
+sh install.sh
+console "Done installing nbextensions"


### PR DESCRIPTION
The dockerfile version of the narrative installer included a list of which nbextensions to activate, instead of using the included nbextension installer file. This means that it was missing the new bulk import cell.

Now it just uses the installer as it should.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
Running a narrative from a container should allow you to make a bulk import cell. No other changes.
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:
(mostly not applicable in this case)
- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
