### PR TITLE
DATAUP-322, min max cell: fix user settings

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -450,7 +450,7 @@ define([
                             subtitle: ''
                         },
                         codeCell: {
-                            userSettings: {
+                            'user-settings': {
                                 showCodeInputArea: true
                             },
                             jobInfo: {

--- a/nbextensions/advancedViewCell/widgets/advancedViewCellWidget.js
+++ b/nbextensions/advancedViewCell/widgets/advancedViewCellWidget.js
@@ -707,7 +707,7 @@ define([
                     }
                 })
                 .catch(function (err) {
-                    alert('internal error'),
+                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/nbextensions/advancedViewCell/widgets/advancedViewCellWidget.js
+++ b/nbextensions/advancedViewCell/widgets/advancedViewCellWidget.js
@@ -707,7 +707,6 @@ define([
                     }
                 })
                 .catch(function (err) {
-                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -2319,7 +2319,6 @@ define([
                     renderUI();
                 })
                 .catch(function(err) {
-                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -2319,7 +2319,7 @@ define([
                     renderUI();
                 })
                 .catch(function(err) {
-                    alert('internal error'),
+                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/nbextensions/codeCell/main.js
+++ b/nbextensions/codeCell/main.js
@@ -37,7 +37,7 @@ define([
         cell.minimize = function () {
             var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
-                showCode = utils.getCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea');
+                showCode = utils.getCellMeta(cell, 'kbase.codeCell.user-settings.showCodeInputArea');
 
             if (showCode) {
                 inputArea.classList.remove('-show');
@@ -48,7 +48,7 @@ define([
         cell.maximize = function () {
             var inputArea = this.input.find('.input_area').get(0),
                 outputArea = this.element.find('.output_wrapper'),
-                showCode = utils.getCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea');
+                showCode = utils.getCellMeta(cell, 'kbase.codeCell.user-settings.showCodeInputArea');
 
             if (showCode) {
                 if (!inputArea.classList.contains('-show')) {
@@ -76,7 +76,7 @@ define([
             var codeInputArea = this.input.find('.input_area')[0];
             if (codeInputArea) {
                 codeInputArea.classList.toggle('-show');
-                utils.setCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea', this.isCodeShowing(), true);
+                utils.setCellMeta(cell, 'kbase.codeCell.user-settings.showCodeInputArea', this.isCodeShowing(), true);
                 // NB purely for side effect - toolbar refresh
                 cell.metadata = cell.metadata;
             }
@@ -101,7 +101,7 @@ define([
         // can chose to override this and this choice should be remembered.
         // import/job cells dont' show code input area as regular code cells do.
         if (utils.getCellMeta(cell, 'kbase.codeCell.jobInfo')) {
-            utils.setCellMeta(cell, 'kbase.codeCell.userSettings.showCodeInputArea', false);
+            utils.setCellMeta(cell, 'kbase.codeCell.user-settings.showCodeInputArea', false);
         }
 
         var widget = CodeCell.make({
@@ -157,7 +157,7 @@ define([
                 subtitle: data.language
             },
             codeCell: {
-                userSettings: {
+                'user-settings': {
                     showCodeInputArea: true
                 }
             }

--- a/nbextensions/editorCell/widgets/editors/readsSet/editor.js
+++ b/nbextensions/editorCell/widgets/editors/readsSet/editor.js
@@ -1132,7 +1132,7 @@ define([
                     renderUI();
                 })
                 .catch(function(err) {
-                    alert('internal error'),
+                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/nbextensions/editorCell/widgets/editors/readsSet/editor.js
+++ b/nbextensions/editorCell/widgets/editors/readsSet/editor.js
@@ -1132,7 +1132,6 @@ define([
                     renderUI();
                 })
                 .catch(function(err) {
-                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/nbextensions/viewCell/widgets/viewCellWidget.js
+++ b/nbextensions/viewCell/widgets/viewCellWidget.js
@@ -1142,7 +1142,6 @@ define([
                     }
                 })
                 .catch(function(err) {
-                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/nbextensions/viewCell/widgets/viewCellWidget.js
+++ b/nbextensions/viewCell/widgets/viewCellWidget.js
@@ -1142,7 +1142,7 @@ define([
                     }
                 })
                 .catch(function(err) {
-                    alert('internal error'),
+                    alert('internal error');
                     console.error('INTERNAL ERROR', err);
                 });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1470,7 +1470,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "bytes": {
       "version": "1.0.0",
@@ -1642,9 +1643,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001159",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-      "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==",
+      "version": "1.0.30001164",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
+      "integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg==",
       "dev": true
     },
     "caseless": {
@@ -2221,6 +2222,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -2232,6 +2234,7 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2292,7 +2295,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -5394,7 +5398,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -5843,7 +5848,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "4.0.6",
@@ -5854,7 +5860,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -7061,6 +7068,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -7952,11 +7960,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -11474,49 +11477,6 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
-    "pre-commit": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
-      "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "spawn-sync": "^1.0.15",
-        "which": "1.2.x"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-        },
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11559,7 +11519,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -11588,7 +11549,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",
@@ -12157,7 +12119,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-json-parse": {
       "version": "1.0.1",
@@ -12784,15 +12747,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
-      }
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -13090,6 +13044,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -14519,7 +14474,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -14776,7 +14732,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.1",
@@ -15152,7 +15109,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,5 @@
     "stylelint": "stylelint --config .stylelintrc.yaml --fix kbase-extension/scss/**/*.scss",
     "sassv": "sass --version"
   },
-  "dependencies": {
-    "pre-commit": "^1.2.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
# Description of PR purpose/changes

Standardise the way that kbase cells refer to `user-settings`; for some reason, the code cell uses `userSettings`, whereas everywhere else uses `user-settings`.

Removes the annoying `pre-commit` module, which was forcing tests to be run whenever you tried to commit.

Also fixed an issue where someone had used a comma instead of a semi-colon, which eslint highlighted; the lines were of the form
```
alert('internal error'),  // COMMA!!
console.error('INTERNAL ERROR', err);
```
(there's no such thing as too much warning)


# Jira Ticket / Issue #

https://kbase-jira.atlassian.net/browse/DATAUP-322

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass locally 
- [x] Changes available by spinning up a local narrative and navigating to see that nothing has changed.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
