### PR TITLE
DATAUP-322: fix user settings

### DIFF
--- a/nbextensions/codeCell/main.js
+++ b/nbextensions/codeCell/main.js
@@ -1,30 +1,16 @@
 define([
-    'bluebird',
     'jquery',
     'uuid',
     'base/js/namespace',
     'common/utils',
-    'common/appUtils',
-    'common/props',
-    'common/cellUtils',
-    'common/pythonInterop',
-    'common/ui',
-    'common/jupyter',
     'kb_common/html',
     './widgets/codeCell',
     'custom/custom'
 ], function (
-    Promise,
     $,
     Uuid,
     Jupyter,
     utils,
-    AppUtils,
-    Props,
-    cellUtils,
-    PythonInterop,
-    UI,
-    jupyter,
     html,
     CodeCell
 ) {

--- a/nbextensions/codeCell/main.js
+++ b/nbextensions/codeCell/main.js
@@ -91,6 +91,22 @@ define([
             return;
         }
 
+        // migrate from 'userSettings' to 'user-settings'
+        if (utils.getCellMeta(cell, 'kbase.codeCell')) {
+            let cellMeta = utils.getCellMeta(cell, 'kbase.codeCell'),
+                oldSettings = cellMeta.userSettings,
+                newSettings = cellMeta['user-settings'];
+            if (oldSettings) {
+                if (newSettings) {
+                    // merge, with old (saved) settings taking priority
+                    Object.assign(newSettings, oldSettings);
+                    oldSettings = newSettings;
+                }
+                cellMeta['user-settings'] = oldSettings;
+                delete cellMeta.userSettings;
+                utils.setCellMeta(cell, 'kbase.codeCell', cellMeta);
+            }
+        }
         specializeCell(cell);
 
         // The kbase property is only used for managing runtime state of the cell
@@ -99,7 +115,7 @@ define([
 
         // Code cell input area is always set to be open by default, but users
         // can chose to override this and this choice should be remembered.
-        // import/job cells dont' show code input area as regular code cells do.
+        // import/job cells don't show code input area as regular code cells do.
         if (utils.getCellMeta(cell, 'kbase.codeCell.jobInfo')) {
             utils.setCellMeta(cell, 'kbase.codeCell.user-settings.showCodeInputArea', false);
         }
@@ -114,19 +130,6 @@ define([
         cell.renderMinMax();
         // force toolbar rerender.
         cell.metadata = cell.metadata;
-    }
-
-    function fixupCell(cell) {
-        if (cell.metadata.kbase && cell.metadata.kbase.type) {
-            return;
-        }
-        return upgradeCell({
-            cell: cell,
-            kbase: {
-                type: 'code',
-                language: 'python'
-            }
-        });
     }
 
     function upgradeCell(cell, data) {
@@ -173,32 +176,25 @@ define([
     }
 
     function ensureCodeCell(cell) {
-        if (cell.cell_type === 'code') {
-            if (cell.metadata.kbase) {
-                if (cell.metadata.kbase.type) {
-                    if (cell.metadata.kbase.type === 'code') {
-                        // fully flocked jupyter/kbase code cell
-                        return true;
-                    } else {
-                        // a typed kbase cell, and not a code cell
-                        return false;
-                    }
-                } else {
-                    // a code cell with a kbase property but no type specified
-                    // must be a pre-code-cell-extension code cell, which can be
-                    // converted.
-                    fixupCell(cell);
-                    return true;
-                }
-            } else {
-                // a plain code cell with no kbase-stuff is possible, but unlikely, still, convert.
-                fixupCell(cell);
-                return true;
-            }
-        } else {
-            // not a code cell, sorry.
+        if (cell.cell_type !== 'code') {
             return false;
         }
+        if (cell.metadata.kbase && cell.metadata.kbase.type) {
+            return cell.metadata.kbase.type === 'code';
+        }
+        // a code cell with a kbase property but no type specified
+        // must be a pre-code-cell-extension code cell, which can be
+        // converted.
+        // a plain code cell with no kbase-stuff is possible, but unlikely
+        // still, convert it.
+        upgradeCell({
+            cell: cell,
+            kbase: {
+                type: 'code',
+                language: 'python'
+            }
+        });
+        return true;
     }
 
     function initializeExtension() {
@@ -216,7 +212,6 @@ define([
             var cell = payload.cell;
             var setupData = payload.data;
             var jupyterCellType = payload.type;
-            // var hasKBaseMetadata = payload.cell.metadata && payload.cell.metadata.kbase;
             if (jupyterCellType === 'code' &&
                 (!setupData || setupData.type === 'code')) {
                 try {

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -1,5 +1,3 @@
-/*jslint white: true*/
-/*global module */
 // process.env.CHROME_BIN = require('puppeteer').executablePath();
 module.exports = function (config) {
     'use strict';
@@ -29,6 +27,7 @@ module.exports = function (config) {
             'kbase-extension/static/kbase/js/api/RestAPIClient.js': ['coverage'],
             'nbextensions/appCell2/widgets/tabs/*.js': ['coverage'],
             'nbextensions/bulkImportCell/**/*.js': ['coverage'],
+            'nbextensions/codeCell/**/*.js': ['coverage'],
             'kbase-extension/static/kbase/js/*.js': ['coverage']
         },
         files: [
@@ -45,6 +44,7 @@ module.exports = function (config) {
             {pattern: 'nbextensions/appCell2/**/*.js', included: false, served: true},
             {pattern: 'nbextensions/bulkImportCell/**/*.js', included: false},
             {pattern: 'nbextensions/bulkImportCell/**/*.json', included: false},
+            {pattern: 'nbextensions/codeCell/**/*.js', included: false, served: true},
             {pattern: 'test/testConfig.json', included: false, served: true, nocache: true},
             {pattern: 'test/*.tok', included: false, served: true, nocache: true},
             {pattern: 'test/data/**/*', included: false, served: true},

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -46,10 +46,6 @@ define('narrativeMocks', [
         return mockCell;
     }
 
-    // inputArea = this.input.find('.input_area').get(0),
-    // outputArea = this.element.find('.output_wrapper'),
-    // viewInputArea = this.element.find('[data-subarea-type="${dataSubareaType}"]'),
-
     /**
      * Builds some mock cell metadata based on the kbaseCellType being mocked.
      * This cell type should be one of:
@@ -100,6 +96,14 @@ define('narrativeMocks', [
                     },
                 };
                 break;
+            case 'codeWithUserSettings':
+                meta.codeCell = {
+                    'userSettings': {
+                        showCodeInputArea: true
+                    },
+                };
+                break;
+
             default:
                 // if we don't know the cell type, return a blank metadata
                 meta = {};

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -34,9 +34,10 @@ define('narrativeMocks', [
             cell_type: cellType,
             renderMinMax: () => {},
             element: $cellContainer,
-            input: $('<div>').addClass('input'),
-            output: $('<div>').addClass('output')
+            input: $('<div>').addClass('input').append('<div>').addClass('input_area'),
+            output: $('<div>').addClass('output_wrapper').append('<div>').addClass('output'),
         };
+
         $cellContainer
             .append($toolbar)
             .append(mockCell.input)
@@ -44,6 +45,10 @@ define('narrativeMocks', [
         $('body').append($cellContainer);
         return mockCell;
     }
+
+    // inputArea = this.input.find('.input_area').get(0),
+    // outputArea = this.element.find('.output_wrapper'),
+    // viewInputArea = this.element.find('[data-subarea-type="${dataSubareaType}"]'),
 
     /**
      * Builds some mock cell metadata based on the kbaseCellType being mocked.
@@ -78,11 +83,21 @@ define('narrativeMocks', [
                     },
                     inputs: {}
                 };
-                meta.attributes.title = 'Import from Staging Area',
+                meta.attributes.title = 'Import from Staging Area';
                 meta.attributes.subtitle = 'Import files into your Narrative as data objects';
                 break;
             case 'app':
                 meta.appCell = {
+                    'user-settings': {
+                        showCodeInputArea: false
+                    },
+                };
+                break;
+            case 'code':
+                meta.codeCell = {
+                    'user-settings': {
+                        showCodeInputArea: false
+                    },
                 };
                 break;
             default:

--- a/test/unit/spec/nbextensions/bulkImportCell/main-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/main-spec.js
@@ -1,5 +1,3 @@
-/* global describe it expect beforeEach spyOn afterEach beforeAll afterAll */
-
 define([
     'jquery',
     '../../../../../../narrative/nbextensions/bulkImportCell/main',

--- a/test/unit/spec/nbextensions/codeCell/main-spec.js
+++ b/test/unit/spec/nbextensions/codeCell/main-spec.js
@@ -1,0 +1,102 @@
+define([
+    'jquery',
+    '../../../../../../narrative/nbextensions/codeCell/main',
+    '../../../../../../narrative/nbextensions/codeCell/widgets/codeCell',
+    'base/js/namespace',
+    'narrativeMocks'
+], (
+    $,
+    Main,
+    codeCell,
+    Jupyter,
+    Mocks
+) => {
+    'use strict';
+
+    function isCodeCell(cell) {
+        if (cell.cell_type !== 'code' || !cell.metadata.kbase) {
+            return false;
+        }
+        return cell.metadata.kbase.type === 'code';
+    }
+
+    describe('test the codeCell entrypoint module', () => {
+        beforeAll(() => {
+            Jupyter.narrative = {
+                getAuthToken: () => 'fakeToken'
+            };
+        });
+
+        afterAll(() => {
+            Jupyter.narrative = null;
+        });
+
+        beforeEach(() => {
+            // mock the notebook for the main module
+            const cell = Mocks.buildMockCell('code', 'code');
+            // the mock has two cells, a plain mock code cell, and
+            // a mock codeCell
+            Jupyter.notebook = Mocks.buildMockNotebook({
+                cells: [cell],
+                fullyLoaded: true
+            });
+        });
+
+        afterEach(() => {
+            Jupyter.notebook = null;
+        });
+
+        it('should have a load_ipython_extension function', () => {
+            expect(Main.load_ipython_extension).toBeDefined();
+        });
+
+        it('should initialize the notebook on start', () => {
+            // expect that setupNotebook was called, which we can
+            // proxy by checking on Jupyter.notebook.get_cells.
+            spyOn(Jupyter.notebook, 'get_cells').and.callThrough();
+            Main.load_ipython_extension();
+            expect(Jupyter.notebook.get_cells).toHaveBeenCalled();
+        });
+
+        it('should turn a newly inserted cell into a code cell', (done) => {
+            const newCell = Mocks.buildMockCell('code');
+            Jupyter.notebook.cells.push(newCell);
+            Main.load_ipython_extension();
+            $([Jupyter.events]).trigger('insertedAtIndex.Cell', {
+                type: 'code',
+                index: 1,
+                cell: newCell,
+                data: {
+                    type: 'code'
+                }
+            });
+            // there's no other triggers except to wait a moment
+            // for the cell to get turned into a bulk import cell
+            // and if it takes more than 100ms, it SHOULD fail.
+            setTimeout(() => {
+                expect(isCodeCell(newCell)).toBeTruthy();
+                done();
+            }, 100);
+        });
+
+        it('should not turn a plain code cell into a kbase code cell', (done) => {
+            const newCell = Mocks.buildMockCell('code');
+            Jupyter.notebook.cells.push(newCell);
+            Main.load_ipython_extension();
+            $([Jupyter.events]).trigger('insertedAtIndex.Cell', {
+                type: 'code',
+                index: 1,
+                cell: newCell,
+                data: {}
+            });
+            // there's no other triggers except to wait a moment
+            // for the cell to get turned into a bulk import cell
+            // and if it takes more than 100ms, it SHOULD fail.
+            setTimeout(() => {
+                expect(newCell.cellType).toBeUndefined();
+                expect(isCodeCell(newCell)).toBeFalsy();
+                done();
+            }, 100);
+        });
+    });
+});


### PR DESCRIPTION
# Description of PR purpose/changes

A previous PR standardised the way that we refer to `user-settings` in cell metadata. This ensures that saved narratives will have their cell metadata correctly reconstituted.

Added some basic `codeCell` tests and specific tests for the `userSettings` key in the kbase metadata.

Doing this as a separate PR so it doesn't get lost in the cell min/max stuff.

# Jira Ticket / Issue #

https://kbase-jira.atlassian.net/browse/DATAUP-322

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local narrative and enjoying the view.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
