### PR TITLE
DATAUP-322: Ensure initial cell min/max state is set

### DIFF
--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -343,6 +343,9 @@ define([
             cell.metadata = meta;
             render()
                 .then(() => {
+                    cell.renderMinMax();
+                    // force toolbar refresh
+                    cell.metadata = cell.metadata;
                     updateState();
                     toggleTab(state.tab.selected);
                 });


### PR DESCRIPTION
# Description of PR purpose/changes

Ensure that the initial cell min/max state is set properly. At present, the bulk upload cells are always expanded when a narrative opens; this corrects the situation so that they are only expanded if they were saved in that state.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-322

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local narrative, creating two bulk import cells, and setting one to minimised and one to maximised. Save the narrative. Reload the narrative and note that the initial cell state is correct.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - N/A
- [ ] My changes generate no new warnings -- oops
- [x] New and existing unit tests pass locally with my changes
