### PR TITLE
make codecov chill out with its annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
# Description of PR purpose/changes

Codecov has recently started to be obnoxiously noisy about what's tested or not in PRs. I admit this can be helpful, but IMO seeing a code coverage difference is enough, and the annotations clutter the file view of the PR, and they can only be disabled per file.

It's really annoying.

This PR adds a `codecov.yml` file that still keeps all the defaults, but disables that annotation as described here:
https://docs.codecov.io/docs/github-checks-beta#yaml-configuration-for-github-checks-and-codecov

# Jira Ticket / Issue #
N/A - no ticket. 

# Testing Instructions
N/A - no tests needed, just a config update

# Dev Checklist:
N/A - no new code, just a config
