### PR TITLE
DATAUP-313 Add job status skeleton

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateList.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateList.js
@@ -1,0 +1,157 @@
+define([
+    'bluebird',
+    'common/runtime',
+    'common/ui',
+    'common/format',
+    'kb_common/html',
+    './jobStateListRow'
+], function(
+    Promise,
+    Runtime,
+    UI,
+    format,
+    html,
+    JobStateListRow
+) {
+    'use strict';
+
+    var t = html.tag,
+        div = t('div'),
+        p = t('p'),
+        span = t('span'),
+        table = t('table'),
+        tr = t('tr'),
+        td = t('td'),
+        th = t('th'),
+        tbody = t('tbody');
+
+
+    function renderTable() {
+        return table({class: 'table'}, [
+            tbody()
+        ]);
+    }
+
+    function factory(config) {
+        var container, ui, listeners = [],
+            runtime = Runtime.make(),
+            widgets = {},
+            model = config.model,
+            parentJobId,
+            parentListener;
+
+        function createTableRow(id) {
+            var table = container.getElementsByTagName('tbody')[0];
+            var newRow = document.createElement('tr');
+            newRow.setAttribute('data-element-job-id', id);
+            newRow.classList.add('job-info');
+            table.appendChild(newRow);
+            return newRow;
+        }
+
+        function start(arg) {
+            return Promise.try(function() {
+                container = arg.node;
+                container.classList.add('batch-mode-list');
+                ui = UI.make({ node: container });
+                container.innerHTML = renderTable();
+                parentJobId = arg.parentJobId;
+
+                return Promise.try(() => {
+                    createJobStateWidget('parent', parentJobId, model.getItem('exec.jobState.status'), arg.clickFunction, true);
+                    container.getElementsByTagName('tr')[0].classList.add('job-selected'); // start with the parent selected
+
+                    for (var i=0; i<Math.max(arg.batchSize, arg.childJobs.length); i++) {
+                        var jobId = null,
+                            initialState = null;
+                        if (i < arg.childJobs.length) {
+                            jobId = arg.childJobs[i].job_id;
+                            initialState = arg.childJobs[i].status;
+                        }
+                        createJobStateWidget(i, jobId, initialState, arg.clickFunction);  // can make null ones. these need to be updated.
+                    }
+                })
+                .then(() => { startParentListener() });
+            });
+        }
+
+        function startParentListener() {
+            parentListener = runtime.bus().listen({
+                channel: {
+                    jobId: parentJobId
+                },
+                key: {
+                    type: 'job-status'
+                },
+                handle: handleJobStatusUpdate
+            });
+        }
+
+        /**
+         * Pass the job state to all row widgets, if it exists.
+         * @param {Object} message
+         */
+        function handleJobStatusUpdate(message) {
+            if (message.jobState.child_jobs) {
+                message.jobState.child_jobs.forEach((state, idx) => {
+                    widgets[idx].updateState(state);
+                });
+            }
+        }
+
+        /**
+         * Creates a job state widget and puts it in the widgets object, keyed by the index.
+         * This assumes that all child job states will always be returned in the same order
+         * on each state lookup, with new ones added to the end of the list. This also adds
+         * to the bottom of the job state list table.
+         *
+         * Each job state widget knows which child job index it's in, so it can look up its
+         * state as well.
+         * @param {int} jobIndex
+         * @param {string} jobId
+         */
+        function createJobStateWidget(jobIndex, jobId, initialState, clickFunction, isParentJob) {
+            widgets[jobIndex] = JobStateListRow.make({
+                model: model
+            });
+            widgets[jobIndex].start({
+                node: createTableRow(jobIndex),
+                name: isParentJob ? 'Parent Job' : 'Child Job ' + (jobIndex+1),
+                jobId: jobId,
+                initialState: initialState,
+                isParentJob: isParentJob ? true : false,
+                clickFunction: function(jobRow, jobId, isParentJob) {
+                    Array.from(container.getElementsByClassName('job-selected')).forEach((elem) => {
+                        elem.classList.remove('job-selected');
+                    });
+                    if (jobId) {
+                        jobRow.classList.add('job-selected');
+                        clickFunction({
+                            jobId: jobId,
+                            isParentJob: isParentJob,
+                            jobIndex: jobIndex
+                        });
+                    }
+                }
+            });
+        }
+
+        function stop() {
+            return Promise.try(function() {
+                runtime.bus().removeListener(parentListener);
+            });
+        }
+
+        return {
+            start: start,
+            stop: stop
+        };
+    }
+
+    return {
+        make: function(config) {
+            return factory(config);
+        }
+    };
+
+});

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateListRow.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateListRow.js
@@ -1,0 +1,122 @@
+define([
+    'bluebird',
+    'kb_common/html'
+], function(
+    Promise,
+    html
+) {
+    'use strict';
+
+    var t = html.tag,
+        div = t('div'),
+        td = t('td'),
+        th = t('th'),
+        span = t('span');
+
+    function niceState(jobState) {
+        var label, icon, color;
+        switch (jobState) {
+            case 'completed':
+                label = 'success';
+                icon = 'fa fa-check';
+                color = 'green';
+                break;
+            case 'queued':
+                label = jobState;
+                icon = 'fa fa-angle-double-right';
+                color = 'green';
+                break;
+            case 'running':
+                label = jobState;
+                icon = 'fa fa-spinner';
+                color = 'green';
+                break;
+            case 'error':
+                label = jobState;
+                icon = 'fa fa-times';
+                color = 'red';
+                break;
+            case 'terminated':
+                label = jobState;
+                icon = 'fa fa-times';
+                color = 'orange';
+                break;
+            case 'does_not_exist':
+                label = 'does not exist';
+                icon = 'fa fa-question';
+                color = 'orange';
+                break;
+            default:
+                label = jobState;
+                icon = 'fa fa-question';
+                color = 'black';
+        }
+
+        return td({
+            style: {
+                color: color,
+                fontWeight: 'bold'
+            },
+        }, [
+            span({
+                class: icon
+            }),
+            ' ' + label
+        ]);
+    }
+
+    function factory() {
+        var container,
+            name,
+            jobId,
+            clickFunction,
+            isParentJob;
+
+        function updateRowStatus(jobStatus) {
+            jobStatus = jobStatus ? jobStatus : 'Job still pending.';
+            var jobIdDiv = '';
+            container.innerHTML = th({}, [div(isParentJob ? name.toUpperCase() : name), jobIdDiv]) + niceState(jobStatus);
+        }
+
+        function start(arg) {
+            return Promise.try(function() {
+                container = arg.node;               // this is the row (tr) that this renders
+                container.onclick = () => {
+                    if (jobId) {
+                        clickFunction(container, jobId, isParentJob);
+                    }
+                };
+
+                jobId = arg.jobId;                  // id of child job
+                name = arg.name;
+                isParentJob = arg.isParentJob;
+                clickFunction = arg.clickFunction;  // called on click (after some ui junk)
+                updateRowStatus(arg.initialState);
+            });
+        }
+
+        function stop() {
+        }
+
+        function updateState(newState) {
+            if (!jobId) {
+                jobId = newState.job_id;
+            }
+            let status = newState.status ? newState.status : null;
+            updateRowStatus(status);
+        }
+
+        return {
+            start: start,
+            stop: stop,
+            updateState: updateState
+        };
+    }
+
+    return {
+        make: function() {
+            return factory();
+        }
+    };
+
+});

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTab.js
@@ -1,0 +1,183 @@
+define([
+    'bluebird',
+    'kb_common/html',
+    'common/ui',
+    'common/runtime',
+    'util/jobLogViewer',
+    './jobStateList'
+], function (
+    Promise,
+    html,
+    UI,
+    Runtime,
+    LogViewer,
+    JobStateList
+) {
+    'use strict';
+
+    var t = html.tag,
+        div = t('div');
+
+    function factory(config) {
+        // The top level node used by this widget.
+        let container;
+
+        // The handy UI module interface to this container.
+        let ui;
+
+        // A cheap widget collection.
+        let widgets = {},
+            queueListener,
+            model = config.model,
+            selectedJobId = config.jobId;
+
+        /**
+         * Used only if we're in Batch mode.
+         */
+        function batchLayout() {
+            var list = div({ class: 'col-md-3 batch-mode-col', dataElement: 'kb-job-list-wrapper' }, [
+                ui.buildPanel({
+                    title: 'Job Batch',
+                    name: 'subjobs',
+                    classes: [
+                        'kb-panel-light'
+                    ]
+                })
+            ]);
+
+            var jobStatus = div({ class: 'col-md-9 batch-mode-col',  dataElement: 'kb-job-status-wrapper' },[
+                ui.buildCollapsiblePanel({
+                    title: 'Job Log',
+                    name: 'job-log-section-toggle',
+                    hidden: false,
+                    type: 'default',
+                    collapsed: true,
+                    classes: ['kb-panel-container'],
+                    body: div({}, [
+                        ui.buildPanel({
+                            name: 'log',
+                            classes: [
+                                'kb-panel-light'
+                            ]
+                        })
+                    ])
+                })
+            ]);
+            return div({}, [list, jobStatus]);
+        }
+
+        function queueLayout() {
+            return div({
+                dataElement: 'kb-job-status-wrapper'
+            }, [
+                'This job is currently queued for execution and will start running soon.'
+            ]);
+        }
+
+        function getSelectedJobId() {
+            return config.clickedId;
+        }
+
+        function startBatch() {
+            return Promise.try(function() {
+                container.innerHTML = batchLayout();
+
+                //display widgets
+                widgets.log = LogViewer.make();
+
+                //rows as widgets to get live update
+                widgets.stateList = JobStateList.make({
+                    model: model
+                });
+
+                let childJobs = model.getItem('exec.jobState.child_jobs');
+                if (childJobs.length > 0) {
+                    selectedJobId = childJobs.job_id;
+                }
+                startDetails({
+                    jobId: selectedJobId,
+                    isParentJob: true
+                });
+
+                function startDetails(arg) {
+                    var selectedJobId = arg.jobId ? arg.jobId : model.getItem('exec.jobState.job_id');
+                    config.clickedId = selectedJobId;
+                    return Promise.all([
+                        widgets.log.start({
+                            node: ui.getElement('log.body'),
+                            jobId: selectedJobId,
+                            parentJobId: model.getItem('exec.jobState.job_id')
+                        })
+                    ]);
+                }
+                return Promise.all([
+                    widgets.stateList.start({
+                        node: ui.getElement('subjobs.body'),
+                        childJobs: model.getItem('exec.jobState.child_jobs'),
+                        clickFunction: startDetails,
+                        parentJobId: model.getItem('exec.jobState.job_id'),
+                        batchSize: model.getItem('exec.jobState.batch_size')
+                    })
+                ]);
+            });
+        }
+
+        /**
+         * Can start in 2 modes.
+         * 1. If the app is running, or has ever been running (so, )
+         * @param {object} arg
+         *  - node - the node to attach this tab to
+         *  -
+         */
+        function start(arg) {
+            container = arg.node.appendChild(document.createElement('div'));
+            ui = UI.make({
+                node: container
+            });
+
+            if (model.getItem('exec.jobState.status') === 'queued') {
+                container.innerHTML = queueLayout();
+                queueListener = Runtime.make().bus().listen({
+                    channel: {
+                        jobId: model.getItem('exec.jobState.job_id')
+                    },
+                    key: {
+                        type: 'job-status'
+                    },
+                    handle: (message) => {
+                        if (message.jobState.status !== 'queued') {
+                            container.innerHTML = '';
+                            Runtime.make().bus().removeListener(queueListener);
+                            startBatch();
+                        }
+                    }
+                });
+            }
+            else {
+                startBatch();
+            }
+        }
+
+        function stop() {
+            return Promise.try(function () {
+                if (widgets) {
+                    return Promise.all(Object.keys(widgets).map(function (key) {
+                        return widgets[key].stop();
+                    }));
+                }
+            });
+        }
+
+        return {
+            start: start,
+            stop: stop,
+            getSelectedJobId: getSelectedJobId
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -13,6 +13,7 @@ define([
     './cellTabs',
     './cellControlPanel',
     'common/cellComponents/tabs/infoTab',
+    'common/cellComponents/tabs/jobStatus/jobStatusTab',
     './tabs/configure',
     './fileTypePanel',
     'json!./testAppObj.json'
@@ -31,6 +32,7 @@ define([
     CellTabs,
     CellControlPanel,
     InfoTabWidget,
+    JobStatusTabWidget,
     ConfigureWidget,
     FileTypePanel,
     TestAppObj
@@ -131,9 +133,9 @@ define([
                         label: 'Info',
                         widget: InfoTabWidget,
                     },
-                    logs: {
+                    jobStatus: {
                         label: 'Job Status',
-                        widget: DefaultWidget()
+                        widget: JobStatusTabWidget
                     },
                     results: {
                         label: 'Result',
@@ -381,7 +383,8 @@ define([
                 workspaceInfo: workspaceInfo,
                 cell: cell,
                 model: model,
-                spec: spec
+                spec: spec,
+                jobId: undefined
             });
 
             let node = document.createElement('div');
@@ -444,8 +447,8 @@ define([
                             enabled: true,
                             visible: true
                         },
-                        logs: {
-                            enabled: false,
+                        jobStatus: {
+                            enabled: true,
                             visible: true
                         },
                         results: {

--- a/nbextensions/bulkImportCell/testAppObj.json
+++ b/nbextensions/bulkImportCell/testAppObj.json
@@ -1,471 +1,846 @@
 {
-    "app": {
-      "gitCommitHash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
-      "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-      "spec": {
-        "behavior": {
-          "kb_service_input_mapping": [
-            {
-              "narrative_system_variable": "workspace",
-              "target_property": "workspace_name"
-            },
-            {
-              "input_parameter": "import_type",
-              "target_property": "import_type"
-            },
-            {
-              "input_parameter": "fastq_fwd_staging_file_name",
-              "target_property": "fastq_fwd_staging_file_name"
-            },
-            {
-              "input_parameter": "fastq_rev_staging_file_name",
-              "target_property": "fastq_rev_staging_file_name"
-            },
-            {
-              "input_parameter": "sra_staging_file_name",
-              "target_property": "sra_staging_file_name"
-            },
-            {
-              "input_parameter": "sequencing_tech",
-              "target_property": "sequencing_tech"
-            },
-            {
-              "input_parameter": "name",
-              "target_property": "name"
-            },
-            {
-              "input_parameter": "single_genome",
-              "target_property": "single_genome"
-            },
-            {
-              "input_parameter": "interleaved",
-              "target_property": "interleaved"
-            },
-            {
-              "input_parameter": "insert_size_mean",
-              "target_property": "insert_size_mean"
-            },
-            {
-              "input_parameter": "insert_size_std_dev",
-              "target_property": "insert_size_std_dev"
-            },
-            {
-              "input_parameter": "read_orientation_outward",
-              "target_property": "read_orientation_outward"
-            }
-          ],
-          "kb_service_method": "import_reads_from_staging",
-          "kb_service_name": "kb_uploadmethods",
-          "kb_service_output_mapping": [
-            {
-              "narrative_system_variable": "workspace",
-              "target_property": "wsName"
-            },
-            {
-              "service_method_output_path": [
-                "0",
-                "obj_ref"
-              ],
-              "target_property": "obj_ref",
-              "target_type_transform": "resolved-ref"
-            },
-            {
-              "service_method_output_path": [
-                "0",
-                "report_name"
-              ],
-              "target_property": "report_name"
-            },
-            {
-              "service_method_output_path": [
-                "0",
-                "report_ref"
-              ],
-              "target_property": "report_ref"
-            },
-            {
-              "constant_value": "16",
-              "target_property": "report_window_line_height"
-            }
-          ],
-          "kb_service_url": "",
-          "kb_service_version": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b"
-        },
-        "fixed_parameters": [],
-        "full_info": {
-          "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-          "module_name": "kb_uploadmethods",
-          "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
-          "name": "Import FASTQ/SRA File as Reads from Staging Area",
-          "ver": "1.0.43",
-          "authors": [
-            "tgu2"
-          ],
-          "contact": "http://kbase.us/contact-us/",
-          "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "description": "<p> Import a FASTQ/SRA file into your Narrative as a Reads data object\nPlease see the <a href=\"http://kbase.us/data-upload-download-guide/\">Data Upload/Download Guide</a> for more information. </p>",
-          "technical_description": "none",
-          "app_type": "app",
-          "suggestions": {
-            "related_methods": [],
-            "next_methods": [],
-            "related_apps": [],
-            "next_apps": []
-          },
-          "icon": {
-            "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
-          },
-          "categories": [
-            "inactive",
-            "reads",
-            "upload"
-          ],
-          "screenshots": [],
-          "publications": [],
-          "namespace": "kb_uploadmethods"
-        },
-        "info": {
-          "app_type": "app",
-          "authors": [
-            "tgu2"
-          ],
-          "categories": [
-            "inactive",
-            "reads",
-            "upload"
-          ],
-          "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
-          "icon": {
-            "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
-          },
-          "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-          "input_types": [],
-          "module_name": "kb_uploadmethods",
-          "name": "Import FASTQ/SRA File as Reads from Staging Area",
-          "namespace": "kb_uploadmethods",
-          "output_types": [
-            "KBaseFile.PairedEndLibrary",
-            "KBaseFile.SingleEndLibrary"
-          ],
-          "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "ver": "1.0.43"
-        },
-        "job_id_output_field": "docker",
-        "parameters": [
+  "app": {
+    "gitCommitHash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
+    "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+    "spec": {
+      "behavior": {
+        "kb_service_input_mapping": [
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              "FASTQ/FASTA"
-            ],
-            "description": "Import file type ['FASTQ/FASTA' or 'SRA']",
-            "disabled": 0,
-            "dropdown_options": {
-              "multiselection": 0,
-              "options": [
-                {
-                  "display": "FASTQ/FASTA",
-                  "index": 0,
-                  "value": "FASTQ/FASTA"
-                },
-                {
-                  "display": "SRA",
-                  "index": 1,
-                  "value": "SRA"
-                }
-              ]
-            },
-            "field_type": "dropdown",
-            "id": "import_type",
-            "optional": 0,
-            "short_hint": "Import file type ['FASTQ/FASTA' or 'SRA']",
-            "ui_class": "parameter",
-            "ui_name": "Import File Type"
+            "narrative_system_variable": "workspace",
+            "target_property": "workspace_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
-            "disabled": 0,
-            "dynamic_dropdown_options": {
-              "data_source": "ftp_staging",
-              "multiselection": 0,
-              "query_on_empty_input": 1,
-              "result_array_index": 0,
-              "service_params": null
-            },
-            "field_type": "dynamic_dropdown",
-            "id": "fastq_fwd_staging_file_name",
-            "optional": 1,
-            "short_hint": "Short read file containing a paired end library in FASTA/FASTQ format",
-            "ui_class": "parameter",
-            "ui_name": "Forward/Left FASTA/FASTQ File Path"
+            "input_parameter": "import_type",
+            "target_property": "import_type"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
-            "disabled": 0,
-            "dynamic_dropdown_options": {
-              "data_source": "ftp_staging",
-              "multiselection": 0,
-              "query_on_empty_input": 1,
-              "result_array_index": 0,
-              "service_params": null
-            },
-            "field_type": "dynamic_dropdown",
-            "id": "fastq_rev_staging_file_name",
-            "optional": 1,
-            "short_hint": "Second short read file containing a paired end library in FASTA/FASTQ format.",
-            "ui_class": "parameter",
-            "ui_name": "Reverse/Right FASTA/FASTQ File Path"
+            "input_parameter": "fastq_fwd_staging_file_name",
+            "target_property": "fastq_fwd_staging_file_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "SRA staing file path",
-            "disabled": 0,
-            "dynamic_dropdown_options": {
-              "data_source": "ftp_staging",
-              "multiselection": 0,
-              "query_on_empty_input": 1,
-              "result_array_index": 0,
-              "service_params": null
-            },
-            "field_type": "dynamic_dropdown",
-            "id": "sra_staging_file_name",
-            "optional": 1,
-            "short_hint": "SRA staing file path",
-            "ui_class": "parameter",
-            "ui_name": "SRA File Path"
+            "input_parameter": "fastq_rev_staging_file_name",
+            "target_property": "fastq_rev_staging_file_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              "Illumina"
-            ],
-            "description": "The name of the sequencing technology used to create the reads file",
-            "disabled": 0,
-            "dropdown_options": {
-              "multiselection": 0,
-              "options": [
-                {
-                  "display": "Illumina",
-                  "index": 0,
-                  "value": "Illumina"
-                },
-                {
-                  "display": "PacBio CLR",
-                  "index": 1,
-                  "value": "PacBio CLR"
-                },
-                {
-                  "display": "PacBio CCS",
-                  "index": 2,
-                  "value": "PacBio CCS"
-                },
-                {
-                  "display": "IonTorrent",
-                  "index": 3,
-                  "value": "IonTorrent"
-                },
-                {
-                  "display": "NanoPore",
-                  "index": 4,
-                  "value": "NanoPore"
-                },
-                {
-                  "display": "Unknown",
-                  "index": 5,
-                  "value": "Unknown"
-                }
-              ]
-            },
-            "field_type": "dropdown",
-            "id": "sequencing_tech",
-            "optional": 0,
-            "short_hint": "The name of the sequencing technology used to create the reads file",
-            "ui_class": "parameter",
-            "ui_name": "Sequencing Technology"
+            "input_parameter": "sra_staging_file_name",
+            "target_property": "sra_staging_file_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "Provide a name for the Reads object that will be created by this importer",
-            "disabled": 0,
-            "field_type": "text",
-            "id": "name",
-            "optional": 0,
-            "short_hint": "Provide a name for the Reads object that will be created by this importer",
-            "text_options": {
-              "is_output_name": 1,
-              "placeholder": "",
-              "regex_constraint": [],
-              "valid_ws_types": [
-                "KBaseFile.SingleEndLibrary",
-                "KBaseFile.PairedEndLibrary"
-              ]
-            },
-            "ui_class": "output",
-            "ui_name": "Reads Object Name"
+            "input_parameter": "sequencing_tech",
+            "target_property": "sequencing_tech"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "checkbox_options": {
-              "checked_value": 1,
-              "unchecked_value": 0
-            },
-            "default_values": [
-              "1"
-            ],
-            "description": "Select if the reads are from a single genome, leave blank if from a metagenome",
-            "disabled": 0,
-            "field_type": "checkbox",
-            "id": "single_genome",
-            "optional": 0,
-            "short_hint": "Select if the reads are from a single genome, leave blank if from a metagenome",
-            "ui_class": "parameter",
-            "ui_name": "Single Genome"
+            "input_parameter": "name",
+            "target_property": "name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "checkbox_options": {
-              "checked_value": 1,
-              "unchecked_value": 0
-            },
-            "default_values": [
-              "0"
-            ],
-            "description": "Select if reads file is interleaved",
-            "disabled": 0,
-            "field_type": "checkbox",
-            "id": "interleaved",
-            "optional": 0,
-            "short_hint": "Select if reads file is interleaved",
-            "ui_class": "parameter",
-            "ui_name": "Interleaved"
+            "input_parameter": "single_genome",
+            "target_property": "single_genome"
           },
           {
-            "advanced": 1,
-            "allow_multiple": 0,
-            "checkbox_options": {
-              "checked_value": 1,
-              "unchecked_value": 0
-            },
-            "default_values": [
-              "0"
-            ],
-            "description": "Select if reads in a pair point outward",
-            "disabled": 0,
-            "field_type": "checkbox",
-            "id": "read_orientation_outward",
-            "optional": 1,
-            "short_hint": "Select if reads in a pair point outward",
-            "ui_class": "parameter",
-            "ui_name": "Reads Orientation Outward"
+            "input_parameter": "interleaved",
+            "target_property": "interleaved"
           },
           {
-            "advanced": 1,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "The standard deviation of insert lengths",
-            "disabled": 0,
-            "field_type": "text",
-            "id": "insert_size_std_dev",
-            "optional": 1,
-            "short_hint": "The standard deviation of insert lengths",
-            "text_options": {
-              "is_output_name": 0,
-              "placeholder": "",
-              "regex_constraint": [],
-              "validate_as": "float"
-            },
-            "ui_class": "parameter",
-            "ui_name": "St. Dev. of Insert Size"
+            "input_parameter": "insert_size_mean",
+            "target_property": "insert_size_mean"
           },
           {
-            "advanced": 1,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "The mean (average) insert length",
-            "disabled": 0,
-            "field_type": "text",
-            "id": "insert_size_mean",
-            "optional": 1,
-            "short_hint": "The mean (average) insert length",
-            "text_options": {
-              "is_output_name": 0,
-              "placeholder": "",
-              "regex_constraint": [],
-              "validate_as": "float"
-            },
-            "ui_class": "parameter",
-            "ui_name": "Mean Insert Size"
+            "input_parameter": "insert_size_std_dev",
+            "target_property": "insert_size_std_dev"
+          },
+          {
+            "input_parameter": "read_orientation_outward",
+            "target_property": "read_orientation_outward"
           }
         ],
-        "widgets": {
-          "input": "null",
-          "output": "no-display"
-        }
+        "kb_service_method": "import_reads_from_staging",
+        "kb_service_name": "kb_uploadmethods",
+        "kb_service_output_mapping": [
+          {
+            "narrative_system_variable": "workspace",
+            "target_property": "wsName"
+          },
+          {
+            "service_method_output_path": [
+              "0",
+              "obj_ref"
+            ],
+            "target_property": "obj_ref",
+            "target_type_transform": "resolved-ref"
+          },
+          {
+            "service_method_output_path": [
+              "0",
+              "report_name"
+            ],
+            "target_property": "report_name"
+          },
+          {
+            "service_method_output_path": [
+              "0",
+              "report_ref"
+            ],
+            "target_property": "report_ref"
+          },
+          {
+            "constant_value": "16",
+            "target_property": "report_window_line_height"
+          }
+        ],
+        "kb_service_url": "",
+        "kb_service_version": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b"
       },
-      "tag": "release",
-      "version": "1.0.43"
-    },
-    "executionStats": {
-      "full_app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-      "time_range": "*",
-      "type": "a",
-      "number_of_calls": 170,
-      "number_of_errors": 63,
-      "total_exec_time": 70242.75900101662,
-      "total_queue_time": 40118.08499789238,
-      "module_name": "kb_uploadmethods"
-    },
-    "fsm": {
-      "currentState": {
-        "code": "built",
-        "mode": "editing",
-        "params": "complete"
+      "fixed_parameters": [],
+      "full_info": {
+        "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+        "module_name": "kb_uploadmethods",
+        "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
+        "name": "Import FASTQ/SRA File as Reads from Staging Area",
+        "ver": "1.0.43",
+        "authors": [
+          "tgu2"
+        ],
+        "contact": "http://kbase.us/contact-us/",
+        "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "description": "<p> Import a FASTQ/SRA file into your Narrative as a Reads data object\nPlease see the <a href=\"http://kbase.us/data-upload-download-guide/\">Data Upload/Download Guide</a> for more information. </p>",
+        "technical_description": "none",
+        "app_type": "app",
+        "suggestions": {
+          "related_methods": [],
+          "next_methods": [],
+          "related_apps": [],
+          "next_apps": []
+        },
+        "icon": {
+          "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
+        },
+        "categories": [
+          "inactive",
+          "reads",
+          "upload"
+        ],
+        "screenshots": [],
+        "publications": [],
+        "namespace": "kb_uploadmethods"
+      },
+      "info": {
+        "app_type": "app",
+        "authors": [
+          "tgu2"
+        ],
+        "categories": [
+          "inactive",
+          "reads",
+          "upload"
+        ],
+        "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
+        "icon": {
+          "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
+        },
+        "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+        "input_types": [],
+        "module_name": "kb_uploadmethods",
+        "name": "Import FASTQ/SRA File as Reads from Staging Area",
+        "namespace": "kb_uploadmethods",
+        "output_types": [
+          "KBaseFile.PairedEndLibrary",
+          "KBaseFile.SingleEndLibrary"
+        ],
+        "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "ver": "1.0.43"
+      },
+      "job_id_output_field": "docker",
+      "parameters": [
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            "FASTQ/FASTA"
+          ],
+          "description": "Import file type ['FASTQ/FASTA' or 'SRA']",
+          "disabled": 0,
+          "dropdown_options": {
+            "multiselection": 0,
+            "options": [
+              {
+                "display": "FASTQ/FASTA",
+                "index": 0,
+                "value": "FASTQ/FASTA"
+              },
+              {
+                "display": "SRA",
+                "index": 1,
+                "value": "SRA"
+              }
+            ]
+          },
+          "field_type": "dropdown",
+          "id": "import_type",
+          "optional": 0,
+          "short_hint": "Import file type ['FASTQ/FASTA' or 'SRA']",
+          "ui_class": "parameter",
+          "ui_name": "Import File Type"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
+          "disabled": 0,
+          "dynamic_dropdown_options": {
+            "data_source": "ftp_staging",
+            "multiselection": 0,
+            "query_on_empty_input": 1,
+            "result_array_index": 0,
+            "service_params": null
+          },
+          "field_type": "dynamic_dropdown",
+          "id": "fastq_fwd_staging_file_name",
+          "optional": 1,
+          "short_hint": "Short read file containing a paired end library in FASTA/FASTQ format",
+          "ui_class": "parameter",
+          "ui_name": "Forward/Left FASTA/FASTQ File Path"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
+          "disabled": 0,
+          "dynamic_dropdown_options": {
+            "data_source": "ftp_staging",
+            "multiselection": 0,
+            "query_on_empty_input": 1,
+            "result_array_index": 0,
+            "service_params": null
+          },
+          "field_type": "dynamic_dropdown",
+          "id": "fastq_rev_staging_file_name",
+          "optional": 1,
+          "short_hint": "Second short read file containing a paired end library in FASTA/FASTQ format.",
+          "ui_class": "parameter",
+          "ui_name": "Reverse/Right FASTA/FASTQ File Path"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "SRA staing file path",
+          "disabled": 0,
+          "dynamic_dropdown_options": {
+            "data_source": "ftp_staging",
+            "multiselection": 0,
+            "query_on_empty_input": 1,
+            "result_array_index": 0,
+            "service_params": null
+          },
+          "field_type": "dynamic_dropdown",
+          "id": "sra_staging_file_name",
+          "optional": 1,
+          "short_hint": "SRA staing file path",
+          "ui_class": "parameter",
+          "ui_name": "SRA File Path"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            "Illumina"
+          ],
+          "description": "The name of the sequencing technology used to create the reads file",
+          "disabled": 0,
+          "dropdown_options": {
+            "multiselection": 0,
+            "options": [
+              {
+                "display": "Illumina",
+                "index": 0,
+                "value": "Illumina"
+              },
+              {
+                "display": "PacBio CLR",
+                "index": 1,
+                "value": "PacBio CLR"
+              },
+              {
+                "display": "PacBio CCS",
+                "index": 2,
+                "value": "PacBio CCS"
+              },
+              {
+                "display": "IonTorrent",
+                "index": 3,
+                "value": "IonTorrent"
+              },
+              {
+                "display": "NanoPore",
+                "index": 4,
+                "value": "NanoPore"
+              },
+              {
+                "display": "Unknown",
+                "index": 5,
+                "value": "Unknown"
+              }
+            ]
+          },
+          "field_type": "dropdown",
+          "id": "sequencing_tech",
+          "optional": 0,
+          "short_hint": "The name of the sequencing technology used to create the reads file",
+          "ui_class": "parameter",
+          "ui_name": "Sequencing Technology"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "Provide a name for the Reads object that will be created by this importer",
+          "disabled": 0,
+          "field_type": "text",
+          "id": "name",
+          "optional": 0,
+          "short_hint": "Provide a name for the Reads object that will be created by this importer",
+          "text_options": {
+            "is_output_name": 1,
+            "placeholder": "",
+            "regex_constraint": [],
+            "valid_ws_types": [
+              "KBaseFile.SingleEndLibrary",
+              "KBaseFile.PairedEndLibrary"
+            ]
+          },
+          "ui_class": "output",
+          "ui_name": "Reads Object Name"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "checkbox_options": {
+            "checked_value": 1,
+            "unchecked_value": 0
+          },
+          "default_values": [
+            "1"
+          ],
+          "description": "Select if the reads are from a single genome, leave blank if from a metagenome",
+          "disabled": 0,
+          "field_type": "checkbox",
+          "id": "single_genome",
+          "optional": 0,
+          "short_hint": "Select if the reads are from a single genome, leave blank if from a metagenome",
+          "ui_class": "parameter",
+          "ui_name": "Single Genome"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "checkbox_options": {
+            "checked_value": 1,
+            "unchecked_value": 0
+          },
+          "default_values": [
+            "0"
+          ],
+          "description": "Select if reads file is interleaved",
+          "disabled": 0,
+          "field_type": "checkbox",
+          "id": "interleaved",
+          "optional": 0,
+          "short_hint": "Select if reads file is interleaved",
+          "ui_class": "parameter",
+          "ui_name": "Interleaved"
+        },
+        {
+          "advanced": 1,
+          "allow_multiple": 0,
+          "checkbox_options": {
+            "checked_value": 1,
+            "unchecked_value": 0
+          },
+          "default_values": [
+            "0"
+          ],
+          "description": "Select if reads in a pair point outward",
+          "disabled": 0,
+          "field_type": "checkbox",
+          "id": "read_orientation_outward",
+          "optional": 1,
+          "short_hint": "Select if reads in a pair point outward",
+          "ui_class": "parameter",
+          "ui_name": "Reads Orientation Outward"
+        },
+        {
+          "advanced": 1,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "The standard deviation of insert lengths",
+          "disabled": 0,
+          "field_type": "text",
+          "id": "insert_size_std_dev",
+          "optional": 1,
+          "short_hint": "The standard deviation of insert lengths",
+          "text_options": {
+            "is_output_name": 0,
+            "placeholder": "",
+            "regex_constraint": [],
+            "validate_as": "float"
+          },
+          "ui_class": "parameter",
+          "ui_name": "St. Dev. of Insert Size"
+        },
+        {
+          "advanced": 1,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "The mean (average) insert length",
+          "disabled": 0,
+          "field_type": "text",
+          "id": "insert_size_mean",
+          "optional": 1,
+          "short_hint": "The mean (average) insert length",
+          "text_options": {
+            "is_output_name": 0,
+            "placeholder": "",
+            "regex_constraint": [],
+            "validate_as": "float"
+          },
+          "ui_class": "parameter",
+          "ui_name": "Mean Insert Size"
+        }
+      ],
+      "widgets": {
+        "input": "null",
+        "output": "no-display"
       }
     },
-    "output": {
-      "byJob": {}
+    "tag": "release",
+    "version": "1.0.43"
+  },
+  "exec": {
+    "jobState": {
+      "authstrat": "kbaseworkspace",
+      "batch_size": 3,
+      "cell_id": "13395335-1f3d-4e0c-80f7-44b634968da0",
+      "child_jobs": [],
+      "created": 1607109147000,
+      "finished": 1607109627617,
+      "job_id": "5fca8a1bd257f9f38c9862a0",
+      "job_output": {
+        "id": "5fca8a1bd257f9f38c9862a0",
+        "result": [
+          {
+            "batch_results": {
+              "5fca8a3168dcf051ac8c79e3": {
+                "final_job_state": {
+                  "authstrat": "kbaseworkspace",
+                  "child_jobs": [],
+                  "condor_job_ads": {
+                    "CommittedSuspensionTime": 0,
+                    "CommittedTime": 0,
+                    "CompletionDate": 0,
+                    "CpusUsage": null,
+                    "CumulativeRemoteSysCpu": 0,
+                    "CumulativeRemoteUserCpu": 0,
+                    "CumulativeSuspensionTime": 0,
+                    "CumulativeTransferTime": null,
+                    "DiskUsage": 325,
+                    "DiskUsage_RAW": 320,
+                    "HoldReason": null,
+                    "HoldReasonCode": null,
+                    "ImageSize_RAW": 2,
+                    "JobCurrentFinishTransferInputDate": null,
+                    "JobCurrentFinishTransferOutputDate": null,
+                    "JobCurrentStartDate": 1607109176,
+                    "JobCurrentStartExecutingDate": null,
+                    "JobCurrentStartTransferInputDate": null,
+                    "JobCurrentStartTransferOutputDate": null,
+                    "LastRemoteHost": null,
+                    "RemoteHost": "slot1_1@ci-core-condorworker-mixed-privileged-partionable-6-1",
+                    "RemoteUserCpu": 0,
+                    "ResidentSetSize": null,
+                    "ResidentSetSize_RAW": null
+                  },
+                  "created": 1607109169000,
+                  "exec_start_time": 1607109169000,
+                  "finish_time": 1607109486097,
+                  "finished": 1607109486097,
+                  "job_id": "5fca8a3168dcf051ac8c79e3",
+                  "job_input": {
+                    "app_id": "MEGAHIT",
+                    "method": "MEGAHIT.run_megahit",
+                    "narrative_cell_info": {},
+                    "params": [
+                      {
+                        "k_list": [],
+                        "k_max": null,
+                        "k_min": null,
+                        "k_step": null,
+                        "megahit_parameter_preset": null,
+                        "min_contig_len": 500,
+                        "min_count": null,
+                        "output_contigset_name": "reads_test3_contigs",
+                        "read_library_ref": "57373/6/1",
+                        "workspace_name": "ialarmedalien:narrative_1607108970427"
+                      }
+                    ],
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0",
+                    "requirements": {
+                      "clientgroup": "njs",
+                      "cpu": 2,
+                      "disk": 100,
+                      "memory": 23000
+                    },
+                    "service_ver": "cc91ddfe376f907aa56cfb3dd1b1b21cae8885a6",
+                    "source_ws_objects": []
+                  },
+                  "job_output": {
+                    "id": "5fca8a3168dcf051ac8c79e3",
+                    "result": [
+                      {
+                        "report_name": "kb_megahit_report_c99b640d-23a3-4865-9727-fd6ef05df3d6",
+                        "report_ref": "57373/17/1"
+                      }
+                    ],
+                    "version": "1.1"
+                  },
+                  "job_state": "completed",
+                  "queued": 1607109169066,
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_c99b640d-23a3-4865-9727-fd6ef05df3d6",
+                      "report_ref": "57373/17/1"
+                    }
+                  ],
+                  "running": 1607109187951,
+                  "scheduler_id": "23204",
+                  "scheduler_type": "condor",
+                  "status": "completed",
+                  "updated": 1607109486235,
+                  "user": "ialarmedalien"
+                },
+                "is_error": false,
+                "result_package": {
+                  "error": null,
+                  "function": {
+                    "method_name": "run_megahit",
+                    "module_name": "MEGAHIT",
+                    "version": "2.2.2"
+                  },
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_c99b640d-23a3-4865-9727-fd6ef05df3d6",
+                      "report_ref": "57373/17/1"
+                    }
+                  ],
+                  "run_context": {
+                    "job_id": "5fca8a3168dcf051ac8c79e3",
+                    "location": "njsw",
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0"
+                  }
+                }
+              },
+              "5fca8a31d257f9f38c9862a1": {
+                "final_job_state": {
+                  "authstrat": "kbaseworkspace",
+                  "child_jobs": [],
+                  "condor_job_ads": {
+                    "CommittedSuspensionTime": 0,
+                    "CommittedTime": 0,
+                    "CompletionDate": 0,
+                    "CpusUsage": null,
+                    "CumulativeRemoteSysCpu": 0,
+                    "CumulativeRemoteUserCpu": 0,
+                    "CumulativeSuspensionTime": 0,
+                    "CumulativeTransferTime": null,
+                    "DiskUsage": 325,
+                    "DiskUsage_RAW": 320,
+                    "HoldReason": null,
+                    "HoldReasonCode": null,
+                    "ImageSize_RAW": 2,
+                    "JobCurrentFinishTransferInputDate": null,
+                    "JobCurrentFinishTransferOutputDate": null,
+                    "JobCurrentStartDate": 1607109176,
+                    "JobCurrentStartExecutingDate": null,
+                    "JobCurrentStartTransferInputDate": null,
+                    "JobCurrentStartTransferOutputDate": null,
+                    "LastRemoteHost": null,
+                    "RemoteHost": "slot1_1@ci-core-condorworker-mixed-privileged-partionable-2-1",
+                    "RemoteUserCpu": 0,
+                    "ResidentSetSize": null,
+                    "ResidentSetSize_RAW": null
+                  },
+                  "created": 1607109169000,
+                  "exec_start_time": 1607109169000,
+                  "finish_time": 1607109486663,
+                  "finished": 1607109486663,
+                  "job_id": "5fca8a31d257f9f38c9862a1",
+                  "job_input": {
+                    "app_id": "MEGAHIT",
+                    "method": "MEGAHIT.run_megahit",
+                    "narrative_cell_info": {},
+                    "params": [
+                      {
+                        "k_list": [],
+                        "k_max": null,
+                        "k_min": null,
+                        "k_step": null,
+                        "megahit_parameter_preset": null,
+                        "min_contig_len": 500,
+                        "min_count": null,
+                        "output_contigset_name": "reads_test2_contigs",
+                        "read_library_ref": "57373/4/1",
+                        "workspace_name": "ialarmedalien:narrative_1607108970427"
+                      }
+                    ],
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0",
+                    "requirements": {
+                      "clientgroup": "njs",
+                      "cpu": 2,
+                      "disk": 100,
+                      "memory": 23000
+                    },
+                    "service_ver": "cc91ddfe376f907aa56cfb3dd1b1b21cae8885a6",
+                    "source_ws_objects": []
+                  },
+                  "job_output": {
+                    "id": "5fca8a31d257f9f38c9862a1",
+                    "result": [
+                      {
+                        "report_name": "kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e",
+                        "report_ref": "57373/16/1"
+                      }
+                    ],
+                    "version": "1.1"
+                  },
+                  "job_state": "completed",
+                  "queued": 1607109169578,
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e",
+                      "report_ref": "57373/16/1"
+                    }
+                  ],
+                  "running": 1607109187944,
+                  "scheduler_id": "23205",
+                  "scheduler_type": "condor",
+                  "status": "completed",
+                  "updated": 1607109486818,
+                  "user": "ialarmedalien"
+                },
+                "is_error": false,
+                "result_package": {
+                  "error": null,
+                  "function": {
+                    "method_name": "run_megahit",
+                    "module_name": "MEGAHIT",
+                    "version": "2.2.2"
+                  },
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e",
+                      "report_ref": "57373/16/1"
+                    }
+                  ],
+                  "run_context": {
+                    "job_id": "5fca8a31d257f9f38c9862a1",
+                    "location": "njsw",
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0"
+                  }
+                }
+              },
+              "5fca8a32b254b87cbf066b09": {
+                "final_job_state": {
+                  "authstrat": "kbaseworkspace",
+                  "child_jobs": [],
+                  "condor_job_ads": {
+                    "CommittedSuspensionTime": 0,
+                    "CommittedTime": 0,
+                    "CompletionDate": 0,
+                    "CpusUsage": null,
+                    "CumulativeRemoteSysCpu": 0,
+                    "CumulativeRemoteUserCpu": 0,
+                    "CumulativeSuspensionTime": 0,
+                    "CumulativeTransferTime": null,
+                    "DiskUsage": 325,
+                    "DiskUsage_RAW": 320,
+                    "HoldReason": null,
+                    "HoldReasonCode": null,
+                    "ImageSize_RAW": 2,
+                    "JobCurrentFinishTransferInputDate": null,
+                    "JobCurrentFinishTransferOutputDate": null,
+                    "JobCurrentStartDate": 1607109176,
+                    "JobCurrentStartExecutingDate": null,
+                    "JobCurrentStartTransferInputDate": null,
+                    "JobCurrentStartTransferOutputDate": null,
+                    "LastRemoteHost": null,
+                    "RemoteHost": "slot1_1@ci-core-condorworker-mixed-privileged-partionable-3-1",
+                    "RemoteUserCpu": 0,
+                    "ResidentSetSize": null,
+                    "ResidentSetSize_RAW": null
+                  },
+                  "created": 1607109170000,
+                  "exec_start_time": 1607109170000,
+                  "finish_time": 1607109524887,
+                  "finished": 1607109524887,
+                  "job_id": "5fca8a32b254b87cbf066b09",
+                  "job_input": {
+                    "app_id": "MEGAHIT",
+                    "method": "MEGAHIT.run_megahit",
+                    "narrative_cell_info": {},
+                    "params": [
+                      {
+                        "k_list": [],
+                        "k_max": null,
+                        "k_min": null,
+                        "k_step": null,
+                        "megahit_parameter_preset": null,
+                        "min_contig_len": 500,
+                        "min_count": null,
+                        "output_contigset_name": "reads_test_contigs",
+                        "read_library_ref": "57373/2/1",
+                        "workspace_name": "ialarmedalien:narrative_1607108970427"
+                      }
+                    ],
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0",
+                    "requirements": {
+                      "clientgroup": "njs",
+                      "cpu": 2,
+                      "disk": 100,
+                      "memory": 23000
+                    },
+                    "service_ver": "cc91ddfe376f907aa56cfb3dd1b1b21cae8885a6",
+                    "source_ws_objects": []
+                  },
+                  "job_output": {
+                    "id": "5fca8a32b254b87cbf066b09",
+                    "result": [
+                      {
+                        "report_name": "kb_megahit_report_90cd1717-5e2e-4a4a-a798-c099b1052410",
+                        "report_ref": "57373/18/1"
+                      }
+                    ],
+                    "version": "1.1"
+                  },
+                  "job_state": "completed",
+                  "queued": 1607109170059,
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_90cd1717-5e2e-4a4a-a798-c099b1052410",
+                      "report_ref": "57373/18/1"
+                    }
+                  ],
+                  "running": 1607109187890,
+                  "scheduler_id": "23206",
+                  "scheduler_type": "condor",
+                  "status": "completed",
+                  "updated": 1607109525035,
+                  "user": "ialarmedalien"
+                },
+                "is_error": false,
+                "result_package": {
+                  "error": null,
+                  "function": {
+                    "method_name": "run_megahit",
+                    "module_name": "MEGAHIT",
+                    "version": "2.2.2"
+                  },
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_90cd1717-5e2e-4a4a-a798-c099b1052410",
+                      "report_ref": "57373/18/1"
+                    }
+                  ],
+                  "run_context": {
+                    "job_id": "5fca8a32b254b87cbf066b09",
+                    "location": "njsw",
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0"
+                  }
+                }
+              }
+            },
+            "report_name": "batch_report_1607109609490",
+            "report_ref": "57373/19/1"
+          }
+        ],
+        "version": "1.1"
+      },
+      "queued": 1607109147274,
+      "run_id": "13395335-1f3d-4e0c-80f7-44b634968da0",
+      "running": 1607109162603,
+      "scheduler_id": "23203",
+      "scheduler_type": "condor",
+      "status": "completed",
+      "updated": 1607109627760,
+      "user": "ialarmedalien",
+      "wsid": 57373
     },
-    "params": {
-      "fastq_fwd_staging_file_name": "",
-      "fastq_rev_staging_file_name": "",
-      "import_type": "SRA",
-      "insert_size_mean": null,
-      "insert_size_std_dev": null,
-      "interleaved": 0,
-      "name": "KBase_object_details_22020-10-14T232042188.json_reads",
-      "read_orientation_outward": 0,
-      "sequencing_tech": "Illumina",
-      "single_genome": 1,
-      "sra_staging_file_name": "KBase_object_details_22020-10-14T232042188.json"
+    "jobStateUpdated": 1607109635241,
+    "launchState": {
+      "cell_id": "13395335-1f3d-4e0c-80f7-44b634968da0",
+      "event": "launched_job",
+      "event_at": "2020-12-04T19:12:27.690847Z",
+      "job_id": "5fca8a1bd257f9f38c9862a0",
+      "run_id": "8c202a66-e868-4cf4-a990-bab2393985ae"
     },
-    "user-settings": {
-      "showCodeInputArea": false
+    "outputWidgetInfo": {
+      "name": "no-display",
+      "params": {
+        "report_name": "batch_report_1607109609490",
+        "report_ref": "57373/19/1"
+      },
+      "tag": "dev"
     }
+  },
+  "executionStats": {
+    "full_app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+    "time_range": "*",
+    "type": "a",
+    "number_of_calls": 170,
+    "number_of_errors": 63,
+    "total_exec_time": 70242.75900101662,
+    "total_queue_time": 40118.08499789238,
+    "module_name": "kb_uploadmethods"
+  },
+  "fsm": {
+    "currentState": {
+      "code": "built",
+      "mode": "editing",
+      "params": "complete"
+    }
+  },
+  "output": {
+    "byJob": {}
+  },
+  "params": {
+    "fastq_fwd_staging_file_name": "",
+    "fastq_rev_staging_file_name": "",
+    "import_type": "SRA",
+    "insert_size_mean": null,
+    "insert_size_std_dev": null,
+    "interleaved": 0,
+    "name": "KBase_object_details_22020-10-14T232042188.json_reads",
+    "read_orientation_outward": 0,
+    "sequencing_tech": "Illumina",
+    "single_genome": 1,
+    "sra_staging_file_name": "KBase_object_details_22020-10-14T232042188.json"
+  },
+  "user-settings": {
+    "showCodeInputArea": false
   }
+}

--- a/test/data/testAppObj.json
+++ b/test/data/testAppObj.json
@@ -1,471 +1,846 @@
 {
-    "app": {
-      "gitCommitHash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
-      "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-      "spec": {
-        "behavior": {
-          "kb_service_input_mapping": [
-            {
-              "narrative_system_variable": "workspace",
-              "target_property": "workspace_name"
-            },
-            {
-              "input_parameter": "import_type",
-              "target_property": "import_type"
-            },
-            {
-              "input_parameter": "fastq_fwd_staging_file_name",
-              "target_property": "fastq_fwd_staging_file_name"
-            },
-            {
-              "input_parameter": "fastq_rev_staging_file_name",
-              "target_property": "fastq_rev_staging_file_name"
-            },
-            {
-              "input_parameter": "sra_staging_file_name",
-              "target_property": "sra_staging_file_name"
-            },
-            {
-              "input_parameter": "sequencing_tech",
-              "target_property": "sequencing_tech"
-            },
-            {
-              "input_parameter": "name",
-              "target_property": "name"
-            },
-            {
-              "input_parameter": "single_genome",
-              "target_property": "single_genome"
-            },
-            {
-              "input_parameter": "interleaved",
-              "target_property": "interleaved"
-            },
-            {
-              "input_parameter": "insert_size_mean",
-              "target_property": "insert_size_mean"
-            },
-            {
-              "input_parameter": "insert_size_std_dev",
-              "target_property": "insert_size_std_dev"
-            },
-            {
-              "input_parameter": "read_orientation_outward",
-              "target_property": "read_orientation_outward"
-            }
-          ],
-          "kb_service_method": "import_reads_from_staging",
-          "kb_service_name": "kb_uploadmethods",
-          "kb_service_output_mapping": [
-            {
-              "narrative_system_variable": "workspace",
-              "target_property": "wsName"
-            },
-            {
-              "service_method_output_path": [
-                "0",
-                "obj_ref"
-              ],
-              "target_property": "obj_ref",
-              "target_type_transform": "resolved-ref"
-            },
-            {
-              "service_method_output_path": [
-                "0",
-                "report_name"
-              ],
-              "target_property": "report_name"
-            },
-            {
-              "service_method_output_path": [
-                "0",
-                "report_ref"
-              ],
-              "target_property": "report_ref"
-            },
-            {
-              "constant_value": "16",
-              "target_property": "report_window_line_height"
-            }
-          ],
-          "kb_service_url": "",
-          "kb_service_version": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b"
-        },
-        "fixed_parameters": [],
-        "full_info": {
-          "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-          "module_name": "kb_uploadmethods",
-          "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
-          "name": "Import FASTQ/SRA File as Reads from Staging Area",
-          "ver": "1.0.43",
-          "authors": [
-            "tgu2"
-          ],
-          "contact": "http://kbase.us/contact-us/",
-          "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "description": "<p> Import a FASTQ/SRA file into your Narrative as a Reads data object\nPlease see the <a href=\"http://kbase.us/data-upload-download-guide/\">Data Upload/Download Guide</a> for more information. </p>",
-          "technical_description": "none",
-          "app_type": "app",
-          "suggestions": {
-            "related_methods": [],
-            "next_methods": [],
-            "related_apps": [],
-            "next_apps": []
-          },
-          "icon": {
-            "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
-          },
-          "categories": [
-            "inactive",
-            "reads",
-            "upload"
-          ],
-          "screenshots": [],
-          "publications": [],
-          "namespace": "kb_uploadmethods"
-        },
-        "info": {
-          "app_type": "app",
-          "authors": [
-            "tgu2"
-          ],
-          "categories": [
-            "inactive",
-            "reads",
-            "upload"
-          ],
-          "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
-          "icon": {
-            "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
-          },
-          "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-          "input_types": [],
-          "module_name": "kb_uploadmethods",
-          "name": "Import FASTQ/SRA File as Reads from Staging Area",
-          "namespace": "kb_uploadmethods",
-          "output_types": [
-            "KBaseFile.PairedEndLibrary",
-            "KBaseFile.SingleEndLibrary"
-          ],
-          "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
-          "ver": "1.0.43"
-        },
-        "job_id_output_field": "docker",
-        "parameters": [
+  "app": {
+    "gitCommitHash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
+    "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+    "spec": {
+      "behavior": {
+        "kb_service_input_mapping": [
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              "FASTQ/FASTA"
-            ],
-            "description": "Import file type ['FASTQ/FASTA' or 'SRA']",
-            "disabled": 0,
-            "dropdown_options": {
-              "multiselection": 0,
-              "options": [
-                {
-                  "display": "FASTQ/FASTA",
-                  "index": 0,
-                  "value": "FASTQ/FASTA"
-                },
-                {
-                  "display": "SRA",
-                  "index": 1,
-                  "value": "SRA"
-                }
-              ]
-            },
-            "field_type": "dropdown",
-            "id": "import_type",
-            "optional": 0,
-            "short_hint": "Import file type ['FASTQ/FASTA' or 'SRA']",
-            "ui_class": "parameter",
-            "ui_name": "Import File Type"
+            "narrative_system_variable": "workspace",
+            "target_property": "workspace_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
-            "disabled": 0,
-            "dynamic_dropdown_options": {
-              "data_source": "ftp_staging",
-              "multiselection": 0,
-              "query_on_empty_input": 1,
-              "result_array_index": 0,
-              "service_params": null
-            },
-            "field_type": "dynamic_dropdown",
-            "id": "fastq_fwd_staging_file_name",
-            "optional": 1,
-            "short_hint": "Short read file containing a paired end library in FASTA/FASTQ format",
-            "ui_class": "parameter",
-            "ui_name": "Forward/Left FASTA/FASTQ File Path"
+            "input_parameter": "import_type",
+            "target_property": "import_type"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
-            "disabled": 0,
-            "dynamic_dropdown_options": {
-              "data_source": "ftp_staging",
-              "multiselection": 0,
-              "query_on_empty_input": 1,
-              "result_array_index": 0,
-              "service_params": null
-            },
-            "field_type": "dynamic_dropdown",
-            "id": "fastq_rev_staging_file_name",
-            "optional": 1,
-            "short_hint": "Second short read file containing a paired end library in FASTA/FASTQ format.",
-            "ui_class": "parameter",
-            "ui_name": "Reverse/Right FASTA/FASTQ File Path"
+            "input_parameter": "fastq_fwd_staging_file_name",
+            "target_property": "fastq_fwd_staging_file_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "SRA staing file path",
-            "disabled": 0,
-            "dynamic_dropdown_options": {
-              "data_source": "ftp_staging",
-              "multiselection": 0,
-              "query_on_empty_input": 1,
-              "result_array_index": 0,
-              "service_params": null
-            },
-            "field_type": "dynamic_dropdown",
-            "id": "sra_staging_file_name",
-            "optional": 1,
-            "short_hint": "SRA staing file path",
-            "ui_class": "parameter",
-            "ui_name": "SRA File Path"
+            "input_parameter": "fastq_rev_staging_file_name",
+            "target_property": "fastq_rev_staging_file_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              "Illumina"
-            ],
-            "description": "The name of the sequencing technology used to create the reads file",
-            "disabled": 0,
-            "dropdown_options": {
-              "multiselection": 0,
-              "options": [
-                {
-                  "display": "Illumina",
-                  "index": 0,
-                  "value": "Illumina"
-                },
-                {
-                  "display": "PacBio CLR",
-                  "index": 1,
-                  "value": "PacBio CLR"
-                },
-                {
-                  "display": "PacBio CCS",
-                  "index": 2,
-                  "value": "PacBio CCS"
-                },
-                {
-                  "display": "IonTorrent",
-                  "index": 3,
-                  "value": "IonTorrent"
-                },
-                {
-                  "display": "NanoPore",
-                  "index": 4,
-                  "value": "NanoPore"
-                },
-                {
-                  "display": "Unknown",
-                  "index": 5,
-                  "value": "Unknown"
-                }
-              ]
-            },
-            "field_type": "dropdown",
-            "id": "sequencing_tech",
-            "optional": 0,
-            "short_hint": "The name of the sequencing technology used to create the reads file",
-            "ui_class": "parameter",
-            "ui_name": "Sequencing Technology"
+            "input_parameter": "sra_staging_file_name",
+            "target_property": "sra_staging_file_name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "Provide a name for the Reads object that will be created by this importer",
-            "disabled": 0,
-            "field_type": "text",
-            "id": "name",
-            "optional": 0,
-            "short_hint": "Provide a name for the Reads object that will be created by this importer",
-            "text_options": {
-              "is_output_name": 1,
-              "placeholder": "",
-              "regex_constraint": [],
-              "valid_ws_types": [
-                "KBaseFile.SingleEndLibrary",
-                "KBaseFile.PairedEndLibrary"
-              ]
-            },
-            "ui_class": "output",
-            "ui_name": "Reads Object Name"
+            "input_parameter": "sequencing_tech",
+            "target_property": "sequencing_tech"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "checkbox_options": {
-              "checked_value": 1,
-              "unchecked_value": 0
-            },
-            "default_values": [
-              "1"
-            ],
-            "description": "Select if the reads are from a single genome, leave blank if from a metagenome",
-            "disabled": 0,
-            "field_type": "checkbox",
-            "id": "single_genome",
-            "optional": 0,
-            "short_hint": "Select if the reads are from a single genome, leave blank if from a metagenome",
-            "ui_class": "parameter",
-            "ui_name": "Single Genome"
+            "input_parameter": "name",
+            "target_property": "name"
           },
           {
-            "advanced": 0,
-            "allow_multiple": 0,
-            "checkbox_options": {
-              "checked_value": 1,
-              "unchecked_value": 0
-            },
-            "default_values": [
-              "0"
-            ],
-            "description": "Select if reads file is interleaved",
-            "disabled": 0,
-            "field_type": "checkbox",
-            "id": "interleaved",
-            "optional": 0,
-            "short_hint": "Select if reads file is interleaved",
-            "ui_class": "parameter",
-            "ui_name": "Interleaved"
+            "input_parameter": "single_genome",
+            "target_property": "single_genome"
           },
           {
-            "advanced": 1,
-            "allow_multiple": 0,
-            "checkbox_options": {
-              "checked_value": 1,
-              "unchecked_value": 0
-            },
-            "default_values": [
-              "0"
-            ],
-            "description": "Select if reads in a pair point outward",
-            "disabled": 0,
-            "field_type": "checkbox",
-            "id": "read_orientation_outward",
-            "optional": 1,
-            "short_hint": "Select if reads in a pair point outward",
-            "ui_class": "parameter",
-            "ui_name": "Reads Orientation Outward"
+            "input_parameter": "interleaved",
+            "target_property": "interleaved"
           },
           {
-            "advanced": 1,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "The standard deviation of insert lengths",
-            "disabled": 0,
-            "field_type": "text",
-            "id": "insert_size_std_dev",
-            "optional": 1,
-            "short_hint": "The standard deviation of insert lengths",
-            "text_options": {
-              "is_output_name": 0,
-              "placeholder": "",
-              "regex_constraint": [],
-              "validate_as": "float"
-            },
-            "ui_class": "parameter",
-            "ui_name": "St. Dev. of Insert Size"
+            "input_parameter": "insert_size_mean",
+            "target_property": "insert_size_mean"
           },
           {
-            "advanced": 1,
-            "allow_multiple": 0,
-            "default_values": [
-              ""
-            ],
-            "description": "The mean (average) insert length",
-            "disabled": 0,
-            "field_type": "text",
-            "id": "insert_size_mean",
-            "optional": 1,
-            "short_hint": "The mean (average) insert length",
-            "text_options": {
-              "is_output_name": 0,
-              "placeholder": "",
-              "regex_constraint": [],
-              "validate_as": "float"
-            },
-            "ui_class": "parameter",
-            "ui_name": "Mean Insert Size"
+            "input_parameter": "insert_size_std_dev",
+            "target_property": "insert_size_std_dev"
+          },
+          {
+            "input_parameter": "read_orientation_outward",
+            "target_property": "read_orientation_outward"
           }
         ],
-        "widgets": {
-          "input": "null",
-          "output": "no-display"
-        }
+        "kb_service_method": "import_reads_from_staging",
+        "kb_service_name": "kb_uploadmethods",
+        "kb_service_output_mapping": [
+          {
+            "narrative_system_variable": "workspace",
+            "target_property": "wsName"
+          },
+          {
+            "service_method_output_path": [
+              "0",
+              "obj_ref"
+            ],
+            "target_property": "obj_ref",
+            "target_type_transform": "resolved-ref"
+          },
+          {
+            "service_method_output_path": [
+              "0",
+              "report_name"
+            ],
+            "target_property": "report_name"
+          },
+          {
+            "service_method_output_path": [
+              "0",
+              "report_ref"
+            ],
+            "target_property": "report_ref"
+          },
+          {
+            "constant_value": "16",
+            "target_property": "report_window_line_height"
+          }
+        ],
+        "kb_service_url": "",
+        "kb_service_version": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b"
       },
-      "tag": "release",
-      "version": "1.0.43"
-    },
-    "executionStats": {
-      "full_app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-      "time_range": "*",
-      "type": "a",
-      "number_of_calls": 170,
-      "number_of_errors": 63,
-      "total_exec_time": 70242.75900101662,
-      "total_queue_time": 40118.08499789238,
-      "module_name": "kb_uploadmethods"
-    },
-    "fsm": {
-      "currentState": {
-        "code": "built",
-        "mode": "editing",
-        "params": "complete"
+      "fixed_parameters": [],
+      "full_info": {
+        "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+        "module_name": "kb_uploadmethods",
+        "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
+        "name": "Import FASTQ/SRA File as Reads from Staging Area",
+        "ver": "1.0.43",
+        "authors": [
+          "tgu2"
+        ],
+        "contact": "http://kbase.us/contact-us/",
+        "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "description": "<p> Import a FASTQ/SRA file into your Narrative as a Reads data object\nPlease see the <a href=\"http://kbase.us/data-upload-download-guide/\">Data Upload/Download Guide</a> for more information. </p>",
+        "technical_description": "none",
+        "app_type": "app",
+        "suggestions": {
+          "related_methods": [],
+          "next_methods": [],
+          "related_apps": [],
+          "next_apps": []
+        },
+        "icon": {
+          "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
+        },
+        "categories": [
+          "inactive",
+          "reads",
+          "upload"
+        ],
+        "screenshots": [],
+        "publications": [],
+        "namespace": "kb_uploadmethods"
+      },
+      "info": {
+        "app_type": "app",
+        "authors": [
+          "tgu2"
+        ],
+        "categories": [
+          "inactive",
+          "reads",
+          "upload"
+        ],
+        "git_commit_hash": "25e7a896377f5ec50bd15a27ade9f279cb16cd0b",
+        "icon": {
+          "url": "img?method_id=kb_uploadmethods/import_fastq_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
+        },
+        "id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+        "input_types": [],
+        "module_name": "kb_uploadmethods",
+        "name": "Import FASTQ/SRA File as Reads from Staging Area",
+        "namespace": "kb_uploadmethods",
+        "output_types": [
+          "KBaseFile.PairedEndLibrary",
+          "KBaseFile.SingleEndLibrary"
+        ],
+        "subtitle": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "tooltip": "Import a FASTQ/SRA file into your Narrative as a Reads data object",
+        "ver": "1.0.43"
+      },
+      "job_id_output_field": "docker",
+      "parameters": [
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            "FASTQ/FASTA"
+          ],
+          "description": "Import file type ['FASTQ/FASTA' or 'SRA']",
+          "disabled": 0,
+          "dropdown_options": {
+            "multiselection": 0,
+            "options": [
+              {
+                "display": "FASTQ/FASTA",
+                "index": 0,
+                "value": "FASTQ/FASTA"
+              },
+              {
+                "display": "SRA",
+                "index": 1,
+                "value": "SRA"
+              }
+            ]
+          },
+          "field_type": "dropdown",
+          "id": "import_type",
+          "optional": 0,
+          "short_hint": "Import file type ['FASTQ/FASTA' or 'SRA']",
+          "ui_class": "parameter",
+          "ui_name": "Import File Type"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
+          "disabled": 0,
+          "dynamic_dropdown_options": {
+            "data_source": "ftp_staging",
+            "multiselection": 0,
+            "query_on_empty_input": 1,
+            "result_array_index": 0,
+            "service_params": null
+          },
+          "field_type": "dynamic_dropdown",
+          "id": "fastq_fwd_staging_file_name",
+          "optional": 1,
+          "short_hint": "Short read file containing a paired end library in FASTA/FASTQ format",
+          "ui_class": "parameter",
+          "ui_name": "Forward/Left FASTA/FASTQ File Path"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2",
+          "disabled": 0,
+          "dynamic_dropdown_options": {
+            "data_source": "ftp_staging",
+            "multiselection": 0,
+            "query_on_empty_input": 1,
+            "result_array_index": 0,
+            "service_params": null
+          },
+          "field_type": "dynamic_dropdown",
+          "id": "fastq_rev_staging_file_name",
+          "optional": 1,
+          "short_hint": "Second short read file containing a paired end library in FASTA/FASTQ format.",
+          "ui_class": "parameter",
+          "ui_name": "Reverse/Right FASTA/FASTQ File Path"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "SRA staing file path",
+          "disabled": 0,
+          "dynamic_dropdown_options": {
+            "data_source": "ftp_staging",
+            "multiselection": 0,
+            "query_on_empty_input": 1,
+            "result_array_index": 0,
+            "service_params": null
+          },
+          "field_type": "dynamic_dropdown",
+          "id": "sra_staging_file_name",
+          "optional": 1,
+          "short_hint": "SRA staing file path",
+          "ui_class": "parameter",
+          "ui_name": "SRA File Path"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            "Illumina"
+          ],
+          "description": "The name of the sequencing technology used to create the reads file",
+          "disabled": 0,
+          "dropdown_options": {
+            "multiselection": 0,
+            "options": [
+              {
+                "display": "Illumina",
+                "index": 0,
+                "value": "Illumina"
+              },
+              {
+                "display": "PacBio CLR",
+                "index": 1,
+                "value": "PacBio CLR"
+              },
+              {
+                "display": "PacBio CCS",
+                "index": 2,
+                "value": "PacBio CCS"
+              },
+              {
+                "display": "IonTorrent",
+                "index": 3,
+                "value": "IonTorrent"
+              },
+              {
+                "display": "NanoPore",
+                "index": 4,
+                "value": "NanoPore"
+              },
+              {
+                "display": "Unknown",
+                "index": 5,
+                "value": "Unknown"
+              }
+            ]
+          },
+          "field_type": "dropdown",
+          "id": "sequencing_tech",
+          "optional": 0,
+          "short_hint": "The name of the sequencing technology used to create the reads file",
+          "ui_class": "parameter",
+          "ui_name": "Sequencing Technology"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "Provide a name for the Reads object that will be created by this importer",
+          "disabled": 0,
+          "field_type": "text",
+          "id": "name",
+          "optional": 0,
+          "short_hint": "Provide a name for the Reads object that will be created by this importer",
+          "text_options": {
+            "is_output_name": 1,
+            "placeholder": "",
+            "regex_constraint": [],
+            "valid_ws_types": [
+              "KBaseFile.SingleEndLibrary",
+              "KBaseFile.PairedEndLibrary"
+            ]
+          },
+          "ui_class": "output",
+          "ui_name": "Reads Object Name"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "checkbox_options": {
+            "checked_value": 1,
+            "unchecked_value": 0
+          },
+          "default_values": [
+            "1"
+          ],
+          "description": "Select if the reads are from a single genome, leave blank if from a metagenome",
+          "disabled": 0,
+          "field_type": "checkbox",
+          "id": "single_genome",
+          "optional": 0,
+          "short_hint": "Select if the reads are from a single genome, leave blank if from a metagenome",
+          "ui_class": "parameter",
+          "ui_name": "Single Genome"
+        },
+        {
+          "advanced": 0,
+          "allow_multiple": 0,
+          "checkbox_options": {
+            "checked_value": 1,
+            "unchecked_value": 0
+          },
+          "default_values": [
+            "0"
+          ],
+          "description": "Select if reads file is interleaved",
+          "disabled": 0,
+          "field_type": "checkbox",
+          "id": "interleaved",
+          "optional": 0,
+          "short_hint": "Select if reads file is interleaved",
+          "ui_class": "parameter",
+          "ui_name": "Interleaved"
+        },
+        {
+          "advanced": 1,
+          "allow_multiple": 0,
+          "checkbox_options": {
+            "checked_value": 1,
+            "unchecked_value": 0
+          },
+          "default_values": [
+            "0"
+          ],
+          "description": "Select if reads in a pair point outward",
+          "disabled": 0,
+          "field_type": "checkbox",
+          "id": "read_orientation_outward",
+          "optional": 1,
+          "short_hint": "Select if reads in a pair point outward",
+          "ui_class": "parameter",
+          "ui_name": "Reads Orientation Outward"
+        },
+        {
+          "advanced": 1,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "The standard deviation of insert lengths",
+          "disabled": 0,
+          "field_type": "text",
+          "id": "insert_size_std_dev",
+          "optional": 1,
+          "short_hint": "The standard deviation of insert lengths",
+          "text_options": {
+            "is_output_name": 0,
+            "placeholder": "",
+            "regex_constraint": [],
+            "validate_as": "float"
+          },
+          "ui_class": "parameter",
+          "ui_name": "St. Dev. of Insert Size"
+        },
+        {
+          "advanced": 1,
+          "allow_multiple": 0,
+          "default_values": [
+            ""
+          ],
+          "description": "The mean (average) insert length",
+          "disabled": 0,
+          "field_type": "text",
+          "id": "insert_size_mean",
+          "optional": 1,
+          "short_hint": "The mean (average) insert length",
+          "text_options": {
+            "is_output_name": 0,
+            "placeholder": "",
+            "regex_constraint": [],
+            "validate_as": "float"
+          },
+          "ui_class": "parameter",
+          "ui_name": "Mean Insert Size"
+        }
+      ],
+      "widgets": {
+        "input": "null",
+        "output": "no-display"
       }
     },
-    "output": {
-      "byJob": {}
+    "tag": "release",
+    "version": "1.0.43"
+  },
+  "exec": {
+    "jobState": {
+      "authstrat": "kbaseworkspace",
+      "batch_size": 3,
+      "cell_id": "13395335-1f3d-4e0c-80f7-44b634968da0",
+      "child_jobs": [],
+      "created": 1607109147000,
+      "finished": 1607109627617,
+      "job_id": "5fca8a1bd257f9f38c9862a0",
+      "job_output": {
+        "id": "5fca8a1bd257f9f38c9862a0",
+        "result": [
+          {
+            "batch_results": {
+              "5fca8a3168dcf051ac8c79e3": {
+                "final_job_state": {
+                  "authstrat": "kbaseworkspace",
+                  "child_jobs": [],
+                  "condor_job_ads": {
+                    "CommittedSuspensionTime": 0,
+                    "CommittedTime": 0,
+                    "CompletionDate": 0,
+                    "CpusUsage": null,
+                    "CumulativeRemoteSysCpu": 0,
+                    "CumulativeRemoteUserCpu": 0,
+                    "CumulativeSuspensionTime": 0,
+                    "CumulativeTransferTime": null,
+                    "DiskUsage": 325,
+                    "DiskUsage_RAW": 320,
+                    "HoldReason": null,
+                    "HoldReasonCode": null,
+                    "ImageSize_RAW": 2,
+                    "JobCurrentFinishTransferInputDate": null,
+                    "JobCurrentFinishTransferOutputDate": null,
+                    "JobCurrentStartDate": 1607109176,
+                    "JobCurrentStartExecutingDate": null,
+                    "JobCurrentStartTransferInputDate": null,
+                    "JobCurrentStartTransferOutputDate": null,
+                    "LastRemoteHost": null,
+                    "RemoteHost": "slot1_1@ci-core-condorworker-mixed-privileged-partionable-6-1",
+                    "RemoteUserCpu": 0,
+                    "ResidentSetSize": null,
+                    "ResidentSetSize_RAW": null
+                  },
+                  "created": 1607109169000,
+                  "exec_start_time": 1607109169000,
+                  "finish_time": 1607109486097,
+                  "finished": 1607109486097,
+                  "job_id": "5fca8a3168dcf051ac8c79e3",
+                  "job_input": {
+                    "app_id": "MEGAHIT",
+                    "method": "MEGAHIT.run_megahit",
+                    "narrative_cell_info": {},
+                    "params": [
+                      {
+                        "k_list": [],
+                        "k_max": null,
+                        "k_min": null,
+                        "k_step": null,
+                        "megahit_parameter_preset": null,
+                        "min_contig_len": 500,
+                        "min_count": null,
+                        "output_contigset_name": "reads_test3_contigs",
+                        "read_library_ref": "57373/6/1",
+                        "workspace_name": "ialarmedalien:narrative_1607108970427"
+                      }
+                    ],
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0",
+                    "requirements": {
+                      "clientgroup": "njs",
+                      "cpu": 2,
+                      "disk": 100,
+                      "memory": 23000
+                    },
+                    "service_ver": "cc91ddfe376f907aa56cfb3dd1b1b21cae8885a6",
+                    "source_ws_objects": []
+                  },
+                  "job_output": {
+                    "id": "5fca8a3168dcf051ac8c79e3",
+                    "result": [
+                      {
+                        "report_name": "kb_megahit_report_c99b640d-23a3-4865-9727-fd6ef05df3d6",
+                        "report_ref": "57373/17/1"
+                      }
+                    ],
+                    "version": "1.1"
+                  },
+                  "job_state": "completed",
+                  "queued": 1607109169066,
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_c99b640d-23a3-4865-9727-fd6ef05df3d6",
+                      "report_ref": "57373/17/1"
+                    }
+                  ],
+                  "running": 1607109187951,
+                  "scheduler_id": "23204",
+                  "scheduler_type": "condor",
+                  "status": "completed",
+                  "updated": 1607109486235,
+                  "user": "ialarmedalien"
+                },
+                "is_error": false,
+                "result_package": {
+                  "error": null,
+                  "function": {
+                    "method_name": "run_megahit",
+                    "module_name": "MEGAHIT",
+                    "version": "2.2.2"
+                  },
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_c99b640d-23a3-4865-9727-fd6ef05df3d6",
+                      "report_ref": "57373/17/1"
+                    }
+                  ],
+                  "run_context": {
+                    "job_id": "5fca8a3168dcf051ac8c79e3",
+                    "location": "njsw",
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0"
+                  }
+                }
+              },
+              "5fca8a31d257f9f38c9862a1": {
+                "final_job_state": {
+                  "authstrat": "kbaseworkspace",
+                  "child_jobs": [],
+                  "condor_job_ads": {
+                    "CommittedSuspensionTime": 0,
+                    "CommittedTime": 0,
+                    "CompletionDate": 0,
+                    "CpusUsage": null,
+                    "CumulativeRemoteSysCpu": 0,
+                    "CumulativeRemoteUserCpu": 0,
+                    "CumulativeSuspensionTime": 0,
+                    "CumulativeTransferTime": null,
+                    "DiskUsage": 325,
+                    "DiskUsage_RAW": 320,
+                    "HoldReason": null,
+                    "HoldReasonCode": null,
+                    "ImageSize_RAW": 2,
+                    "JobCurrentFinishTransferInputDate": null,
+                    "JobCurrentFinishTransferOutputDate": null,
+                    "JobCurrentStartDate": 1607109176,
+                    "JobCurrentStartExecutingDate": null,
+                    "JobCurrentStartTransferInputDate": null,
+                    "JobCurrentStartTransferOutputDate": null,
+                    "LastRemoteHost": null,
+                    "RemoteHost": "slot1_1@ci-core-condorworker-mixed-privileged-partionable-2-1",
+                    "RemoteUserCpu": 0,
+                    "ResidentSetSize": null,
+                    "ResidentSetSize_RAW": null
+                  },
+                  "created": 1607109169000,
+                  "exec_start_time": 1607109169000,
+                  "finish_time": 1607109486663,
+                  "finished": 1607109486663,
+                  "job_id": "5fca8a31d257f9f38c9862a1",
+                  "job_input": {
+                    "app_id": "MEGAHIT",
+                    "method": "MEGAHIT.run_megahit",
+                    "narrative_cell_info": {},
+                    "params": [
+                      {
+                        "k_list": [],
+                        "k_max": null,
+                        "k_min": null,
+                        "k_step": null,
+                        "megahit_parameter_preset": null,
+                        "min_contig_len": 500,
+                        "min_count": null,
+                        "output_contigset_name": "reads_test2_contigs",
+                        "read_library_ref": "57373/4/1",
+                        "workspace_name": "ialarmedalien:narrative_1607108970427"
+                      }
+                    ],
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0",
+                    "requirements": {
+                      "clientgroup": "njs",
+                      "cpu": 2,
+                      "disk": 100,
+                      "memory": 23000
+                    },
+                    "service_ver": "cc91ddfe376f907aa56cfb3dd1b1b21cae8885a6",
+                    "source_ws_objects": []
+                  },
+                  "job_output": {
+                    "id": "5fca8a31d257f9f38c9862a1",
+                    "result": [
+                      {
+                        "report_name": "kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e",
+                        "report_ref": "57373/16/1"
+                      }
+                    ],
+                    "version": "1.1"
+                  },
+                  "job_state": "completed",
+                  "queued": 1607109169578,
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e",
+                      "report_ref": "57373/16/1"
+                    }
+                  ],
+                  "running": 1607109187944,
+                  "scheduler_id": "23205",
+                  "scheduler_type": "condor",
+                  "status": "completed",
+                  "updated": 1607109486818,
+                  "user": "ialarmedalien"
+                },
+                "is_error": false,
+                "result_package": {
+                  "error": null,
+                  "function": {
+                    "method_name": "run_megahit",
+                    "module_name": "MEGAHIT",
+                    "version": "2.2.2"
+                  },
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e",
+                      "report_ref": "57373/16/1"
+                    }
+                  ],
+                  "run_context": {
+                    "job_id": "5fca8a31d257f9f38c9862a1",
+                    "location": "njsw",
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0"
+                  }
+                }
+              },
+              "5fca8a32b254b87cbf066b09": {
+                "final_job_state": {
+                  "authstrat": "kbaseworkspace",
+                  "child_jobs": [],
+                  "condor_job_ads": {
+                    "CommittedSuspensionTime": 0,
+                    "CommittedTime": 0,
+                    "CompletionDate": 0,
+                    "CpusUsage": null,
+                    "CumulativeRemoteSysCpu": 0,
+                    "CumulativeRemoteUserCpu": 0,
+                    "CumulativeSuspensionTime": 0,
+                    "CumulativeTransferTime": null,
+                    "DiskUsage": 325,
+                    "DiskUsage_RAW": 320,
+                    "HoldReason": null,
+                    "HoldReasonCode": null,
+                    "ImageSize_RAW": 2,
+                    "JobCurrentFinishTransferInputDate": null,
+                    "JobCurrentFinishTransferOutputDate": null,
+                    "JobCurrentStartDate": 1607109176,
+                    "JobCurrentStartExecutingDate": null,
+                    "JobCurrentStartTransferInputDate": null,
+                    "JobCurrentStartTransferOutputDate": null,
+                    "LastRemoteHost": null,
+                    "RemoteHost": "slot1_1@ci-core-condorworker-mixed-privileged-partionable-3-1",
+                    "RemoteUserCpu": 0,
+                    "ResidentSetSize": null,
+                    "ResidentSetSize_RAW": null
+                  },
+                  "created": 1607109170000,
+                  "exec_start_time": 1607109170000,
+                  "finish_time": 1607109524887,
+                  "finished": 1607109524887,
+                  "job_id": "5fca8a32b254b87cbf066b09",
+                  "job_input": {
+                    "app_id": "MEGAHIT",
+                    "method": "MEGAHIT.run_megahit",
+                    "narrative_cell_info": {},
+                    "params": [
+                      {
+                        "k_list": [],
+                        "k_max": null,
+                        "k_min": null,
+                        "k_step": null,
+                        "megahit_parameter_preset": null,
+                        "min_contig_len": 500,
+                        "min_count": null,
+                        "output_contigset_name": "reads_test_contigs",
+                        "read_library_ref": "57373/2/1",
+                        "workspace_name": "ialarmedalien:narrative_1607108970427"
+                      }
+                    ],
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0",
+                    "requirements": {
+                      "clientgroup": "njs",
+                      "cpu": 2,
+                      "disk": 100,
+                      "memory": 23000
+                    },
+                    "service_ver": "cc91ddfe376f907aa56cfb3dd1b1b21cae8885a6",
+                    "source_ws_objects": []
+                  },
+                  "job_output": {
+                    "id": "5fca8a32b254b87cbf066b09",
+                    "result": [
+                      {
+                        "report_name": "kb_megahit_report_90cd1717-5e2e-4a4a-a798-c099b1052410",
+                        "report_ref": "57373/18/1"
+                      }
+                    ],
+                    "version": "1.1"
+                  },
+                  "job_state": "completed",
+                  "queued": 1607109170059,
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_90cd1717-5e2e-4a4a-a798-c099b1052410",
+                      "report_ref": "57373/18/1"
+                    }
+                  ],
+                  "running": 1607109187890,
+                  "scheduler_id": "23206",
+                  "scheduler_type": "condor",
+                  "status": "completed",
+                  "updated": 1607109525035,
+                  "user": "ialarmedalien"
+                },
+                "is_error": false,
+                "result_package": {
+                  "error": null,
+                  "function": {
+                    "method_name": "run_megahit",
+                    "module_name": "MEGAHIT",
+                    "version": "2.2.2"
+                  },
+                  "result": [
+                    {
+                      "report_name": "kb_megahit_report_90cd1717-5e2e-4a4a-a798-c099b1052410",
+                      "report_ref": "57373/18/1"
+                    }
+                  ],
+                  "run_context": {
+                    "job_id": "5fca8a32b254b87cbf066b09",
+                    "location": "njsw",
+                    "parent_job_id": "5fca8a1bd257f9f38c9862a0"
+                  }
+                }
+              }
+            },
+            "report_name": "batch_report_1607109609490",
+            "report_ref": "57373/19/1"
+          }
+        ],
+        "version": "1.1"
+      },
+      "queued": 1607109147274,
+      "run_id": "13395335-1f3d-4e0c-80f7-44b634968da0",
+      "running": 1607109162603,
+      "scheduler_id": "23203",
+      "scheduler_type": "condor",
+      "status": "completed",
+      "updated": 1607109627760,
+      "user": "ialarmedalien",
+      "wsid": 57373
     },
-    "params": {
-      "fastq_fwd_staging_file_name": "",
-      "fastq_rev_staging_file_name": "",
-      "import_type": "SRA",
-      "insert_size_mean": null,
-      "insert_size_std_dev": null,
-      "interleaved": 0,
-      "name": "KBase_object_details_22020-10-14T232042188.json_reads",
-      "read_orientation_outward": 0,
-      "sequencing_tech": "Illumina",
-      "single_genome": 1,
-      "sra_staging_file_name": "KBase_object_details_22020-10-14T232042188.json"
+    "jobStateUpdated": 1607109635241,
+    "launchState": {
+      "cell_id": "13395335-1f3d-4e0c-80f7-44b634968da0",
+      "event": "launched_job",
+      "event_at": "2020-12-04T19:12:27.690847Z",
+      "job_id": "5fca8a1bd257f9f38c9862a0",
+      "run_id": "8c202a66-e868-4cf4-a990-bab2393985ae"
     },
-    "user-settings": {
-      "showCodeInputArea": false
+    "outputWidgetInfo": {
+      "name": "no-display",
+      "params": {
+        "report_name": "batch_report_1607109609490",
+        "report_ref": "57373/19/1"
+      },
+      "tag": "dev"
     }
+  },
+  "executionStats": {
+    "full_app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+    "time_range": "*",
+    "type": "a",
+    "number_of_calls": 170,
+    "number_of_errors": 63,
+    "total_exec_time": 70242.75900101662,
+    "total_queue_time": 40118.08499789238,
+    "module_name": "kb_uploadmethods"
+  },
+  "fsm": {
+    "currentState": {
+      "code": "built",
+      "mode": "editing",
+      "params": "complete"
+    }
+  },
+  "output": {
+    "byJob": {}
+  },
+  "params": {
+    "fastq_fwd_staging_file_name": "",
+    "fastq_rev_staging_file_name": "",
+    "import_type": "SRA",
+    "insert_size_mean": null,
+    "insert_size_std_dev": null,
+    "interleaved": 0,
+    "name": "KBase_object_details_22020-10-14T232042188.json_reads",
+    "read_orientation_outward": 0,
+    "sequencing_tech": "Illumina",
+    "single_genome": 1,
+    "sra_staging_file_name": "KBase_object_details_22020-10-14T232042188.json"
+  },
+  "user-settings": {
+    "showCodeInputArea": false
   }
+}


### PR DESCRIPTION
# Description of PR purpose/changes

This PR is to kick off the job status tab work. I poached the batchApp code to get everything rolling. This is purely a skeleton PR with zero testing, and is not pretty. The intent of this PR is just to provide a working Space for AJ and I to complete the job log work and the job status table work. 

<img width="1022" alt="Screen Shot 2020-12-04 at 4 46 57 PM" src="https://user-images.githubusercontent.com/56279459/101230187-5c5fd500-3650-11eb-9349-96be72260e9f.png">


# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [ ] Tests pass in travis and locally 
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
