### PR TITLE
adding 'view log' link to status table

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateList.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateList.js
@@ -44,6 +44,9 @@ define([
                     th({
                         class: `${cssBaseClass}__table_head_cell--action`
                     }, ['Action']),
+                    th({
+                        class: `${cssBaseClass}__table_head_cell--log-view`
+                    }, ['Logs']),
                 ])
             ]),
             tbody({

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateListRow.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateListRow.js
@@ -13,7 +13,7 @@ define([
         span = t('span'),
         cssBaseClass = 'kb-job-state';
 
-    function niceState(jobState) {
+    function createStateCell(jobState) {
         let label, icon;
         switch (jobState) {
             case 'completed':
@@ -54,7 +54,7 @@ define([
         ]);
     }
 
-    function getAction(jobState) {
+    function createActionCell(jobState) {
         let label;
         switch (jobState) {
             case 'completed':
@@ -83,7 +83,18 @@ define([
         }, [
             label
         ]);
+    }
 
+    function createLogLinkCell(jobState) {
+        return td({
+            class: `${cssBaseClass}__cell--log-view`,
+        }, [
+            span({
+                class: `${cssBaseClass}__log_link--${jobState}`
+            }, [
+                'View logs'
+            ])
+        ]);
     }
 
     function factory() {
@@ -104,8 +115,9 @@ define([
                 ),
                 jobIdDiv
             ])
-            + niceState(jobStatus)
-            + getAction(jobStatus);
+            + createStateCell(jobStatus)
+            + createActionCell(jobStatus)
+            + createLogLinkCell(jobStatus);
         }
 
         function start(arg) {

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTab.js
@@ -52,7 +52,7 @@ define([
                 class: 'col-md-6 batch-mode-col',
                 dataElement: 'kb-job-status-wrapper'
             },[
-                ui.buildCollapsiblePanel({
+                ui.buildPanel({
                     title: 'Job Log',
                     name: 'job-log-section-toggle',
                     hidden: false,


### PR DESCRIPTION
# Description of PR purpose/changes

Adding in a link to view the logs, and making the log viewer panel non-collapsible so it's always shown.

new table appearance:
<img width="1062" alt="Screenshot 2020-12-07 at 14 54 49" src="https://user-images.githubusercontent.com/556057/101415140-3dee1980-389c-11eb-8d83-67e3cd925265.png">

# Jira Ticket / Issue #

https://kbase-jira.atlassian.net/browse/DATAUP-313

# Testing Instructions
* Details for how to test the PR: 
- [ ] Tests pass in travis and locally 
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
