### PR TITLE
Dataup 365 test fix

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -5,16 +5,8 @@ define([
     'common/events',
     'common/runtime',
     'widgets/appWidgets2/errorControl',
-    'css!google-code-prettify/prettify.css'
-], function(
-    Promise,
-    PR,
-    html,
-    Events,
-    Runtime,
-    ErrorControlFactory
-) {
-
+    'css!google-code-prettify/prettify.css',
+], function (Promise, PR, html, Events, Runtime, ErrorControlFactory) {
     'use strict';
 
     const t = html.tag,
@@ -26,7 +18,7 @@ define([
     function factory(config) {
         var runtime = Runtime.make(),
             bus = runtime.bus().makeChannelBus({
-                description: 'Field bus'
+                description: 'Field bus',
             }),
             places,
             parent,
@@ -53,7 +45,7 @@ define([
         } catch (ex) {
             console.error('Error creating input control', ex);
             inputControl = ErrorControlFactory.make({
-                message: ex.message
+                message: ex.message,
             }).make();
         }
 
@@ -63,48 +55,54 @@ define([
                 inputControl: html.genId(),
             };
 
-            var content = td({
-                class: `${cssBaseClass}__tableCell`,
-                id: ids.fieldPanel,
-                dataElement: 'field-panel'
-            }, [
-                label({
-                    class: `${cssBaseClass}__cell_label`,
-                    title: spec.ui.label || spec.ui.id,
-                    for: ids.inputControl,
-                    id: events.addEvent({
-                        type: 'click',
-                        handler: function() {
-                            places.infoPanel.querySelector('[data-element="big-tip"]').classList.toggle('hidden');
-                        }
-                    })
-                }, [
-                    spec.ui.label || spec.ui.id
-                ]),
-                div({
-                    class: `${cssBaseClass}__input_control`,
-                    id: ids.inputControl,
-                    dataElement: 'input-control'
-                })
-            ]);
+            var content = td(
+                {
+                    class: `${cssBaseClass}__tableCell`,
+                    id: ids.fieldPanel,
+                    dataElement: 'field-panel',
+                },
+                [
+                    label(
+                        {
+                            class: `${cssBaseClass}__cell_label`,
+                            title: spec.ui.label || spec.ui.id,
+                            for: ids.inputControl,
+                            id: events.addEvent({
+                                type: 'click',
+                                handler: function () {
+                                    places.infoPanel
+                                        .querySelector('[data-element="big-tip"]')
+                                        .classList.toggle('hidden');
+                                },
+                            }),
+                        },
+                        [spec.ui.label || spec.ui.id]
+                    ),
+                    div({
+                        class: `${cssBaseClass}__input_control`,
+                        id: ids.inputControl,
+                        dataElement: 'input-control',
+                    }),
+                ]
+            );
 
             return {
                 content: content,
-                places: ids
+                places: ids,
             };
         }
 
         // LIFECYCLE
 
         function attach(node) {
-            return Promise.try(function() {
+            return Promise.try(function () {
                 parent = node;
                 let containerDiv = document.createElement('div');
                 containerDiv.classList.add(`${cssBaseClass}__param_container`);
 
                 container = parent.appendChild(containerDiv);
                 var events = Events.make({
-                    node: container
+                    node: container,
                 });
 
                 var rendered = render(events);
@@ -118,7 +116,7 @@ define([
                 places = {
                     field: document.getElementById(fieldId),
                     message: document.getElementById(rendered.places.message),
-                    inputControl: document.getElementById(rendered.places.inputControl)
+                    inputControl: document.getElementById(rendered.places.inputControl),
                 };
                 if (inputControl.attach) {
                     return inputControl.attach(places.inputControl);
@@ -127,26 +125,35 @@ define([
         }
 
         function start(arg) {
-            return attach(arg.node)
-                .then(function() {
-                    if (inputControl.start) {
-                        return inputControl.start({
-                            node: places.inputControl
+            return attach(arg.node).then(function () {
+                if (inputControl.start) {
+                    return inputControl
+                        .start({
+                            node: places.inputControl,
                         })
-                            .then(function() {
-                                // TODO: get rid of this pattern
-                                bus.emit('run', {
-                                    node: places.inputControl
-                                });
+                        .then(function () {
+                            // TODO: get rid of this pattern
+                            bus.emit('run', {
+                                node: places.inputControl,
                             });
-                    }
-                });
+                        });
+                }
+            });
         }
 
         function stop() {
-            return Promise.try(function() {
-                return inputControl.stop()
-                    .then(function() {
+            return Promise.try(function () {
+                return inputControl
+                    .stop()
+                    .then(() => {
+                        if (parent && container) {
+                            parent.removeChild(container);
+                        }
+                        bus.stop();
+                        return null;
+                    })
+                    .catch((err) => {
+                        console.error('error stopping field table cell widget: ', err);
                         if (parent && container) {
                             parent.removeChild(container);
                         }
@@ -159,13 +166,13 @@ define([
         return {
             start: start,
             stop: stop,
-            bus: bus
+            bus: bus,
         };
     }
 
     return {
-        make: function(config) {
+        make: function (config) {
             return factory(config);
-        }
+        },
     };
 });

--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -95,50 +95,51 @@ define([
         // LIFECYCLE
 
         function attach(node) {
-            return Promise.try(function () {
-                parent = node;
-                let containerDiv = document.createElement('div');
-                containerDiv.classList.add(`${cssBaseClass}__param_container`);
+            parent = node;
+            let containerDiv = document.createElement('div');
+            containerDiv.classList.add(`${cssBaseClass}__param_container`);
 
-                container = parent.appendChild(containerDiv);
-                var events = Events.make({
-                    node: container,
-                });
-
-                var rendered = render(events);
-                container.innerHTML = rendered.content;
-                events.attachEvents();
-                // TODO: use the pattern in which the render returns an object,
-                // which includes events and other functions to be run after
-                // content is added to the dom.
-                PR.prettyPrint(null, container);
-
-                places = {
-                    field: document.getElementById(fieldId),
-                    message: document.getElementById(rendered.places.message),
-                    inputControl: document.getElementById(rendered.places.inputControl),
-                };
-                if (inputControl.attach) {
-                    return inputControl.attach(places.inputControl);
-                }
+            container = parent.appendChild(containerDiv);
+            var events = Events.make({
+                node: container,
             });
+
+            var rendered = render(events);
+            container.innerHTML = rendered.content;
+            events.attachEvents();
+            // TODO: use the pattern in which the render returns an object,
+            // which includes events and other functions to be run after
+            // content is added to the dom.
+            PR.prettyPrint(null, container);
+
+            places = {
+                field: document.getElementById(fieldId),
+                message: document.getElementById(rendered.places.message),
+                inputControl: document.getElementById(rendered.places.inputControl),
+            };
+
+            //TODO: why do this? it seems recursive? could we even call attach in this case? it's not a public method
+            // if (inputControl.attach) {
+            //     return inputControl.attach(places.inputControl);
+            // }
         }
 
         function start(arg) {
-            return attach(arg.node).then(function () {
-                if (inputControl.start) {
-                    return inputControl
-                        .start({
-                            node: places.inputControl,
-                        })
-                        .then(function () {
-                            // TODO: get rid of this pattern
-                            bus.emit('run', {
-                                node: places.inputControl,
-                            });
-                        });
-                }
-            });
+            attach(arg.node);
+
+            return inputControl
+                .start({
+                    node: places.inputControl,
+                })
+                .then(function () {
+                    // TODO: get rid of this pattern
+                    bus.emit('run', {
+                        node: places.inputControl,
+                    });
+                })
+                .catch((err) => {
+                    console.error('error starting field table cell widget: ', err);
+                });
         }
 
         function stop() {

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -406,6 +406,7 @@ define([
                         },
                         [ex.message]
                     );
+
                     document.getElementById(
                         filePathParams.view[spec.id].id
                     ).innerHTML = errorDisplay;
@@ -462,7 +463,7 @@ define([
                     ]),
                 ].join('');
 
-                Promise.all(
+                return Promise.all(
                     filePathParams.layout.map(async (parameterId) => {
                         await createFilePathWidget(appSpec, filePathParams, parameterId);
                     })
@@ -474,8 +475,7 @@ define([
 
         function start(arg) {
             return Promise.try(function () {
-                let container = arg.node;
-                doAttach(container);
+                doAttach(arg.node);
 
                 model.setItem('appSpec', arg.appSpec);
                 model.setItem('parameters', arg.parameters);
@@ -493,10 +493,13 @@ define([
 
                 let filePathRows = ui.getElements(`${cssClassType}-fields-row`);
 
-                filePathRows.forEach((filePathRow) => {
-                    renderFilePathRow(filePathRow);
+                return Promise.all(
+                    filePathRows.map(async (filePathRow) => {
+                        await renderFilePathRow(filePathRow);
+                    })
+                ).then(() => {
+                    updateRowNumbers(filePathRows);
                 });
-                updateRowNumbers(filePathRows);
             }).catch((error) => {
                 throw new Error('Unable to start file path widget: ', error);
             });

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -500,36 +500,33 @@ define([
         }
 
         function start(arg) {
-            return Promise.try(function () {
-                // send parent the ready message
+            // send parent the ready message
+            doAttach(arg.node);
 
-                doAttach(arg.node);
+            model.setItem('appSpec', arg.appSpec);
+            model.setItem('parameters', arg.parameters);
 
-                model.setItem('appSpec', arg.appSpec);
-                model.setItem('parameters', arg.parameters);
-
-                bus.on('parameter-changed', function (message) {
-                    // Also, tell each of our inputs that a param has changed.
-                    widgets.forEach(function (widget) {
-                        widget.bus.send(message, {
-                            key: {
-                                type: 'parameter-changed',
-                                parameter: message.parameter,
-                            },
-                        });
+            bus.on('parameter-changed', function (message) {
+                // Also, tell each of our inputs that a param has changed.
+                widgets.forEach(function (widget) {
+                    widget.bus.send(message, {
+                        key: {
+                            type: 'parameter-changed',
+                            parameter: message.parameter,
+                        },
                     });
                 });
-
-                return renderParameters()
-                    .then(function () {
-                        // do something after success
-                        attachEvents();
-                    })
-                    .catch(function (err) {
-                        // do somethig with the error.
-                        console.error('ERROR in start', err);
-                    });
             });
+
+            return renderParameters()
+                .then(function () {
+                    // do something after success
+                    attachEvents();
+                })
+                .catch(function (err) {
+                    // do somethig with the error.
+                    console.error('ERROR in start', err);
+                });
         }
 
         function stop() {

--- a/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
@@ -1,31 +1,80 @@
 define([
+    'base/js/namespace',
     'common/cellComponents/fieldTableCellWidget',
     'widgets/appWidgets2/paramResolver',
     'common/props',
     'common/spec',
     'json!../../../../data/testAppObj.json',
-], function(
-    fieldCellWidget,
-    ParamResolver,
-    Props,
-    Spec,
-    TestAppObject
-) {
+], function (Jupyter, fieldCellWidget, ParamResolver, Props, Spec, TestAppObject) {
     'use strict';
 
-    describe('The Field Table Cell Widget module', function() {
-        it('loads', function() {
+    describe('The Field Table Cell Widget module', function () {
+        it('loads', function () {
             expect(fieldCellWidget).not.toBe(null);
         });
 
-        it('has expected functions', function() {
+        it('has expected functions', function () {
             expect(fieldCellWidget.make).toBeDefined();
         });
-
     });
 
-    describe('The Field Table Cell Widget instance', function() {
-        let node, parameterSpec, paramResolver, inputControlFacotry, appSpec, closeParameters, mockFieldWidget;
+    describe('The Field Table Cell Widget instance', function () {
+        let node, mockFieldWidget;
+
+        const parameterSpec = {
+            data: {
+                constraints: {
+                    required: false,
+                    options: undefined,
+                    min_length: 1,
+                    max_length: 10000,
+                },
+                defaultValue: '',
+                nullValue: '',
+                sequence: false,
+                type: 'string',
+            },
+            id: 'fastq_fwd_staging_file_name',
+            multipleItems: false,
+            original: {
+                advanced: 0,
+                allow_multiple: 0,
+                default_values: [''],
+                description:
+                    'Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2',
+                disabled: 0,
+                dynamic_dropdown_options: {
+                    data_source: 'ftp_staging',
+                    multiselection: 0,
+                    query_on_empty_input: 1,
+                    result_array_index: 0,
+                    service_params: null,
+                },
+                field_type: 'dynamic_dropdown',
+                id: 'fastq_fwd_staging_file_name',
+                optional: 1,
+                short_hint: 'Short read file containing a paired end library in FASTA/FASTQ format',
+                ui_class: 'parameter',
+                ui_name: 'Forward/Left FASTA/FASTQ File Path',
+            },
+            ui: {
+                advanced: false,
+                class: 'parameter',
+                control: 'dynamic_dropdown',
+                description:
+                    'Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2',
+                hint: 'Short read file containing a paired end library in FASTA/FASTQ format',
+                label: 'Forward/Left FASTA/FASTQ File Path',
+                type: 'dynamic_dropdown',
+            },
+        };
+
+        const closeParameters = [
+            'fastq_fwd_staging_file_name',
+            'fastq_rev_staging_file_name',
+            'sra_staging_file_name',
+            'name',
+        ];
 
         beforeAll(() => {
             Jupyter.narrative = {
@@ -37,117 +86,81 @@ define([
             Jupyter.narrative = null;
         });
 
-        beforeEach(function () {
+        beforeEach(async () => {
             node = document.createElement('div');
             document.getElementsByTagName('body')[0].appendChild(node);
 
-            parameterSpec = {
-                data: {
-                    constraints: {
-                        required: false,
-                        options: undefined,
-                        min_length: 1,
-                        max_length: 10000
-                    },
-                    defaultValue: '',
-                    nullValue: '',
-                    sequence: false,
-                    type: 'string'
-                },
-                id: 'fastq_fwd_staging_file_name',
-                multipleItems: false,
-                original: {
-                    advanced: 0,
-                    allow_multiple: 0,
-                    default_values: [''],
-                    description: 'Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2',
-                    disabled: 0,
-                    dynamic_dropdown_options: {
-                        data_source: 'ftp_staging',
-                        multiselection: 0,
-                        query_on_empty_input: 1,
-                        result_array_index: 0,
-                        service_params: null
-                    },
-                    field_type: 'dynamic_dropdown',
-                    id: 'fastq_fwd_staging_file_name',
-                    optional: 1,
-                    short_hint: 'Short read file containing a paired end library in FASTA/FASTQ format',
-                    ui_class: 'parameter',
-                    ui_name: 'Forward/Left FASTA/FASTQ File Path'
-                },
-                ui: {
-                    advanced: false,
-                    class: 'parameter',
-                    control: 'dynamic_dropdown',
-                    description: 'Valid file extensions for FASTA: .fasta, .fna, .fa   Valid file extensions for FASTQ: .fastq, .fnq, .fq; Compressed files (containing files with vaild extentions): .zip, .gz, .bz2, .tar.gz, .tar.bz2',
-                    hint: 'Short read file containing a paired end library in FASTA/FASTQ format',
-                    label: 'Forward/Left FASTA/FASTQ File Path',
-                    type: 'dynamic_dropdown'
-                }
-            };
-
-            paramResolver = ParamResolver.make();
-
-            inputControlFacotry = paramResolver.loadInputControl(parameterSpec);
-
             const model = Props.make({
                 data: TestAppObject,
-                onUpdate: (props) => {},
+                onUpdate: () => {},
             });
 
-            appSpec = Spec.make({
+            const appSpec = Spec.make({
                 appSpec: model.getItem('app.spec'),
             });
 
-            closeParameters = [
-                'fastq_fwd_staging_file_name',
-                'fastq_rev_staging_file_name',
-                'sra_staging_file_name',
-                'name'
-            ];
+            const paramResolver = ParamResolver.make();
 
-            return mockFieldWidget = fieldCellWidget.make({
-                inputControlFactory: inputControlFacotry,
-                showHint: true,
-                useRowHighight: true,
-                initialValue: '',
-                appSpec: appSpec,
-                parameterSpec: parameterSpec,
-                workspaceId: 56236,
-                referenceType: 'name',
-                paramsChannelName: 'Test Channel',
-                closeParameters: closeParameters
+            await paramResolver.loadInputControl(parameterSpec).then((inputControlFactory) => {
+                return (mockFieldWidget = fieldCellWidget.make({
+                    inputControlFactory: inputControlFactory,
+                    showHint: true,
+                    useRowHighight: true,
+                    initialValue: '',
+                    appSpec: appSpec,
+                    parameterSpec: parameterSpec,
+                    workspaceId: 56236,
+                    referenceType: 'name',
+                    paramsChannelName: 'Test Channel',
+                    closeParameters: closeParameters,
+                }));
             });
         });
 
-        it('has a factory which can be invoked', function() {
+        afterEach(async () => {
+            await mockFieldWidget.stop().catch((err) => {
+                console.warn(
+                    'got an error when trying to stop, this is normal if stopped already (e.g. after final test run)',
+                    err
+                );
+            });
+
+            node = null;
+            document.body.innnerHTML = '';
+            mockFieldWidget = null;
+        });
+
+        it('has a factory which can be invoked', function () {
             expect(mockFieldWidget).not.toBe(null);
         });
 
-        it('has the required methods', function() {
+        it('has the required methods', function () {
             expect(mockFieldWidget.start).toBeDefined();
             expect(mockFieldWidget.stop).toBeDefined();
             expect(mockFieldWidget.bus).toBeDefined();
         });
 
         it('has a method start which returns the correct object', () => {
-            return mockFieldWidget.start({
-                node: node
-            }).then(() => {
-                expect(node.innerHTML).toContain('kb-field-cell__cell_label');
-                expect(node.innerHTML).toContain('kb-field-cell__input_control');
-            });
+            return mockFieldWidget
+                .start({
+                    node: node,
+                })
+                .then(() => {
+                    expect(node.innerHTML).toContain('kb-field-cell__cell_label');
+                    expect(node.innerHTML).toContain('kb-field-cell__input_control');
+                });
         });
 
         it('has a method stop which returns null', () => {
-            return mockFieldWidget.start({
-                node: node
-            }).then(() => {
-                mockFieldWidget.stop().then((result) =>{
-                    expect(result).toBeNull();
+            return mockFieldWidget
+                .start({
+                    node: node,
+                })
+                .then(() => {
+                    mockFieldWidget.stop().then((result) => {
+                        expect(result).toBeNull();
+                    });
                 });
-            });
         });
     });
 });

--- a/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
@@ -1,32 +1,25 @@
 define([
+    'base/js/namespace',
     'common/cellComponents/filePathWidget',
     'jquery',
     'common/runtime',
     'common/props',
     'common/spec',
     'json!../../../../data/testAppObj.json',
-], function(
-    FilePathWidget,
-    $,
-    Runtime,
-    Props,
-    Spec,
-    TestAppObject
-) {
+], function (Jupyter, FilePathWidget, $, Runtime, Props, Spec, TestAppObject) {
     'use strict';
 
-    describe('The file path widget module', function() {
-        it('loads', function() {
+    describe('The file path widget module', function () {
+        it('loads', function () {
             expect(FilePathWidget).not.toBe(null);
         });
 
-        it('has expected functions', function() {
+        it('has expected functions', function () {
             expect(FilePathWidget.make).toBeDefined();
         });
-
     });
 
-    describe('The file path widget instance', function() {
+    describe('The file path widget instance', function () {
         beforeAll(() => {
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
@@ -46,7 +39,7 @@ define([
 
             const model = Props.make({
                 data: TestAppObject,
-                onUpdate: (props) => {},
+                onUpdate: () => {},
             });
 
             spec = Spec.make({
@@ -66,67 +59,74 @@ define([
 
         afterEach(() => {
             $('body').empty();
+            filePathWidget = null;
+            node = null;
         });
 
-        it('has a make function that returns an object', function() {
+        it('has a make function that returns an object', function () {
             expect(filePathWidget).not.toBe(null);
         });
 
-        it('has the required methods', function() {
+        it('has the required methods', function () {
             expect(filePathWidget.start).toBeDefined();
             expect(filePathWidget.stop).toBeDefined();
             expect(filePathWidget.bus).toBeDefined();
         });
 
         it('should start and render itself', () => {
-            return filePathWidget.start({
-                node: node,
-                appSpec: spec,
-                parameters: parameters,
-            }).then(() => {
-                const contents = [
-                    'File Paths',
-                    'kb-file-path__table',
-                    'kb-file-path__table_row',
-                    'kb-file-path__file_number',
-                    '1',
-                    'fastq_rev_staging_file_name',
-                    'fa fa-trash-o fa-lg',
-                    'Add Row'
-                ];
-                contents.forEach( (item) => {
-                    expect(node.innerHTML).toContain(item);
+            return filePathWidget
+                .start({
+                    node: node,
+                    appSpec: spec,
+                    parameters: parameters,
+                })
+                .then(() => {
+                    const contents = [
+                        'File Paths',
+                        'kb-file-path__table',
+                        'kb-file-path__table_row',
+                        'kb-file-path__file_number',
+                        '1',
+                        'fastq_rev_staging_file_name',
+                        'fa fa-trash-o fa-lg',
+                        'Add Row',
+                    ];
+                    contents.forEach((item) => {
+                        expect(node.innerHTML).toContain(item);
+                    });
                 });
-            });
         });
 
         it('should add a row when Add Row button is clicked', () => {
-            return filePathWidget.start({
-                node: node,
-                appSpec: spec,
-                parameters: parameters,
-            }).then(() => {
-                let preClickNumberOfRows = $('tr').length;
-                expect(preClickNumberOfRows).toEqual(1);
-                $('button')[1].click();
-                let postClickNumberOfRows = $('tr').length;
-                expect(postClickNumberOfRows).toEqual(2);
-            });
+            return filePathWidget
+                .start({
+                    node: node,
+                    appSpec: spec,
+                    parameters: parameters,
+                })
+                .then(() => {
+                    let preClickNumberOfRows = $('tr').length;
+                    expect(preClickNumberOfRows).toEqual(1);
+                    $('button')[1].click();
+                    let postClickNumberOfRows = $('tr').length;
+                    expect(postClickNumberOfRows).toEqual(2);
+                });
         });
 
         it('should delete a row when trashcan button is clicked', () => {
-            return filePathWidget.start({
-                node: node,
-                appSpec: spec,
-                parameters: parameters,
-            }).then(() => {
-                let preClickNumberOfRows = $('tr').length;
-                expect(preClickNumberOfRows).toEqual(1);
-                $('button')[0].click();
-                let postClickNumberOfRows = $('tr').length;
-                expect(postClickNumberOfRows).toEqual(0);
-            });
+            return filePathWidget
+                .start({
+                    node: node,
+                    appSpec: spec,
+                    parameters: parameters,
+                })
+                .then(() => {
+                    let preClickNumberOfRows = $('tr').length;
+                    expect(preClickNumberOfRows).toEqual(1);
+                    $('button')[0].click();
+                    let postClickNumberOfRows = $('tr').length;
+                    expect(postClickNumberOfRows).toEqual(0);
+                });
         });
-
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

* This PR is to fix tests for the file input widget and field table cell widget which were failing previously after some updates. 
* In the process of fixing the tests themselves I found some issues with promise resolution so I cleaned that up a bit. 
* I am still seeing intermittent issues with some of the tests where we get warnings about not being able to set "innerHTML" or retrieve "getAuthToken" when trying to initialize the widgets. I am not clear on what's going on here, I've tried troubleshooting to no avail and it doesn't seem to have an impact on the tests actually succeeding so not sure if it's a karma synchronicity red herring or what. If anyone has input or advice I would love to pair on this. 

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-365
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_
--> No visible changes here as it's all refactoring, run the unit tests and they should (mostly) succeed.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)
