### PR TITLE
Dataup 369 results container

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
@@ -1,0 +1,80 @@
+define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events'], function (
+    Promise,
+    $,
+    html,
+    UI,
+    Events
+) {
+    'use strict';
+
+    let tag = html.tag,
+        div = tag('div');
+
+    function OutputWidget() {
+        let container, ui;
+
+        function renderOutput(data) {
+            return new Promise((resolve) => {
+                console.log('ready to render object output with data: ', data);
+                resolve(true);
+            });
+        }
+
+        function renderLayout() {
+            const events = Events.make();
+
+            const content = ui.buildCollapsiblePanel({
+                title: 'Objects',
+                name: 'created-objects-toggle',
+                hidden: false,
+                type: 'default',
+                classes: ['kb-panel-container'],
+                body: div,
+            });
+
+            let objectContainer = div({ dataElement: 'created-objects' }, [content]);
+
+            return {
+                content: objectContainer,
+                events: events,
+            };
+        }
+
+        function doAttach(node) {
+            container = node;
+            ui = UI.make({
+                node: container,
+            });
+
+            let layout = renderLayout();
+
+            container.innerHTML = layout.content;
+            layout.events.attachEvents(container);
+        }
+
+        function start(arg) {
+            // send parent the ready message
+            doAttach(arg.node);
+
+            return renderOutput(arg.data).catch(function (err) {
+                // do somethig with the error.
+                console.error('ERROR in start', err);
+            });
+        }
+
+        function stop() {
+            return Promise.try(() => {
+                container.innerHTML = '';
+            });
+        }
+
+        return {
+            start: start,
+            stop: stop,
+        };
+    }
+
+    return {
+        make: OutputWidget,
+    };
+});

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/reportWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/reportWidget.js
@@ -1,0 +1,81 @@
+define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events'], function (
+    Promise,
+    $,
+    html,
+    UI,
+    Events
+) {
+    'use strict';
+
+    let tag = html.tag,
+        div = tag('div');
+
+    function ReportWidget() {
+        let container, ui;
+
+        function renderReport(data) {
+            return new Promise((resolve) => {
+                console.log('ready to render report with data: ', data);
+                resolve(true);
+            });
+        }
+
+        function renderLayout() {
+            const events = Events.make();
+
+            const content = ui.buildCollapsiblePanel({
+                title: 'Report',
+                name: 'report-section-toggle',
+                hidden: false,
+                type: 'default',
+                classes: ['kb-panel-container'],
+                body: div,
+            });
+
+            const reportContainer = div({ dataElement: 'report-widget' }, [content]);
+            const reportPanel = div({ dataElement: 'html-panel' }, [reportContainer]);
+
+            return {
+                content: reportPanel,
+                events: events,
+            };
+        }
+
+        function doAttach(node) {
+            container = node;
+            ui = UI.make({
+                node: container,
+            });
+
+            let layout = renderLayout();
+
+            container.innerHTML = layout.content;
+            layout.events.attachEvents(container);
+        }
+
+        function start(arg) {
+            // send parent the ready message
+            doAttach(arg.node);
+
+            return renderReport(arg.data).catch(function (err) {
+                // do somethig with the error.
+                console.error('ERROR in start', err);
+            });
+        }
+
+        function stop() {
+            return Promise.try(() => {
+                container.innerHTML = '';
+            });
+        }
+
+        return {
+            start: start,
+            stop: stop,
+        };
+    }
+
+    return {
+        make: ReportWidget,
+    };
+});

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
@@ -1,0 +1,78 @@
+define(['bluebird', 'common/events', './outputWidget', './reportWidget'], (
+    Promise,
+    Events,
+    OutputWidget,
+    ReportWidget
+) => {
+    'use strict';
+
+    function ResultsTab(config) {
+        const model = config.model;
+        let container = null;
+
+        function buildOutputWidget(arg) {
+            const outputWidget = OutputWidget.make();
+
+            return outputWidget.start({
+                node: arg.node,
+                data: arg.data,
+            });
+        }
+
+        function buildReportWidget(arg) {
+            const reportWidget = ReportWidget.make();
+
+            return reportWidget.start({
+                node: arg.node,
+                data: arg.data,
+            });
+        }
+
+        function start(arg) {
+            return Promise.try(() => {
+                container = arg.node;
+                let events = Events.make();
+
+                //TODO: not entirely certian this is the right data to send to each widget, or if there should be any other checks here. Will need to confirm by digging deeper into the resultsViewer widget, line 76
+                const jobState = model.getItem('exec.jobState');
+                const result = model.getItem('exec.outputWidgetInfo');
+
+                //then build output object and report widgets
+                let objectNode = document.createElement('div');
+                container.appendChild(objectNode);
+
+                let reportNode = document.createElement('div');
+                container.appendChild(reportNode);
+
+                buildOutputWidget({
+                    node: objectNode,
+                    data: jobState.job_output.result,
+                }).then(() => {
+                    events.attachEvents(container);
+                });
+
+                buildReportWidget({
+                    node: reportNode,
+                    data: result.params,
+                }).then(() => {
+                    events.attachEvents(container);
+                });
+            });
+        }
+
+        function stop() {
+            return Promise.try(() => {
+                container.innerHTML = '';
+            });
+        }
+
+        return {
+            start: start,
+            stop: stop,
+        };
+    }
+
+    return {
+        make: ResultsTab,
+    };
+});

--- a/test/unit/spec/common/cellComponents/tabs/results-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results-spec.js
@@ -1,0 +1,63 @@
+define([
+    'common/cellComponents/tabs/results/resultsTab',
+    'base/js/namespace',
+    'common/props',
+    'json!../../../../../data/testAppObj.json',
+], (ResultsTab, Jupyter, Props, TestAppObject) => {
+    'use strict';
+
+    describe('test the bulk import cell results tab', () => {
+        beforeAll(() => {
+            Jupyter.narrative = {
+                getAuthToken: () => 'fakeToken',
+            };
+
+            expect(TestAppObject).toBeDefined();
+        });
+
+        afterAll(() => {
+            Jupyter.narrative = null;
+        });
+
+        it('should start and render itself', () => {
+            const node = document.createElement('div');
+            document.getElementsByTagName('body')[0].appendChild(node);
+            const model = Props.make({
+                data: TestAppObject,
+                onUpdate: () => {},
+            });
+
+            const results = ResultsTab.make({ model });
+            return results
+                .start({
+                    node: node,
+                })
+                .then(() => {
+                    // just make sure it renders the "Objects" and "Report" headers
+                    expect(node.innerHTML).toContain('Objects');
+                    expect(node.innerHTML).toContain('Report');
+                });
+        });
+
+        it('should stop itself and empty the node it was in', () => {
+            const node = document.createElement('div');
+            document.getElementsByTagName('body')[0].appendChild(node);
+            const model = Props.make({
+                data: TestAppObject,
+                onUpdate: () => {},
+            });
+
+            const results = ResultsTab.make({ model });
+            return results
+                .start({
+                    node: node,
+                })
+                .then(() => {
+                    return results.stop();
+                })
+                .then(() => {
+                    expect(node.innerHTML).toEqual('');
+                });
+        });
+    });
+});


### PR DESCRIPTION
# Description of PR purpose/changes

* This is the initial implementation of the results tab, which includes the output objects and report widget. For now they have data sent to them but display nothing. I didn't dig deep enough into the code to ensure the right data was making it to each place, just wanted to get something in there to make sure all the plumbing was working as expected. 

I wrote some fast tests for the results tab, but nothing for reports or output yet as I wanted to keep the scope of this small. 

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-369
- [x] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Load up a bulk import tab and go to the results tab (for now I left it default enabled). You should see a Objects and Report header

![Screen Shot 2020-12-13 at 9 01 30 PM](https://user-images.githubusercontent.com/4184019/102042504-dbf34f80-3d86-11eb-8808-ac697fcc047c.png)

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)
