### PR TITLE
DATAUP-331 DATAUP-265 Add additional apps to dropdown

### DIFF
--- a/kbase-extension/static/kbase/config/staging_upload.json
+++ b/kbase-extension/static/kbase/config/staging_upload.json
@@ -42,6 +42,10 @@
         },{
             "id": "sample_set",
             "name": "Sample Set"
+        },
+        {
+            "id": "decompress",
+            "name": "Decompress/Unpack"
         }
     ],
     "app_info": {
@@ -155,6 +159,42 @@
             "app_output_param": "set_name",
             "app_output_suffix": "_sample_set",
             "multiselect": false
+        },
+        "decompress": {
+            "app_id": "kb_uploadmethods/unpack_staging_file",
+            "app_input_param": "staging_file_subdir_path",
+            "app_input_param_type": "string",
+            "app_static_params": {},
+            "app_output_param": "",
+            "app_output_suffix": "",
+            "multiselect": false
+        },
+        "sra_reads": {
+            "app_id": "kb_uploadmethods/import_sra_as_reads_from_staging",
+            "app_input_param": "sra_staging_file_name",
+            "app_input_param_type": "string",
+            "app_static_params": {"import_type": "SRA"},
+            "app_output_param": "name",
+            "app_output_suffix": "_reads",
+            "multiselect": false
+        },
+        "fastq_reads_interleaved": {
+            "app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+            "app_input_param": "fastq_fwd_staging_file_name",
+            "app_input_param_type": "string",
+            "app_static_params": {"import_type": "FASTQ/FASTA"},
+            "app_output_param": "name",
+            "app_output_suffix": "_reads",
+            "multiselect": false
+        },
+        "fastq_reads_noninterleaved": {
+            "app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+            "app_input_param": "fastq_fwd_staging_file_name",
+            "app_input_param_type": "string",
+            "app_static_params": {"import_type": "FASTQ/FASTA"},
+            "app_output_param": "name",
+            "app_output_suffix": "_reads",
+            "multiselect": true
         }
     }
 }


### PR DESCRIPTION
# Description of PR purpose/changes

* This adds the correct UIs for the additional FASTQ/SRA apps, instead of all using one UI
* This hooks up the decompress app

# Testing Instructions
* Spin up a local narrative and press the uploads in staging.. You might have to update narrative/kbase-extension/static/kbase/js/util/kbaseApiUtil.js to use dev instead of prod
* Test on CI (Once they are released in https://github.com/kbaseapps/kb_uploadmethods/pull/310)

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
