### PR TITLE
fix SCT-2914 / PUBLIC-1493 - movement of unselected cells

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 ### Version NEXT
 - SCT-2778 - convert data slideout, public tab, refseq data source to use searchapi2/rpc api rather than searchapi2/legacy.
 - enhance integration testing support to add service, host, browser, screen size support
+- SCT-2914 / PUBLIC-1493 - fix up/down cell movement behavior for unselected cells
 
 ### Version 4.3.1
 - Fixed problem where code cells could forget their toggled state after saving.

--- a/kbase-extension/static/kbase/custom/custom.css
+++ b/kbase-extension/static/kbase/custom/custom.css
@@ -315,13 +315,29 @@ div#notebook {
   color: #ccc;
 }
 
+.cell.unselected .btn-default:hover {
+    color: #000;
+  }
+
 .cell.unselected .kb-cell-toolbar .title-container {
   opacity: 0.5;
 }
 
-.cell.unselected .kb-cell-toolbar .buttons-container {
-  opacity: 0.2;
+.btn.btn-default.kb-btn-expander.-minimized {
+  color: rgba(255,137,0,1);
 }
+
+.cell.unselected .kb-btn-expander.-minimized {
+  color: rgba(255,137,0, 0.5);
+}
+
+.cell.unselected .kb-btn-expander.-minimized:hover {
+    color: rgba(255,137,0, 1);
+  }
+
+/* .cell.unselected .kb-cell-toolbar .buttons-container {
+  opacity: 0.2;
+} */
 
 .kb-btn-icon {
   display: inline-block;

--- a/kbase-extension/static/kbase/js/userMenu.js
+++ b/kbase-extension/static/kbase/js/userMenu.js
@@ -82,10 +82,10 @@ define([
                             div({style: 'display:inline-block; width: 34px; vertical-align: top;'}, [
                                 span({class: 'fa fa-user', style: 'font-size: 150%; margin-right: 10px;'})
                             ]),
-                            div({style: 'display: inline-block', 'data-element': 'user-label'}, [
-                                displayName,
+                            div({style: 'display: inline-block'}, [
+                                span({'data-element': 'realname'}, displayName),
                                 br(),
-                                i({}, userName)
+                                i({'data-element': 'username'}, userName)
                             ])
                         ])
                     ]),

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
@@ -22,7 +22,7 @@ define([
 ) {
     'use strict';
 
-    var t = html.tag,
+    const t = html.tag,
         div = t('div'),
         a = t('a'),
         button = t('button'),
@@ -50,11 +50,13 @@ define([
             readOnly = Jupyter.narrative.readonly;
 
         function doMoveCellUp() {
-            Jupyter.notebook.move_cell_up();
+            const cellIndex = Jupyter.notebook.find_cell_index(cell);
+            Jupyter.notebook.move_cell_up(cellIndex);
         }
 
         function doMoveCellDown() {
-            Jupyter.notebook.move_cell_down();
+            const cellIndex = Jupyter.notebook.find_cell_index(cell);
+            Jupyter.notebook.move_cell_down(cellIndex);
         }
 
         function doDeleteCell() {
@@ -199,10 +201,8 @@ define([
         }
 
         function renderOptions(cell, events) {
-            var toggleMinMax = utils.getCellMeta(cell, 'kbase.cellState.toggleMinMax', 'maximized'),
-                toggleIcon = (toggleMinMax === 'maximized' ? 'minus' : 'plus'),
-                dropdownId = html.genId(),
-                menuItems = [];
+            const dropdownId = html.genId();
+            const menuItems = [];
 
             if (cell.cell_type === 'code') {
                 menuItems.push({
@@ -403,12 +403,12 @@ define([
                         ])),
 
                         (function () {
-                            var toggleMinMax = utils.getCellMeta(cell, 'kbase.cellState.toggleMinMax', 'maximized'),
+                            const toggleMinMax = utils.getCellMeta(cell, 'kbase.cellState.toggleMinMax', 'maximized'),
                                 toggleIcon = (toggleMinMax === 'maximized' ? 'minus' : 'plus'),
-                                color = (toggleMinMax === 'maximized' ? '#000' : 'rgba(255,137,0,1)');
+                                classModifier = (toggleMinMax === 'maximized' ? '-maximized' : '-minimized');
                             return button({
                                 type: 'button',
-                                class: 'btn btn-default btn-xs',
+                                class: `btn btn-default btn-xs kb-btn-expander ${classModifier}`,
                                 dataToggle: 'tooltip',
                                 dataPlacement: 'left',
                                 title: true,
@@ -418,10 +418,7 @@ define([
                                 id: events.addEvent({type: 'click', handler: doToggleMinMaxCell})
                             }, [
                                 span({
-                                    class: 'fa fa-' + toggleIcon + '-square-o fa-lg',
-                                    style: {
-                                        color: color
-                                    }
+                                    class: 'fa fa-' + toggleIcon + '-square-o fa-lg'
                                 })
                             ]);
                         }())

--- a/test/integration/specs/kbaseCellToolbarMenu_test.js
+++ b/test/integration/specs/kbaseCellToolbarMenu_test.js
@@ -1,0 +1,317 @@
+/*global describe, it, browser, expect, $, afterEach, beforeEach*/
+/* eslint {strict: ['error', 'global']} */
+'use strict';
+
+const {login, openNarrative, sendString, clickWhenReady} = require('../wdioUtils.js');
+
+/*
+Notes:
+
+The test narrative has 4 markdown cells, each collapsed. The initial collapsed
+state makes some tests easier, because they all have a title.
+*/
+
+const testData = {
+    common: {
+        unselectedBorder: '1px 1px 1px 5px solid rgb(204, 204, 204)',
+        selectedBorder: '1px 1px 1px 5px solid rgb(75, 184, 86)',
+    },
+    all: {
+        TEST_CASE1: {
+            cellIndex: 1,
+            title: "Narrative Cell Toolbar Testing"
+        },
+        TEST_CASE2: {
+            cellIndex: 2,
+            title: "Cell 1"
+        },
+        TEST_CASE3: {
+            cellIndex: 3,
+            title: "Cell 2"
+        },
+        TEST_CASE4: {
+            cellIndex: 3,
+            title: "Cell 2"
+        },
+        TEST_CASE5: {
+            cellIndex: 4,
+            body: "Cell 3"
+        }
+    },
+    ci: {
+        TEST_CASE1: {
+            narrativeId: 58675,
+        },
+        TEST_CASE2: {
+            narrativeId: 58675,
+        },
+        TEST_CASE3: {
+            narrativeId: 58675,
+        },
+        TEST_CASE4: {
+            narrativeId: 58675,
+        },
+        TEST_CASE5: {
+            narrativeId: 58675,
+        }
+    },
+    'narrative-dev': {
+        TEST_CASE1: {
+            narrativeId: 80970,
+        },
+        TEST_CASE2: {
+            narrativeId: 80970,
+        },
+        TEST_CASE3: {
+            narrativeId: 80970,
+        },
+        TEST_CASE4: {
+            narrativeId: 80970,
+        },
+        TEST_CASE5: {
+            narrativeId: 80970,
+        }
+    }
+};
+
+const testCases = mergeObjects([testData[browser.config.testParams.ENV], testData.all]);
+
+function mergeObjects(listOfObjects) {
+    const simpleObjectPrototype = Object.getPrototypeOf({});
+
+    function isSimpleObject(obj) {
+        return Object.getPrototypeOf(obj) === simpleObjectPrototype;
+    }
+
+    function merge(obj1, obj2, keyStack) {
+        Object.keys(obj2).forEach(function (key) {
+            const obj1Value = obj1[key];
+            const obj2Value = obj2[key];
+            const obj1Type = typeof obj1Value;
+            // var obj2Type = typeof obj2Value;
+            if (obj1Type === 'undefined') {
+                obj1[key] = obj2[key];
+            } else if (isSimpleObject(obj1Value) && isSimpleObject(obj2Value)) {
+                keyStack.push(key);
+                merge(obj1Value, obj2Value, keyStack);
+                keyStack.pop();
+            } else {
+                console.error('UNMERGABLE', obj1Type, obj1Value);
+                throw new Error('Unmergable at ' + keyStack.join('.') + ':' + key);
+            }
+        });
+    }
+
+    const base = JSON.parse(JSON.stringify(listOfObjects[0]));
+    for (let i = 1; i < listOfObjects.length; i += 1) {
+        merge(base, listOfObjects[i], []);
+    }
+    return base;
+}
+
+
+
+async function waitForCell(notebookContainer, cellIndex){
+    return await browser.waitUntil(async () => {
+        const cell = await notebookContainer.$(`.cell:nth-child(${cellIndex})`);
+        return cell;
+    });
+    // return await panel.$$('[role="table"][data-test-id="result"] > div > [role="row"]');
+}
+
+async function waitForCellWithTitle(container, cellIndex, title) {
+    const cell = await waitForCell(container, cellIndex);
+    await browser.waitUntil(async () => {
+        const titleElement = await cell.$('[data-element="title"]');
+        const text = await titleElement.getText();
+        return text === title;
+    });
+    return cell;
+}
+
+async function waitForCellWithBody(container, cellIndex, bodyText) {
+    const cell = await waitForCell(container, cellIndex);
+    await browser.waitUntil(async () => {
+        const element = await cell.$('.text_cell_render.rendered_html');
+        const text = await element.getText();
+        return text === bodyText;
+    });
+    return cell;
+}
+
+async function selectCell(container, cellIndex, title) {
+    const cell = await waitForCellWithTitle(container, cellIndex, title);
+
+    // Make sure not selected.
+    // We do this by inspecting the border.
+    const borderStyle = await cell.getCSSProperty('border');
+    expect(borderStyle.value).toEqual(testData.common.unselectedBorder);
+
+    // Click on title area to select cell.
+    const titleArea = await cell.$('.title-container');
+    await clickWhenReady(titleArea);
+
+    await browser.waitUntil(async () => {
+        const borderStyle = await cell.getCSSProperty('border');
+        return borderStyle.value === testData.common.selectedBorder;
+    });
+
+    return cell;
+}
+
+async function selectCellWithBody(container, cellIndex, body) {
+    const cell = await waitForCellWithBody(container, cellIndex, body);
+
+    // Make sure not selected.
+    // We do this by inspecting the border.
+    const borderStyle = await cell.getCSSProperty('border');
+    expect(borderStyle.value).toEqual(testData.common.unselectedBorder);
+
+    // Click on title area to select cell.
+    const bodyArea = await cell.$('.text_cell_render.rendered_html');
+    await clickWhenReady(bodyArea);
+
+    await browser.waitUntil(async () => {
+        const borderStyle = await cell.getCSSProperty('border');
+        return borderStyle.value === testData.common.selectedBorder;
+    });
+
+    return cell;
+}
+
+describe('Test kbaseCellToolbarMenu', () => {
+    beforeEach(async () => {
+        await browser.setTimeout({ 'implicit': 30000 });
+        await browser.reloadSession();
+    });
+
+    afterEach(async () => {
+        await browser.deleteCookies();
+    });
+
+    it('moves a minimized selected cell down', async () => {
+        const testCase = testCases.TEST_CASE1;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+
+        const cell = await waitForCellWithTitle(narrativeContainer, testCase.cellIndex, testCase.title);
+
+        // Find and click the move-down button
+        const downButton = await cell.$('[data-test="cell-move-down"]');
+        await clickWhenReady(downButton);
+        await waitForCellWithTitle(narrativeContainer, testCase.cellIndex + 1, testCase.title);
+    });
+
+    it('moves a minimized unselected cell down', async () => {
+        const testCase = testCases.TEST_CASE2;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+
+        const cell = await waitForCellWithTitle(narrativeContainer, testCase.cellIndex, testCase.title);
+
+        // Find and click the move-down button
+        const downButton = await cell.$('[data-test="cell-move-down"]');
+        await clickWhenReady(downButton);
+        await waitForCellWithTitle(narrativeContainer, testCase.cellIndex + 1, testCase.title);
+    });
+
+    it('moves a minimized unselected cell up', async () => {
+        const testCase = testCases.TEST_CASE3;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+
+        const cell = await waitForCellWithTitle(narrativeContainer, testCase.cellIndex, testCase.title);
+
+        // Find and click the move-ups button
+        const upButton = await cell.$('[data-test="cell-move-up"]');
+        await clickWhenReady(upButton);
+        await waitForCellWithTitle(narrativeContainer, testCase.cellIndex - 1, testCase.title);
+    });
+
+     // select cell
+    it('selects a minimized cell', async () => {
+        const testCase = testCases.TEST_CASE4;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+        await selectCell(narrativeContainer, testCase.cellIndex, testCase.title);
+    });
+
+    // select cell and move down
+    it('selects a minimized cell and moves it down', async () => {
+        const testCase = testCases.TEST_CASE4;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+        const cell = await selectCell(narrativeContainer, testCase.cellIndex, testCase.title);
+        const downButton = await cell.$('[data-test="cell-move-down"]');
+        await clickWhenReady(downButton);
+        await waitForCellWithTitle(narrativeContainer, testCase.cellIndex + 1, testCase.title);
+    });
+
+    // select cell and move up
+    it('selects a minimized cell and moves it up', async () => {
+        const testCase = testCases.TEST_CASE4;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+        const cell = await selectCell(narrativeContainer, testCase.cellIndex, testCase.title);
+        const upButton = await cell.$('[data-test="cell-move-up"]');
+        await clickWhenReady(upButton);
+        await waitForCellWithTitle(narrativeContainer, testCase.cellIndex - 1, testCase.title);
+    });
+
+    // Everything above, but cells are expanded.
+
+    it('moves an expanded unselected cell down', async () => {
+        const testCase = testCases.TEST_CASE5;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+
+        const cell = await waitForCellWithBody(narrativeContainer, testCase.cellIndex, testCase.body);
+
+        // Find and click the move-down button
+        const downButton = await cell.$('[data-test="cell-move-down"]');
+        await clickWhenReady(downButton);
+        await waitForCellWithBody(narrativeContainer, testCase.cellIndex + 1, testCase.body);
+    });
+
+    it('moves an expanded unselected cell up', async () => {
+        const testCase = testCases.TEST_CASE5;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+
+        const cell = await waitForCellWithBody(narrativeContainer, testCase.cellIndex, testCase.body);
+
+        // Find and click the move-down button
+        const button = await cell.$('[data-test="cell-move-up"]');
+        await clickWhenReady(button);
+        await waitForCellWithBody(narrativeContainer, testCase.cellIndex - 1, testCase.body);
+    });
+
+    it('selects an expanded cell', async () => {
+        const testCase = testCases.TEST_CASE5;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+        await selectCellWithBody(narrativeContainer, testCase.cellIndex, testCase.body);
+    });
+
+    // select cell and move down
+    it('selects an expanded cell and moves it down', async () => {
+        const testCase = testCases.TEST_CASE5;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+        const cell = await selectCellWithBody(narrativeContainer, testCase.cellIndex, testCase.body);
+        const downButton = await cell.$('[data-test="cell-move-down"]');
+        await clickWhenReady(downButton);
+        await waitForCellWithBody(narrativeContainer, testCase.cellIndex + 1, testCase.body);
+    });
+
+    // select cell and move up
+    it('selects an expanded cell and moves it up', async () => {
+        const testCase = testCases.TEST_CASE5;
+        await login();
+        const narrativeContainer = await openNarrative(testCase.narrativeId);
+        const cell = await selectCellWithBody(narrativeContainer, testCase.cellIndex, testCase.body);
+        const upButton = await cell.$('[data-test="cell-move-up"]');
+        await clickWhenReady(upButton);
+        await waitForCellWithBody(narrativeContainer, testCase.cellIndex - 1, testCase.body);
+    });
+});

--- a/test/integration/wdioUtils.js
+++ b/test/integration/wdioUtils.js
@@ -93,13 +93,15 @@ async function openNarrative(workspaceId) {
 
     await clickWhenReady(loginButton);
 
-    const userLabelElement = await $('[data-element="user-label"]');
+    const realnameElement = await $('[data-element="realname"]');
+    const usernameElement = await $('[data-element="username"]');
     await browser.waitUntil(async () => {
-        const userLabelText = await userLabelElement.getText();
-        return (userLabelText && userLabelText.length > 0);
+        const text = await realnameElement.getText();
+        return (text && text.length > 0);
     });
-    const text = await userLabelElement.getText();
-    console.warn(`Logged in as user ${text}`);
+    const realname = await realnameElement.getText();
+    const username = await usernameElement.getText();
+    console.warn(`Signed in as user "${realname}" (${username})`);
     await loginButton.click();
     
     // Ensure narrative notebook has displayed
@@ -110,6 +112,7 @@ async function openNarrative(workspaceId) {
         timeout,
         timeoutMsg: `Timeout after waiting ${timeout}ms for narrative to appear`
     });
+    return container;
 }
 
 module.exports = {


### PR DESCRIPTION
# Description of PR purpose/changes

Fixes an issue with using the up and down arrow cell movement controls in unselected cells. Rather than the the unselected moving, the selected cell moves.

In addition, the styling of the toolbar controls in unselected cells is a bit too dim, and they don't respond well to hovering.

The fix for the cell movement is to have the cell movement commands include the index of the target (unselected) cell. The styling issue was a matter of adding classes to better support unselected cell styles, and altering the styles to make the controls a bit darker (they were double-subdued by being both a gray color and also having low opacity applied, which was probably unintentional), and in addition when hovering they appear as in selected cells (full color, background color applied.)

To support integration tests, some additional markup changes were required.

- fix movement of unselected cells
- improve styling of toolbar controls in unselected cells
- integration tests for the above, for ci and narrative-dev

# Jira Ticket / Issue #
original: https://kbase-jira.atlassian.net/browse/PUBLIC-1493
work tracking: https://kbase-jira.atlassian.net/browse/SCT-2914
- [x] Added the Jira Ticket to the title of the PR 

# Testing Instructions
* Details for how to test the PR: 
- [x] Tests pass in travis and locally 
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
