### PR TITLE
Updating PR template with trussresources site URL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,21 @@
 # Description of PR purpose/changes
 
-* Please include a summary of the change and which issue is fixed. 
+* Please include a summary of the change and which issue is fixed.
 * Please also include relevant motivation and context.
 * List any dependencies that are required for this change.
 
 # Jira Ticket / Issue #
 e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
-- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)
+- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)
 
 # Testing Instructions
-* Details for how to test the PR: 
-- [ ] Tests pass in travis and locally 
+* Details for how to test the PR:
+- [ ] Tests pass locally and in GitHub Actions
 - [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_
 
 # Dev Checklist:
 
-- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
+- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/development
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
@@ -23,7 +23,8 @@ e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
-- [ ] I have run Black and Flake8 on changed Python Code manually or with git precommit (and the travis build passes)
+- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
+- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
 
 # Updating Version and Release Notes (if applicable)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
 
 # Dev Checklist:
 
-- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/development
+- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation


### PR DESCRIPTION
# Description of PR purpose/changes

* Updating the PR template to be in sync with the truss branch template, and to correct the URL for the reference website

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] N/A

# Testing Instructions
* Details for how to test the PR: 
- [x] Read `.github/pull_request_template.md`
- [x] That's it!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
