### PR TITLE
Updating PR template with trussresources site URL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 # Jira Ticket / Issue #
 e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
-- [ ] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)
+- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)
 
 # Testing Instructions
 * Details for how to test the PR:
@@ -15,7 +15,7 @@ e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
 
 # Dev Checklist:
 
-- [ ] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
+- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/development
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
 
 # Dev Checklist:
 
-- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/development
+- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation


### PR DESCRIPTION
# Description of PR purpose/changes

Updating PR template with trussresources site URL

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [-] Added the Jira Ticket to the title of the PR e.g. (DATAUP-69 Adds a PR template)

# Testing Instructions
* Details for how to test the PR: 
- [x] Read the doc

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/truss.works/kbasetruss/development
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
