### PR TITLE
DATAUP-322: Remove errorPage.css

### DIFF
--- a/kbase-extension/kbase_templates/403.html
+++ b/kbase-extension/kbase_templates/403.html
@@ -5,7 +5,9 @@
 
 {% block stylesheet %}
 {{super()}}
-    <link rel="stylesheet" href="{{ static_url("kbase/css/errorPage.css") }}" type="text/css" />
+<style type="text/css">
+  #header, #site { display: block }
+</style>
 {% endblock %}
 
 {% block loading_message %}

--- a/kbase-extension/kbase_templates/error.html
+++ b/kbase-extension/kbase_templates/error.html
@@ -5,7 +5,9 @@
 
 {% block stylesheet %}
 {{super()}}
-    <link rel="stylesheet" href="{{ static_url("kbase/css/errorPage.css") }}" type="text/css" />
+<style type="text/css">
+  #header, #site { display: block }
+</style>
 {% endblock %}
 
 {% block loading_message %}

--- a/kbase-extension/kbase_templates/generic_error.html
+++ b/kbase-extension/kbase_templates/generic_error.html
@@ -5,7 +5,9 @@
 
 {% block stylesheet %}
 {{super()}}
-    <link rel="stylesheet" href="{{ static_url("kbase/css/errorPage.css") }}" type="text/css" />
+<style type="text/css">
+  #header, #site { display: block }
+</style>
 {% endblock %}
 
 {% block loading_message %}


### PR DESCRIPTION
# Description of PR purpose/changes

Remove mentions in the page templates to `errorPage.css` and put the css declarations in the files themselves (only one line, so no point in maintaining a file).

I thought I had already made this change in another PR, but perhaps it got accidentally undone? Anyway.

# Jira Ticket / Issue #
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, using the devTools to slow down page load, and seeing that the resulting error is correctly displayed.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
