### PR TITLE
change hamburger menu link to 'narratives'

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,8 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
 ### Version NEXT
 - SCT-2778 - convert data slideout, public tab, refseq data source to use searchapi2/rpc api rather than searchapi2/legacy.
-- enhance integration testing support to add service, host, browser, screen size support
+- Enhanced integration testing support to add service, host, browser, screen size support.
+- Changed the "Dashboard" link in hamburger menu to "Narratives" and use the new /narratives path.
 
 ### Version 4.3.1
 - Fixed problem where code cells could forget their toggled state after saving.

--- a/kbase-extension/kbase_templates/narrative_header.html
+++ b/kbase-extension/kbase_templates/narrative_header.html
@@ -6,7 +6,7 @@
                     <span class="fa fa-navicon"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="kb-nav-menu">
-                    <li><a href="/#dashboard" target="_blank"><div class="kb-nav-menu-icon"><span class="fa fa-dashboard"></span></div> Dashboard</a></li>
+                    <li><a href="/narratives" target="_blank"><div class="kb-nav-menu-icon"><span class="fa fa-files-o"></span></div> Narratives</a></li>
                     <li class="divider"></li>
                     <li><a id="kb-about-btn"><div class="kb-nav-menu-icon"><span class="fa fa-info-circle"></span></div> About the Narrative</a></li>
                     <li class="divider"></li>


### PR DESCRIPTION
# Description of PR purpose/changes

A tiny PR to change the "dashboard" link to go to the new "narratives" path.
Just a little cleanup that needs to be done before staging the release.

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules