### PR TITLE
DATAUP-330 port removal of grunt test from truss branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     },
     "scripts": {
         "bower": "bower install",
-        "test": "grunt test",
+        "test": "karma start test/unit/karma.conf.js",
+        "test-grunt": "grunt test",
         "build": "grunt build"
     },
     "dependencies": {}

--- a/test/unit/run_tests.py
+++ b/test/unit/run_tests.py
@@ -96,7 +96,7 @@ try:
         print("narrative started")
         try:
             resp_unit = subprocess.check_call(
-                ["npx", "grunt", "test"],
+                ["npm", "run", "test"],
                 stderr=subprocess.STDOUT,
                 shell=False,
             )  # nosec

--- a/test/unit/test-main.js
+++ b/test/unit/test-main.js
@@ -1,15 +1,9 @@
-/*jslint white: true*/
-
-var tests = [
-    'text', 'json'
+/* eslint-disable strict */
+/* global requirejs */
+const tests = [
+    ...['text', 'json'],
+    ...Object.keys(window.__karma__.files).filter(file => /[sS]pec\.js$/.test(file))
 ];
-for (var file in window.__karma__.files) {
-    if (window.__karma__.files.hasOwnProperty(file)) {
-        if (/[sS]pec\.js$/.test(file)) {
-            tests.push(file);
-        }
-    }
-}
 
 // hack to make jed (the i18n library that Jupyter uses) happy.
 document.nbjs_translations = {
@@ -66,11 +60,11 @@ requirejs.config({
     callback: function() {
         'use strict';
 
-        require(['testUtil'], function(TestUtil) {
-            TestUtil.make().then(function() {
+        require(['testUtil'], (TestUtil) => {
+            TestUtil.make().then(() => {
                 window.__karma__.start();
             });
-        }, function (error) {
+        }, (error) => {
             console.error('Failed to open TestUtil file.');
             console.error(error);
             throw error;


### PR DESCRIPTION
# Description of PR purpose/changes

This is the first of probably many PRs around fixing the frontend unit tests. See the ticket linked below for further details.

This simply ports the recent change to the truss branch that sidesteps using `grunt` and `grunt-karma` to start the test suite. The way grunt captures logs can lead to some false errors. See this PR for more info: https://github.com/kbase/narrative/pull/2110

Practically, this doesn't change the experience of running tests, just how they get started.

There's also a little modernization to the `test-main.js` startup script.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
running `make test` or `make test-frontend-unit` will still work.
Alternately, start a local headless narrative on port 32323 with:
```
kbase-narrative --no-browser --port=32323
```
and run
```
npm run test
```
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook