### PR TITLE
DATAUP-330 fix app info panel widget and tests

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appInfoPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/appInfoPanel.js
@@ -1,4 +1,3 @@
-/*global define*/
 /*jslint white:true,browser:true*/
 /**
  * Creates an informational panel for Apps, based on some general app info.
@@ -15,79 +14,72 @@ define([
     'kb_service/client/narrativeMethodStore',
     'handlebars',
     'text!kbase/templates/app_info_panel.html'
-], function(
+], (
     Promise,
     Runtime,
     Catalog,
     NarrativeMethodStore,
     Handlebars,
     appInfoPanelTmpl
-) {
+) => {
     'use strict';
 
     function factory(config) {
-        var container,
-            runtime = Runtime.make(),
+        const runtime = Runtime.make(),
             nms = new NarrativeMethodStore(runtime.config('services.narrative_method_store.url')),
             catalog = new Catalog(runtime.config('services.catalog.url')),
             appId = config.appId,
             appModule = config.appModule,
             tag = config.tag || 'release',
-            infoPanel = Handlebars.compile(appInfoPanelTmpl),
+            infoPanel = Handlebars.compile(appInfoPanelTmpl);
+        let container,
             info = {};
 
         function start(arg) {
-            return Promise.try(function() {
-                    container = arg.node;
+            container = arg.node;
 
-                    var infoProms = [
-                        /* Get the method full info so we can populate the description */
-                        nms.get_method_full_info({ 'ids': [appId], 'tag': tag })
-                        .then(function(methodInfo) {
-                            methodInfo = methodInfo[0] || {};
-                            var desc = methodInfo.description || '';
-                            info.description = new Handlebars.SafeString(desc);
+            var infoProms = [
+                /* Get the method full info so we can populate the description */
+                nms.get_method_full_info({ 'ids': [appId], 'tag': tag })
+                    .then(function(methodInfo) {
+                        methodInfo = methodInfo[0] || {};
+                        var desc = methodInfo.description || '';
+                        info.description = new Handlebars.SafeString(desc);
 
-                            var authorList = methodInfo.authors || [];
-                            info.authorList = authorList.join(', ');
-                            info.multiAuthors = authorList.length > 1;
-                        }),
+                        var authorList = methodInfo.authors || [];
+                        info.authorList = authorList.join(', ');
+                        info.multiAuthors = authorList.length > 1;
+                    }),
 
-                        /* Get the method stats so we know how many times it was run. */
-                        catalog.get_exec_aggr_stats({ 'full_app_ids': [appId] })
-                        .then(function(appStats) {
-                            console.log('app stats', appStats);
-                            appStats = appStats[0] || {};
-                            info.runCount = appStats.number_of_calls || 'unknown';
-                        }),
+                /* Get the method stats so we know how many times it was run. */
+                catalog.get_exec_aggr_stats({ 'full_app_ids': [appId] })
+                    .then(function(appStats) {
+                        appStats = appStats[0] || {};
+                        info.runCount = appStats.number_of_calls || 'unknown';
+                    }),
 
-                        /* Get the module info so we know when it was last updated. */
-                        catalog.get_module_info({ 'module_name': appModule })
-                        .then(function(moduleInfo) {
-                            moduleInfo = moduleInfo[tag] || {};
-                            var timestamp = moduleInfo.timestamp || 'unknown';
-                            var dateString = 'unknown';
-                            try {
-                                dateString = new Date(timestamp).toLocaleDateString();
-                            } catch (e) {
-                                //pass
-                            }
-                            info.updateDate = dateString;
-                        })
-                    ];
-                    return Promise.all(infoProms);
-                })
-                .then(function() {
-                    return Promise.try(function() {
-                        container.html(infoPanel(info));
-                    });
+                /* Get the module info so we know when it was last updated. */
+                catalog.get_module_info({ 'module_name': appModule })
+                    .then(function(moduleInfo) {
+                        moduleInfo = moduleInfo[tag] || {};
+                        var timestamp = moduleInfo.timestamp || 'unknown';
+                        var dateString = 'unknown';
+                        try {
+                            dateString = new Date(timestamp).toLocaleDateString();
+                        } catch (e) {
+                            //pass
+                        }
+                        info.updateDate = dateString;
+                    })
+            ];
+            return Promise.all(infoProms)
+                .then(() => {
+                    container.html(infoPanel(info));
                 });
         }
 
         function stop() {
-            return Promise.try(function() {
-                container.html('');
-            });
+            return Promise.resolve(container.html(''));
         }
 
         return {

--- a/test/unit/spec/appWidgets/infoPanelSpec.js
+++ b/test/unit/spec/appWidgets/infoPanelSpec.js
@@ -23,15 +23,24 @@ define([
         });
     }
 
+    /**
+     * Mock data for the NMS.get_method_full_info call.
+     */
     const methodFullInfoMock = [[{
         description: 'This is a KBase wrapper for SomeModule.',
         authors: ['author1', 'author2']
     }]];
 
+    /**
+     * Mock data for the Catalog.get_exec_aggr_stats call.
+     */
     const getExecAggrStatsMock = [[{
         number_of_calls: 5
     }]];
 
+    /**
+     * Mock data for the Catalog.get_module_info call.
+     */
     const getModuleInfoMock = [{
         module_name: 'SomeModule',
         release: {

--- a/test/unit/spec/appWidgets/infoPanelSpec.js
+++ b/test/unit/spec/appWidgets/infoPanelSpec.js
@@ -6,60 +6,113 @@
 
 define([
     'jquery',
-    'bluebird',
+    'narrativeConfig',
     'kbase/js/widgets/appInfoPanel'
 ], function(
     $,
-    Promise,
+    Config,
     InfoPanel
 ) {
     'use strict';
 
     function makeDummyPanel() {
         return InfoPanel.make({
-            appId: 'MegaHit/run_megahit',
-            appModule: 'MegaHit',
+            appId: 'SomeModule/some_app',
+            appModule: 'SomeModule',
             tag: 'release'
         });
     }
 
-    describe('Test the App Info Panel module', function() {
-        it('Loaded the module', function() {
-            expect(InfoPanel).not.toBe(null);
-        });
+    const methodFullInfoMock = [[{
+        description: 'This is a KBase wrapper for SomeModule.',
+        authors: ['author1', 'author2']
+    }]];
 
-        it('Has expected functions', function() {
-            expect(InfoPanel.make).toBeDefined();
-        });
+    const getExecAggrStatsMock = [[{
+        number_of_calls: 5
+    }]];
 
-        it('Can be instantiated', function() {
-            expect(makeDummyPanel()).not.toBe(null);
-        });
+    const getModuleInfoMock = [{
+        module_name: 'SomeModule',
+        release: {
+            timestamp: 1555098756211
+        }
+    }];
 
-        it('Has expected functions when instantiated', function() {
-            var panel = makeDummyPanel();
-            expect(panel.start).toBeDefined();
-            expect(panel.stop).toBeDefined();
-        });
+    describe('Test the App Info Panel module', () => {
+        beforeEach(() => {
+            jasmine.Ajax.install();
+            jasmine.Ajax.stubRequest(Config.url('narrative_method_store'), /get_method_full_info/)
+                .andReturn({
+                    status: 200,
+                    statusText: 'HTTP/1 200 OK',
+                    contentType: 'application/json',
+                    responseText: JSON.stringify({
+                        version: '1.1',
+                        id: '12345',
+                        result: methodFullInfoMock
+                    })
+                });
 
-        it('Can render with "start" and return a Promise', function(done) {
-            var panel = makeDummyPanel();
-            var myNode = $('<div>');
-            panel.start({ node: myNode })
-                .then(function() {
-                    expect(myNode.find('.kb-app-cell-info-desc p:first-child').text()).toEqual('This is a KBase wrapper for MEGAHIT.');
-                    done();
+            jasmine.Ajax.stubRequest(Config.url('catalog'), /get_exec_aggr_stats/)
+                .andReturn({
+                    status: 200,
+                    statusText: 'HTTP/1 200 OK',
+                    contentType: 'application/json',
+                    responseText: JSON.stringify({
+                        version: '1.1',
+                        id: '12345',
+                        result: getExecAggrStatsMock
+                    })
+                });
+
+            jasmine.Ajax.stubRequest(Config.url('catalog'), /get_module_info/)
+                .andReturn({
+                    status: 200,
+                    statusText: 'HTTP/1 200 OK',
+                    contentType: 'application/json',
+                    responseText: JSON.stringify({
+                        version: '1.1',
+                        id: '12345',
+                        result: getModuleInfoMock
+                    })
                 });
         });
 
-        it('Can unrender with "stop" and return a Promise', function(done) {
-            var panel = makeDummyPanel();
-            var myNode = $('<div>');
-            panel.start({ node: myNode });
-            panel.stop()
-                .then(function() {
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+        });
+
+        it('Loads the module with its expected constructor', () => {
+            expect(InfoPanel).not.toBe(null);
+            expect(InfoPanel.make).toBeDefined();
+        });
+
+        it('Has expected functions when instantiated', () => {
+            const panel = makeDummyPanel();
+            ['start', 'stop'].forEach(fn => {
+                expect(panel[fn]).toBeDefined();
+            });
+        });
+
+        it('Can render with "start" and return a Promise', () => {
+            const panel = makeDummyPanel();
+            const myNode = $('<div>');
+            return panel.start({ node: myNode })
+                .then(() => {
+                    expect(myNode.find('.kb-app-cell-info-desc').text()).toContain('This is a KBase wrapper for SomeModule.');
+                });
+        });
+
+        it('Can unrender with "stop" and return a Promise', () => {
+            const panel = makeDummyPanel();
+            const myNode = $('<div>');
+            return panel.start({ node: myNode })
+                .then(() => {
+                    return panel.stop();
+                })
+                .then(() => {
                     expect(myNode.text()).toEqual('');
-                    done();
                 });
         });
     });


### PR DESCRIPTION
# Description of PR purpose/changes

Fixes the tests (and the module) for the app info panel popup. This is the popup that appears with app info when clicking the ellipsis menu in app cells (NOT the "info" tab, which has its own tests).
* The tests weren't mocked and made calls to NMS and Catalog that could fail and cause a false failure of the unit tests.
* The module was using Promises improperly (well, inefficiently) and needed a little modernization.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
Viewing the popup should work just the same as before.
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook