### PR TITLE
DATAUP-330 fix auth tests

### DIFF
--- a/test/unit/spec/api/authSpec.js
+++ b/test/unit/spec/api/authSpec.js
@@ -161,6 +161,28 @@ define([
             jasmine.Ajax.uninstall();
         });
 
+        it('Should make a new Auth client that has the expected functions', () => {
+            const auth = Auth.make({url: Config.url('auth')});
+            expect(auth).not.toBeNull();
+            [
+                'putCurrentProfile',
+                'getCurrentProfile',
+                'getUserProfile',
+                'getAuthToken',
+                'setAuthToken',
+                'clearAuthToken',
+                'revokeAuthToken',
+                'getTokenInfo',
+                'getUserNames',
+                'searchUserNames',
+                'validateToken',
+                'setCookie',
+                'getCookie'
+            ].forEach(fn => {
+                expect(auth[fn]).toBeDefined();
+            });
+        });
+
         /* test that running functions with "invalid" tokens fail properly, such that
          * 1. the token is attached to the Auth header
          * 2. an error is returned from the request
@@ -207,28 +229,6 @@ define([
                         expect(error.responseJSON).toBeDefined();
                         expect(error.responseJSON).toEqual(NO_TOKEN_ERROR);
                     });
-            });
-        });
-
-        it('Should make a new Auth client that has the expected functions', () => {
-            const auth = Auth.make({url: Config.url('auth')});
-            expect(auth).not.toBeNull();
-            [
-                'putCurrentProfile',
-                'getCurrentProfile',
-                'getUserProfile',
-                'getAuthToken',
-                'setAuthToken',
-                'clearAuthToken',
-                'revokeAuthToken',
-                'getTokenInfo',
-                'getUserNames',
-                'searchUserNames',
-                'validateToken',
-                'setCookie',
-                'getCookie'
-            ].forEach(fn => {
-                expect(auth[fn]).toBeDefined();
             });
         });
 

--- a/test/unit/spec/api/authSpec.js
+++ b/test/unit/spec/api/authSpec.js
@@ -86,6 +86,14 @@ define([
             });
     }
 
+    /*
+     * Each case here represents the following:
+     * - an auth api method that can accept no input (it gets the token straight from the
+     *   cookie)
+     * - a set of inputs for that method
+     * - the auth service api request endpoint
+     * These will then all be tested when no token is available.
+     */
     const noTokenCases = [{
         method: 'getTokenInfo',
         inputs: [],
@@ -108,6 +116,14 @@ define([
         request: 'users/search/foo'
     }];
 
+    /*
+     * Each case here represents the following:
+     * - an auth api method that can accept either no input (it gets the token straight from the
+     *   cookie) or a given token
+     * - a set of inputs for that method
+     * - the auth service api request endpoint
+     * These will then be tested when a mocked invalid token is given.
+     */
     const badTokenCases = [
         ...noTokenCases,
         {

--- a/test/unit/spec/api/authSpec.js
+++ b/test/unit/spec/api/authSpec.js
@@ -449,9 +449,5 @@ define([
             expect(authClient.getAuthToken()).toBeNull();
             expect(authClient.getCookie('narrative_session')).toBeNull();
         });
-
-        xit('Should revoke an auth token on request', () => {
-            // This deletes the token. Should be mocked?
-        });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

This changes the auth api tests so that their calls to the auth service are mocked.
I understand there's issues with this pattern. If the auth service changes, then the tests are invalid. I argue that this is why we also have integration tests - the unit tests should test that the Javascript API code works as expected.

The main fixes here are as per other tests - fix how we handle Promises in Jasmine, and remove the necessity for making network calls.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
Just run the tests! The auth api wasn't touched, so nothing should be different in the Narrative.
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
