### PR TITLE
DATAUP-330 fix narrativeLogin tests, add a cleanup function to narrativeLogin

### DIFF
--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -295,10 +295,10 @@ define ([
          * communication with other KBase resources.
          */
         clearTokenCheckTimers();
-        var sessionToken = authClient.getAuthToken();
+        const sessionToken = authClient.getAuthToken();
         return Promise.all([authClient.getTokenInfo(sessionToken), authClient.getUserProfile(sessionToken)])
-            .then(function(results) {
-                var tokenInfo = results[0];
+            .then((results) => {
+                let tokenInfo = results[0];
                 sessionInfo = tokenInfo;
                 this.sessionInfo = tokenInfo;
                 this.sessionInfo.token = sessionToken;
@@ -306,20 +306,21 @@ define ([
                 this.sessionInfo.user_id = this.sessionInfo.user;
                 initEvents();
                 initTokenTimer(sessionInfo.expires);
-                UserMenu.make({
+                if (!noServer) {
+                    ipythonLogin(sessionToken);
+                }
+                $(document).trigger('loggedIn', this.sessionInfo);
+                $(document).trigger('loggedIn.kbase', this.sessionInfo);
+                const userMenu = UserMenu.make({
                     target: $elem,
                     token: sessionToken,
                     userName: sessionInfo.user,
                     email: results[1].email,
                     displayName: results[1].display
                 });
-                if (!noServer) {
-                    ipythonLogin(sessionToken);
-                }
-                $(document).trigger('loggedIn', this.sessionInfo);
-                $(document).trigger('loggedIn.kbase', this.sessionInfo);
-            }.bind(this))
-            .catch(function(error) {
+                return userMenu.start();
+            })
+            .catch((error) => {
                 console.error(error);
                 if (document.location.hostname.indexOf('localhost') !== -1 ||
                     document.location.hostname.indexOf('0.0.0.0') !== -1) {

--- a/kbase-extension/static/kbase/js/narrativeLogin.js
+++ b/kbase-extension/static/kbase/js/narrativeLogin.js
@@ -105,7 +105,7 @@ define ([
     function showNotLoggedInDialog() {
         const message = `
         <p>You are logged out (or your session has expired).</p>
-        <p>You will be redirected to the sign in page after closing this, or ${AUTO_LOGOUT_DELAY / 1000} seconds, 
+        <p>You will be redirected to the sign in page after closing this, or ${AUTO_LOGOUT_DELAY / 1000} seconds,
            whichever comes first.</p>
         `;
         var dialog = new BootstrapDialog({
@@ -159,9 +159,9 @@ define ([
     }
 
     // When true, will cause the token check interval timer to return early.
-    // Should be set true when an async process is running inside the 
+    // Should be set true when an async process is running inside the
     // interval function, and set false when that process is completed.
-    
+
     let hasViewedAboutToLogout = false;
 
     let tokenCheckEnabled = true;
@@ -225,7 +225,7 @@ define ([
             if (validateOnCheck) {
                 // ensure we don't enter this check a second time.
                 // hmm, this is really an edge case, but possible.
-                // in order to meet this condition, the validateToken() call would 
+                // in order to meet this condition, the validateToken() call would
                 // need to take longer than browserSleepValidateTime which is currently
                 // hard coded in the config at 1 minute.
                 disableTokenCheck();
@@ -244,7 +244,7 @@ define ([
                     .finally(() => {
                         enableTokenCheck();
                     });
-                
+
             }
         }, TOKEN_MONITORING_INTERVAL);
     }
@@ -334,6 +334,7 @@ define ([
     return {
         init,
         sessionInfo,
-        getAuthToken
+        getAuthToken,
+        clearTokenCheckTimers
     };
 });

--- a/kbase-extension/static/kbase/js/userMenu.js
+++ b/kbase-extension/static/kbase/js/userMenu.js
@@ -101,18 +101,29 @@ define([
         }
 
         function logout() {
-            const logoutBtn = $(a({type: 'button', class: 'btn btn-primary'}, ['Sign Out']))
+            const logoutBtn = $(a({
+                type: 'button',
+                class: 'btn btn-primary',
+                dataElement: 'signout'
+            }, ['Sign Out']))
                 .click(() => {
                     dialog.hide();
                     $(document).trigger('logout.kbase', true);
                 });
-            const cancelBtn = $(a({type: 'button', class: 'btn btn-default'}, ['Cancel']))
+            const cancelBtn = $(a({
+                type: 'button',
+                class: 'btn btn-default',
+                dataElement: 'cancel-signout'
+            }, ['Cancel']))
                 .click(() => {
                     dialog.hide();
                 });
             const dialog = new BootstrapDialog({
                 title: 'Sign Out?',
-                body: 'Sign out of KBase? This will end your session. Any unsaved changes in any open Narrative will be lost.',
+                body: div(
+                    { dataElement: 'signout-warning-body' },
+                    'Sign out of KBase? This will end your session. Any unsaved changes in any open Narrative will be lost.'
+                ),
                 buttons: [cancelBtn, logoutBtn]
             });
             dialog.onHidden(() => dialog.destroy());

--- a/kbase-extension/static/kbase/js/userMenu.js
+++ b/kbase-extension/static/kbase/js/userMenu.js
@@ -41,25 +41,21 @@ define([
             profileClient = new UserProfile(NarrativeConfig.url('user_profile'), {token: token}),
             gravatarDefault = 'identicon';
 
-        var token = config.token;
-        if (!token) {
-            // fail elegantly
+        function start() {
+            return Promise.resolve(profileClient.get_user_profile([userName]))
+                .then((profile) => {
+                    if (profile.length &&
+                        profile[0] &&
+                        profile[0].profile &&
+                        profile[0].profile.userdata &&
+                        profile[0].profile.userdata.gravatarDefault) {
+                        gravatarDefault = profile[0].profile.userdata.gravatarDefault;
+                    }
+                })
+                .finally(() => {
+                    render();
+                });
         }
-
-        Promise.resolve(profileClient.get_user_profile([userName]))
-            .then(function(profile) {
-                if (profile.length > 0 &&
-                    profile[0] &&
-                    profile[0].profile &&
-                    profile[0].profile.userdata &&
-                    profile[0].profile.userdata.avatar &&
-                    profile[0].profile.userdata.avatar) {
-                    gravatarDefault = profile[0].profile.userdata.avatar.gravatar_default;
-                }
-            })
-            .finally(function() {
-                render();
-            });
 
         function renderAvatar() {
             return img({
@@ -71,7 +67,7 @@ define([
         }
 
         function render() {
-            var menu = div({class: 'dropdown', style: 'display:inline-block'}, [
+            const menu = div({class: 'dropdown', style: 'display:inline-block'}, [
                 button({type: 'button', class: 'btn btn-default dropdown-toggle', 'data-toggle': 'dropdown', 'aria-expanded': 'false'}, [
                     renderAvatar(),
                     span({class: 'caret', style: 'margin-left: 5px;'})
@@ -104,34 +100,29 @@ define([
             target.find('#signout-button').click(logout);
         }
 
-        function renderError(error) {
-
-        }
-
         function logout() {
-            var logoutBtn = $(a({type: 'button', class: 'btn btn-primary'}, ['Sign Out']))
-                            .click(function() {
-                                dialog.hide();
-                                // dialog.destroy();
-                                $(document).trigger('logout.kbase', true);
-                            });
-            var cancelBtn = $(a({type: 'button', class: 'btn btn-default'}, ['Cancel']))
-                            .click(function() {
-                                dialog.hide();
-                                // dialog.destroy();
-                            });
-            var dialog = new BootstrapDialog({
+            const logoutBtn = $(a({type: 'button', class: 'btn btn-primary'}, ['Sign Out']))
+                .click(() => {
+                    dialog.hide();
+                    $(document).trigger('logout.kbase', true);
+                });
+            const cancelBtn = $(a({type: 'button', class: 'btn btn-default'}, ['Cancel']))
+                .click(() => {
+                    dialog.hide();
+                });
+            const dialog = new BootstrapDialog({
                 title: 'Sign Out?',
                 body: 'Sign out of KBase? This will end your session. Any unsaved changes in any open Narrative will be lost.',
                 buttons: [cancelBtn, logoutBtn]
             });
+            dialog.onHidden(() => dialog.destroy());
             dialog.show();
         }
 
         return {
             render: render,
-            renderError: renderError,
-            logout: logout
+            logout: logout,
+            start: start
         };
     }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -1,6 +1,5 @@
 /*global define*/
 /*jslint white: true*/
-/*global Catalog*/
 /**
  * A widget that contains functions and function information for the Narrative.
  * When initialized, it uses a loading gif while waiting for functions to load
@@ -30,10 +29,9 @@ define([
     'common/runtime',
     'kb_common/jsonRpc/dynamicServiceClient',
     'kbaseNarrative',
-    'catalog-client-api',
     'kbase-client-api',
     'bootstrap'
-], function(
+], (
     KBWidget,
     $,
     Promise,
@@ -53,7 +51,7 @@ define([
     kbaseAppCard,
     Runtime,
     DynamicServiceClient
-) {
+) => {
     'use strict';
     return KBWidget({
         name: 'kbaseNarrativeAppPanel',
@@ -64,7 +62,6 @@ define([
             autopopulate: true,
             title: 'Apps',
             methodStoreURL: Config.url('narrative_method_store'),
-            catalogURL: Config.url('catalog'),
             moduleLink: '/#catalog/modules/',
             methodHelpLink: '/#appcatalog/app/',
             appHelpLink: '/#appcatalog/app/l.a/'
@@ -351,32 +348,33 @@ define([
                     }
                 })
                 .append('<span class="fa fa-arrow-right"></span>')
-                .click(function() {
-                    // only load the appCatalog on click
-                    if (!this.appCatalog) {
-                        this.appCatalog = new KBaseCatalogBrowser(
-                            this.$appCatalogBody, {
-                                ignoreCategories: this.ignoreCategories,
-                                tag: this.currentTag
-                            }
-                        );
-                    }
-
-                    this.$slideoutBtn.tooltip('hide');
-                    this.trigger('hideGalleryPanelOverlay.Narrative');
-                    this.trigger('toggleSidePanelOverlay.Narrative', this.$appCatalogContainer);
-                    // Need to rerender (not refresh data) because in some states, the catalog browser looks to see
-                    // if things are hidden or not. When this panel is hidden, then refreshed, all sections will
-                    // think they have no content and nothing will display.
-                    this.appCatalog.rerender();
-                }.bind(this));
+                .click(() => this.spawnCatalogBrowser());
 
             this.addButton(this.$slideoutBtn);
 
             this.methClient = new NarrativeMethodStore(this.options.methodStoreURL);
-            this.catalog = new Catalog(this.options.catalogURL, {token: Runtime.make().authToken()});
             this.refreshFromService();
             return this;
+        },
+
+        spawnCatalogBrowser: function () {
+            // only load the appCatalog on click
+            if (!this.appCatalog) {
+                this.appCatalog = new KBaseCatalogBrowser(
+                    this.$appCatalogBody, {
+                        ignoreCategories: this.ignoreCategories,
+                        tag: this.currentTag
+                    }
+                );
+            }
+
+            this.$slideoutBtn.tooltip('hide');
+            this.trigger('hideGalleryPanelOverlay.Narrative');
+            this.trigger('toggleSidePanelOverlay.Narrative', this.$appCatalogContainer);
+            // Need to rerender (not refresh data) because in some states, the catalog browser looks to see
+            // if things are hidden or not. When this panel is hidden, then refreshed, all sections will
+            // think they have no content and nothing will display.
+            this.appCatalog.rerender();
         },
 
         detach: function () {

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -46,6 +46,7 @@ module.exports = function (config) {
             {pattern: 'test/*.tok', included: false, served: true, nocache: true},
             {pattern: 'test/data/**/*', included: false, served: true},
             'test/unit/testUtil.js',
+            'test/unit/mocks.js',
             'test/unit/test-main.js'
         ],
         exclude: [

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -1,0 +1,284 @@
+/* global jasmine */
+/**
+ * This module contains several mock objects that can be reused throughout unit tests.
+ * General usage is as per other AMD modules, e.g.:
+ * define(['narrativeMocks'], (Mocks) => {
+ *      const mockCell = Mocks.buildMockCell('code');
+ *      // now this mockCell can be used in various ways
+ *      // it's incomplete for a real Jupyter cell, but should still be mostly
+ *      // functional in many Narrative contexts
+ * })
+ */
+
+define('narrativeMocks', [
+    'jquery',
+    'uuid',
+    'narrativeConfig'
+], (
+    $,
+    UUID,
+    Config
+) => {
+    'use strict';
+    /**
+     * Creates a mock Jupyter notebook cell of some type.
+     * @param {string} cellType the type of cell it should be
+     * @param {string} kbaseCellType if present, mock up an extended cell by adding some
+     *      base metadata.
+     */
+    function buildMockCell(cellType, kbaseCellType, data) {
+        const $cellContainer = $(document.createElement('div'));
+        const $icon = $('<div>').attr('data-element', 'icon');
+        const $toolbar = $('<div>').addClass('celltoolbar');
+        $toolbar.append($icon);
+        const metadata = kbaseCellType ? buildMockExtensionCellMetadata(kbaseCellType, data) : {};
+        const mockCell = {
+            metadata: {kbase: metadata},
+            cell_type: cellType,
+            renderMinMax: () => {},
+            element: $cellContainer,
+            input: $('<div>').addClass('input').append('<div>').addClass('input_area'),
+            output: $('<div>').addClass('output_wrapper').append('<div>').addClass('output'),
+            celltoolbar: {
+                rebuild: () => {}
+            }
+        };
+
+        $cellContainer
+            .append($toolbar)
+            .append(mockCell.input)
+            .append(mockCell.output);
+        $('body').append($cellContainer);
+        return mockCell;
+    }
+
+    /**
+     * Builds some mock cell metadata based on the kbaseCellType being mocked.
+     * This cell type should be one of:
+     *  app-bulk-import
+     *  app
+     *  (others to be added as tests get filled out)
+     * The metadata is expected to go under the `kbase` key in a real cell.
+     * So it should go like this:
+     * cell.metadata = {
+     *  kbase: <result of this function>,
+     *  ... other cell metadata from Jupyter ...
+     * }
+     * @param {string} kbaseCellType
+     */
+    function buildMockExtensionCellMetadata(kbaseCellType, data) {
+        let meta = {
+            type: kbaseCellType,
+            attributes: {
+                id: new UUID(4).format(),
+                status: 'new',
+                created: (new Date()).toUTCString(),
+                title: '',
+                subtitle: ''
+            },
+            data: data
+        };
+        switch(kbaseCellType) {
+            case 'app-bulk-import':
+                meta.bulkImportCell = {
+                    'user-settings': {
+                        showCodeInputArea: false
+                    },
+                    inputs: {}
+                };
+                meta.attributes.title = 'Import from Staging Area';
+                meta.attributes.subtitle = 'Import files into your Narrative as data objects';
+                break;
+            case 'app':
+                meta.appCell = {
+                    'user-settings': {
+                        showCodeInputArea: false
+                    },
+                };
+                break;
+            case 'code':
+                meta.codeCell = {
+                    'user-settings': {
+                        showCodeInputArea: false
+                    },
+                };
+                break;
+            case 'codeWithUserSettings':
+                meta.codeCell = {
+                    'userSettings': {
+                        showCodeInputArea: true
+                    },
+                };
+                break;
+
+            default:
+                // if we don't know the cell type, return a blank metadata
+                meta = {};
+                break;
+        }
+        return meta;
+    }
+
+    /**
+     * Builds a mock Jupyter notebook object with a few keys, but mostly
+     * an empty object for modification for whatever testing purposes.
+     * @param {object} options a set of options for the mock notebook, with the following:
+     *  - deleteCallback: function to be called when `delete_cell` is called.
+     *  - fullyLoaded: boolean, if true, then treat the notebook as fully loaded
+     *  - cells: a list of mocked cells (see buildMockCell)
+     *  - readOnly: boolean, true if the Narrative should be read-only
+     */
+    function buildMockNotebook(options) {
+        options = options || {};
+        const cells = options.cells || [];
+
+        function insertCell(type, index, data) {
+            let cell = buildMockCell(type, '', data);
+            if (index <= 0) {
+                index = 0;
+            }
+            cells.splice(index, 0, cell);
+            return cell;
+        }
+
+        let mockNotebook = {
+            delete_cell: () => options.deleteCallback ? options.deleteCallback() : null,
+            find_cell_index: () => 1,
+            get_cells: () => cells,
+            get_cell: (index) => {
+                if (cells.length === 0) {
+                    return null;
+                }
+                if (index <= 0) {
+                    return cells[0];
+                }
+                else if (index >= cells.length) {
+                    return null;
+                }
+                return cells[index];
+            },
+            _fully_loaded: options.fullyLoaded,
+            cells: cells,
+            writable: !options.readOnly,
+            insert_cell_above: (type, index, data) => insertCell(type, index-1, data),
+            insert_cell_below: (type, index, data) => insertCell(type, index+1, data),
+        };
+
+        return mockNotebook;
+    }
+
+    /**
+     * Uses jasmine.Ajax to mock a request to the service wizard. It will return
+     * the proper dynamic service URL that will be requested. If it's to be mocked,
+     * be sure to have a mock for that endpoint as well.
+     *
+     * This should be used whenever a dynamic service call is to be mocked.
+     * @param {object} options
+     *  - module - the module to mock. This should be its registered name.
+     *  - url - the fake url to return. Stub requests to this, too!
+     *  - statusCode - optional, default 200 - the HTTP status to return. Set to something in the
+     *      500 range to mock an error.
+     *  - statusText - optional, default 'OK' - a status text to return, if you're changing the
+     *      mocked status from 200, this should get changed, too.
+     */
+    function mockServiceWizardLookup(options) {
+        const wizardResponse = {
+            git_commit_hash: 'fake_commit_hash',
+            hash: 'another_fake_hash',
+            health: 'healthy',
+            module_name: options.module,
+            url: options.url
+        };
+
+        mockJsonRpc1Call({
+            url: Config.url('service_wizard'),
+            body: options.module,
+            statusCode: options.statusCode || 200,
+            statusText: options.statusText || 'HTTP/1.1 200 OK',
+            response: wizardResponse
+        });
+    }
+
+    /**
+     * Mocks a KBase-style JSON-RPC 1.1 request. Can use like this for a simple happy response:
+     * mockJsonRpc1Call({
+     *  url: Config.url('workspace'),
+     *  body: 'get_objects2',
+     *  response: { data: [{data: {some block of expected workspace data}}]}
+     * });
+     * Or like this for a fail response:
+     * mockJsonRpc1Call({
+     *  url: Config.url('workspace'),
+     *  body: 'get_objects2',
+     *  statusCode: 500,
+     *  statusText: 'http/1.1 500 Internal Service Error',
+     *  response: {error: 'something bad happened'}
+     * })
+     * @param {object} args
+     * - url - the url endpoint to mock
+     * - body - optional, default = empty string
+     *   something from the body to identify the request, either a string or regex. For a KBase
+     *   service call, this can be a function method
+     * -
+     */
+    function mockJsonRpc1Call(args) {
+        const requestBody = args.body || '';
+        const jsonRpcResponse = {
+            version: '1.1',
+            id: '12345',
+            result: [args.response]
+        };
+        const serviceResponse = {
+            status: args.statusCode || 200,
+            statusText: args.statusText || 'HTTP/1.1 200 OK',
+            contentType: 'application/json',
+            responseText: JSON.stringify(jsonRpcResponse)
+        };
+        jasmine.Ajax.stubRequest(args.url, requestBody)
+            .andReturn(serviceResponse);
+    }
+
+    /**
+     * A simple auth request mocker. This takes a path to the auth REST service,
+     * a response to return, and the status code, and builds a mock that satisfies
+     * all of that.
+     * @param {string} request the path request
+     * @param {object} responseObj the response to send
+     * @param {int} status the status code to return
+     */
+    function mockAuthRequest(request, responseObj, status) {
+        let reqUrl = `${Config.url('auth')}/api/V2/${request}`;
+        jasmine.Ajax.stubRequest(reqUrl)
+            .andReturn({
+                status: status,
+                contentType: 'application/json',
+                responseText: JSON.stringify(responseObj)
+            });
+    }
+
+    const cookieKeys = ['kbase_session'];
+
+    function setAuthToken(token) {
+        cookieKeys.forEach((key) => {
+            document.cookie = `${key}=${token}`;
+        });
+    }
+
+    function clearAuthToken() {
+        cookieKeys.forEach((key) => {
+            document.cookie = `${key}=`;
+        });
+    }
+
+
+    return {
+        buildMockCell: buildMockCell,
+        buildMockNotebook: buildMockNotebook,
+        mockServiceWizardLookup: mockServiceWizardLookup,
+        mockJsonRpc1Call: mockJsonRpc1Call,
+        mockAuthRequest: mockAuthRequest,
+        setAuthToken: setAuthToken,
+        clearAuthToken: clearAuthToken
+    };
+
+});

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -173,7 +173,7 @@ define('narrativeMocks', [
      * be sure to have a mock for that endpoint as well.
      *
      * This should be used whenever a dynamic service call is to be mocked.
-     * @param {object} options
+     * @param {object} args
      *  - module - the module to mock. This should be its registered name.
      *  - url - the fake url to return. Stub requests to this, too!
      *  - statusCode - optional, default 200 - the HTTP status to return. Set to something in the
@@ -181,20 +181,20 @@ define('narrativeMocks', [
      *  - statusText - optional, default 'OK' - a status text to return, if you're changing the
      *      mocked status from 200, this should get changed, too.
      */
-    function mockServiceWizardLookup(options) {
+    function mockServiceWizardLookup(args) {
         const wizardResponse = {
             git_commit_hash: 'fake_commit_hash',
             hash: 'another_fake_hash',
             health: 'healthy',
-            module_name: options.module,
-            url: options.url
+            module_name: args.module,
+            url: args.url
         };
 
         mockJsonRpc1Call({
             url: Config.url('service_wizard'),
-            body: options.module,
-            statusCode: options.statusCode || 200,
-            statusText: options.statusText || 'HTTP/1.1 200 OK',
+            body: new RegExp(args.module),
+            statusCode: args.statusCode || 200,
+            statusText: args.statusText || 'HTTP/1.1 200 OK',
             response: wizardResponse
         });
     }

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -1,28 +1,27 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach, beforeAll*/
-/*jslint white: true*/
+/*global describe, it, expect, jasmine, beforeEach, afterEach */
 
 define ([
     'jquery',
     'narrativeConfig',
     'kbaseNarrative',
     'base/js/namespace',
-    'narrativeLogin'
+    'narrativeLogin',
+    'narrativeMocks'
 ], (
     $,
     Config,
     Narrative,
     Jupyter,
-    NarrativeLogin
+    NarrativeLogin,
+    Mocks
 ) => {
     'use strict';
 
     const DEFAULT_FULLY_LOADED = false,
         DEFAULT_WRITABLE = false,
         DEFAULT_NOTEBOOK_NAME = 'some notebook',
-        FAKE_TOKEN = 'foo';
+        TEST_TOKEN = 'foo',
+        TEST_USER = 'some_user';
 
     describe('Test the kbaseNarrative module', () => {
         let loginDiv = $('<div>');
@@ -30,27 +29,25 @@ define ([
         beforeEach(async () => {
             // we need to be "logged in" for various tests to work, especially initing the Narrative object.
             // this means mocking up some auth responses, and the NarrativeLogin object.
-            document.cookie='kbase_session=' + FAKE_TOKEN;
+            Mocks.setAuthToken(TEST_TOKEN);
             jasmine.Ajax.install();
-            jasmine.Ajax.stubRequest(/\/token$/).andReturn({
-                status: 200,
-                statusText: 'HTTP/1.1 200 OK',
-                contentType: 'application/json',
-                responseText: JSON.stringify({
-                    type: 'Login',
-                    id: 'some-token-id',
-                    name: null,
-                    user: 'some_user',
-                })
-            });
-            jasmine.Ajax.stubRequest(/\/me$/).andReturn({
-                status: 200,
-                statusText: 'HTTP/1.1 200 OK',
-                contentType: 'application/json',
-                responseText: JSON.stringify({
-                    display: 'Some User',
-                    user: 'some_user',
-                })
+            Mocks.mockAuthRequest('token', {
+                expires: Date.now() + 10 * 60 * 60 * 24 * 1000,
+                created: Date.now(),
+                name: 'some_token',
+                id: 'some_uuid',
+                type: 'Login',
+                user: TEST_USER,
+                cachefor: 500000
+            }, 200);
+            Mocks.mockAuthRequest('me', {
+                display: 'Some User',
+                user: TEST_USER,
+                email: `${TEST_USER}@kbase.us`,
+            }, 200);
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('user_profile'),
+                response: [{}]
             });
 
             // mock a jupyter notebook.
@@ -98,6 +95,8 @@ define ([
         afterEach(() => {
             jasmine.Ajax.uninstall();
             Jupyter.notebook = null;
+            NarrativeLogin.clearTokenCheckTimers();
+            Mocks.clearAuthToken();
         });
 
         it('Should instantiate', () => {
@@ -158,7 +157,7 @@ define ([
 
         it('Should provide an auth token when requested', () => {
             const narr = new Narrative();
-            expect(narr.getAuthToken()).toBe(FAKE_TOKEN);
+            expect(narr.getAuthToken()).toBe(TEST_TOKEN);
         });
 
     });

--- a/test/unit/spec/narrativeLoginSpec.js
+++ b/test/unit/spec/narrativeLoginSpec.js
@@ -1,19 +1,113 @@
-define (
-	[
-		'jquery',
-		'narrativeLogin'
-	], function(
-		$,
-		Login
-	) {
-    describe('Test the kbaseNarrative module', function() {
-        it('Should do things', function() {
-            expect(Login.init).not.toBe(null);
+/* global describe, it, expect, jasmine, beforeEach, afterEach */
+define ([
+    'jquery',
+    'narrativeLogin',
+    'narrativeConfig'
+], (
+    $,
+    Login,
+    Config
+) => {
+    'use strict';
+
+    const cookieKeys = ['kbase_session'],
+        FAKE_TOKEN = 'some_fake_token';
+
+    function setToken(token) {
+        cookieKeys.forEach((key) => {
+            document.cookie = `${key}=${token}`;
+        });
+    }
+
+    function clearToken() {
+        cookieKeys.forEach((key) => {
+            document.cookie = `${key}=`;
+        });
+    }
+
+    /**
+     *
+     * @param {string} request the path request
+     * @param {object} responseObj the response to send
+     * @param {int} status the status code to return
+     */
+    function mockAuthRequest(request, responseObj, status) {
+        let reqUrl = `${Config.url('auth')}/api/V2/${request}`;
+        jasmine.Ajax.stubRequest(reqUrl)
+            .andReturn({
+                status: status,
+                contentType: 'application/json',
+                responseText: JSON.stringify(responseObj)
+            });
+    }
+
+    describe('Test the kbaseNarrative module', () => {
+        beforeEach(() => {
+            setToken(FAKE_TOKEN);
+            jasmine.Ajax.install();
         });
 
-        it('Should instantiate on a DOM node', function() {
-            var $node = $("<div>");
-            Login.init($node);
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+            clearToken();
+        });
+
+        it('Should instantiate and have expected functions', () => {
+            expect(Login).toBeDefined();
+            ['init', 'sessionInfo', 'getAuthToken', 'clearTokenCheckTimers'].forEach(item => {
+                expect(Login[item]).toBeDefined();
+            });
+        });
+
+        it('Should instantiate on a DOM node in the happy path', () => {
+            const $node = $('<div>'),
+                fakeUser = 'some_user',
+                fakeName = 'Some User',
+                tokenInfo = {
+                    expires: Date.now() + 10 * 60 * 60 * 24 * 1000,
+                    created: Date.now(),
+                    name: 'some_token',
+                    id: 'some_uuid',
+                    type: 'Login',
+                    user: 'some_user',
+                    cachefor: 500000
+                },
+                profileInfo = {
+                    created: Date.now() - 10000,
+                    lastlogin: Date.now(),
+                    display: fakeName,
+                    roles: [],
+                    customroles: [],
+                    user: fakeUser,
+                    local: false,
+                    email: `${fakeName}@kbase.us`,
+                    idents: []
+
+                };
+            // these should capture the happy path calls that Login.init should make
+            // copying some boilerplate from specs/api/authSpec
+            // TODO: move boilerplate to a mocks module
+
+            mockAuthRequest('token', tokenInfo, 200);
+            mockAuthRequest('me', profileInfo, 200);
+            return Login.init($node, true)  // true here means there's no kernel
+                .then(() => {
+                    const request = jasmine.Ajax.requests.mostRecent();
+                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+                    Login.clearTokenCheckTimers();
+                });
+        });
+
+        it('Should throw an error when instantiating with a bad token', () => {
+            const $node = $('<div>');
+            mockAuthRequest('token', {error: {}}, 401);
+            mockAuthRequest('me', {error: {}}, 401);
+            return Login.init($node, true)  // true here means there's no kernel
+                .then(() => {
+                    const request = jasmine.Ajax.requests.mostRecent();
+                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+                    Login.clearTokenCheckTimers();
+                });
         });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -328,7 +328,7 @@ define([
                 }
             });
 
-            spyOn(appPanel, 'spawnCatalogBrowser'); //.and.callThrough();
+            spyOn(appPanel, 'spawnCatalogBrowser');
             $panel.find('button.btn .fa-arrow-right').click();
             expect(appPanel.spawnCatalogBrowser).toHaveBeenCalled();
             $(document).off('loggedInQuery.kbase');

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -1,49 +1,132 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach, spyOn*/
-/*jslint white: true*/
+/* global describe, it, expect, jasmine, beforeEach, afterEach , spyOn */
 define([
     'jquery',
-    'jquery-ui',
     'kbaseNarrativeAppPanel',
     'base/js/namespace',
-    'kbaseNarrative',
-    'bootstrap'
-], function($, jqueryui, AppPanel, Jupyter, Narrative) {
+    'narrativeConfig',
+    'narrativeMocks',
+], ($, AppPanel, Jupyter, Config, Mocks) => {
     'use strict';
-    var $panel = $('<div>');
-    var appPanel = null;
+    let $panel,
+        appPanel;
+    const FAKE_USER = 'some_user',
+        FAKE_TOKEN = 'some_fake_token',
+        NS_URL = 'https://kbase.us/service/fakeNSUrl',
+        CATEGORY_A = 'categorya',
+        CATEGORY_B = 'categoryb',
+
+        // a map of ignored categories returned from NarrativeService.get_ignored_categories
+        // maps from category name -> 1 (if ignored)
+        IGNORED_CATEGORIES = {
+            inactive: 1
+        },
+        APP_INFO = {
+            module_versions: {
+                a_module: '0.1',
+                another_module: '0.2'
+            },
+            app_infos: {
+                'a_module/an_app': {
+                    info: {
+                        id: 'a_module/an_app',
+                        module_name: 'a_module',
+                        git_commit_hash: 'blahblahhash',
+                        name: 'Run An App from A Module',
+                        ver: '1.0.0',
+                        subtitle: 'Run an app',
+                        tooltip: 'Run an app',
+                        icon: {url: 'img?method_id=a_module/an_app&image_name=an_app.png&tag=release'},
+                        categories: ['active', CATEGORY_A],
+                        authors: [FAKE_USER],
+                        input_types: [
+                            'Module1.Type1',
+                            'Module2.Type2'
+                        ],
+                        output_types: ['ModuleOut.TypeOut'],
+                        app_type: 'app',
+                        namespace: 'a_module',
+                        short_input_types: ['Type1', 'Type2'],
+                        short_output_types: ['TypeOut']
+                    }
+                },
+                'another_module/another_app': {
+                    info: {
+                        id: 'another_module/another_app',
+                        module_name: 'another_module',
+                        git_commit_hash: 'blahblahhash',
+                        name: 'Run An App from A Module',
+                        ver: '1.0.0',
+                        subtitle: 'Run an app',
+                        tooltip: 'Run an app',
+                        icon: {url: 'img?method_id=another_module/another_app&image_name=an_app.png&tag=release'},
+                        categories: ['active', CATEGORY_B],
+                        authors: [FAKE_USER],
+                        input_types: [
+                            'Module1.Type1',
+                        ],
+                        output_types: ['ModuleOut.TypeOut'],
+                        app_type: 'app',
+                        namespace: 'another_module',
+                        short_input_types: ['Type1'],
+                        short_output_types: ['TypeOut']
+                    },
+                    favorite: 1612814706712
+                }
+            }
+        };
 
     describe('Test the kbaseNarrativeAppPanel widget', function() {
-        beforeEach(function(done) {
-            Jupyter.narrative = new Narrative();
-            Jupyter.narrative.userId = 'narrativetest';
-            Jupyter.narrative.narrController = {
-                uiModeIs: p => false
+        beforeEach(() => {
+            Jupyter.narrative = {
+                getAuthToken: () => FAKE_TOKEN,
+                userId: FAKE_USER,
+                narrController: {
+                    uiModeIs: () => false
+                }
             };
+
             // just a dummy mock so we don't see error messages. Don't actually need a kernel.
             Jupyter.notebook = {
                 kernel: {
-                    execute: function(inputs) { }
+                    execute: () => {}
                 }
             };
-            appPanel = new AppPanel($panel);
-            appPanel.refreshFromService().then(function() {
-                done();
+
+            jasmine.Ajax.install();
+            Mocks.mockServiceWizardLookup({
+                module: 'NarrativeService',
+                url: NS_URL
             });
+            Mocks.mockJsonRpc1Call({
+                url: NS_URL,
+                body: /get_all_app_info/,
+                response: APP_INFO
+            });
+            Mocks.mockJsonRpc1Call({
+                url: NS_URL,
+                body: /get_ignore_categories/,
+                response: IGNORED_CATEGORIES
+            });
+
+            $panel = $('<div>');
+            appPanel = new AppPanel($panel);
+            return appPanel.refreshFromService();
         });
-        afterEach(function() {
+
+        afterEach(() => {
             appPanel.detach();
             $panel = $('<div>');
             appPanel = null;
+            Jupyter.notebook = null;
+            Jupyter.narrative = null;
+            jasmine.Ajax.uninstall();
         });
 
-        it('Should initialize properly', function() {
-            expect(appPanel).toEqual(jasmine.any(Object));
+        it('Should initialize properly', () => {
+            expect(appPanel).toBeDefined();
         });
 
-        it('Should have a working search interface', function() {
+        it('Should have a working search interface', () => {
             // search bar should start invisible
             expect(appPanel.$methodList.children().children().length).not.toBe(0);
 
@@ -51,28 +134,31 @@ define([
             appPanel.refreshPanel();
             expect(appPanel.$methodList.children().children().length).toBe(0);
 
-            appPanel.bsSearch.val('genome');
+            appPanel.bsSearch.val('Type1');
             appPanel.refreshPanel();
-            expect(appPanel.$methodList.children().children().length).not.toBe(0);
+            // should have favorites, categoryA, categoryB
+            expect(appPanel.$methodList.children().children().length).toBe(3);
 
-            //TODO:
-            // verify by setting output:genome and making sure there's only one output category
+            appPanel.bsSearch.val('Type2');
+            appPanel.refreshPanel();
+            // should have favorites and categoryA
+            expect(appPanel.$methodList.children().children().length).toBe(1);
         });
 
-        it('Should trigger search by jquery event filterMethods.Narrative', function () {
-            expect(appPanel.$methodList.children().children().length).not.toBe(0);
+        it('Should trigger search by jquery event filterMethods.Narrative', () => {
+            expect(appPanel.$methodList.children().children().length).toBe(3);
 
             $(document).trigger('filterMethods.Narrative', 'should show nothing');
             expect(appPanel.$methodList.children().children().length).toBe(0);
         });
 
         it('Should reset search by jquery event removeFilterMethods.Narrative', () => {
-            expect(appPanel.$methodList.children().children().length).not.toBe(0);
+            expect(appPanel.$methodList.children().children().length).toBe(3);
 
             $(document).trigger('filterMethods.Narrative', 'should show nothing');
             expect(appPanel.$methodList.children().children().length).toBe(0);
             $(document).trigger('removeFilterMethods.Narrative');
-            expect(appPanel.$methodList.children().children().length).not.toBe(0);
+            expect(appPanel.$methodList.children().children().length).toBe(3);
         });
 
         it('Should toggle search bar visibility by hitting a button', () => {
@@ -85,55 +171,53 @@ define([
             expect(appPanel.app_offset).toBeTrue();
         });
 
-        it('Should have a working filter menu', function() {
+        it('Should have a working filter menu', () => {
             // Should have a filter menu.
             var dropdownSelector = '#kb-app-panel-filter';
             expect($panel.find(dropdownSelector).length).not.toBe(0);
             // should have category, input types, output types, name a-z, name z-a
             var filterList = ['category', 'input types', 'output types', 'name a-z', 'name z-a'];
-            $panel.find(dropdownSelector).parent().find('.dropdown-menu li').each(function (idx, item) {
+            $panel.find(dropdownSelector).parent().find('.dropdown-menu li').each((idx, item) => {
                 expect($(item).text().toLowerCase()).toEqual(filterList[idx]);
             });
             // should default to category
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('category');
             var appListSel = '.kb-function-body > div:last-child > div > div';
             // spot check category list.
-            var categoryList = $panel.find(appListSel + '> div.row').toArray().map(function(elem) {
+            var categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
                 var str = elem.innerText.toLowerCase();
                 return str.substring(0, str.lastIndexOf(' '));
             });
             // no "my favorites" because we're not logged in
-            expect(categoryList.indexOf('comparative genomics')).not.toBe(-1);
-            expect(categoryList.indexOf('expression')).not.toBe(-1);
-            expect(categoryList.indexOf('genome annotation')).not.toBe(-1);
+            expect(categoryList.indexOf(CATEGORY_A)).not.toBe(-1);
+            expect(categoryList.indexOf(CATEGORY_B)).not.toBe(-1);
 
             // click input types
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(2) a').click();
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('input');
-            categoryList = $panel.find(appListSel + '> div.row').toArray().map(function(elem) {
+            categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
                 var str = elem.innerText.toLowerCase();
                 return str.substring(0, str.lastIndexOf(' '));
             });
-            expect(categoryList.indexOf('assembly')).not.toBe(-1);
-            expect(categoryList.indexOf('fba')).not.toBe(-1);
-            expect(categoryList.indexOf('fbamodel')).not.toBe(-1);
+            expect(categoryList.indexOf('type1')).not.toBe(-1);
+            expect(categoryList.indexOf('type2')).not.toBe(-1);
 
             // click output types
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(3) a').click();
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('output');
-            categoryList = $panel.find(appListSel + '> div.row').toArray().map(function(elem) {
+            categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
                 var str = elem.innerText.toLowerCase();
                 return str.substring(0, str.lastIndexOf(' '));
             });
-            expect(categoryList.indexOf('assemblyset')).not.toBe(-1);
-            expect(categoryList.indexOf('fbacomparison')).not.toBe(-1);
-            expect(categoryList.indexOf('pangenome')).not.toBe(-1);
+            expect(categoryList.indexOf('typeout')).not.toBe(-1);
+            expect(categoryList.indexOf('type1')).toBe(-1);
+            expect(categoryList.indexOf('type2')).toBe(-1);
 
             // click name a-z
             // show alphabetical names of apps
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(4) a').click();
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('a-z');
-            var appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map(function(item) {
+            var appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map((item) => {
                 return item.innerText.toLowerCase();
             });
             // sort it, then compare to see if in same order. remember, we don't have favorites that pop to the top.
@@ -142,7 +226,7 @@ define([
             // click name z-a
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(5) a').click();
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('z-a');
-            appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map(function(item) {
+            appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map((item) => {
                 return item.innerText.toLowerCase();
             });
             // sort it, then compare to see if in same order. remember, we don't have favorites that pop to the top.
@@ -150,9 +234,8 @@ define([
 
         });
 
-        it('Should have a working version toggle button', function() {
-            // TODO: Should probably inject some NarrativeTest apps in CI where this will be test.
-            appPanel.$toggleVersionBtn.tooltip = function() { };  // to stop any jquery/bootstrap nonsense that happens in testing.
+        it('Should have a working version toggle button', () => {
+            appPanel.$toggleVersionBtn.tooltip = () => {};  // to stop any jquery/bootstrap nonsense that happens in testing.
             var toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
             expect(toggleBtn.length).toBe(1);
             spyOn(appPanel, 'refreshFromService');
@@ -168,14 +251,14 @@ define([
             expect(toggleBtn.text()).toEqual('R');
         });
 
-        it('Should have a working refresh button', function() {
+        it('Should have a working refresh button', () => {
             var refreshBtn = $panel.find('.btn-toolbar button:nth-child(3)');
             spyOn(appPanel, 'refreshFromService');
             refreshBtn.click();
             expect(appPanel.refreshFromService).toHaveBeenCalled();
             expect(appPanel.refreshFromService).toHaveBeenCalledWith('release');
             var toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
-            appPanel.$toggleVersionBtn.tooltip = function() { };  // to stop any jquery/bootstrap nonsense that happens in testing.
+            appPanel.$toggleVersionBtn.tooltip = () => {};  // to stop any jquery/bootstrap nonsense that happens in testing.
             toggleBtn.click();
             refreshBtn.click();
             expect(appPanel.refreshFromService).toHaveBeenCalledWith('beta');
@@ -185,13 +268,24 @@ define([
         });
 
         it('Should respond to getFunctionSpecs.Narrative by returning a set of app specs', (done) => {
+            const lookupId = 'a_module/an_app',
+                dummySpec = {
+                    info: {
+                        id: lookupId
+                    }
+                };
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('narrative_method_store'),
+                response: [dummySpec]
+            });
+
             const cb = (specs) => {
                 expect(specs).toBeDefined();
-                expect(specs.methods['kb_quast/run_QUAST_app']).toEqual(jasmine.any(Object));
+                expect(specs.methods[lookupId]).toEqual(dummySpec);
                 done();
             };
             const appRequest = {
-                methods: ['kb_quast/run_QUAST_app']
+                methods: [lookupId]
             };
             $(document).trigger('getFunctionSpecs.Narrative', [appRequest, cb]);
         });
@@ -205,35 +299,38 @@ define([
             const appRequest = {
                 methods: ['notAModule/notAnApp']
             };
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('narrative_method_store'),
+                response: {error: 'repository notAModule wasn\'t registered'},
+                statusCode: 500
+            });
             $(document).trigger('getFunctionSpecs.Narrative', [appRequest, cb]);
         });
 
         it('Should return an empty list when requesting empty methods', (done) => {
             const cb = (specs) => {
-                console.log(specs);
                 expect(specs).toEqual({});
                 done();
             };
             $(document).trigger('getFunctionSpecs.Narrative', [{}, cb]);
         });
 
-        it('Should have a working catalog slideout button', function() {
+        it('Should have a working catalog slideout button', () => {
             // spoof being logged in from the catalog widget's point of view
 
             $(document).on('loggedInQuery.kbase', (e, cb) => {
                 if (cb) {
                     cb({
-                        token: 'fake_token',
-                        user_id: 'narrativetest',
-                        kbase_sessionid: 'narrativetest_session'
+                        token: FAKE_TOKEN,
+                        user_id: FAKE_USER,
+                        kbase_sessionid: 'fake_session'
                     });
                 }
             });
 
-            expect(appPanel.appCatalog).toBeNull();
+            spyOn(appPanel, 'spawnCatalogBrowser'); //.and.callThrough();
             $panel.find('button.btn .fa-arrow-right').click();
-            expect(appPanel.appCatalog).not.toBeNull();
-
+            expect(appPanel.spawnCatalogBrowser).toHaveBeenCalled();
             $(document).off('loggedInQuery.kbase');
         });
 
@@ -246,8 +343,6 @@ define([
         });
 
         it('Should know how to set its list height', (done) => {
-            // appPanel.setListHeight('10px', true);
-            // expect(appPanel.$methodList.css('height')).toEqual('10px');
             appPanel.setListHeight('100px', false);
             expect(appPanel.$methodList.css('height')).toEqual('100px');
             appPanel.setListHeight('123px', true);
@@ -257,14 +352,27 @@ define([
             }, 1000);
         });
 
-        xit('Should trigger the insert app function when clicking on an app', (done) => {
-            $(document).on('appClicked.Narrative', (app, tag, params) => {
-                console.log(app);
-                console.log(tag);
-                console.log(params);
+        it('Should trigger the insert app function when clicking on an app', (done) => {
+            const appId = 'a_module/an_app',
+                dummySpec = {
+                    info: {
+                        id: appId
+                    }
+                },
+                appTag = 'release';
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('narrative_method_store'),
+                response: [dummySpec]
+            });
+            // in actual usage, this event gets bound to either $(document) or some other
+            // widget that it percolates up to. Jasmine doesn't like that, so we bind it here
+            appPanel.on('appClicked.Narrative', (event, app, tag, params) => {
+                expect(app).toEqual(dummySpec);
+                expect(tag).toEqual(appTag);
+                expect(params).not.toBeDefined();
                 done();
             });
-            appPanel.triggerApp('megahit/run_megahit', 'release');
+            appPanel.triggerApp(appId, 'release');
         });
 
         it('Should know how to show an error', () => {

--- a/test/unit/spec/userMenuSpec.js
+++ b/test/unit/spec/userMenuSpec.js
@@ -13,6 +13,16 @@ define([
         TEST_NAME = 'Test User',
         TEST_EMAIL = 'test_user@kbase.us';
 
+    function makeTestUserMenu($elem) {
+        return UserMenu.make({
+            target: $elem,
+            token: TEST_TOKEN,
+            userName: TEST_USER,
+            email: TEST_EMAIL,
+            displayName: TEST_NAME
+        });
+    }
+
     describe('Test the UserMenu module', () => {
         beforeEach(() => {
             jasmine.Ajax.install();
@@ -36,13 +46,7 @@ define([
             expect(UserMenu).toBeDefined();
             expect(UserMenu.make).toBeDefined();
             const $elem = $('<div>');
-            const userMenu = UserMenu.make({
-                target: $elem,
-                token: TEST_TOKEN,
-                userName: TEST_USER,
-                email: TEST_EMAIL,
-                displayName: TEST_NAME
-            });
+            const userMenu = makeTestUserMenu($elem);
             ['start', 'render', 'logout'].forEach(fn => {
                 expect(userMenu[fn]).toBeDefined();
             });
@@ -50,13 +54,7 @@ define([
 
         it('Should start and create a menu in the target node with an empty user profile', () => {
             const $elem = $('<div>');
-            const userMenu = UserMenu.make({
-                target: $elem,
-                token: TEST_TOKEN,
-                userName: TEST_USER,
-                email: TEST_EMAIL,
-                displayName: TEST_NAME
-            });
+            const userMenu = makeTestUserMenu($elem);
             return userMenu.start()
                 .then(() => {
                     expect($elem.find('.login-button-avatar')).toBeDefined();
@@ -70,13 +68,7 @@ define([
 
         it('Should trigger a logout popup when clicking the logout button', () => {
             const $elem = $('<div>');
-            const userMenu = UserMenu.make({
-                target: $elem,
-                token: TEST_TOKEN,
-                userName: TEST_USER,
-                email: TEST_EMAIL,
-                displayName: TEST_NAME
-            });
+            const userMenu = makeTestUserMenu($elem);
             return userMenu.start()
                 .then(() => {
                     expect(document.querySelector('.modal [data-element="signout-warning-body"]')).toBeNull();

--- a/test/unit/spec/userMenuSpec.js
+++ b/test/unit/spec/userMenuSpec.js
@@ -1,0 +1,103 @@
+/* global describe, it, expect, jasmine, beforeEach, afterEach */
+
+define([
+    'jquery',
+    'userMenu',
+    'narrativeConfig'
+], ($, UserMenu, Config) => {
+    'use strict';
+
+    const TEST_TOKEN = 'fake_token',
+        TEST_USER = 'test_user',
+        TEST_NAME = 'Test User',
+        TEST_EMAIL = 'test_user@kbase.us';
+
+    describe('Test the UserMenu module', () => {
+        beforeEach(() => {
+            jasmine.Ajax.install();
+            jasmine.Ajax.stubRequest(Config.url('user_profile'))
+                .andReturn({
+                    status: 200,
+                    contentType: 'application/json',
+                    responseText: JSON.stringify({
+                        version: '1.1',
+                        id: '12345',
+                        result: [[{
+                            profile: {
+                                userdata: {
+                                    gravatarDefault: 'identicon'
+                                }
+                            }
+                        }]]
+                    })
+                });
+        });
+
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+        });
+
+        it('Should make a user menu object with expected elements', () => {
+            expect(UserMenu).toBeDefined();
+            expect(UserMenu.make).toBeDefined();
+            const $elem = $('<div>');
+            const userMenu = UserMenu.make({
+                target: $elem,
+                token: TEST_TOKEN,
+                userName: TEST_USER,
+                email: TEST_EMAIL,
+                displayName: TEST_NAME
+            });
+            ['start', 'render', 'logout'].forEach(fn => {
+                expect(userMenu[fn]).toBeDefined();
+            });
+        });
+
+        it('Should start and create a menu in the target node with an empty user profile', () => {
+            const $elem = $('<div>');
+            const userMenu = UserMenu.make({
+                target: $elem,
+                token: TEST_TOKEN,
+                userName: TEST_USER,
+                email: TEST_EMAIL,
+                displayName: TEST_NAME
+            });
+            return userMenu.start()
+                .then(() => {
+                    expect($elem.find('.login-button-avatar')).toBeDefined();
+                    const $profileItem = $elem.find('[data-menu-item="userlabel"]');
+                    expect($profileItem).toBeDefined();
+                    expect($profileItem.attr('href')).toEqual(`/#people/${TEST_USER}`);
+                    expect($profileItem.text()).toContain(TEST_NAME);
+                    expect($profileItem.text()).toContain(TEST_USER);
+                });
+        });
+
+        it('Should trigger a logout popup when clicking the logout button', () => {
+            const $elem = $('<div>');
+            const userMenu = UserMenu.make({
+                target: $elem,
+                token: TEST_TOKEN,
+                userName: TEST_USER,
+                email: TEST_EMAIL,
+                displayName: TEST_NAME
+            });
+            return userMenu.start()
+                .then(() => {
+                    expect(document.querySelector('.modal')).toBeNull();
+                    jasmine.clock().install();
+                    // click the signout button
+                    $elem.find('#signout-button').click();
+                    jasmine.clock().tick(2000);
+                    // expect to see the modal appear now
+                    expect(document.querySelector('.modal')).not.toBeNull();
+                    // click the cancel button (it has the default button style)
+                    document.querySelector('.modal-dialog .btn.btn-default').click();
+                    jasmine.clock().tick(2000);
+                    // expect the modal to go away
+                    expect(document.querySelector('.modal')).toBeNull();
+                    jasmine.clock().uninstall();
+                });
+        });
+    });
+});

--- a/test/unit/spec/userMenuSpec.js
+++ b/test/unit/spec/userMenuSpec.js
@@ -3,8 +3,9 @@
 define([
     'jquery',
     'userMenu',
-    'narrativeConfig'
-], ($, UserMenu, Config) => {
+    'narrativeConfig',
+    'narrativeMocks'
+], ($, UserMenu, Config, Mocks) => {
     'use strict';
 
     const TEST_TOKEN = 'fake_token',
@@ -15,22 +16,16 @@ define([
     describe('Test the UserMenu module', () => {
         beforeEach(() => {
             jasmine.Ajax.install();
-            jasmine.Ajax.stubRequest(Config.url('user_profile'))
-                .andReturn({
-                    status: 200,
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({
-                        version: '1.1',
-                        id: '12345',
-                        result: [[{
-                            profile: {
-                                userdata: {
-                                    gravatarDefault: 'identicon'
-                                }
-                            }
-                        }]]
-                    })
-                });
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('user_profile'),
+                response: [{
+                    profile: {
+                        userdata: {
+                            gravatarDefault: 'identicon'
+                        }
+                    }
+                }]
+            });
         });
 
         afterEach(() => {
@@ -84,18 +79,18 @@ define([
             });
             return userMenu.start()
                 .then(() => {
-                    expect(document.querySelector('.modal')).toBeNull();
+                    expect(document.querySelector('.modal [data-element="signout-warning-body"]')).toBeNull();
                     jasmine.clock().install();
                     // click the signout button
                     $elem.find('#signout-button').click();
                     jasmine.clock().tick(2000);
                     // expect to see the modal appear now
-                    expect(document.querySelector('.modal')).not.toBeNull();
+                    expect(document.querySelector('.modal [data-element="signout-warning-body"]')).not.toBeNull();
                     // click the cancel button (it has the default button style)
-                    document.querySelector('.modal-dialog .btn.btn-default').click();
+                    document.querySelector('a[data-element="cancel-signout"]').click();
                     jasmine.clock().tick(2000);
                     // expect the modal to go away
-                    expect(document.querySelector('.modal')).toBeNull();
+                    expect(document.querySelector('.modal [data-element="signout-warning-body"]')).toBeNull();
                     jasmine.clock().uninstall();
                 });
         });

--- a/test/unit/test-main.js
+++ b/test/unit/test-main.js
@@ -30,6 +30,7 @@ requirejs.config({
         bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
         bootstrap: 'ext_components/bootstrap/dist/js/bootstrap.min',
         testUtil: '../../test/unit/testUtil',
+        narrativeMocks: '../../test/unit/mocks',
         bluebird: 'ext_components/bluebird/js/browser/bluebird.min',
         jed: 'components/jed/jed',
         custom: 'kbase/custom'


### PR DESCRIPTION
# Description of PR purpose/changes

This rewrites the tests for the narrativeLogin module to handle promises properly, and mock out calls to the auth service.
This also exposes the clearTokenCheckTimers function from that module. Without this, there's no way to clear the timers, and they seem to just go off anyway during the remainder of the test suite. This would cause, among other things, a redirect to the logout page if tests run for too long. 

That redirection is something that's definitely one of the causes of our test miseries, and having a tighter control on how that happens is necessary.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
Yet again, there should be no visible narrative changes. The only actual code change is to expose that interval clearing function, and it's only used by the test suite.
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook