### PR TITLE
DATAUP-330: Update docker image nodejs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
         auto-update-conda: true
         condarc-file: test/condarc.yml
 
-    - name: Use Node JS 10.x
+    - name: Use Node JS 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 14.x
 
     - name: Install JS dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # Made available under the KBase Open Source License
 #
 
-FROM kbase/narrbase:6.1
+FROM kbase/narrbase:6.2
 
 # These ARGs values are passed in via the docker build command
 ARG BUILD_DATE
@@ -22,15 +22,10 @@ ARG SKIP_MINIFY
 
 EXPOSE 8888
 
-# Remove Debian's older Tornado package - updated/removed in the narrbase package
-#RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y python-tornado
-
-RUN echo Skip=$SKIP_MINIFY
-
 # install pyopenssl cryptography idna and requests is the same as installing
 # requests[security]
-RUN source activate base
-RUN conda install -c conda-forge ndg-httpsclient==0.5.1 pyasn1==0.4.5 pyopenssl==19.0.0 cryptography==2.7 idna==2.8 requests==2.21.0 \
+RUN source activate base && \
+    conda install -c conda-forge ndg-httpsclient==0.5.1 pyasn1==0.4.5 pyopenssl==19.0.0 cryptography==2.7 idna==2.8 requests==2.21.0 \
           beautifulsoup4==4.8.1 html5lib==1.0.1
 
 # Copy in the narrative repo
@@ -39,31 +34,22 @@ ADD ./kbase-logdb.conf /tmp/kbase-logdb.conf
 ADD ./deployment/ /kb/deployment/
 WORKDIR /kb/dev_container/narrative
 
-# Generate a version file that we can scrape later
-RUN mkdir -p /kb/deployment/ui-common/ && ./src/scripts/kb-update-config -f src/config.json.templ -o /kb/deployment/ui-common/narrative_version
-
-# Install Javascript dependencies
-RUN npm install -g grunt-cli && \
+RUN \
+    # Generate a version file that we can scrape later
+    mkdir -p /kb/deployment/ui-common/ && \
+    ./src/scripts/kb-update-config -f src/config.json.templ -o /kb/deployment/ui-common/narrative_version && \
+    # install JS deps
+    npm install -g grunt-cli && \
     npm install && \
-    ./node_modules/.bin/bower install --allow-root --config.interactive=false
-
-# Compile Javascript down into an itty-bitty ball unless SKIP_MINIFY is non-empty
-RUN [ -n "$SKIP_MINIFY" ] || grunt minify
-
-# Add Tini. Tini operates as a process subreaper for jupyter. This prevents
-# kernel crashes. See Jupyter Notebook known issues here:˜
-# http://jupyter-notebook.readthedocs.org/en/latest/public_server.html#known-issues
-# ENV TINI_VERSION v0.8.4
-# ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-# RUN chmod +x /usr/bin/tini
-
-RUN /bin/bash scripts/install_narrative_docker.sh
-
-# RUN ./fixupURL.sh && chmod 666 /kb/dev_container/narrative/src/config.json
-RUN pip install jupyter-console==6.0.0
-
-WORKDIR /tmp
-RUN mkdir /tmp/narrative && \
+    ./node_modules/.bin/bower install --allow-root --config.interactive=false && \
+    # Compile Javascript down into an itty-bitty ball unless SKIP_MINIFY is non-empty
+    echo Skip=$SKIP_MINIFY && \
+    [ -n "$SKIP_MINIFY" ] || grunt minify && \
+    # install the narrative and jupyter console
+    /bin/bash scripts/install_narrative_docker.sh && \
+    pip install jupyter-console==6.0.0 && \
+    cd /tmp && \
+    mkdir /tmp/narrative && \
     chown -R nobody:www-data /tmp/narrative /kb/dev_container/narrative/kbase-extension; find / -xdev \( -perm -4000 \) -type f -print -exec rm {} \;
 
 # Set a default value for the environment variable VERSION_CHECK that gets expanded in the config.json.templ

--- a/narrbase-image/Dockerfile
+++ b/narrbase-image/Dockerfile
@@ -3,41 +3,36 @@ FROM kbase/kb_python:python3
 ENV NOTEBOOK_VERSION 6.0.2
 ENV IPYTHON_VERSION 7.9.0
 ENV IPYWIDGETS_VERSION 7.5.0
-# ENV NODEJS_VERSION 11
-
-RUN mkdir -p /kb/installers
+ENV NODEJS_VERSION 14
+ENV TAR /bin/tar
 
 # Install Base libraries, Node, R and Jupyter Notebook and ipywidgets from distinct channels
 ADD ./conda-requirements /root/conda
 
-RUN conda update -n base -c defaults conda && \
+RUN mkdir -p /kb/installers && \
+    # run conda installs
+    conda update -n base -c defaults conda && \
     conda install conda && \
     conda install -c conda-forge --file /root/conda/base && \
     conda install -c etetoolkit ete3 && \
     conda install -c anaconda-platform --file /root/conda/base.anaconda-platform && \
     conda install -c javascript --file /root/conda/base.javascript && \
-    # conda install -c wakari --file /root/conda/base.wakari && \
     conda install --file /root/conda/biokbase-requirements.txt && \
     conda install -c r r-base && \
     conda install -c conda-forge --file /root/conda/r.conda-forge && \
     conda install -c r --file /root/conda/r.r && \
-    conda install -c conda-forge nodejs
-
-# Install apt-get prereqs for node, R
-RUN apt-get update && \
-    apt-get install -y gfortran gnupg
-
-# Install nodejs at a useful version
-# RUN curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash - && \
-#     apt-get install -y nodejs
+    # Install apt-get prereqs for node and R
+    apt-get update && \
+    apt-get install -y gfortran gnupg && \
+    # Install nodejs at a useful version
+    curl -sL https://deb.nodesource.com/setup_${NODEJS_VERSION}.x | bash - && \
+    apt-get install -y nodejs
 
 # Install misc R packages not available on Conda
 ADD ./r-packages-postconda.R /root/r-packages.R
-ENV TAR /bin/tar
-RUN R --vanilla < /root/r-packages.R
-
-# Install IPython, Jupyter Notebook, and ipywidgets at controlled versions
-RUN conda install -c conda-forge ipython=${IPYTHON_VERSION} notebook=${NOTEBOOK_VERSION} ipywidgets==${IPYWIDGETS_VERSION} && \
+RUN R --vanilla < /root/r-packages.R && \
+    # Install IPython, Jupyter Notebook, and ipywidgets at controlled versions
+    conda install -c conda-forge ipython=${IPYTHON_VERSION} notebook=${NOTEBOOK_VERSION} ipywidgets==${IPYWIDGETS_VERSION} && \
     conda update six && \
     jupyter nbextension enable --py widgetsnbextension
 

--- a/scripts/build_narrative_container.sh
+++ b/scripts/build_narrative_container.sh
@@ -8,7 +8,7 @@ NAR_NAME="kbase/narrative"
 NAR_VER_NAME="kbase/narrative_version"  # Image for serving up the narrative version
 HEADLESS_NAME="kbase/narrative_headless"
 NAR_BASE="kbase/narrbase"
-NAR_BASE_VER="6.1"
+NAR_BASE_VER="6.2"
 
 # Get the current branch, so that we can tag images to branch
 BRANCH=${TRAVIS_BRANCH:-`git symbolic-ref --short HEAD`}


### PR DESCRIPTION
# Description of PR purpose/changes

Narrative builds were failing due to the version of node installed on the base image. This PR updates the `narrbase` image to use the current nodejs release. In addition, the docker file commands are concatenated to reduce the number of layers in the resulting docker images.

Note that the 'Build' workflow requires `kbase/narrbase:6.2` to be present on ghcr.io.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [x] Changes available by examining the docker container for the narrative and running (e.g.) `node --version`; it should return 14.x. More importantly, the GitHub image build workflow should pass!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [x] [Version has been bumped](https://semver.org/) for the `narrbase` image
