### PR TITLE
Changes to get the narrative_version container built/pushed

### DIFF
--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -19,7 +19,7 @@ docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
 export MY_APP2="$MY_APP"_version
 
-docker build -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" \
+docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
                 --build-arg BUILD_DATE=$DATE \
                 --build-arg VCS_REF=$COMMIT \
                 --build-arg BRANCH="$GITHUB_HEAD_REF" \
@@ -29,4 +29,4 @@ docker build -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" \
                 -f Dockerfile2 \
                 .
 docker rmi kbase/narrative:tmp
-docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"

--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -5,6 +5,7 @@ export MY_APP=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export NARRATIVE_VERSION_NUM=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
 
 docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker build --build-arg BUILD_DATE="$DATE" \
@@ -13,4 +14,19 @@ docker build --build-arg BUILD_DATE="$DATE" \
              --build-arg PULL_REQUEST="$PR" \
              --label us.kbase.vcs-pull-req="$PR" \
              -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
+export MY_APP=narrative_version
+
+docker build -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" \
+                --build-arg BUILD_DATE=$DATE \
+                --build-arg VCS_REF=$COMMIT \
+                --build-arg BRANCH="$GITHUB_HEAD_REF" \
+                --build-arg PULL_REQUEST="$PR" \
+                --label us.kbase.vcs-pull-req="$PR" \
+                --build-arg NARRATIVE_VERSION=$NARRATIVE_VERSION_NUM \
+                -f Dockerfile2 \
+                .
+docker rmi kbase/narrative:tmp
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"

--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -6,6 +6,7 @@ export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
 export NARRATIVE_VERSION_NUM=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
+export MY_APP2="$MY_APP"_version
 
 docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker build --build-arg BUILD_DATE="$DATE" \
@@ -17,7 +18,6 @@ docker build --build-arg BUILD_DATE="$DATE" \
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
-export MY_APP2="$MY_APP"_version
 
 docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
                 --build-arg BUILD_DATE=$DATE \

--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -17,7 +17,7 @@ docker build --build-arg BUILD_DATE="$DATE" \
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
-export MY_APP=narrative_version
+export MY_APP2="$MY_APP"_version
 
 docker build -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" \
                 --build-arg BUILD_DATE=$DATE \

--- a/.github/workflows/scripts/build_test_pr.sh
+++ b/.github/workflows/scripts/build_test_pr.sh
@@ -6,6 +6,7 @@ export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
 export NARRATIVE_VERSION_NUM=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
+export MY_APP2="$MY_APP"_version
 
 echo $DOCKER_TOKEN | docker login ghcr.io -u $DOCKER_ACTOR --password-stdin
 docker build --build-arg BUILD_DATE="$DATE" \
@@ -17,7 +18,6 @@ docker build --build-arg BUILD_DATE="$DATE" \
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
-export MY_APP2="$MY_APP"_version
 
 docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
                 --build-arg BUILD_DATE=$DATE \

--- a/.github/workflows/scripts/build_test_pr.sh
+++ b/.github/workflows/scripts/build_test_pr.sh
@@ -5,6 +5,7 @@ export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-dev
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export NARRATIVE_VERSION_NUM=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
 
 echo $DOCKER_TOKEN | docker login ghcr.io -u $DOCKER_ACTOR --password-stdin
 docker build --build-arg BUILD_DATE="$DATE" \
@@ -14,4 +15,18 @@ docker build --build-arg BUILD_DATE="$DATE" \
              --label us.kbase.vcs-pull-req="$PR" \
              -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
-	
+
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
+export MY_APP2="$MY_APP"_version
+
+docker build -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" \
+                --build-arg BUILD_DATE=$DATE \
+                --build-arg VCS_REF=$COMMIT \
+                --build-arg BRANCH="$GITHUB_HEAD_REF" \
+                --build-arg PULL_REQUEST="$PR" \
+                --label us.kbase.vcs-pull-req="$PR" \
+                --build-arg NARRATIVE_VERSION=$NARRATIVE_VERSION_NUM \
+                -f Dockerfile2 \
+                .
+docker rmi kbase/narrative:tmp
+docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"

--- a/.github/workflows/scripts/build_test_pr.sh
+++ b/.github/workflows/scripts/build_test_pr.sh
@@ -19,7 +19,7 @@ docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
 export MY_APP2="$MY_APP"_version
 
-docker build -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" \
+docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
                 --build-arg BUILD_DATE=$DATE \
                 --build-arg VCS_REF=$COMMIT \
                 --build-arg BRANCH="$GITHUB_HEAD_REF" \
@@ -29,4 +29,4 @@ docker build -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" \
                 -f Dockerfile2 \
                 .
 docker rmi kbase/narrative:tmp
-docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"

--- a/.github/workflows/scripts/tag_prod_latest.sh
+++ b/.github/workflows/scripts/tag_prod_latest.sh
@@ -5,13 +5,13 @@ export MY_APP=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export MY_APP2="$MY_APP"_version
 
 docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 
-export MY_APP2="$MY_APP"_version
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"

--- a/.github/workflows/scripts/tag_prod_latest.sh
+++ b/.github/workflows/scripts/tag_prod_latest.sh
@@ -10,3 +10,8 @@ docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
+
+export MY_APP2="$MY_APP"_version
+docker pull ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"

--- a/.github/workflows/scripts/tag_test_latest.sh
+++ b/.github/workflows/scripts/tag_test_latest.sh
@@ -5,13 +5,13 @@ export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-dev
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export MY_APP2="$MY_APP"_version
 
 docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 
-export MY_APP2="$MY_APP"_version
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"

--- a/.github/workflows/scripts/tag_test_latest.sh
+++ b/.github/workflows/scripts/tag_test_latest.sh
@@ -10,3 +10,8 @@ docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
+
+export MY_APP2="$MY_APP"_version
+docker pull ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"


### PR DESCRIPTION
# Description of PR purpose/changes

* The narrative_version container is not being built/pushed by the GHA, this is a fork with updates to test GHA builds for the additional image

# Jira Ticket / Issue #
No jira ticket on this one.

# Testing Instructions
* Details for how to test the PR:
- [X] Tests pass locally and in GitHub Actions
- [x] Check the list of packages to verify that a narrative_version package with the current PR as the version has been created.

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
