### PR TITLE
DATAUP-330: eslint, formatting, and variable name standardisation

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/actionButtons.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/actionButtons.js
@@ -1,8 +1,4 @@
-define([
-    'kb_common/html',
-], function(
-    html
-){
+define(['common/html'], (html) => {
     'use strict';
     function factory(config) {
         /**
@@ -25,7 +21,7 @@ define([
 
          */
 
-        var t = html.tag,
+        const t = html.tag,
             div = t('div');
 
         const actionButtons = config.actionButtons,
@@ -34,11 +30,12 @@ define([
             runAction = config.runAction;
 
         function buildLayout(events) {
-            return div({
-                class: 'kb-btn-action__container',
-            }, [
-                buildActionButtons(events)
-            ]);
+            return div(
+                {
+                    class: 'kb-btn-action__container',
+                },
+                [buildActionButtons(events)]
+            );
         }
 
         function buildActionButtons(events) {
@@ -49,7 +46,7 @@ define([
                 if (button.icon) {
                     icon = {
                         name: button.icon.name,
-                        size: 2
+                        size: 2,
                     };
                 }
                 return ui.buildButton({
@@ -61,11 +58,11 @@ define([
                     event: {
                         type: 'actionButton',
                         data: {
-                            action: key
-                        }
+                            action: key,
+                        },
                     },
                     icon: icon,
-                    label: button.label
+                    label: button.label,
                 });
             });
             bus.on('actionButton', (message) => {
@@ -73,29 +70,32 @@ define([
                 runAction(action);
             });
 
-            return div({
-                class: 'kb-btn-action__list btn-group'
-            }, buttonList);
+            return div(
+                {
+                    class: 'kb-btn-action__list btn-group',
+                },
+                buttonList
+            );
         }
 
         function setState(newState) {
-            let state = newState;
+            const state = newState;
             for (const btnName of Object.keys(actionButtons.availableButtons)) {
                 ui.hideButton(btnName);
             }
             ui.showButton(state.name);
-            state.disabled ? ui.disableButton(state.name): ui.enableButton(state.name);
+            state.disabled ? ui.disableButton(state.name) : ui.enableButton(state.name);
         }
 
         return {
             setState: setState,
-            buildLayout: buildLayout
+            buildLayout: buildLayout,
         };
     }
 
     return {
-        make: function(config) {
+        make: function (config) {
             return factory(config);
-        }
+        },
     };
 });

--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -23,10 +23,7 @@ define([
             inputControlFactory = config.inputControlFactory,
             fieldId = html.genId(),
             spec = config.parameterSpec;
-        let places,
-            parent,
-            container,
-            inputControl;
+        let places, parent, container, inputControl;
 
         try {
             inputControl = inputControlFactory.make({
@@ -137,8 +134,8 @@ define([
                         node: places.inputControl,
                     });
                 })
-                .catch((err) => {
-                    console.error('error starting field table cell widget: ', err);
+                .catch((error) => {
+                    throw new Error('Unable to start fieldTableCellWidget: ', error);
                 });
         }
 
@@ -154,7 +151,7 @@ define([
                         return null;
                     })
                     .catch((err) => {
-                        console.error('error stopping field table cell widget: ', err);
+                        console.error('Error stopping fieldTableCellWidget: ', err);
                         if (parent && container) {
                             parent.removeChild(container);
                         }

--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -6,7 +6,7 @@ define([
     'common/runtime',
     'widgets/appWidgets2/errorControl',
     'css!google-code-prettify/prettify.css',
-], function (Promise, PR, html, Events, Runtime, ErrorControlFactory) {
+], (Promise, PR, html, Events, Runtime, ErrorControlFactory) => {
     'use strict';
 
     const t = html.tag,
@@ -16,17 +16,17 @@ define([
         cssBaseClass = 'kb-field-cell';
 
     function factory(config) {
-        var runtime = Runtime.make(),
+        const runtime = Runtime.make(),
             bus = runtime.bus().makeChannelBus({
                 description: 'Field bus',
             }),
-            places,
-            parent,
-            container,
             inputControlFactory = config.inputControlFactory,
-            inputControl,
             fieldId = html.genId(),
             spec = config.parameterSpec;
+        let places,
+            parent,
+            container,
+            inputControl;
 
         try {
             inputControl = inputControlFactory.make({
@@ -50,12 +50,12 @@ define([
         }
 
         function render(events) {
-            var ids = {
+            const ids = {
                 fieldPanel: html.genId(),
                 inputControl: html.genId(),
             };
 
-            var content = td(
+            const content = td(
                 {
                     class: `${cssBaseClass}__tableCell`,
                     id: ids.fieldPanel,
@@ -96,15 +96,15 @@ define([
 
         function attach(node) {
             parent = node;
-            let containerDiv = document.createElement('div');
+            const containerDiv = document.createElement('div');
             containerDiv.classList.add(`${cssBaseClass}__param_container`);
 
             container = parent.appendChild(containerDiv);
-            var events = Events.make({
+            const events = Events.make({
                 node: container,
             });
 
-            var rendered = render(events);
+            const rendered = render(events);
             container.innerHTML = rendered.content;
             events.attachEvents();
             // TODO: use the pattern in which the render returns an object,
@@ -131,7 +131,7 @@ define([
                 .start({
                     node: places.inputControl,
                 })
-                .then(function () {
+                .then(() => {
                     // TODO: get rid of this pattern
                     bus.emit('run', {
                         node: places.inputControl,
@@ -143,7 +143,7 @@ define([
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(() => {
                 return inputControl
                     .stop()
                     .then(() => {

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -503,7 +503,7 @@ define([
                     updateRowNumbers(filePathRows);
                 });
             }).catch((error) => {
-                throw new Error('Unable to start file path widget: ', error);
+                throw new Error('Unable to start filePathWidget: ', error);
             });
         }
 

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -8,7 +8,7 @@ define([
     'common/cellComponents/fieldTableCellWidget',
     'widgets/appWidgets2/paramResolver',
     'common/runtime',
-], function (Promise, $, html, UI, Events, Props, FieldWidget, ParamResolver, Runtime) {
+], (Promise, $, html, UI, Events, Props, FieldWidget, ParamResolver, Runtime) => {
     'use strict';
 
     const tag = html.tag,
@@ -24,24 +24,21 @@ define([
         cssClassType = 'parameter';
 
     function factory(config) {
-        let runtime = Runtime.make(),
+        const runtime = Runtime.make(),
             paramsBus = config.bus,
             workspaceId = config.workspaceId,
             initialParams = config.initialParams,
-            container,
-            ui,
-            bus,
             model = Props.make(),
             paramResolver = ParamResolver.make(),
             widgets = [],
-            events = Events.make();
-
-        bus = runtime.bus().makeChannelBus({
-            description: 'A file path widget',
-        });
+            events = Events.make(),
+            bus = runtime.bus().makeChannelBus({
+                description: 'A file path widget',
+            });
+        let container, ui;
 
         function makeFieldWidget(inputWidget, appSpec, parameterSpec, value, closeParameters) {
-            let fieldWidget = FieldWidget.make({
+            const fieldWidget = FieldWidget.make({
                 inputControlFactory: inputWidget,
                 showHint: true,
                 useRowHighight: true,
@@ -55,7 +52,7 @@ define([
             });
 
             // Forward all changed parameters to the controller. That is our main job!
-            fieldWidget.bus.on('changed', function (message) {
+            fieldWidget.bus.on('changed', (message) => {
                 paramsBus.send(
                     {
                         parameter: parameterSpec.id,
@@ -77,27 +74,27 @@ define([
                 });
             });
 
-            fieldWidget.bus.on('touched', function () {
+            fieldWidget.bus.on('touched', () => {
                 paramsBus.emit('parameter-touched', {
                     parameter: parameterSpec.id,
                 });
             });
 
             // An input widget may ask for the current model value at any time.
-            fieldWidget.bus.on('sync', function () {
+            fieldWidget.bus.on('sync', () => {
                 paramsBus.emit('parameter-sync', {
                     parameter: parameterSpec.id,
                 });
             });
 
-            fieldWidget.bus.on('sync-params', function (message) {
+            fieldWidget.bus.on('sync-params', (message) => {
                 paramsBus.emit('sync-params', {
                     parameters: message.parameters,
                     replyToChannel: fieldWidget.bus.channelName,
                 });
             });
 
-            fieldWidget.bus.on('set-param-state', function (message) {
+            fieldWidget.bus.on('set-param-state', (message) => {
                 paramsBus.emit('set-param-state', {
                     id: parameterSpec.id,
                     state: message.state,
@@ -123,7 +120,7 @@ define([
             /*
              * Or in fact any parameter value at any time...
              */
-            fieldWidget.bus.on('get-parameter-value', function (message) {
+            fieldWidget.bus.on('get-parameter-value', (message) => {
                 paramsBus
                     .request(
                         {
@@ -133,7 +130,7 @@ define([
                             key: 'get-parameter-value',
                         }
                     )
-                    .then(function (response) {
+                    .then((response) => {
                         bus.emit('parameter-value', {
                             parameter: response.parameter,
                         });
@@ -176,13 +173,13 @@ define([
                                         }
                                     )
                                     .then((result) => {
-                                        let returnVal = {};
+                                        const returnVal = {};
                                         returnVal[paramName] = result.value;
                                         return returnVal;
                                     });
                             })
                         ).then((results) => {
-                            let combined = {};
+                            const combined = {};
                             results.forEach((res) => {
                                 Object.keys(res).forEach((key) => {
                                     combined[key] = res[key];
@@ -211,7 +208,7 @@ define([
         }
 
         function updateRowNumbers(filePathRows) {
-            filePathRows.forEach(function (filePathRow, index) {
+            filePathRows.forEach((filePathRow, index) => {
                 $(filePathRow)
                     .find(`.${cssBaseClass}__file_number`)
                     .text(index + 1);
@@ -228,7 +225,7 @@ define([
                     })
                 );
 
-            let filePathRows = ui.getElements(`${cssClassType}-fields-row`);
+            const filePathRows = ui.getElements(`${cssClassType}-fields-row`);
 
             filePathRows.forEach((filePathRow) => {
                 // Only render row if it does not have the file path widgets as children (aka an empty row)
@@ -300,7 +297,7 @@ define([
                 node: container,
                 bus: bus,
             });
-            let layout = renderLayout();
+            const layout = renderLayout();
             container.innerHTML = layout;
             events.attachEvents(container);
         }
@@ -322,7 +319,7 @@ define([
         // }
 
         function makeFilePathsLayout(params) {
-            let view = {},
+            const view = {},
                 paramMap = {};
 
             const orderedParams = params.map((param) => {
@@ -332,7 +329,7 @@ define([
 
             const layout = orderedParams
                 .map((parameterId) => {
-                    let id = html.genId();
+                    const id = html.genId();
                     view[parameterId] = {
                         id: id,
                     };
@@ -356,7 +353,7 @@ define([
 
         function findPathParams(params) {
             return params.layout
-                .filter(function (id) {
+                .filter((id) => {
                     const original = params.specs[id].original;
 
                     let isFilePathParam = false;
@@ -376,7 +373,7 @@ define([
 
                     return isFilePathParam;
                 })
-                .map(function (id) {
+                .map((id) => {
                     return params.specs[id];
                 });
         }
@@ -417,7 +414,7 @@ define([
 
         function deleteRow(e) {
             $(e.target).closest('tr').remove();
-            let filePathRows = ui.getElements(`${cssClassType}-fields-row`);
+            const filePathRows = ui.getElements(`${cssClassType}-fields-row`);
             updateRowNumbers(filePathRows);
         }
 
@@ -425,7 +422,7 @@ define([
             const appSpec = model.getItem('appSpec');
 
             const params = model.getItem('parameters');
-            let filePathParams = makeFilePathsLayout(findPathParams(params));
+            const filePathParams = makeFilePathsLayout(findPathParams(params));
 
             if (!filePathParams.layout.length) {
                 ui.getElement(`${cssClassType}s-area`).classList.add('hidden');
@@ -434,16 +431,19 @@ define([
                     td({
                         class: `${cssBaseClass}__file_number`,
                     }),
-                    td({
-                        class: `${cssBaseClass}__params`
-                    },[
-                        div(
-                            {
-                                class: `${cssBaseClass}__param_container row`,
-                            },
-                            [filePathParams.content]
-                        )
-                    ]),
+                    td(
+                        {
+                            class: `${cssBaseClass}__params`,
+                        },
+                        [
+                            div(
+                                {
+                                    class: `${cssBaseClass}__param_container row`,
+                                },
+                                [filePathParams.content]
+                            ),
+                        ]
+                    ),
                     td({}, [
                         button(
                             {
@@ -476,14 +476,14 @@ define([
         }
 
         function start(arg) {
-            return Promise.try(function () {
+            return Promise.try(() => {
                 doAttach(arg.node);
 
                 model.setItem('appSpec', arg.appSpec);
                 model.setItem('parameters', arg.parameters);
 
-                paramsBus.on('parameter-changed', function (message) {
-                    widgets.forEach(function (widget) {
+                paramsBus.on('parameter-changed', (message) => {
+                    widgets.forEach((widget) => {
                         widget.bus.send(message, {
                             key: {
                                 type: 'parameter-changed',
@@ -493,7 +493,7 @@ define([
                     });
                 });
 
-                let filePathRows = ui.getElements(`${cssClassType}-fields-row`);
+                const filePathRows = ui.getElements(`${cssClassType}-fields-row`);
 
                 return Promise.all(
                     filePathRows.map(async (filePathRow) => {
@@ -508,7 +508,7 @@ define([
         }
 
         function stop() {
-            return Promise.try(function () {
+            return Promise.try(() => {
                 // really unhook things here.
             });
         }

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -522,15 +522,16 @@ define([
                     // do something after success
                     attachEvents();
                 })
-                .catch((err) => {
-                    // do somethig with the error.
-                    console.error('ERROR in start', err);
+                .catch((error) => {
+                    throw new Error('Unable to start paramsWidget: ', error);
                 });
         }
 
         function stop() {
             return Promise.try(() => {
-                container.innerHTML = '';
+                if (container) {
+                    container.innerHTML = '';
+                }
             });
         }
 

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -1,6 +1,5 @@
 define([
     'bluebird',
-    'jquery',
     // CDN
     'common/html',
     // LOCAL
@@ -10,28 +9,28 @@ define([
     'common/cellComponents/fieldTableCellWidget',
     'widgets/appWidgets2/paramResolver',
     'common/runtime',
-], function (Promise, $, html, UI, Events, Props, FieldWidget, ParamResolver, Runtime) {
+], (Promise, html, UI, Events, Props, FieldWidget, ParamResolver, Runtime) => {
     'use strict';
 
-    let tag = html.tag,
+    const tag = html.tag,
         form = tag('form'),
         span = tag('span'),
         div = tag('div');
 
     function factory(config) {
-        let runtime = Runtime.make(),
+        const runtime = Runtime.make(),
             bus = config.bus,
             workspaceId = config.workspaceId,
             initialParams = config.initialParams,
-            container,
-            ui,
-            places = {},
             model = Props.make(),
             paramResolver = ParamResolver.make(),
             settings = {
                 showAdvanced: null,
             },
             widgets = [];
+        let container,
+            ui,
+            places = {};
 
         // DATA
         /*
@@ -77,7 +76,7 @@ define([
       */
 
         function makeFieldWidget(inputWidget, appSpec, parameterSpec, value, closeParameters) {
-            let fieldWidget = FieldWidget.make({
+            const fieldWidget = FieldWidget.make({
                 inputControlFactory: inputWidget,
                 showHint: true,
                 useRowHighight: true,
@@ -91,7 +90,7 @@ define([
             });
 
             // Forward all changed parameters to the controller. That is our main job!
-            fieldWidget.bus.on('changed', function (message) {
+            fieldWidget.bus.on('changed', (message) => {
                 bus.send(
                     {
                         parameter: parameterSpec.id,
@@ -113,27 +112,27 @@ define([
                 });
             });
 
-            fieldWidget.bus.on('touched', function () {
+            fieldWidget.bus.on('touched', () => {
                 bus.emit('parameter-touched', {
                     parameter: parameterSpec.id,
                 });
             });
 
             // An input widget may ask for the current model value at any time.
-            fieldWidget.bus.on('sync', function () {
+            fieldWidget.bus.on('sync', () => {
                 bus.emit('parameter-sync', {
                     parameter: parameterSpec.id,
                 });
             });
 
-            fieldWidget.bus.on('sync-params', function (message) {
+            fieldWidget.bus.on('sync-params', (message) => {
                 bus.emit('sync-params', {
                     parameters: message.parameters,
                     replyToChannel: fieldWidget.bus.channelName,
                 });
             });
 
-            fieldWidget.bus.on('set-param-state', function (message) {
+            fieldWidget.bus.on('set-param-state', (message) => {
                 bus.emit('set-param-state', {
                     id: parameterSpec.id,
                     state: message.state,
@@ -159,7 +158,7 @@ define([
             /*
              * Or in fact any parameter value at any time...
              */
-            fieldWidget.bus.on('get-parameter-value', function (message) {
+            fieldWidget.bus.on('get-parameter-value', (message) => {
                 bus.request(
                     {
                         parameter: message.parameter,
@@ -167,7 +166,7 @@ define([
                     {
                         key: 'get-parameter-value',
                     }
-                ).then(function (response) {
+                ).then((response) => {
                     bus.emit('parameter-value', {
                         parameter: response.parameter,
                     });
@@ -211,13 +210,13 @@ define([
                                         }
                                     )
                                     .then((result) => {
-                                        let returnVal = {};
+                                        const returnVal = {};
                                         returnVal[paramName] = result.value;
                                         return returnVal;
                                     });
                             })
                         ).then((results) => {
-                            let combined = {};
+                            const combined = {};
                             results.forEach((res) => {
                                 Object.keys(res).forEach((key) => {
                                     combined[key] = res[key];
@@ -342,7 +341,7 @@ define([
                 node: container,
                 bus: bus,
             });
-            let layout = renderLayout();
+            const layout = renderLayout();
             container.innerHTML = layout.content;
             layout.events.attachEvents(container);
 
@@ -354,36 +353,36 @@ define([
 
         // EVENTS
         function attachEvents() {
-            bus.on('reset-to-defaults', function () {
-                widgets.forEach(function (widget) {
+            bus.on('reset-to-defaults', () => {
+                widgets.forEach((widget) => {
                     widget.bus.emit('reset-to-defaults');
                 });
             });
 
-            bus.on('toggle-advanced', function () {
+            bus.on('toggle-advanced', () => {
                 settings.showAdvanced = !settings.showAdvanced;
                 showHideAdvanced();
             });
 
-            runtime.bus().on('workspace-changed', function () {
+            runtime.bus().on('workspace-changed', () => {
                 // tell each input widget about this amazing event!
-                widgets.forEach(function (widget) {
+                widgets.forEach((widget) => {
                     widget.bus.emit('workspace-changed');
                 });
             });
         }
 
         function makeParamsLayout(params) {
-            let view = {},
+            const view = {},
                 paramMap = {};
 
-            const orderedParams = params.map(function (param) {
+            const orderedParams = params.map((param) => {
                 paramMap[param.id] = param;
                 return param.id;
             });
 
             const layout = orderedParams
-                .map(function (parameterId) {
+                .map((parameterId) => {
                     const elementId = html.genId();
                     const advanced = paramMap[parameterId].ui.advanced ? parameterId : false;
 
@@ -440,12 +439,12 @@ define([
                 });
         }
 
-        /* 
+        /*
             Filter out any inputs which may not be parameters (e.g. file inputs, output fields), map these to the parameter ID so we can use it to create the expected layout
         */
         function filterParameters(params) {
             return params.layout
-                .filter(function (id) {
+                .filter((id) => {
                     const original = params.specs[id].original;
 
                     let isParameter = false;
@@ -457,7 +456,7 @@ define([
                                 original.dynamic_dropdown_options.data_source !== 'ftp_staging';
                         }
 
-                        //looking for output fields - these should go in file paths
+                        // looking for output fields - these should go in file paths
                         else if (original.text_options && original.text_options.is_output_name) {
                             isParameter = false;
                         }
@@ -470,7 +469,7 @@ define([
 
                     return isParameter;
                 })
-                .map(function (id) {
+                .map((id) => {
                     return params.specs[id];
                 });
         }
@@ -482,7 +481,7 @@ define([
             // Separate out the params into the primary groups.
             const appSpec = model.getItem('appSpec');
             const params = model.getItem('parameters');
-            let filteredParams = makeParamsLayout(filterParameters(params));
+            const filteredParams = makeParamsLayout(filterParameters(params));
             //if there aren't any parameters we can just hide the whole area
             if (!filteredParams.layout.length) {
                 ui.getElement('parameters-area').classList.add('hidden');
@@ -506,9 +505,9 @@ define([
             model.setItem('appSpec', arg.appSpec);
             model.setItem('parameters', arg.parameters);
 
-            bus.on('parameter-changed', function (message) {
+            bus.on('parameter-changed', (message) => {
                 // Also, tell each of our inputs that a param has changed.
-                widgets.forEach(function (widget) {
+                widgets.forEach((widget) => {
                     widget.bus.send(message, {
                         key: {
                             type: 'parameter-changed',
@@ -519,11 +518,11 @@ define([
             });
 
             return renderParameters()
-                .then(function () {
+                .then(() => {
                     // do something after success
                     attachEvents();
                 })
-                .catch(function (err) {
+                .catch((err) => {
                     // do somethig with the error.
                     console.error('ERROR in start', err);
                 });

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
@@ -1,19 +1,12 @@
-// eslint-disable-line no-redeclare
-define([
-    'common/format',
-    'common/utils',
-], function(
-    format,
-    utils
-) {
+define(['common/format', 'common/utils'], (format, utils) => {
     'use strict';
 
     const toBoolean = utils.toBoolean;
 
-    const DOMTagA = function(innerHTML, options) {
+    const DOMTagA = function (innerHTML, options) {
         const tag = document.createElement('a');
-        if(options) {
-            if(options.class) {
+        if (options) {
+            if (options.class) {
                 tag.classList = options.class.split(' ');
             }
             tag.href = options.href;
@@ -29,17 +22,19 @@ define([
         return item;
     };
 
-    const appendChildren = function(node, children) {
-        children.forEach(function(child) { node.appendChild(child); });
+    const appendChildren = function (node, children) {
+        children.forEach((child) => {
+            node.appendChild(child);
+        });
     };
 
-    const listLinks = function(links) {
+    const listLinks = function (links) {
         const out = [];
         const separator = document.createTextNode(', ');
         const conjunction = document.createTextNode(' and ');
-        links.forEach(function(link, ix) {
+        links.forEach((link, ix) => {
             out.push(link);
-            if(ix < links.length - 2) {
+            if (ix < links.length - 2) {
                 out.push(separator.cloneNode());
             } else if (ix === links.length - 2) {
                 out.push(conjunction);
@@ -52,14 +47,11 @@ define([
         const model = config.model;
 
         function start(arg) {
-            let appSpec = model.getItem('app.spec');    // for plain app cell
+            let appSpec = model.getItem('app.spec'); // for plain app cell
             if (!appSpec && arg.currentApp) {
                 appSpec = model.getItem(`app.specs.${arg.currentApp}`); // for bulk cells
             }
-            const appRef = [
-                appSpec.info.id,
-                model.getItem('app').tag
-            ].filter(toBoolean).join('/');
+            const appRef = [appSpec.info.id, model.getItem('app').tag].filter(toBoolean).join('/');
 
             const methodFullInfo = appSpec.full_info;
 
@@ -70,39 +62,35 @@ define([
             // RUN COUNT AND AVERAGE RUNTIME
             const execStats = model.getItem('executionStats');
             let avgRuntime;
-            if( execStats
-                && execStats.total_exec_time
-                && execStats.number_of_calls > 0
-            ) {
-                avgRuntime = format.niceDuration(1000*(
-                    execStats.total_exec_time/execStats.number_of_calls
-                ));
+            if (execStats && execStats.total_exec_time && execStats.number_of_calls > 0) {
+                avgRuntime = format.niceDuration(
+                    1000 * (execStats.total_exec_time / execStats.number_of_calls)
+                );
             }
             let runtimeAvgListItem = document.createTextNode('');
-            if(avgRuntime) {
-                runtimeAvgListItem = DOMTagLI(''
-                    + `This app has been run ${execStats.number_of_calls}`
-                    + ` times and its average execution time is ${avgRuntime}.`
+            if (avgRuntime) {
+                runtimeAvgListItem = DOMTagLI(
+                    '' +
+                        `This app has been run ${execStats.number_of_calls}` +
+                        ` times and its average execution time is ${avgRuntime}.`
                 );
             }
 
             // LIST OF PARAMETERS
             const parametersList = document.createElement('ul');
-            appSpec.parameters.forEach(function(param) {
+            appSpec.parameters.forEach((param) => {
                 const textOptions = param.text_options;
                 let types = [];
-                if(textOptions && Array.isArray(textOptions.valid_ws_types)) {
-                    const typesArray = (textOptions.valid_ws_types
-                        .map(function(type) {
-                            const linkType = DOMTagA(type, {
-                                class: 'cm-em',
-                                href: '/#spec/type/' + type,
-                                target: '_blank'
-                            });
-                            return linkType;
-                        })
-                    );
-                    if(typesArray.length) {
+                if (textOptions && Array.isArray(textOptions.valid_ws_types)) {
+                    const typesArray = textOptions.valid_ws_types.map((type) => {
+                        const linkType = DOMTagA(type, {
+                            class: 'cm-em',
+                            href: '/#spec/type/' + type,
+                            target: '_blank',
+                        });
+                        return linkType;
+                    });
+                    if (typesArray.length) {
                         types = listLinks(typesArray);
                     }
                 }
@@ -110,32 +98,28 @@ define([
                 const paramUIName = document.createElement('span');
                 paramUIName.innerHTML = param.ui_name;
                 li.appendChild(paramUIName);
-                if(types.length) {
+                if (types.length) {
                     li.appendChild(document.createTextNode(': '));
                 }
                 appendChildren(li, types);
                 parametersList.appendChild(li);
             });
             const parametersListItem = document.createElement('li');
-            parametersListItem.appendChild(document.createTextNode(
-                'Parameters: '
-            ));
+            parametersListItem.appendChild(document.createTextNode('Parameters: '));
             parametersListItem.appendChild(parametersList);
 
             // AUTHORS/OWNERS
             const authors = appSpec.info.authors;
             let authorsListItem = document.createTextNode('');
-            if(authors.length) {
-                const authorsArray = authors.map(function(author) {
+            if (authors.length) {
+                const authorsArray = authors.map((author) => {
                     return DOMTagA(author, {
                         href: '/#people/' + author,
-                        target: '_blank'
+                        target: '_blank',
                     });
                 });
                 authorsListItem = document.createElement('li');
-                authorsListItem.appendChild(document.createTextNode(
-                    'Authors: '
-                ));
+                authorsListItem.appendChild(document.createTextNode('Authors: '));
                 appendChildren(authorsListItem, listLinks(authorsArray));
             }
 
@@ -143,10 +127,10 @@ define([
             const versionListItem = DOMTagLI(`Version: ${appSpec.info.ver}`);
 
             // CATALOG LINK
-            const linkCatalog = DOMTagA(
-                'View Full Documentation',
-                { href: '/#appcatalog/app/' + appRef, target: '_blank' }
-            );
+            const linkCatalog = DOMTagA('View Full Documentation', {
+                href: '/#appcatalog/app/' + appRef,
+                target: '_blank',
+            });
             const linkCatalogListItem = document.createElement('li');
             linkCatalogListItem.appendChild(linkCatalog);
 
@@ -174,14 +158,13 @@ define([
         return {
             hide: () => {},
             start: start,
-            stop: stop
+            stop: stop,
         };
     }
 
     return {
-        make: function(config) {
+        make: function (config) {
             return factory(config);
-        }
+        },
     };
 });
-

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
@@ -1,15 +1,15 @@
 /**
  * Should get fed data to view.
  */
-define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], function (
+define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], (
     Promise,
     html,
     UI,
     APIUtil
-) {
+) => {
     'use strict';
 
-    let tag = html.tag,
+    const tag = html.tag,
         div = tag('div'),
         tr = tag('tr'),
         th = tag('th'),
@@ -32,7 +32,7 @@ define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], function (
             const reportLookupParam = reports.map((ref) => {
                 return {
                     ref: ref,
-                    included: ['objects_created']
+                    included: ['objects_created'],
                 };
             });
             /* when we do the lookup, data will get returned as:
@@ -49,13 +49,14 @@ define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], function (
              */
             // key this off of the object id to make lookups easier once we
             // fetch the names later.
-            let createdObjects = {};
+            const createdObjects = {};
             let objectKeys = [];
-            return workspaceClient.get_objects2({objects: reportLookupParam})
+            return workspaceClient
+                .get_objects2({ objects: reportLookupParam })
                 .then((reportData) => {
-                    reportData.data.forEach(report => {
+                    reportData.data.forEach((report) => {
                         if ('objects_created' in report.data) {
-                            report.data.objects_created.forEach(obj => {
+                            report.data.objects_created.forEach((obj) => {
                                 createdObjects[obj.ref] = obj;
                             });
                         }
@@ -64,8 +65,8 @@ define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], function (
                     // the same order.
                     objectKeys = Object.keys(createdObjects);
                     // turn the refs into an array: [{"ref": ref}]
-                    const infoLookupParam = objectKeys.map(ref => ({'ref': ref}));
-                    return workspaceClient.get_object_info_new({objects: infoLookupParam});
+                    const infoLookupParam = objectKeys.map((ref) => ({ ref: ref }));
+                    return workspaceClient.get_object_info_new({ objects: infoLookupParam });
                 })
                 .then((objectInfo) => {
                     objectInfo.forEach((info, idx) => {
@@ -92,20 +93,12 @@ define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], function (
                     if (data.length === 0) {
                         return emptyData;
                     }
-                    let objectTable = table({class: 'table table-bordered table-striped'}, [
-                        tr([
-                            th('Created Object Name'),
-                            th('Type'),
-                            th('Description')
-                        ]),
-                        ...data.map(obj => {
+                    const objectTable = table({ class: 'table table-bordered table-striped' }, [
+                        tr([th('Created Object Name'), th('Type'), th('Description')]),
+                        ...data.map((obj) => {
                             const parsedType = APIUtil.parseWorkspaceType(obj.type);
-                            return tr([
-                                td(obj.name),
-                                td(parsedType.type),
-                                td(obj.description)
-                            ]);
-                        })
+                            return tr([td(obj.name), td(parsedType.type), td(obj.description)]);
+                        }),
                     ]);
                     return objectTable;
                 })
@@ -133,20 +126,21 @@ define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], function (
             // this is the main layout div. don't do anything yet.
             container.innerHTML = div({
                 dataElement: 'created-objects',
-                class: 'kb-created-objects'
+                class: 'kb-created-objects',
             });
-            return renderOutput(arg.reports, arg.workspaceClient)
-                .then((renderedOutput) => {
-                    ui.setContent('created-objects',
-                        ui.buildCollapsiblePanel({
-                            title: 'Objects',
-                            name: 'created-objects-toggle',
-                            hidden: false,
-                            type: 'default',
-                            classes: ['kb-panel-container'],
-                            body: renderedOutput,
-                        }));
-                });
+            return renderOutput(arg.reports, arg.workspaceClient).then((renderedOutput) => {
+                ui.setContent(
+                    'created-objects',
+                    ui.buildCollapsiblePanel({
+                        title: 'Objects',
+                        name: 'created-objects-toggle',
+                        hidden: false,
+                        type: 'default',
+                        classes: ['kb-panel-container'],
+                        body: renderedOutput,
+                    })
+                );
+            });
         }
 
         /**
@@ -158,10 +152,9 @@ define(['bluebird', 'common/html', 'common/ui', 'util/kbaseApiUtil'], function (
          */
         function start(arg) {
             // send parent the ready message
-            return doAttach(arg)
-                .catch((err) => {
-                    console.error('Error while starting the created objects view', err);
-                });
+            return doAttach(arg).catch((err) => {
+                console.error('Error while starting the created objects view', err);
+            });
         }
 
         function stop() {

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/reportWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/reportWidget.js
@@ -1,13 +1,13 @@
-define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events'], function (
+define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events'], (
     Promise,
     $,
     html,
     UI,
     Events
-) {
+) => {
     'use strict';
 
-    let tag = html.tag,
+    const tag = html.tag,
         div = tag('div');
 
     function ReportWidget() {
@@ -47,7 +47,7 @@ define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events'], func
                 node: container,
             });
 
-            let layout = renderLayout();
+            const layout = renderLayout();
 
             container.innerHTML = layout.content;
             layout.events.attachEvents(container);
@@ -57,7 +57,7 @@ define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events'], func
             // send parent the ready message
             doAttach(arg.node);
 
-            return renderReport(arg.data).catch(function (err) {
+            return renderReport(arg.data).catch((err) => {
                 // do somethig with the error.
                 console.error('ERROR in start', err);
             });

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
@@ -78,20 +78,19 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
          */
         function start(arg) {
             container = arg.node;
-            let events = Events.make();
+            const events = Events.make(),
+                reports = getReportRefs();
 
-            const reports = getReportRefs();
-
-            let spinnerNode = document.createElement('div');
+            const spinnerNode = document.createElement('div');
             spinnerNode.classList.add('kb-loading-spinner');
-            spinnerNode.innerHTML = UI.loading({size: '2x'});
+            spinnerNode.innerHTML = UI.loading({ size: '2x' });
             container.appendChild(spinnerNode);
 
-            let objectNode = document.createElement('div');
+            const objectNode = document.createElement('div');
             container.appendChild(objectNode);
             objectNode.classList.add('hidden');
 
-            let reportNode = document.createElement('div');
+            const reportNode = document.createElement('div');
             container.appendChild(reportNode);
             reportNode.classList.add('hidden');
 

--- a/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
@@ -19,8 +19,6 @@ define([
     });
 
     describe('The Field Table Cell Widget instance', () => {
-        let node, fieldCellWidgetInstance;
-
         const parameterSpec = {
             data: {
                 constraints: {
@@ -77,6 +75,7 @@ define([
         ];
 
         beforeAll(() => {
+            window.kbaseRuntime = null;
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
             };
@@ -87,8 +86,8 @@ define([
         });
 
         beforeEach(async () => {
-            node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(node);
+            this.node = document.createElement('div');
+            document.getElementsByTagName('body')[0].appendChild(this.node);
 
             const model = Props.make({
                 data: TestAppObject,
@@ -102,7 +101,7 @@ define([
             const paramResolver = ParamResolver.make();
 
             await paramResolver.loadInputControl(parameterSpec).then((inputControlFactory) => {
-                return (fieldCellWidgetInstance = FieldCellWidget.make({
+                return (this.fieldCellWidgetInstance = FieldCellWidget.make({
                     inputControlFactory: inputControlFactory,
                     showHint: true,
                     useRowHighight: true,
@@ -118,48 +117,49 @@ define([
         });
 
         afterEach(async () => {
-            await fieldCellWidgetInstance.stop().catch((err) => {
-                console.warn(
-                    'got an error when trying to stop, this is normal if stopped already (e.g. after final test run)',
-                    err
-                );
-            });
-
-            node = null;
-            document.body.innnerHTML = '';
-            fieldCellWidgetInstance = null;
+            if (this.fieldCellWidgetInstance) {
+                await this.fieldCellWidgetInstance.stop()
+                .catch((err) => {
+                    console.warn(
+                        'got an error when trying to stop, this is normal if stopped already (e.g. after final test run)',
+                        err
+                    );
+                });
+            }
+            document.body.innerHTML = '';
+            window.kbaseRuntime = null;
         });
 
         it('has a factory which can be invoked', () => {
-            expect(fieldCellWidgetInstance).not.toBe(null);
+            expect(this.fieldCellWidgetInstance).not.toBe(null);
         });
 
         it('has the required methods', () => {
             ['bus', 'start', 'stop'].forEach((fn) => {
-                expect(fieldCellWidgetInstance[fn]).toBeDefined();
-                expect(fieldCellWidgetInstance[fn]).toEqual(jasmine.any(Function));
+                expect(this.fieldCellWidgetInstance[fn]).toBeDefined();
             });
         });
 
         it('has a method start which returns the correct object', () => {
-            return fieldCellWidgetInstance
+            return this.fieldCellWidgetInstance
                 .start({
-                    node: node,
+                    node: this.node,
                 })
                 .then(() => {
-                    expect(node.innerHTML).toContain('kb-field-cell__cell_label');
-                    expect(node.innerHTML).toContain('kb-field-cell__input_control');
+                    expect(this.node.innerHTML).toContain('kb-field-cell__cell_label');
+                    expect(this.node.innerHTML).toContain('kb-field-cell__input_control');
                 });
         });
 
         it('has a method stop which returns null', () => {
-            return fieldCellWidgetInstance
+            return this.fieldCellWidgetInstance
                 .start({
-                    node: node,
+                    node: this.node,
                 })
                 .then(() => {
-                    fieldCellWidgetInstance.stop().then((result) => {
+                    this.fieldCellWidgetInstance.stop().then((result) => {
                         expect(result).toBeNull();
+                        this.fieldCellWidgetInstance = null;
                     });
                 });
         });

--- a/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
@@ -5,21 +5,21 @@ define([
     'common/props',
     'common/spec',
     '/test/data/testAppObj',
-], (Jupyter, fieldCellWidget, ParamResolver, Props, Spec, TestAppObject) => {
+], (Jupyter, FieldCellWidget, ParamResolver, Props, Spec, TestAppObject) => {
     'use strict';
 
     describe('The Field Table Cell Widget module', () => {
         it('loads', () => {
-            expect(fieldCellWidget).not.toBe(null);
+            expect(FieldCellWidget).not.toBe(null);
         });
 
         it('has expected functions', () => {
-            expect(fieldCellWidget.make).toBeDefined();
+            expect(FieldCellWidget.make).toBeDefined();
         });
     });
 
     describe('The Field Table Cell Widget instance', () => {
-        let node, mockFieldWidget;
+        let node, fieldCellWidgetInstance;
 
         const parameterSpec = {
             data: {
@@ -102,7 +102,7 @@ define([
             const paramResolver = ParamResolver.make();
 
             await paramResolver.loadInputControl(parameterSpec).then((inputControlFactory) => {
-                return (mockFieldWidget = fieldCellWidget.make({
+                return (fieldCellWidgetInstance = FieldCellWidget.make({
                     inputControlFactory: inputControlFactory,
                     showHint: true,
                     useRowHighight: true,
@@ -118,7 +118,7 @@ define([
         });
 
         afterEach(async () => {
-            await mockFieldWidget.stop().catch((err) => {
+            await fieldCellWidgetInstance.stop().catch((err) => {
                 console.warn(
                     'got an error when trying to stop, this is normal if stopped already (e.g. after final test run)',
                     err
@@ -127,21 +127,22 @@ define([
 
             node = null;
             document.body.innnerHTML = '';
-            mockFieldWidget = null;
+            fieldCellWidgetInstance = null;
         });
 
         it('has a factory which can be invoked', () => {
-            expect(mockFieldWidget).not.toBe(null);
+            expect(fieldCellWidgetInstance).not.toBe(null);
         });
 
         it('has the required methods', () => {
-            expect(mockFieldWidget.start).toBeDefined();
-            expect(mockFieldWidget.stop).toBeDefined();
-            expect(mockFieldWidget.bus).toBeDefined();
+            ['bus', 'start', 'stop'].forEach((fn) => {
+                expect(fieldCellWidgetInstance[fn]).toBeDefined();
+                expect(fieldCellWidgetInstance[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('has a method start which returns the correct object', () => {
-            return mockFieldWidget
+            return fieldCellWidgetInstance
                 .start({
                     node: node,
                 })
@@ -152,12 +153,12 @@ define([
         });
 
         it('has a method stop which returns null', () => {
-            return mockFieldWidget
+            return fieldCellWidgetInstance
                 .start({
                     node: node,
                 })
                 .then(() => {
-                    mockFieldWidget.stop().then((result) => {
+                    fieldCellWidgetInstance.stop().then((result) => {
                         expect(result).toBeNull();
                     });
                 });

--- a/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
@@ -21,6 +21,7 @@ define([
 
     describe('The file path widget instance', () => {
         beforeAll(() => {
+            window.kbaseRuntime = null;
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
             };
@@ -30,27 +31,25 @@ define([
             Jupyter.narrative = null;
         });
 
-        let filePathWidgetInstance, node, spec, parameters;
-
         beforeEach(() => {
             const bus = Runtime.make().bus();
-            node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(node);
+            this.node = document.createElement('div');
+            document.getElementsByTagName('body')[0].appendChild(this.node);
 
             const model = Props.make({
                 data: TestAppObject,
                 onUpdate: () => {},
             });
 
-            spec = Spec.make({
+            this.spec = Spec.make({
                 appSpec: model.getItem('app.spec'),
             });
 
-            parameters = spec.getSpec().parameters;
+            this.parameters = this.spec.getSpec().parameters;
 
             const workspaceId = 54745;
 
-            filePathWidgetInstance = FilePathWidget.make({
+            this.filePathWidgetInstance = FilePathWidget.make({
                 bus: bus,
                 workspaceId: workspaceId,
                 initialParams: model.getItem('params'),
@@ -58,29 +57,26 @@ define([
         });
 
         afterEach(() => {
-            $('body').empty();
-            filePathWidgetInstance = null;
-            node = null;
+            document.body.innerHTML = '';
             window.kbaseRuntime = null;
         });
 
         it('has a make function that returns an object', () => {
-            expect(filePathWidgetInstance).not.toBe(null);
+            expect(this.filePathWidgetInstance).not.toBe(null);
         });
 
         it('has the required methods', () => {
             ['bus', 'start', 'stop'].forEach((fn) => {
-                expect(filePathWidgetInstance[fn]).toBeDefined();
-                expect(filePathWidgetInstance[fn]).toEqual(jasmine.any(Function));
+                expect(this.filePathWidgetInstance[fn]).toBeDefined();
             });
         });
 
         it('should start and render itself', () => {
-            return filePathWidgetInstance
+            return this.filePathWidgetInstance
                 .start({
-                    node: node,
-                    appSpec: spec,
-                    parameters: parameters,
+                    node: this.node,
+                    appSpec: this.spec,
+                    parameters: this.parameters,
                 })
                 .then(() => {
                     const contents = [
@@ -94,39 +90,39 @@ define([
                         'Add Row',
                     ];
                     contents.forEach((item) => {
-                        expect(node.innerHTML).toContain(item);
+                        expect(this.node.innerHTML).toContain(item);
                     });
                 });
         });
 
         it('should add a row when Add Row button is clicked', () => {
-            return filePathWidgetInstance
+            return this.filePathWidgetInstance
                 .start({
-                    node: node,
-                    appSpec: spec,
-                    parameters: parameters,
+                    node: this.node,
+                    appSpec: this.spec,
+                    parameters: this.parameters,
                 })
                 .then(() => {
-                    const preClickNumberOfRows = $(node).find('tr').length;
+                    const preClickNumberOfRows = $(this.node).find('tr').length;
                     expect(preClickNumberOfRows).toEqual(1);
-                    $(node).find('.kb-file-path__button--add_row').click();
-                    const postClickNumberOfRows = $(node).find('tr').length;
+                    $(this.node).find('.kb-file-path__button--add_row').click();
+                    const postClickNumberOfRows = $(this.node).find('tr').length;
                     expect(postClickNumberOfRows).toEqual(2);
                 });
         });
 
         it('should delete a row when trashcan button is clicked', () => {
-            return filePathWidgetInstance
+            return this.filePathWidgetInstance
                 .start({
-                    node: node,
-                    appSpec: spec,
-                    parameters: parameters,
+                    node: this.node,
+                    appSpec: this.spec,
+                    parameters: this.parameters,
                 })
                 .then(() => {
-                    const preClickNumberOfRows = $(node).find('tr').length;
+                    const preClickNumberOfRows = $(this.node).find('tr').length;
                     expect(preClickNumberOfRows).toEqual(1);
-                    $(node).find('.kb-file-path__button--delete').click();
-                    const postClickNumberOfRows = $(node).find('tr').length;
+                    $(this.node).find('.kb-file-path__button--delete').click();
+                    const postClickNumberOfRows = $(this.node).find('tr').length;
                     expect(postClickNumberOfRows).toEqual(0);
                 });
         });

--- a/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
@@ -30,7 +30,7 @@ define([
             Jupyter.narrative = null;
         });
 
-        let filePathWidget, node, spec, parameters;
+        let filePathWidgetInstance, node, spec, parameters;
 
         beforeEach(() => {
             const bus = Runtime.make().bus();
@@ -50,7 +50,7 @@ define([
 
             const workspaceId = 54745;
 
-            filePathWidget = FilePathWidget.make({
+            filePathWidgetInstance = FilePathWidget.make({
                 bus: bus,
                 workspaceId: workspaceId,
                 initialParams: model.getItem('params'),
@@ -59,22 +59,24 @@ define([
 
         afterEach(() => {
             $('body').empty();
-            filePathWidget = null;
+            filePathWidgetInstance = null;
             node = null;
+            window.kbaseRuntime = null;
         });
 
         it('has a make function that returns an object', () => {
-            expect(filePathWidget).not.toBe(null);
+            expect(filePathWidgetInstance).not.toBe(null);
         });
 
         it('has the required methods', () => {
-            expect(filePathWidget.start).toBeDefined();
-            expect(filePathWidget.stop).toBeDefined();
-            expect(filePathWidget.bus).toBeDefined();
+            ['bus', 'start', 'stop'].forEach((fn) => {
+                expect(filePathWidgetInstance[fn]).toBeDefined();
+                expect(filePathWidgetInstance[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('should start and render itself', () => {
-            return filePathWidget
+            return filePathWidgetInstance
                 .start({
                     node: node,
                     appSpec: spec,
@@ -98,7 +100,7 @@ define([
         });
 
         it('should add a row when Add Row button is clicked', () => {
-            return filePathWidget
+            return filePathWidgetInstance
                 .start({
                     node: node,
                     appSpec: spec,
@@ -114,7 +116,7 @@ define([
         });
 
         it('should delete a row when trashcan button is clicked', () => {
-            return filePathWidget
+            return filePathWidgetInstance
                 .start({
                     node: node,
                     appSpec: spec,

--- a/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
@@ -21,6 +21,7 @@ define([
 
     describe('The Parameter instance', () => {
         beforeAll(() => {
+            window.kbaseRuntime = null;
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
             };
@@ -30,12 +31,10 @@ define([
             Jupyter.narrative = null;
         });
 
-        let paramsWidgetInstance, node, parameters;
-
         beforeEach(async () => {
             const bus = Runtime.make().bus();
-            node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(node);
+            this.node = document.createElement('div');
+            document.getElementsByTagName('body')[0].appendChild(this.node);
 
             const model = Props.make({
                 data: TestAppObject,
@@ -46,32 +45,29 @@ define([
                 appSpec: model.getItem('app.spec'),
             });
 
-            parameters = spec.getSpec().parameters;
+            this.parameters = spec.getSpec().parameters;
             const workspaceId = 54745;
             const initialParams = model.getItem('params');
 
-            paramsWidgetInstance = ParamsWidget.make({
+            this.paramsWidgetInstance = ParamsWidget.make({
                 bus: bus,
                 workspaceId: workspaceId,
                 initialParams: initialParams,
             });
 
-            await paramsWidgetInstance.start({
-                node: node,
+            await this.paramsWidgetInstance.start({
+                node: this.node,
                 appSpec: spec,
-                parameters: parameters,
+                parameters: this.parameters,
             });
         });
 
-        afterEach(() => {
-            paramsWidgetInstance.stop().then(() => {
-                node.remove();
-                node = null;
-                paramsWidgetInstance = null;
-                parameters = null;
-                window.kbaseRuntime = null;
-                $('body').empty();
-            });
+        afterEach(async() => {
+            if (this.paramsWidgetInstance) {
+                await this.paramsWidgetInstance.stop();
+            }
+            window.kbaseRuntime = null;
+            document.body.innerHTML = '';
         });
 
         it('should render the correct parameters', () => {
@@ -98,7 +94,7 @@ define([
         it('should render with advanced parameters hidden', () => {
             //get all advanced params using the spec
             const advancedParams = [];
-            for (const [, entry] of Object.entries(parameters.specs)) {
+            for (const [, entry] of Object.entries(this.parameters.specs)) {
                 if (entry.ui.advanced) {
                     advancedParams.push(entry.id);
                 }
@@ -117,8 +113,9 @@ define([
         });
 
         it('should stop itself and empty the node it was in', () => {
-            paramsWidgetInstance.stop().then(() => {
-                expect(node.innerHTML).toEqual('');
+            this.paramsWidgetInstance.stop().then(() => {
+                expect(this.node.innerHTML).toEqual('');
+                this.paramsWidgetInstance = null;
             });
         });
     });

--- a/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
@@ -30,7 +30,7 @@ define([
             Jupyter.narrative = null;
         });
 
-        let paramsWidget, node, parameters;
+        let paramsWidgetInstance, node, parameters;
 
         beforeEach(async () => {
             const bus = Runtime.make().bus();
@@ -50,13 +50,13 @@ define([
             const workspaceId = 54745;
             const initialParams = model.getItem('params');
 
-            paramsWidget = ParamsWidget.make({
+            paramsWidgetInstance = ParamsWidget.make({
                 bus: bus,
                 workspaceId: workspaceId,
                 initialParams: initialParams,
             });
 
-            await paramsWidget.start({
+            await paramsWidgetInstance.start({
                 node: node,
                 appSpec: spec,
                 parameters: parameters,
@@ -64,10 +64,10 @@ define([
         });
 
         afterEach(() => {
-            paramsWidget.stop().then(() => {
+            paramsWidgetInstance.stop().then(() => {
                 node.remove();
                 node = null;
-                paramsWidget = null;
+                paramsWidgetInstance = null;
                 parameters = null;
                 window.kbaseRuntime = null;
                 $('body').empty();
@@ -117,7 +117,7 @@ define([
         });
 
         it('should stop itself and empty the node it was in', () => {
-            paramsWidget.stop().then(() => {
+            paramsWidgetInstance.stop().then(() => {
                 expect(node.innerHTML).toEqual('');
             });
         });

--- a/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
@@ -1,13 +1,13 @@
-define(['common/cellComponents/tabs/infoTab'], (infoTabWidget) => {
+define(['common/cellComponents/tabs/infoTab'], (InfoTab) => {
     'use strict';
 
     describe('The App Info Tab module', () => {
         it('loads', () => {
-            expect(infoTabWidget).not.toBe(null);
+            expect(InfoTab).not.toBe(null);
         });
 
         it('has expected functions', () => {
-            expect(infoTabWidget.make).toBeDefined();
+            expect(InfoTab.make).toBeDefined();
         });
     });
 
@@ -43,23 +43,25 @@ define(['common/cellComponents/tabs/infoTab'], (infoTabWidget) => {
             },
         };
         const appSpec = model.getItem('app.spec');
-        const mockInfoTab = infoTabWidget.make({ model });
+        const infoTabInstance = InfoTab.make({ model });
         let node, infoTabPromise, infoTab;
 
         beforeEach(async () => {
             node = document.createElement('div');
-            infoTabPromise = mockInfoTab.start({ node });
+            infoTabPromise = infoTabInstance.start({ node });
             infoTab = await infoTabPromise;
             return infoTab; // to use infoTab for linter
         });
 
         it('has a factory which can be invoked', () => {
-            expect(mockInfoTab).not.toBe(null);
+            expect(infoTabInstance).not.toBe(null);
         });
 
         it('has the required methods', () => {
-            expect(mockInfoTab.start).toBeDefined();
-            expect(mockInfoTab.stop).toBeDefined();
+            ['start', 'stop'].forEach((fn) => {
+                expect(infoTabInstance[fn]).toBeDefined();
+                expect(infoTabInstance[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('has a method "start" which returns a Promise', () => {
@@ -67,7 +69,7 @@ define(['common/cellComponents/tabs/infoTab'], (infoTabWidget) => {
         });
 
         it('has a method "stop" which returns a Promise', () => {
-            const result = mockInfoTab.stop();
+            const result = infoTabInstance.stop();
             expect(result instanceof Promise).toBeTrue();
         });
 

--- a/test/unit/spec/common/cellComponents/tabs/results/outputWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/outputWidget-spec.js
@@ -3,7 +3,7 @@ define([
     'base/js/namespace',
     'narrativeConfig',
     'kb_service/client/workspace',
-    './fakeResultsData'
+    './fakeResultsData',
 ], (OutputWidget, Jupyter, Config, Workspace, ResultsData) => {
     'use strict';
 
@@ -13,35 +13,33 @@ define([
      */
     function happyWorkspaceMocks() {
         const returnData = {
-            data: []
+            data: [],
         };
-        Object.keys(ResultsData.reports).forEach(ref => {
+        Object.keys(ResultsData.reports).forEach((ref) => {
             returnData.data.push({
-                data: ResultsData.reports[ref]
+                data: ResultsData.reports[ref],
             });
         });
         const returnInfos = Object.values(ResultsData.objectInfos);
-        jasmine.Ajax.stubRequest(Config.url('workspace'), /get_objects2/)
-            .andReturn({
-                status: 200,
-                statusText: 'success',
-                contentType: 'application/json',
-                responseText: JSON.stringify({
-                    version: '1.1',
-                    result: [returnData]
-                })
-            });
+        jasmine.Ajax.stubRequest(Config.url('workspace'), /get_objects2/).andReturn({
+            status: 200,
+            statusText: 'success',
+            contentType: 'application/json',
+            responseText: JSON.stringify({
+                version: '1.1',
+                result: [returnData],
+            }),
+        });
 
-        jasmine.Ajax.stubRequest(Config.url('workspace'), /get_object_info_new/)
-            .andReturn({
-                status: 200,
-                statusText: 'success',
-                contentType: 'application/json',
-                responseText: JSON.stringify({
-                    version: '1.1',
-                    result: [returnInfos]
-                })
-            });
+        jasmine.Ajax.stubRequest(Config.url('workspace'), /get_object_info_new/).andReturn({
+            status: 200,
+            statusText: 'success',
+            contentType: 'application/json',
+            responseText: JSON.stringify({
+                version: '1.1',
+                result: [returnInfos],
+            }),
+        });
     }
 
     describe('test the created objects viewer', () => {
@@ -65,8 +63,9 @@ define([
             happyWorkspaceMocks();
             const node = document.createElement('div');
             document.getElementsByTagName('body')[0].appendChild(node);
-            const widget = OutputWidget.make();
-            return widget.start({node, reports: Object.keys(ResultsData.reports), workspaceClient})
+            const outputWidgetInstance = OutputWidget.make();
+            return outputWidgetInstance
+                .start({ node, reports: Object.keys(ResultsData.reports), workspaceClient })
                 .then(() => {
                     // we should have a table with two rows.
                     expect(node.querySelectorAll('tr').length).toBe(3);
@@ -77,30 +76,29 @@ define([
         it('should start and render an empty area without data', () => {
             const node = document.createElement('div');
             document.getElementsByTagName('body')[0].appendChild(node);
-            const widget = OutputWidget.make();
-            return widget.start({node, reports: [], workspaceClient})
-                .then(() => {
-                    expect(node.innerHTML).toContain('Objects');
-                    expect(node.innerHTML).not.toContain('table');
-                });
+            const outputWidgetInstance = OutputWidget.make();
+            return outputWidgetInstance.start({ node, reports: [], workspaceClient }).then(() => {
+                expect(node.innerHTML).toContain('Objects');
+                expect(node.innerHTML).not.toContain('table');
+            });
         });
 
         it('should stop and clear its node', () => {
             happyWorkspaceMocks();
             const node = document.createElement('div');
             document.getElementsByTagName('body')[0].appendChild(node);
-            const widget = OutputWidget.make();
-            return widget.start({node, reports: Object.keys(ResultsData.reports), workspaceClient})
+            const outputWidgetInstance = OutputWidget.make();
+            return outputWidgetInstance
+                .start({ node, reports: Object.keys(ResultsData.reports), workspaceClient })
                 .then(() => {
                     // we should have a table with two rows.
                     expect(node.querySelectorAll('tr').length).toBe(3);
                     expect(node.innerHTML).toContain('Objects');
-                    return widget.stop();
+                    return outputWidgetInstance.stop();
                 })
                 .then(() => {
                     expect(node.innerHTML).toEqual('');
                 });
         });
-
     });
 });

--- a/test/unit/spec/common/cellComponents/tabs/results/results-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/results-spec.js
@@ -8,8 +8,8 @@ define([
 
     describe('test the bulk import cell results tab', () => {
         const workspaceClient = {
-            get_objects2: () => Promise.resolve({data: []}),
-            get_object_info_new: () => Promise.resolve([])
+            get_objects2: () => Promise.resolve({ data: [] }),
+            get_object_info_new: () => Promise.resolve([]),
         };
         beforeAll(() => {
             Jupyter.narrative = {
@@ -31,8 +31,8 @@ define([
                 onUpdate: () => {},
             });
 
-            const results = ResultsTab.make({ model, workspaceClient });
-            return results
+            const resultsTabInstance = ResultsTab.make({ model, workspaceClient });
+            return resultsTabInstance
                 .start({
                     node: node,
                 })
@@ -51,13 +51,13 @@ define([
                 onUpdate: () => {},
             });
 
-            const results = ResultsTab.make({ model, workspaceClient });
-            return results
+            const resultsTabInstance = ResultsTab.make({ model, workspaceClient });
+            return resultsTabInstance
                 .start({
                     node: node,
                 })
                 .then(() => {
-                    return results.stop();
+                    return resultsTabInstance.stop();
                 })
                 .then(() => {
                     expect(node.innerHTML).toEqual('');


### PR DESCRIPTION
# Description of PR purpose/changes

Prior to looking at test failures in the `truss` branch, I have applied standardised formatting to component files and formatting and variable naming to the test files.

- Ran eslint and prettier on files in `/static/kbase/js/common/cellComponents/` and `test/unit/spec/common/cellComponents/`
- In test files, named the objects produced by each module `<module_name>Instance`

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions -- tests are failing at present!
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
