### PR TITLE
DATAUP-314: adding a new error type

### DIFF
--- a/kbase-extension/static/kbase/js/common/errorDisplay.js
+++ b/kbase-extension/static/kbase/js/common/errorDisplay.js
@@ -1,4 +1,4 @@
-define(['bluebird', 'uuid', 'common/ui', 'common/html'], (Promise, Uuid, UI, html) => {
+define(['bluebird', 'uuid', 'common/html'], (Promise, Uuid, html) => {
     'use strict';
 
     const t = html.tag,
@@ -8,8 +8,9 @@ define(['bluebird', 'uuid', 'common/ui', 'common/html'], (Promise, Uuid, UI, htm
         li = t('li'),
         span = t('span'),
         cssBaseClass = 'kb-error-display',
-        defaultAdvice = 'If the app fails consistently, please contact us at ' +
-        '<a href="https://www.kbase.us/support">https://www.kbase.us/support</a>.';
+        defaultAdvice =
+            'If the app fails consistently, please contact us at ' +
+            '<a href="https://www.kbase.us/support">https://www.kbase.us/support</a>.';
 
     function defaultError() {
         return {
@@ -22,66 +23,87 @@ define(['bluebird', 'uuid', 'common/ui', 'common/html'], (Promise, Uuid, UI, htm
     }
 
     function renderErrorLayout(inputErrorObject) {
-        const errorObject = Object.assign(
-            defaultError(),
-            inputErrorObject
-        );
+        const errorObject = Object.assign(defaultError(), inputErrorObject);
 
         const uniqueID = html.genId();
         const elements = [
-            div({
-                class: `${cssBaseClass}__summary`,
-            },
+            div(
+                {
+                    class: `${cssBaseClass}__summary`,
+                },
                 [
-                    span({
-                        class: `${cssBaseClass}__type`,
-                    }, [errorObject.type]),
+                    span(
+                        {
+                            class: `${cssBaseClass}__type`,
+                        },
+                        [errorObject.type]
+                    ),
                     ': ',
-                    span({
-                        class: `${cssBaseClass}__message`,
-                    }, [errorObject.message]),
+                    span(
+                        {
+                            class: `${cssBaseClass}__message`,
+                        },
+                        [errorObject.message]
+                    ),
                 ]
             ),
 
-            div({
-                class: `${cssBaseClass}__advice`,
-            }, [errorObject.advice]),
+            div(
+                {
+                    class: `${cssBaseClass}__advice`,
+                },
+                [errorObject.advice]
+            ),
 
             errorObject.detail
-            ?   div({
-                class: `${cssBaseClass}__detail_container`,
-            }, [
-                div({
-                    class: `${cssBaseClass}__detail_title`,
-                }, ['Details']),
-                div({
-                    class: `${cssBaseClass}__detail_text`,
-                }, [errorObject.detail]),
-            ])
-            : '',
+                ? div(
+                      {
+                          class: `${cssBaseClass}__detail_container`,
+                      },
+                      [
+                          div(
+                              {
+                                  class: `${cssBaseClass}__detail_title`,
+                              },
+                              ['Details']
+                          ),
+                          div(
+                              {
+                                  class: `${cssBaseClass}__detail_text`,
+                              },
+                              [errorObject.detail]
+                          ),
+                      ]
+                  )
+                : '',
 
             errorObject.stacktrace
-            ?   div({
-                class: `${cssBaseClass}__stacktrace_container`,
-            }, [
-                div({
-                    class: `${cssBaseClass}__stacktrace_title collapsed`,
-                    role: 'button',
-                    dataToggle: "collapse",
-                    dataTarget: '#' + uniqueID,
-                    ariaExpanded: "false",
-                    ariaControls: uniqueID,
-
-                }, [
-                    span({}, ['Error stacktrace']),
-                ]),
-                pre({
-                    class: `${cssBaseClass}__stacktrace_code collapse`,
-                    id: uniqueID,
-                }, [errorObject.stacktrace]),
-            ])
-            : ''
-
+                ? div(
+                      {
+                          class: `${cssBaseClass}__stacktrace_container`,
+                      },
+                      [
+                          div(
+                              {
+                                  class: `${cssBaseClass}__stacktrace_title collapsed`,
+                                  role: 'button',
+                                  dataToggle: 'collapse',
+                                  dataTarget: `#${uniqueID}`,
+                                  ariaExpanded: 'false',
+                                  ariaControls: uniqueID,
+                              },
+                              [span({}, ['Error stacktrace'])]
+                          ),
+                          pre(
+                              {
+                                  class: `${cssBaseClass}__stacktrace_code collapse`,
+                                  id: uniqueID,
+                              },
+                              [errorObject.stacktrace]
+                          ),
+                      ]
+                  )
+                : '',
         ];
         return elements.join('\n');
     }
@@ -93,64 +115,94 @@ define(['bluebird', 'uuid', 'common/ui', 'common/html'], (Promise, Uuid, UI, htm
         return rawError;
     }
 
-    function convertJobError(rawError) {
+    /**
+     * Convert job execution errors for display in the UI. The errors are part of the jobState
+     * object, and can be in several formats; see inline docs for info.
+     *
+     * @param   {object} jobState
+     * @returns {object} normalised error object for the UI
+     */
+    function convertJobError(jobState) {
         const errorObj = {
             location: 'job execution',
+            detail: 'This error occurred dring execution of the app job.',
         };
 
-        if (rawError.error) {
-            // Classic KBase RPC error message
-            errorObj.type = rawError.name;
-            errorObj.message = rawError.message;
-            errorObj.stacktrace = rawError.error;
-            errorObj.detail = null;
-        } else if (rawError.name) {
-            errorObj.type = rawError.name;
-            errorObj.message =  'Error code: ' + String(rawError.code);
-            errorObj.detail = 'This error occurred during execution of the app job.';
-        }
-
-        if (!errorObj.message) {
-            rawError.location = 'job execution';
-            return convertUnknownError(rawError);
+        if (jobState.error) {
+            if (jobState.error.error) {
+                /** KBase RPC error message, in the format
+                 * jobState.error = {
+                 *      name: <error type>,
+                 *      message: <error message>,
+                 *      error: <stacktrace>
+                 * }
+                 */
+                errorObj.type = jobState.error.name;
+                errorObj.message = jobState.error.message;
+                errorObj.stacktrace = jobState.error.error;
+                errorObj.detail = null;
+            } else if (jobState.error.name) {
+                /**
+                 * jobState.error = {
+                 *      name: <error type>,
+                 *      code: <error code>,
+                 * }
+                 */
+                errorObj.type = jobState.error.name;
+                errorObj.message = 'Error code: ' + String(jobState.error.code);
+            }
+            if (!errorObj.message) {
+                jobState.error.location = 'job execution';
+                return convertUnknownError(jobState.error);
+            }
+        } else if (jobState.errormsg) {
+            /**
+             * Error with no separate 'error' object; keys are part of the jobState object:
+             *
+             * jobState.error_code = <error code>
+             * jobState.errormsg = <error message>
+             */
+            errorObj.message = jobState.errormsg;
+            errorObj.type = 'Error code ' + String(jobState.error_code);
         }
 
         return errorObj;
     }
 
     function convertInternalError(rawError) {
-        return Object.assign(
-            defaultError(),
-            {
-                location: 'app cell',
-                type: rawError.title,
-                message: rawError.message,
-                advice: ul(
-                    {   class: `${cssBaseClass}__advice_list`,
-                    },
-                    rawError.advice.map((adv) => {
-                        return li({
+        return Object.assign(defaultError(), {
+            location: 'app cell',
+            type: rawError.title,
+            message: rawError.message,
+            advice: ul(
+                { class: `${cssBaseClass}__advice_list` },
+                rawError.advice.map((adv) => {
+                    return li(
+                        {
                             class: `${cssBaseClass}__advice_list_item`,
                         },
-                            adv
-                        );
-                    })
-                ),
-                detail: rawError.detail,
-            }
-        );
+                        adv
+                    );
+                })
+            ),
+            detail: rawError.detail,
+        });
     }
 
     function factory(config) {
         // unless config is an object with a 'model' attribute,
         // which has functions 'getItem' and 'hasItem',
         // throw an error
-        if (!(config
-            && typeof config === 'object'
-            && Object.prototype.hasOwnProperty.call(config, 'model')
-            && Object.prototype.hasOwnProperty.call(config.model, 'getItem')
-            && Object.prototype.hasOwnProperty.call(config.model, 'hasItem'))) {
-            throw new Error(`Invalid input for the ErrorDisplay module: ${ JSON.stringify(config) }`);
+        if (
+            !(
+                config &&
+                typeof config === 'object' &&
+                Object.prototype.hasOwnProperty.call(config, 'model') &&
+                Object.prototype.hasOwnProperty.call(config.model, 'getItem') &&
+                Object.prototype.hasOwnProperty.call(config.model, 'hasItem')
+            )
+        ) {
+            throw new Error(`Invalid input for the ErrorDisplay module: ${JSON.stringify(config)}`);
         }
 
         const { model } = config;
@@ -162,8 +214,11 @@ define(['bluebird', 'uuid', 'common/ui', 'common/html'], (Promise, Uuid, UI, htm
                 container.classList.add(`${cssBaseClass}__container`);
                 let errorObject;
 
-                if (model.hasItem('exec.jobState.error')) {
-                    errorObject = convertJobError(model.getItem('exec.jobState.error'));
+                if (
+                    model.hasItem('exec.jobState.error') ||
+                    model.hasItem('exec.jobState.errormsg')
+                ) {
+                    errorObject = convertJobError(model.getItem('exec.jobState'));
                 } else if (model.hasItem('internalError')) {
                     errorObject = convertInternalError(model.getItem('internalError'));
                 } else {

--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -198,13 +198,15 @@ define(['common/html', 'common/format', 'common/ui'], (html, format, UI) => {
         // jobState.job_output.result[0].batch_results.
         // Remap to be under jobState.child_jobs
         if (jobState.batch_size && jobState.child_jobs.length === 0) {
-            if (jobState.job_output.result[0].batch_results) {
+            try {
                 jobState.child_jobs = Object.keys(jobState.job_output.result[0].batch_results).map(
                     (item) => {
                         return jobState.job_output.result[0].batch_results[item].final_job_state;
                     }
                 );
             }
+            // eslint-disable-next-line no-empty
+            catch (e) {}
         }
         return jobState;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2052,9 +2052,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001185",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz",
-            "integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
+            "version": "1.0.30001187",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
+            "integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==",
             "dev": true
         },
         "node_modules/chalk": {
@@ -20274,9 +20274,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001185",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz",
-            "integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
+            "version": "1.0.30001187",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz",
+            "integrity": "sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/common/errorDisplay-Spec.js
+++ b/test/unit/spec/common/errorDisplay-Spec.js
@@ -20,10 +20,10 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
             expect(ErrorDisplay).not.toBe(null);
         });
 
-        it('has expected functions', () => {
-            const functions = ['make', 'defaultAdvice', 'cssBaseClass'];
-            functions.forEach((f) => {
-                expect(ErrorDisplay[f]).toBeDefined();
+        it('has expected exports', () => {
+            const exports = ['make', 'defaultAdvice', 'cssBaseClass'];
+            exports.forEach((ex) => {
+                expect(ErrorDisplay[ex]).toBeDefined();
             });
         });
     });
@@ -53,8 +53,10 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
         });
 
         it('has the required methods', () => {
-            expect(errorDisplayInstance.start).toBeDefined();
-            expect(errorDisplayInstance.stop).toBeDefined();
+            ['start', 'stop'].forEach((fn) => {
+                expect(errorDisplayInstance[fn]).toBeDefined();
+                expect(errorDisplayInstance[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('should start and render an error', async () => {
@@ -136,6 +138,27 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
                         advice: defaultAdvice,
                         stacktrace: null,
                     },
+                },
+                {
+                    desc: 'error integrated into jobState object',
+                    in: Props.make({
+                        data: {
+                            exec: {
+                                jobState: {
+                                    status: 'error',
+                                    errormsg: 'A series of unfortunate events',
+                                    error_code: 666,
+                                }
+                            }
+                        }
+                    }),
+                    out: {
+                        type: 'Error code 666',
+                        message: 'A series of unfortunate events',
+                        detail: 'This error occurred during execution of the app job.',
+                        advice: defaultAdvice,
+                        stacktrace: null,
+                    }
                 },
                 {
                     desc: 'unknown job error',


### PR DESCRIPTION
# Description of PR purpose/changes

Building on work previously done in this ticket, I've added code to transform for display another error type that I have seen regularly whilst working on the bulk import cell.

Also included a try/catch around code that converts old-style jobState objects into the newer format to avoid throwing errors if the jobState structure is not as expected.

Updating the `caniuse-lite` package in package-lock.json.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-314
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions -- the new tests do. Globally tests are not passing due to unrelated issues.
- [x] Changes available by spinning up a local narrative and trying to trigger an error where the error message and code are integrated into the `jobState` object. Not as easy as it sounds!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
