### PR TITLE
PTV-1635: improve app and data slideout button and opening behavior

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,1494 +1,1805 @@
 ### OVERVIEW
+
 The Narrative Interface allows users to craft KBase Narratives using a combination of GUI-based commands, Python and R scripts, and graphical output elements.
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
 ### Version NEXT
-- fix bug in data slideout tab selection
+
+-   fix bug in data slideout tab selection (related to PTV-1635)
+-   fix data and app slideout button and opening behavior (related to PTV-1635)
 
 ### Version 4.3.2
-- SCT-2778 - convert data slideout, public tab, refseq data source to use searchapi2/rpc api rather than searchapi2/legacy.
-- Enhanced integration testing support to add service, host, browser, screen size support.
-- Changed the "Dashboard" link in hamburger menu to "Narratives" and use the new /narratives path.
+
+-   SCT-2778 - convert data slideout, public tab, refseq data source to use searchapi2/rpc api rather than searchapi2/legacy.
+-   Enhanced integration testing support to add service, host, browser, screen size support.
+-   Changed the "Dashboard" link in hamburger menu to "Narratives" and use the new /narratives path.
 
 ### Version 4.3.1
-- Fixed problem where code cells could forget their toggled state after saving.
-- Fixed setting up local authentication for developers.
-- DATAUP-69 - added a pull request template to the narrative repo.
-- DATAUP-120 - improve testing documentation
-- DATAUP-164, DATAUP-165 - add automatic linting configuration with flake8 and black for the Python layer.
-- DATAUP-176 - refactored the startup process to be more robust with respect to kernel activity.
-- DATAUP-178 - changed "Add Data" and "+" icon color in the data panel.
-- DATAUP-187 - repositioned Globus link in the staging area.
-- DATAUP-188, DATAUP-228 - adds text and refresh button to the staging area, and stabilized the trash can icon.
-- DATAUP-197 - fixed problem where canceling an app cell could cause it to freeze.
-- DATAUP-204 - made folder names clickable in the staging area.
-- DATAUP-210 - adds a "file too large" error to the staging area when a file is too large to upload.
-- DATAUP-213 - added a "clear all" button that removes all staging area errors.
-- DATAUP-246 - dramatic cleanup and refactor done globally throughout the Narrative stylesheets.
-- DATAUP-266 - fixed a problem where the staging area didn't automatically refresh when a file finishes uploading.
-- DATAUP-301 - fixed a problem where the staging area rendered twice in a row on page load.
+
+-   Fixed problem where code cells could forget their toggled state after saving.
+-   Fixed setting up local authentication for developers.
+-   DATAUP-69 - added a pull request template to the narrative repo.
+-   DATAUP-120 - improve testing documentation
+-   DATAUP-164, DATAUP-165 - add automatic linting configuration with flake8 and black for the Python layer.
+-   DATAUP-176 - refactored the startup process to be more robust with respect to kernel activity.
+-   DATAUP-178 - changed "Add Data" and "+" icon color in the data panel.
+-   DATAUP-187 - repositioned Globus link in the staging area.
+-   DATAUP-188, DATAUP-228 - adds text and refresh button to the staging area, and stabilized the trash can icon.
+-   DATAUP-197 - fixed problem where canceling an app cell could cause it to freeze.
+-   DATAUP-204 - made folder names clickable in the staging area.
+-   DATAUP-210 - adds a "file too large" error to the staging area when a file is too large to upload.
+-   DATAUP-213 - added a "clear all" button that removes all staging area errors.
+-   DATAUP-246 - dramatic cleanup and refactor done globally throughout the Narrative stylesheets.
+-   DATAUP-266 - fixed a problem where the staging area didn't automatically refresh when a file finishes uploading.
+-   DATAUP-301 - fixed a problem where the staging area rendered twice in a row on page load.
 
 ### Version 4.3.0
-- SCT-2664 - Show the app cell status when in a collapsed state.
-- Added an "Info" tab to all app cells with app information.
-- Updated links to new KBase home page and docs site.
-- Fixed an uploader issue where uploads taking longer than 30 seconds would fail.
+
+-   SCT-2664 - Show the app cell status when in a collapsed state.
+-   Added an "Info" tab to all app cells with app information.
+-   Updated links to new KBase home page and docs site.
+-   Fixed an uploader issue where uploads taking longer than 30 seconds would fail.
 
 ### Version 4.2.1
-- Address problems with SampleSet / AMA Viewer widget.
-- SCT-1822 - fix problems with drag and drop data upload failing for more than 100 files (updated the Dropzone widget to version 5.7.0)
-- Updated Globus endpoint to point to the newer Globusconnect server.
-- Updated tons of dependencies. Thanks Jason Fillman!
+
+-   Address problems with SampleSet / AMA Viewer widget.
+-   SCT-1822 - fix problems with drag and drop data upload failing for more than 100 files (updated the Dropzone widget to version 5.7.0)
+-   Updated Globus endpoint to point to the newer Globusconnect server.
+-   Updated tons of dependencies. Thanks Jason Fillman!
 
 ### Version 4.2.0
-- Updated the Narrative interface to connect to the remade Execution Engine.
-- Updated the Narrative interface to streamline events and cookies connected to the Traefik update.
-- Fixed an issue where job log browser state (running, stopped, scrolling) could cross browser sessions.
-- Added a viewer for the SampleSet object.
-- PTV-1446 - fix bug preventing KBaseFeatureValues viewer apps from working and displaying data
+
+-   Updated the Narrative interface to connect to the remade Execution Engine.
+-   Updated the Narrative interface to streamline events and cookies connected to the Traefik update.
+-   Fixed an issue where job log browser state (running, stopped, scrolling) could cross browser sessions.
+-   Added a viewer for the SampleSet object.
+-   PTV-1446 - fix bug preventing KBaseFeatureValues viewer apps from working and displaying data
 
 ### Version 4.1.2
-- Improve display of job logs.
-- Prevent App cell elements from overflowing the page.
-- Job status is now inaccessible before a job enters the queue.
+
+-   Improve display of job logs.
+-   Prevent App cell elements from overflowing the page.
+-   Job status is now inaccessible before a job enters the queue.
 
 ### Version 4.1.1
-- Fix sort order in Narratives panel - should be by most recently saved.
-- Add better error support in data staging uploader - if an upload directory is not available, you should be able to return to the root directory without trouble.
+
+-   Fix sort order in Narratives panel - should be by most recently saved.
+-   Add better error support in data staging uploader - if an upload directory is not available, you should be able to return to the root directory without trouble.
 
 ### Version 4.1.0
-- Introduce Static Narratives, available under the Share menu. First release!
+
+-   Introduce Static Narratives, available under the Share menu. First release!
 
 ### Version 4.0.0
-- Update various software packages
-    - Python to 3.6.9
-    - Jupyter Notebook to 6.0.2
-    - IPython to 7.9.0
+
+-   Update various software packages
+    -   Python to 3.6.9
+    -   Jupyter Notebook to 6.0.2
+    -   IPython to 7.9.0
 
 ### Version 3.11.4
-- Add Annotated Metagenome Assembly viewer widget
-- PTV-1214 - Fix Binned Contig Viewer labels
-- PTV-1341 - Fix column and row labeling in GenomeComparison viewer
-- Improve functionality and options for dynamic dropdowns in apps.
+
+-   Add Annotated Metagenome Assembly viewer widget
+-   PTV-1214 - Fix Binned Contig Viewer labels
+-   PTV-1341 - Fix column and row labeling in GenomeComparison viewer
+-   Improve functionality and options for dynamic dropdowns in apps.
 
 ### Version 3.11.3
-- PTV-1308 - Fix problem where users with a Globus account that's not linked to KBase will see an error when trying to access the Globus interface through the upload area.
-- Add GFF Metagenome object upload type.
+
+-   PTV-1308 - Fix problem where users with a Globus account that's not linked to KBase will see an error when trying to access the Globus interface through the upload area.
+-   Add GFF Metagenome object upload type.
 
 ### Version 3.11.2
-- Improve load times for the Data Panel and the browser in the data slideout (the "My Data" and "Shared with Me" tabs).
-- Set the Narratives tab to lazy load.
-- #1487 - fixed typo in genome feature viewer.
-- Updated data import tutorial for some clarity.
-- Changed Pangenome viewer field names for clarity and consistency.
+
+-   Improve load times for the Data Panel and the browser in the data slideout (the "My Data" and "Shared with Me" tabs).
+-   Set the Narratives tab to lazy load.
+-   #1487 - fixed typo in genome feature viewer.
+-   Updated data import tutorial for some clarity.
+-   Changed Pangenome viewer field names for clarity and consistency.
 
 ### Version 3.11.1
-- Add internal information for users who came to the site from a Google ad click.
-- Improve load time of the App Panel.
-- Fix a bug where jobs canceled in the non-Narrative job browser would cause issues with the corresponding App Cell.
+
+-   Add internal information for users who came to the site from a Google ad click.
+-   Improve load time of the App Panel.
+-   Fix a bug where jobs canceled in the non-Narrative job browser would cause issues with the corresponding App Cell.
 
 ### Version 3.11.0
-- Add an option to share a Narrative with an organization as well as people.
-- SCT-1783 - Reduce the number of network calls to the auth service on startup.
-- SCT-1785 - Reduce the number of network calls to the Catalog/NMS services on startup.
-- SCT-1793 - Lazy-load reports (i.e. if they're not in the brower viewport, don't load them).
-- Fix an issue with nested subdata inputs into apps not being accessible as expected.
-- Removed a bunch of dead code, including the older "service" modules, that haven't been in use for a few years.
+
+-   Add an option to share a Narrative with an organization as well as people.
+-   SCT-1783 - Reduce the number of network calls to the auth service on startup.
+-   SCT-1785 - Reduce the number of network calls to the Catalog/NMS services on startup.
+-   SCT-1793 - Lazy-load reports (i.e. if they're not in the brower viewport, don't load them).
+-   Fix an issue with nested subdata inputs into apps not being accessible as expected.
+-   Removed a bunch of dead code, including the older "service" modules, that haven't been in use for a few years.
 
 ### Version 3.10.1
-- Fixed a critical bug where users with write access to a Narrative (but not share access) were unable to save changes to a Narrative or run Apps.
+
+-   Fixed a critical bug where users with write access to a Narrative (but not share access) were unable to save changes to a Narrative or run Apps.
 
 ### Version 3.10.0
-- Fix tooltip for long object names in the data panel.
-- Add ability to prefix a part of path_to_subdata with WSREF to list options from other objects.
-- SCT-1602 - Add new URL options - /narrative/12345 will find the narrative in workspace 12345 (older URLs like /narrative/ws.12345.obj.1 still work).
-- Fix problem where jobs were not being properly started with an agent token (i.e. weren't guaranteed to have a week-long authentication token).
-- Improved error handling and display when a Narrative doesn't exist or a user doesn't have permission to see it.
-- Add functionality to request access to a Narrative instead of throwing a "not allowed" error.
+
+-   Fix tooltip for long object names in the data panel.
+-   Add ability to prefix a part of path_to_subdata with WSREF to list options from other objects.
+-   SCT-1602 - Add new URL options - /narrative/12345 will find the narrative in workspace 12345 (older URLs like /narrative/ws.12345.obj.1 still work).
+-   Fix problem where jobs were not being properly started with an agent token (i.e. weren't guaranteed to have a week-long authentication token).
+-   Improved error handling and display when a Narrative doesn't exist or a user doesn't have permission to see it.
+-   Add functionality to request access to a Narrative instead of throwing a "not allowed" error.
 
 ### Version 3.9.1
-- SCT-1509 - Ensure access permissions to Globus before redirecting a user there from the Import area.
+
+-   SCT-1509 - Ensure access permissions to Globus before redirecting a user there from the Import area.
 
 ### Version 3.9.0
-- Fix security vulnerability with rendering some user info.
-- SCT-1547 - Add a download endpoint to the staging service, so a user can now download files directly from the FTP stagin area.
-- SCT-1496 - Add functionality for downloading data from the data panel to the FTP Staging area.
-- SCT-1526 - Create a code cell generator as an app output.
+
+-   Fix security vulnerability with rendering some user info.
+-   SCT-1547 - Add a download endpoint to the staging service, so a user can now download files directly from the FTP stagin area.
+-   SCT-1496 - Add functionality for downloading data from the data panel to the FTP Staging area.
+-   SCT-1526 - Create a code cell generator as an app output.
 
 ### Version 3.8.3
-- SCT-1253 - Replace old RNA-Seq data viewers.
-- SCT-1393 - Fix "Objects Created" links in app outputs.
-- SCT-1370 - Give instructions to users on how to link their account to Globus for uploading data.
-- SCT-1395 - Convert object ref and ids to common names for downloading.
-- Add viewers and support for generic data types.
-- Fix RNA-Seq data viewers, including Feature Clusters.
+
+-   SCT-1253 - Replace old RNA-Seq data viewers.
+-   SCT-1393 - Fix "Objects Created" links in app outputs.
+-   SCT-1370 - Give instructions to users on how to link their account to Globus for uploading data.
+-   SCT-1395 - Convert object ref and ids to common names for downloading.
+-   Add viewers and support for generic data types.
+-   Fix RNA-Seq data viewers, including Feature Clusters.
 
 ### Version 3.8.2
-- Add the clustergrammer_widget
-- SCT-1219 - Fix the app cell so it shows an error if an app has multiple outputs, and they're given the same name.
-- Add numpy, scipy, scikit-learn to the base Docker image
+
+-   Add the clustergrammer_widget
+-   SCT-1219 - Fix the app cell so it shows an error if an app has multiple outputs, and they're given the same name.
+-   Add numpy, scipy, scikit-learn to the base Docker image
 
 ### Version 3.8.1
-- SCT-1261 - Changed the 'outdated app' warning to a small icon with a popover text.
-- SCT-886 - Added a default viewer for typed objects that don't have an actual viewer associated with them.
-- Added a test-mode viewer for a new matrix type.
-- SCT-1253 - fixed bugs in how assembly and reads typed objects get viewed - their numbers of reads weren't being presented properly.
-- SCT-1210 - Module-level (not just type) spec files are available for determining object viewers.
-- SCT-1234 - Introduces the clustergrammer Jupyter Notebook widget.
-- SCT-1206 - fixes a cell error that can occur if an app doesn't produce any output objects (including reports).
-- Introduces a new build and deployment strategy.
-- Updates the versions of numpy and pandas so they should work again.
+
+-   SCT-1261 - Changed the 'outdated app' warning to a small icon with a popover text.
+-   SCT-886 - Added a default viewer for typed objects that don't have an actual viewer associated with them.
+-   Added a test-mode viewer for a new matrix type.
+-   SCT-1253 - fixed bugs in how assembly and reads typed objects get viewed - their numbers of reads weren't being presented properly.
+-   SCT-1210 - Module-level (not just type) spec files are available for determining object viewers.
+-   SCT-1234 - Introduces the clustergrammer Jupyter Notebook widget.
+-   SCT-1206 - fixes a cell error that can occur if an app doesn't produce any output objects (including reports).
+-   Introduces a new build and deployment strategy.
+-   Updates the versions of numpy and pandas so they should work again.
 
 ### Version 3.8.0
-- Generalized updates to support viewing the new version of the genome data type.
-- SCT-500 - Fix DomainAnnotation viewer widget.
-- SCT-380 - Updates to the RNA-Seq Volcano plot viewer.
-- KBASE-1916 - Fix data type descriptions in the Example tab of the data slideout.
-- SCT-923 - Improve Mycocosm public data search.
-- SCT-930 - Add a "show report" button to objects in the data panel.
-- Reformat and generalize the job logs for both the App Cell and standalone job log viewer widget.
-- Migrate unit tests to use HeadlessChrome and (optionally) Firefox.
-- Refactor Public Data in the Data Slideout to make use of the new KBase Search API.
-- Display a warning if a typed object has no viewer associated with it.
-- SCT-901 - enhance expression matrix viewer.
-- Add ConditionSet viewer.
-- SCT-1082 - fix regressions in Public Data tab.
-- Fix regression in feature set viewer caused by SCT-762.
+
+-   Generalized updates to support viewing the new version of the genome data type.
+-   SCT-500 - Fix DomainAnnotation viewer widget.
+-   SCT-380 - Updates to the RNA-Seq Volcano plot viewer.
+-   KBASE-1916 - Fix data type descriptions in the Example tab of the data slideout.
+-   SCT-923 - Improve Mycocosm public data search.
+-   SCT-930 - Add a "show report" button to objects in the data panel.
+-   Reformat and generalize the job logs for both the App Cell and standalone job log viewer widget.
+-   Migrate unit tests to use HeadlessChrome and (optionally) Firefox.
+-   Refactor Public Data in the Data Slideout to make use of the new KBase Search API.
+-   Display a warning if a typed object has no viewer associated with it.
+-   SCT-901 - enhance expression matrix viewer.
+-   Add ConditionSet viewer.
+-   SCT-1082 - fix regressions in Public Data tab.
+-   Fix regression in feature set viewer caused by SCT-762.
 
 ### Version 3.7.2
-- SCT-908 - Fix formatting issues with heatmaps.
-- SCT-875 - Accept poorly formatted input data into the RNA-Seq data heatmap viewers.
-- SCT-878 - Deal with very large heatmaps so that they get downloaded instead of displayed inline, otherwise allow it to grow to some proper size and embed it in a scroll panel.
-- SCT-875 - Fix labels on heatmaps under certain data conditions.
-- SCT-809 - Fix configuration view mode when there are deeply nested parameters, especially lists of grouped parameters containing a subdata param.
-- SCT-866 - Improve side panel behavior in view-only mode; stretch data panel to full height.
-- SCT-821 - Add "info" item to view cell menu, also some other cleanup for viewer cells.
-- SCT-762 - Convert the Feature set viewer to use a dynamic service to fetch feature data.
-- SCT-657 - Narrative Public Data search now uses new Search API to find KBase data.
-    - Due to the nature of the Search API, this also changes the interface to require the user to press "enter" to do a search, instead of as-you-type.
-    - Changes the layout of the retrieved items from searching.
-- SCT-804 - General updates to fix a compilation problem with FeatureValues data widgets.
-- SCT-698 - Redo the narrative build so that it uses Conda for installs of R, Python and Jupyter. This updates
+
+-   SCT-908 - Fix formatting issues with heatmaps.
+-   SCT-875 - Accept poorly formatted input data into the RNA-Seq data heatmap viewers.
+-   SCT-878 - Deal with very large heatmaps so that they get downloaded instead of displayed inline, otherwise allow it to grow to some proper size and embed it in a scroll panel.
+-   SCT-875 - Fix labels on heatmaps under certain data conditions.
+-   SCT-809 - Fix configuration view mode when there are deeply nested parameters, especially lists of grouped parameters containing a subdata param.
+-   SCT-866 - Improve side panel behavior in view-only mode; stretch data panel to full height.
+-   SCT-821 - Add "info" item to view cell menu, also some other cleanup for viewer cells.
+-   SCT-762 - Convert the Feature set viewer to use a dynamic service to fetch feature data.
+-   SCT-657 - Narrative Public Data search now uses new Search API to find KBase data.
+    -   Due to the nature of the Search API, this also changes the interface to require the user to press "enter" to do a search, instead of as-you-type.
+    -   Changes the layout of the retrieved items from searching.
+-   SCT-804 - General updates to fix a compilation problem with FeatureValues data widgets.
+-   SCT-698 - Redo the narrative build so that it uses Conda for installs of R, Python and Jupyter. This updates
     the versions to current levels, fixing numpy and pandas incompatibilities
+
 ### Version 3.7.1
-- SCT-793, SCT-496 - Fix version of upstream dependency "file-saver" to 1.3.4; an upstream update had broken and taken down the Pangenome viewer and others.
-- SCT-104 Convert the narrative container to new CI/CD model based on dockerize+environment variables for startup config
+
+-   SCT-793, SCT-496 - Fix version of upstream dependency "file-saver" to 1.3.4; an upstream update had broken and taken down the Pangenome viewer and others.
+-   SCT-104 Convert the narrative container to new CI/CD model based on dockerize+environment variables for startup config
 
 ### Version 3.7.0
-- Update Jupyter Notebook to 5.4.1 with a few KBase adjustments
-    - Prevent Jupyter favicon from overriding ours at various points.
-    - Use local version of Font Awesome.
-    - Use local version of Glyphicons font pack (for Datatables-based widgets).
-    - Use Bootstrap version 3.3.7
-- Update ipywidgets to 7.2.1
-- SCT-559 - Fix ugly race condition that could prevent app cells from being properly rendered when loading an existing Narrative.
-- Re-enable security measure that prevents Markdown cells from rendering JavaScript. We're about a year past the point when that was necessary.
-- SCT-628 - adds a viewer for the CompoundSet object.
-- Bump Tornado dependency to 5.0.0
-- SCT-637 - adds a warning to the loading section if there's an extreme delay (20 seconds) in between loading individual steps.
-- SCT-690 - truncate long Narrative names, show the whole thing on mouseover.
-- SCT-590 - add cache busting to the public data mapping lookup. No more force-refreshing!
-- SCT-706 - fix problem where space characters were sometimes ignored in the app panel search.
-- Remove old Import tab, remove (New) tag and warning from new Import tab.
+
+-   Update Jupyter Notebook to 5.4.1 with a few KBase adjustments
+    -   Prevent Jupyter favicon from overriding ours at various points.
+    -   Use local version of Font Awesome.
+    -   Use local version of Glyphicons font pack (for Datatables-based widgets).
+    -   Use Bootstrap version 3.3.7
+-   Update ipywidgets to 7.2.1
+-   SCT-559 - Fix ugly race condition that could prevent app cells from being properly rendered when loading an existing Narrative.
+-   Re-enable security measure that prevents Markdown cells from rendering JavaScript. We're about a year past the point when that was necessary.
+-   SCT-628 - adds a viewer for the CompoundSet object.
+-   Bump Tornado dependency to 5.0.0
+-   SCT-637 - adds a warning to the loading section if there's an extreme delay (20 seconds) in between loading individual steps.
+-   SCT-690 - truncate long Narrative names, show the whole thing on mouseover.
+-   SCT-590 - add cache busting to the public data mapping lookup. No more force-refreshing!
+-   SCT-706 - fix problem where space characters were sometimes ignored in the app panel search.
+-   Remove old Import tab, remove (New) tag and warning from new Import tab.
 
 ### Version 3.6.3
-- SCT-585 add folder drag and drop upload to the Import area.
-- Remove old link to Search from the Narrative hamburger menu.
-- Relabel public data referencing fungal genomes.
+
+-   SCT-585 add folder drag and drop upload to the Import area.
+-   Remove old link to Search from the Narrative hamburger menu.
+-   Relabel public data referencing fungal genomes.
 
 ### Version 3.6.2
-- Fix problem preventing read-only Narratives from loading.
-- SCT-581 fix failure when reloading tabs in the data staging panel.
-- SCT-582 reconcile labels and order of App Panel with Catalog.
+
+-   Fix problem preventing read-only Narratives from loading.
+-   SCT-581 fix failure when reloading tabs in the data staging panel.
+-   SCT-582 reconcile labels and order of App Panel with Catalog.
 
 ### Version 3.6.1
-- SCT-533 - Remove the accidental test uploader that crept into production.
-- SCT-516 - Set staging panel to auto-refresh after various updates.
-- SCT-531 - Updated App Panel to have the same category names as the external App Catalog.
-- Added fungal genomes as a Public Data option.
-- Added Phytozome plant genomes as a Public Data option.
-- Repaired somewhat broken Doman Annotation viewer.
-- Text fixes to Import Tab tour.
+
+-   SCT-533 - Remove the accidental test uploader that crept into production.
+-   SCT-516 - Set staging panel to auto-refresh after various updates.
+-   SCT-531 - Updated App Panel to have the same category names as the external App Catalog.
+-   Added fungal genomes as a Public Data option.
+-   Added Phytozome plant genomes as a Public Data option.
+-   Repaired somewhat broken Doman Annotation viewer.
+-   Text fixes to Import Tab tour.
 
 ### Version 3.6.0
-- SCT-400 - Deprecates the old Import panel, change text from "Staging (beta)" -> "Import (new)"
-- SCT-417
-  - All older Import functionality should now be available in the new Import panel.
-  - Adds a link to create an app for uploading from a public URL into the staging area.
-  - Cleans up unclear text in the new Import panel.
-  - Adds new (hopefully informative) steps to the Import panel tour.
-  - Move the 'decompress file' button so it should always be visible for archives.
-- PTV-225 - Add more icon clarity to the data sorting options.
-- PTV-886 - Restore missing scrollbar in the Narratives panel.
-- KBASE-5410 - Improve job log viewer, add different.
-- SCT-291 - Initial addition of tools for programmatically accessing the FTP file staging area.
-- SCT-405 - Custom compounds will now display properly in the media viewer.
-- KBASE-5417 - Fix long strings not wrapping correctly when showing object metadata in the Data panel.
+
+-   SCT-400 - Deprecates the old Import panel, change text from "Staging (beta)" -> "Import (new)"
+-   SCT-417
+    -   All older Import functionality should now be available in the new Import panel.
+    -   Adds a link to create an app for uploading from a public URL into the staging area.
+    -   Cleans up unclear text in the new Import panel.
+    -   Adds new (hopefully informative) steps to the Import panel tour.
+    -   Move the 'decompress file' button so it should always be visible for archives.
+-   PTV-225 - Add more icon clarity to the data sorting options.
+-   PTV-886 - Restore missing scrollbar in the Narratives panel.
+-   KBASE-5410 - Improve job log viewer, add different.
+-   SCT-291 - Initial addition of tools for programmatically accessing the FTP file staging area.
+-   SCT-405 - Custom compounds will now display properly in the media viewer.
+-   KBASE-5417 - Fix long strings not wrapping correctly when showing object metadata in the Data panel.
 
 ### Version 3.5.2
-- PTV-682 - Fix problem with rendering a Pangenome widget in a copied Narrative.
-- KBASE-5405 (in progress) - new version of app log viewer.
-- PTV-225 - Fix and clarify data sorting by name, type, and date.
-- PTV-833 - Restore missing genome icons to the data panel.
-- KBASE-5410 - Put the user id onto the link to Globus in the staging upload area.
-- Adds new functionality to the data staging area, including showing file metadata and whether a file has been uploaded before.
+
+-   PTV-682 - Fix problem with rendering a Pangenome widget in a copied Narrative.
+-   KBASE-5405 (in progress) - new version of app log viewer.
+-   PTV-225 - Fix and clarify data sorting by name, type, and date.
+-   PTV-833 - Restore missing genome icons to the data panel.
+-   KBASE-5410 - Put the user id onto the link to Globus in the staging upload area.
+-   Adds new functionality to the data staging area, including showing file metadata and whether a file has been uploaded before.
 
 ### Version 3.5.1
-- TASK-1113/PUBLIC-148 - Import Panel scrolls if panel size is larger than screen size
-- TASK-1114 - Add lock when editing name, that prevents data panel from refreshing with new data. Relinquishes lock after 15 min if no activity.
-- TASK-1116 - Add PhenotypeSet importer to staging area
-- TASK-1117 - Add importer for FBAModels to staging area
-- TASK-1088 - Data Pane maintains filters after refresh due to changes in narrative
-- TASK-1089 - Import data slide out panel tracks what object is added to narrative. "Add" button turns into "copy" if object already exists. Add pop up when user copies and overrides existing object.
-- TASK-1094 - Fix overlapping cells and buttons issue in Firefox
-- Style Fixes
-    - Fix bold font display inconsistencies between different browsers
-    - Move tooltip in data panel from covering buttons to the top
-- KBASE-4756 - Fix data type filtering in data panel slideout.
-- PTV-225 - Fixes sorting by type in data panel
-- PTV-535 - Fix RNA-seq viewer to properly handle multiple input types.
-- PUBLIC-123 - Fix incorrect reaction counts in FBA Model viewer
-- TASK-1158 - Standardize app and object cards in narrative and data panel
+
+-   TASK-1113/PUBLIC-148 - Import Panel scrolls if panel size is larger than screen size
+-   TASK-1114 - Add lock when editing name, that prevents data panel from refreshing with new data. Relinquishes lock after 15 min if no activity.
+-   TASK-1116 - Add PhenotypeSet importer to staging area
+-   TASK-1117 - Add importer for FBAModels to staging area
+-   TASK-1088 - Data Pane maintains filters after refresh due to changes in narrative
+-   TASK-1089 - Import data slide out panel tracks what object is added to narrative. "Add" button turns into "copy" if object already exists. Add pop up when user copies and overrides existing object.
+-   TASK-1094 - Fix overlapping cells and buttons issue in Firefox
+-   Style Fixes
+    -   Fix bold font display inconsistencies between different browsers
+    -   Move tooltip in data panel from covering buttons to the top
+-   KBASE-4756 - Fix data type filtering in data panel slideout.
+-   PTV-225 - Fixes sorting by type in data panel
+-   PTV-535 - Fix RNA-seq viewer to properly handle multiple input types.
+-   PUBLIC-123 - Fix incorrect reaction counts in FBA Model viewer
+-   TASK-1158 - Standardize app and object cards in narrative and data panel
 
 ### Version 3.5.0
-- TASK-1054 - Create a new loading window with a set of tasks to load and connect to (treats the problem of slowly loading websockets, still probably needs some adjusting).
-- TASK-588 - Change status of importers from "suspend" to "error" if the import job fails.
-- KBASE-3778/TASK-1017 - hide "next steps" area of app results tab if there are no next steps available.
-- KBASE-1041 - fix error that shows a version number instead of username for who saved the most recent narrative.
-- TASK-1069 - fix problems with searching and filtering the App panel
-    - Searching by output object type works again.
-    - Added "input:" and "output:" as filters for input object types and output object types (same as "in_type:" and "out_type:", respectively)
-    - Made type search more stringent.
-        - If no "." separator is present, will only match by the type name. E.g. "in_type:Genome" will not match "GenomeSet" or "PanGenome" or "KBaseGenomes.ContigSet", just "ANYMODULE.Genome"
-        - If a "." is present, will only match a full type name, like "KBaseGenomes.Genome"
-    - Non-type search will also search i/o fields now and do fuzzy matching. E.g. "Genome" will match "Annotate Domains in a GenomeSet" (by the name), and "Assemble Reads with MEGAHIT" (by the output object KBaseGenomeAnnotations.Assembly)
-- TASK-1079 - fix problems with code cell rendering and controls.
-- KBASE-5275 - fix title for code cells used to track import jobs.
 
+-   TASK-1054 - Create a new loading window with a set of tasks to load and connect to (treats the problem of slowly loading websockets, still probably needs some adjusting).
+-   TASK-588 - Change status of importers from "suspend" to "error" if the import job fails.
+-   KBASE-3778/TASK-1017 - hide "next steps" area of app results tab if there are no next steps available.
+-   KBASE-1041 - fix error that shows a version number instead of username for who saved the most recent narrative.
+-   TASK-1069 - fix problems with searching and filtering the App panel
+    -   Searching by output object type works again.
+    -   Added "input:" and "output:" as filters for input object types and output object types (same as "in_type:" and "out_type:", respectively)
+    -   Made type search more stringent.
+        -   If no "." separator is present, will only match by the type name. E.g. "in_type:Genome" will not match "GenomeSet" or "PanGenome" or "KBaseGenomes.ContigSet", just "ANYMODULE.Genome"
+        -   If a "." is present, will only match a full type name, like "KBaseGenomes.Genome"
+    -   Non-type search will also search i/o fields now and do fuzzy matching. E.g. "Genome" will match "Annotate Domains in a GenomeSet" (by the name), and "Assemble Reads with MEGAHIT" (by the output object KBaseGenomeAnnotations.Assembly)
+-   TASK-1079 - fix problems with code cell rendering and controls.
+-   KBASE-5275 - fix title for code cells used to track import jobs.
 
 ### Version 3.4.4
-- TASK-932 - fix problem where authentication tokens appear to get lost when a Narrative has been asleep for a while.
-- TASK-956 - fix error handling for the PanGenome viewer (and for other viewers that use the dynamicTable widget).
-- TASK-938 - fix problems and usability in read only mode
-    - Can now double-click on a cell title area to collapse/expand it
-    - Collapse/expand button is now in the top-right of a cell.
-    - Read-only narratives cannot have app inputs modified.
-    - In read-only mode, no data view cells can be added.
-    - In read-only mode, code cells are not editable.
-    - In read-only mode, narrative titles can no longer be edited.
-    - Removed the "config" cog button in the top menu.
-    - Double-clicking markdown content switches to edit mode.
-    - App cells should no longer flash their code area before converting to the widget view on narrative startup.
-- TASK-1041 - when a Narrative is open in multiple locations (whether windows in the same browser with the same user, or different computers all together with different users), and is saved in one location, the other location should now get a notification that it is out of date.
-- PTV-295/TASK-1035 - Fix subdata controls in the App cell's object input area.
-- TASK-816 - Fix problems with a differential expression viewer.
-- TASK-933 - Fixes problems with the volcano plot viewer for expression data.
-- Adds a generic data viewer for all Set data.
-- TASK-1036 - Address problems with FBA Modeling object viewers (FBAModel, Media, etc.)
 
+-   TASK-932 - fix problem where authentication tokens appear to get lost when a Narrative has been asleep for a while.
+-   TASK-956 - fix error handling for the PanGenome viewer (and for other viewers that use the dynamicTable widget).
+-   TASK-938 - fix problems and usability in read only mode
+    -   Can now double-click on a cell title area to collapse/expand it
+    -   Collapse/expand button is now in the top-right of a cell.
+    -   Read-only narratives cannot have app inputs modified.
+    -   In read-only mode, no data view cells can be added.
+    -   In read-only mode, code cells are not editable.
+    -   In read-only mode, narrative titles can no longer be edited.
+    -   Removed the "config" cog button in the top menu.
+    -   Double-clicking markdown content switches to edit mode.
+    -   App cells should no longer flash their code area before converting to the widget view on narrative startup.
+-   TASK-1041 - when a Narrative is open in multiple locations (whether windows in the same browser with the same user, or different computers all together with different users), and is saved in one location, the other location should now get a notification that it is out of date.
+-   PTV-295/TASK-1035 - Fix subdata controls in the App cell's object input area.
+-   TASK-816 - Fix problems with a differential expression viewer.
+-   TASK-933 - Fixes problems with the volcano plot viewer for expression data.
+-   Adds a generic data viewer for all Set data.
+-   TASK-1036 - Address problems with FBA Modeling object viewers (FBAModel, Media, etc.)
 
 ### Version 3.4.3
-- TASK-877 - fix issue where mismatched App names between different versions caused the App Cell to fail to render.
-- Update Expression Sample widget to better handle failures and only show a single widget tab.
-- TASK-816 - update Volcano Plot viewer to improve functionality and performance with different data types.
-- TASK-141 - update available types for sorting in Data Panel slideout.
-- TASK-922 - fix visual problem where red bars indicating a required app input were not visible in certain browsers.
-- Fixed favorites star in App Panel.
-- TASK-959 - sharing panel wasn't updating properly when sharing privileges were changed in a different window
-- TASK-960 - fix problem where a user with sharing privileges who didn't own the Narrative could try and fail to remove privileges from the owner of that Narrative.
+
+-   TASK-877 - fix issue where mismatched App names between different versions caused the App Cell to fail to render.
+-   Update Expression Sample widget to better handle failures and only show a single widget tab.
+-   TASK-816 - update Volcano Plot viewer to improve functionality and performance with different data types.
+-   TASK-141 - update available types for sorting in Data Panel slideout.
+-   TASK-922 - fix visual problem where red bars indicating a required app input were not visible in certain browsers.
+-   Fixed favorites star in App Panel.
+-   TASK-959 - sharing panel wasn't updating properly when sharing privileges were changed in a different window
+-   TASK-960 - fix problem where a user with sharing privileges who didn't own the Narrative could try and fail to remove privileges from the owner of that Narrative.
 
 ### Version 3.4.2
-- Update base Narrative image to include an Ubuntu kernel security update.
-- Add ETE3 to the environment.
-- PTV-409 - fix problem where copying a Narrative using the "Narratives" panel would only make a copy of the currently viewed Narrative.
+
+-   Update base Narrative image to include an Ubuntu kernel security update.
+-   Add ETE3 to the environment.
+-   PTV-409 - fix problem where copying a Narrative using the "Narratives" panel would only make a copy of the currently viewed Narrative.
 
 ### Version 3.4.1
-- Fixed job status widget spamming the kernel with constant update requests.
-- Fixed job status widget not starting its logs as expected.
-- Hide the "outdated job" warning in view only mode so tutorials don't look goofy.
+
+-   Fixed job status widget spamming the kernel with constant update requests.
+-   Fixed job status widget not starting its logs as expected.
+-   Hide the "outdated job" warning in view only mode so tutorials don't look goofy.
 
 ### Version 3.4.0
-__Changes__
-- Modified the Sharing dialog to make the actions more clear.
-- Modified the configuration for publicly available data sources.
-- Made global changes to support the new KBase authentication/authorization system.
-- KBASE-5243 - fix problem where Narratives (and probably data objects) were showing a change date one month into the future.
+
+**Changes**
+
+-   Modified the Sharing dialog to make the actions more clear.
+-   Modified the configuration for publicly available data sources.
+-   Made global changes to support the new KBase authentication/authorization system.
+-   KBASE-5243 - fix problem where Narratives (and probably data objects) were showing a change date one month into the future.
 
 ### Version 3.3.0
-__Changes__
-- Modified how to select an App from the App Panel, now you can sort and group by category, inputs, outputs, and alphabetically.
-- Update a widget for viewing Pan-Genomes, and the underlying table to show data.
-- Fix a bug that added unnecessary data to logs.
-- Fixed several installation problems and technical dependency issues.
-- Updated front end tests.
+
+**Changes**
+
+-   Modified how to select an App from the App Panel, now you can sort and group by category, inputs, outputs, and alphabetically.
+-   Update a widget for viewing Pan-Genomes, and the underlying table to show data.
+-   Fix a bug that added unnecessary data to logs.
+-   Fixed several installation problems and technical dependency issues.
+-   Updated front end tests.
 
 ### Version 3.2.5
-__Changes__
-- Fix problems preventing job logs from being scrolled in apps that are in an error state.
-- Update widgets for viewing Binned Contigs, and the underlying table.
-- Add tests for the above.
+
+**Changes**
+
+-   Fix problems preventing job logs from being scrolled in apps that are in an error state.
+-   Update widgets for viewing Binned Contigs, and the underlying table.
+-   Add tests for the above.
 
 ### Version 3.2.4
-__Changes__
-- Added a viewer widget for Binned Contig objects.
-- Updated the Assembly viewer to improve performance for large Assemblies.
+
+**Changes**
+
+-   Added a viewer widget for Binned Contig objects.
+-   Updated the Assembly viewer to improve performance for large Assemblies.
 
 ### Version 3.2.3
-__Changes__
-- Fixed problems that can occur on initial load (the page with the flashing KBase icons)
-- Further improvements to the sharing interface.
+
+**Changes**
+
+-   Fixed problems that can occur on initial load (the page with the flashing KBase icons)
+-   Further improvements to the sharing interface.
 
 ### Version 3.2.2
-__Changes__
-- Adjusted flow of job log viewing for data import jobs.
-- Changed Narrative sharing interface, fixed cross-browser incompatibilities.
-- Added new importer apps to the data staging panel.
+
+**Changes**
+
+-   Adjusted flow of job log viewing for data import jobs.
+-   Changed Narrative sharing interface, fixed cross-browser incompatibilities.
+-   Added new importer apps to the data staging panel.
 
 ### Version 3.2.1
-__Changes__
-- Added JGI Data policy requirement to the JGI Public Data browser/stager.
-- Fixed a text problem with an FBA viewer tab.
+
+**Changes**
+
+-   Added JGI Data policy requirement to the JGI Public Data browser/stager.
+-   Fixed a text problem with an FBA viewer tab.
 
 ### Version 3.2.0
-__Changes__
-- Added a prototype Public Data option to fetch files from JGI and load them into a user's staging area.
-- Fixed problems with the Sharing popover having a very narrow text box.
-- Updated the Search area to retrieve data from the updated service.
-- Introduced a new Selenium-based browser testing harness.
-- Bumped version of Jupyter Notebook to 4.4.1, IPython to 5.3.0, and IPywidgets to 6.0.0.
+
+**Changes**
+
+-   Added a prototype Public Data option to fetch files from JGI and load them into a user's staging area.
+-   Fixed problems with the Sharing popover having a very narrow text box.
+-   Updated the Search area to retrieve data from the updated service.
+-   Introduced a new Selenium-based browser testing harness.
+-   Bumped version of Jupyter Notebook to 4.4.1, IPython to 5.3.0, and IPywidgets to 6.0.0.
 
 ### Version 3.1.12
-__Changes__
-- Adjusted look and feel of group parameters in app cells.
-- Fixed problems with RNA-seq viewer widgets.
-- Added new categories to the Public data dropdown.
-- Data should now be downloadable in read-only mode.
-- Added a taxonomy viewer widget.
+
+**Changes**
+
+-   Adjusted look and feel of group parameters in app cells.
+-   Fixed problems with RNA-seq viewer widgets.
+-   Added new categories to the Public data dropdown.
+-   Data should now be downloadable in read-only mode.
+-   Added a taxonomy viewer widget.
 
 ### Version 3.1.11
-__Changes__
-- Fixed a problem where the job log in app cells would continue to poll after the job had finished, or after a user had clicked onto a different tab.
-- Fixed a problem with the Hisat viewer widget not working properly.
-- Grouped parameters in apps should now group in the proper order.
-- Minor adjustments to the ordering of buttons in dialog boxes (cancel buttons go on the left, active actions go on the right).
-- Change text of copy button in view only mode.
-- Adjust workflow of Narrative copying in view only mode to make more sense and prevent multi-clicking the copy button.
+
+**Changes**
+
+-   Fixed a problem where the job log in app cells would continue to poll after the job had finished, or after a user had clicked onto a different tab.
+-   Fixed a problem with the Hisat viewer widget not working properly.
+-   Grouped parameters in apps should now group in the proper order.
+-   Minor adjustments to the ordering of buttons in dialog boxes (cancel buttons go on the left, active actions go on the right).
+-   Change text of copy button in view only mode.
+-   Adjust workflow of Narrative copying in view only mode to make more sense and prevent multi-clicking the copy button.
 
 ### Version 3.1.10
-__Changes__
-- Fixed broken Import tab in the data slideout.
-- Adjusted text in staging area tour.
-- Fixed issue in App cells where the tab buttons could crowd each other out.
-- Adjusted behavior of slider buttons in volcano plot widget to be more performant.
+
+**Changes**
+
+-   Fixed broken Import tab in the data slideout.
+-   Adjusted text in staging area tour.
+-   Fixed issue in App cells where the tab buttons could crowd each other out.
+-   Adjusted behavior of slider buttons in volcano plot widget to be more performant.
 
 ### Version 3.1.9
-__Changes__
-- Expanded the reach of the front end code compiler.
-- Adjusted the logic of job polling to only poll jobs that are currently attached to Narrative cells and running.
-- Changed what publicly available data is visible.
-- Fixed data panel timestamps in Safari.
-- Fixed sharing user lookup input field in Safari.
-- Made many visual improvements to the app cell.
+
+**Changes**
+
+-   Expanded the reach of the front end code compiler.
+-   Adjusted the logic of job polling to only poll jobs that are currently attached to Narrative cells and running.
+-   Changed what publicly available data is visible.
+-   Fixed data panel timestamps in Safari.
+-   Fixed sharing user lookup input field in Safari.
+-   Made many visual improvements to the app cell.
 
 ### Version 3.1.8
-__Changes__
-- JIRA TASK-434 Made improvements to speed up loading and (hopefully) improve stability.
-- JIRA TASK-439 Fixed a problem with adding inputs to subselected parameters in apps.
-- JIRA TASK-440 Advanced dropdowns should now have the right horizontal size when un-hidden.
-- Made a change to publically available data - Phytozome genomes are now just part of the genomes list.
-- Fixed issue with viewer cells not rendering properly.
-- Enable a tab that displays which output objects were created in a report viewer.
+
+**Changes**
+
+-   JIRA TASK-434 Made improvements to speed up loading and (hopefully) improve stability.
+-   JIRA TASK-439 Fixed a problem with adding inputs to subselected parameters in apps.
+-   JIRA TASK-440 Advanced dropdowns should now have the right horizontal size when un-hidden.
+-   Made a change to publically available data - Phytozome genomes are now just part of the genomes list.
+-   Fixed issue with viewer cells not rendering properly.
+-   Enable a tab that displays which output objects were created in a report viewer.
 
 ### Version 3.1.7
-__Changes__
-- Fixed an issue where if looking up any job status fails, all job statuses fail to update.
-- Fixed problems with viewing RNA seq object viewers.
-- Fixed a problem with displaying output widgets for many apps.
+
+**Changes**
+
+-   Fixed an issue where if looking up any job status fails, all job statuses fail to update.
+-   Fixed problems with viewing RNA seq object viewers.
+-   Fixed a problem with displaying output widgets for many apps.
 
 ### Version 3.1.6
-__Changes__
-- Created a help menu with some options migrated from the hamburger menu.
-- Fixed staging area uploader configuration to keep up with uploader app changes.
-- JIRA TASK-378 Fixed issue with app parameters not always enforcing "required" constraint.
-- Fix label display in app report viewer.
-- Fix import job panel not updating job status.
-- Minor tweaks to labels in volcano plot viewer.
+
+**Changes**
+
+-   Created a help menu with some options migrated from the hamburger menu.
+-   Fixed staging area uploader configuration to keep up with uploader app changes.
+-   JIRA TASK-378 Fixed issue with app parameters not always enforcing "required" constraint.
+-   Fix label display in app report viewer.
+-   Fix import job panel not updating job status.
+-   Minor tweaks to labels in volcano plot viewer.
 
 ### Version 3.1.5
-__Changes__
-- Added staging area uploaders for Genbank files, and SRA reads.
-- Fixed (other) problems with backend job lookup.
-- Changed group parameters toggle look and feel.
-- Fixed minor UI problems with volcano plot.
-- Fixed potential problem with Cummerbund output viewer.
+
+**Changes**
+
+-   Added staging area uploaders for Genbank files, and SRA reads.
+-   Fixed (other) problems with backend job lookup.
+-   Changed group parameters toggle look and feel.
+-   Fixed minor UI problems with volcano plot.
+-   Fixed potential problem with Cummerbund output viewer.
 
 ### Version 3.1.4
-__Changes__
-- Linked the new reads uploaders to the staging panel.
-- Wired the staging panel to include the subpath (not the username, just any subdirectories) in the input to uploaders.
-- Linked the staging panel to get its uploader specs from a source that includes the currently selected version tag.
-- Added configuration for several data panel properties (max number of items to fetch, etc.).
-- Added a semaphore lock that prevents any backend job lookup calls from being made before the channel is ready.
+
+**Changes**
+
+-   Linked the new reads uploaders to the staging panel.
+-   Wired the staging panel to include the subpath (not the username, just any subdirectories) in the input to uploaders.
+-   Linked the staging panel to get its uploader specs from a source that includes the currently selected version tag.
+-   Added configuration for several data panel properties (max number of items to fetch, etc.).
+-   Added a semaphore lock that prevents any backend job lookup calls from being made before the channel is ready.
 
 ### Version 3.1.3
-__Changes__
-- Fixed bug where read-only Narratives were still interactive (apps had run and reset buttons)
-- Fixed bug where copying a read-only Narrative created a bad forwarding URL.
+
+**Changes**
+
+-   Fixed bug where read-only Narratives were still interactive (apps had run and reset buttons)
+-   Fixed bug where copying a read-only Narrative created a bad forwarding URL.
 
 ### Version 3.1.2
-__Changes__
-- Do an autosave after starting an import job.
-- Hide the code area for the 'Job Status' widget, whenever that widget gets instantiated.
-- Remove 'Object Details...' button from data viewers (it's just hidden for now).
-- In the App Cell Report tab, remove 'Summary' or 'Report' areas if either of those are missing.
+
+**Changes**
+
+-   Do an autosave after starting an import job.
+-   Hide the code area for the 'Job Status' widget, whenever that widget gets instantiated.
+-   Remove 'Object Details...' button from data viewers (it's just hidden for now).
+-   In the App Cell Report tab, remove 'Summary' or 'Report' areas if either of those are missing.
 
 ### Version 3.1.1
-__Changes__
-- Optimized how job status polling works.
+
+**Changes**
+
+-   Optimized how job status polling works.
 
 ### Version 3.1.0
-__Changes__
-- Release of ReadsSet viewer and Reads viewer.
-- Release of support for data palettes (currently disabled in the service)
-- Data now gets fetched from a Narrative Service to support data palettes.
-- Support for an FTP-based data file staging area (currently disabled until import apps catch up).
-- Fixed issue where an undefined app_type field would cause a crash while instantiating an app cell.
+
+**Changes**
+
+-   Release of ReadsSet viewer and Reads viewer.
+-   Release of support for data palettes (currently disabled in the service)
+-   Data now gets fetched from a Narrative Service to support data palettes.
+-   Support for an FTP-based data file staging area (currently disabled until import apps catch up).
+-   Fixed issue where an undefined app_type field would cause a crash while instantiating an app cell.
 
 ### Version 3.1.0-alpha-4
-__Changes__
-- Adjust visuals in Reads viewer.
-- Adjust tooltip for objects from other Narratives.
-- Changed functionality of object copying in data slideout.
+
+**Changes**
+
+-   Adjust visuals in Reads viewer.
+-   Adjust tooltip for objects from other Narratives.
+-   Changed functionality of object copying in data slideout.
 
 ### Version 3.1.0-alpha-3
-__Changes__
-- Updated ReadsSet viewer and Reads viewer.
-- Modified icons for elements from an external Narrative.
-- Improved usability for set editors.
-- Fixed missing upload functions bug.
-- Fixed issues with Narrative copying (from the Narratives panel)
+
+**Changes**
+
+-   Updated ReadsSet viewer and Reads viewer.
+-   Modified icons for elements from an external Narrative.
+-   Improved usability for set editors.
+-   Fixed missing upload functions bug.
+-   Fixed issues with Narrative copying (from the Narratives panel)
 
 ### Version 3.1.0-alpha-2
-__Changes__
-- Fixes problem with data hierarchy when sub-elements are from a different Narrative.
-- Puts a visual label on things from another Narrative.
+
+**Changes**
+
+-   Fixes problem with data hierarchy when sub-elements are from a different Narrative.
+-   Puts a visual label on things from another Narrative.
 
 ### Version 3.1.0-alpha-1
-__Changes__
-- Introduces the concept of data sets with hierarchical manipulation.
-- Sets objects should be able to expand and contract, showing sub objects.
-- Adds Apps that can manipulate data sets (currently only Reads Sets).
-- Rewires all data manipulation code to use a different service.
+
+**Changes**
+
+-   Introduces the concept of data sets with hierarchical manipulation.
+-   Sets objects should be able to expand and contract, showing sub objects.
+-   Adds Apps that can manipulate data sets (currently only Reads Sets).
+-   Rewires all data manipulation code to use a different service.
 
 ### Version 3.0.2
-__Changes__
-- Fixed bug preventing the "Annotate Microbial Genome" app (and others that make use of randomized input strings) from launching.
-- Fixed another bug with CSS files.
+
+**Changes**
+
+-   Fixed bug preventing the "Annotate Microbial Genome" app (and others that make use of randomized input strings) from launching.
+-   Fixed another bug with CSS files.
 
 ### Version 3.0.1
-__Changes__
-- Fixed bug with path to some CSS files.
-- Fixed error where an update to old viewer cells would just produce code that would crash.
-- Fixed error where updated app cells containing Apps made with the KBase SDK weren't updated properly.
+
+**Changes**
+
+-   Fixed bug with path to some CSS files.
+-   Fixed error where an update to old viewer cells would just produce code that would crash.
+-   Fixed error where updated app cells containing Apps made with the KBase SDK weren't updated properly.
 
 ### Version 3.0.0
-__Changes__
-- Final 3.0.0 release!
-- Adjust data import user experience.
+
+**Changes**
+
+-   Final 3.0.0 release!
+-   Adjust data import user experience.
 
 ### Version 3.0.0-alpha-23
-__Changes__
-- Major updates to the App Cell UI
-    - Restructured so each view is a separate tab.
-    - Added a status icon for each App state.
-    - Adjusted failure modes to be more descriptive.
-    - Integrated Report view under Results tab.
-    - Moved many of the sprawling toolbar buttons into a dropdown menu.
-    - Added a modal Info dialog for each app (in toolbar menu).
-    - Remove Jupyter's prompt area... which might cause more problems.
-- Fixed various problems with Jupyter's command-mode shortcuts (again).
-- Import panel should disappear and scroll to running import Job on Import.
-- Changes to improve performance and visibility of Genome Viewer widget.
-- Added an interactive tour for the Narrative (in the hamburger menu).
-- Cells should now all be deleteable in all cases.
-- Updated Ontology view widgets to use tabs.
-- Fixed automated front end test apparatus.
+
+**Changes**
+
+-   Major updates to the App Cell UI
+    -   Restructured so each view is a separate tab.
+    -   Added a status icon for each App state.
+    -   Adjusted failure modes to be more descriptive.
+    -   Integrated Report view under Results tab.
+    -   Moved many of the sprawling toolbar buttons into a dropdown menu.
+    -   Added a modal Info dialog for each app (in toolbar menu).
+    -   Remove Jupyter's prompt area... which might cause more problems.
+-   Fixed various problems with Jupyter's command-mode shortcuts (again).
+-   Import panel should disappear and scroll to running import Job on Import.
+-   Changes to improve performance and visibility of Genome Viewer widget.
+-   Added an interactive tour for the Narrative (in the hamburger menu).
+-   Cells should now all be deleteable in all cases.
+-   Updated Ontology view widgets to use tabs.
+-   Fixed automated front end test apparatus.
 
 ### Version 3.0.0-alpha-22
-__Changes__
-- First pass at an inline clickable interface tour.
-- Fixed problems with Jupyter's command-mode shortcuts overriding whatever they wanted to.
-- Updated front end tests so they should function more seamlessly.
-- Add GenomeAnnotation support to genome, pangenome, and proteome comparison viewers.
-- Add warning for out of date apps.
+
+**Changes**
+
+-   First pass at an inline clickable interface tour.
+-   Fixed problems with Jupyter's command-mode shortcuts overriding whatever they wanted to.
+-   Updated front end tests so they should function more seamlessly.
+-   Add GenomeAnnotation support to genome, pangenome, and proteome comparison viewers.
+-   Add warning for out of date apps.
 
 ### Version 3.0.0-alpha-21
-__Changes__
-- Applied module release version to that module's method specs.
-- Fixed regression preventing cell deletion in some conditions.
-- Added module commit hash to App dropdowns in App Panel for beta and dev Apps.
-- Added 401 error when the Narrative handler is unauthenticated.
-- Addressed issues with job cancellation.
+
+**Changes**
+
+-   Applied module release version to that module's method specs.
+-   Fixed regression preventing cell deletion in some conditions.
+-   Added module commit hash to App dropdowns in App Panel for beta and dev Apps.
+-   Added 401 error when the Narrative handler is unauthenticated.
+-   Addressed issues with job cancellation.
 
 ### Version 3.0.0-alpha-20
-__Changes__
-- Fixed custom parameter widgets.
-- Improved error catching within App Cell.
-- Updated Docker container invocation methods on Narrative Server.
-- Updated Dockerfiles to use new versions of a few dependencies.
-- Fixed DomainAnnotation viewer widget.
-- Updated Data API-based widgets to use latest clients.
-- Added prompt with report option (not working yet) when the JobManager fails to initialize.
+
+**Changes**
+
+-   Fixed custom parameter widgets.
+-   Improved error catching within App Cell.
+-   Updated Docker container invocation methods on Narrative Server.
+-   Updated Dockerfiles to use new versions of a few dependencies.
+-   Fixed DomainAnnotation viewer widget.
+-   Updated Data API-based widgets to use latest clients.
+-   Added prompt with report option (not working yet) when the JobManager fails to initialize.
 
 ### Version 3.0.0-alpha-19
-__Changes__
-- add latest workspace python client
-- update narrative usage of ws client since ServerError has moved
+
+**Changes**
+
+-   add latest workspace python client
+-   update narrative usage of ws client since ServerError has moved
 
 ### Version 3.0.0-alpha-18
-__Changes__
-- revert python workspace client for now (breaks narrative launch)
-- fix error widget for output cell
+
+**Changes**
+
+-   revert python workspace client for now (breaks narrative launch)
+-   fix error widget for output cell
 
 ### Version 3.0.0-alpha-17
-__Changes__
-- fix checkbox validation bug
-- fix viewer widget not getting the cell id and therefore not rendering
-- update python workspace client to latest
+
+**Changes**
+
+-   fix checkbox validation bug
+-   fix viewer widget not getting the cell id and therefore not rendering
+-   update python workspace client to latest
 
 ### Version 3.0.0-alpha-16
-__Changes__
-- fix multiple object input widget
-- remove execution summary widget
-- updated kbase client api lib to bring in updated workspace client
+
+**Changes**
+
+-   fix multiple object input widget
+-   remove execution summary widget
+-   updated kbase client api lib to bring in updated workspace client
 
 ### Version 3.0.0-alpha-15
-__Changes__
-- fix output param marked as parameter triggering error and blocking app cell insertion
-- improve error message when checkbox is misconfigured
-- improve checkbox rules display
 
+**Changes**
+
+-   fix output param marked as parameter triggering error and blocking app cell insertion
+-   improve error message when checkbox is misconfigured
+-   improve checkbox rules display
 
 ### Version 3.0.0-alpha-14
-__Changes__
-- fix job cell (as produced by JobManager()->job_info())
-- relax enforcement of object output name input widget being categorized as an "output" control
-- fix tab label and job count badge in job panel
-- more progress on custom subdata, binary, and select controls
 
+**Changes**
+
+-   fix job cell (as produced by JobManager()->job_info())
+-   relax enforcement of object output name input widget being categorized as an "output" control
+-   fix tab label and job count badge in job panel
+-   more progress on custom subdata, binary, and select controls
 
 ### Version 3.0.0-alpha-13
-__Changes__
-- Fix display of data objects drag-and-dropped or clicked from the data panel
-- Job status lookup and error handling improvements
-- Fixed bug in handling app results
-- Initial implementation of viewers for new objects
-- Fixed ontology dictionary
 
+**Changes**
+
+-   Fix display of data objects drag-and-dropped or clicked from the data panel
+-   Job status lookup and error handling improvements
+-   Fixed bug in handling app results
+-   Initial implementation of viewers for new objects
+-   Fixed ontology dictionary
 
 ### Version 3.0.0-alpha-12
-__Changes__
-- Fixed JobManager.list_jobs (again)
-- Reconnected the 'scroll to app' button in the Jobs panel to existing App Cell widgets
-- Removed the Scroll to App button from Jobs that don't have an accompanying cell to scroll to (might be confusing, still).
-- Fixed a constant spam of Job info from the kernel on page refresh.
-- Restored multiselection in subdata inputs.
+
+**Changes**
+
+-   Fixed JobManager.list_jobs (again)
+-   Reconnected the 'scroll to app' button in the Jobs panel to existing App Cell widgets
+-   Removed the Scroll to App button from Jobs that don't have an accompanying cell to scroll to (might be confusing, still).
+-   Fixed a constant spam of Job info from the kernel on page refresh.
+-   Restored multiselection in subdata inputs.
 
 ### Version 3.0.0-alpha-11
-__Changes__
-- Fixed Narrative metadata to contain a proper list of Apps for showing on the Dashboard.
-- Updated read only mode
-  - Codemirror elements (markdown cell and code cell input areas) are visible, but not editable
-  - App Cells get their button bars hidden
-  - Output areas get their delete areas hidden
-  - Cell toolbars get their buttons hidden (maybe all but the collapse and code toggles should be hidden?)
-- Tweaked placeholder text of Markdown cells.
+
+**Changes**
+
+-   Fixed Narrative metadata to contain a proper list of Apps for showing on the Dashboard.
+-   Updated read only mode
+    -   Codemirror elements (markdown cell and code cell input areas) are visible, but not editable
+    -   App Cells get their button bars hidden
+    -   Output areas get their delete areas hidden
+    -   Cell toolbars get their buttons hidden (maybe all but the collapse and code toggles should be hidden?)
+-   Tweaked placeholder text of Markdown cells.
 
 ### Version 3.0.0-alpha-10
-__Changes__
-- Pressing the Enter key should trigger a positive reponse on most dialogs (e.g. if there are Yes or No options, it should select Yes)
-- Only the user who started a job can delete it (except for owners of a narrative... that's all confusing, though, so it's only users who started a job now).
-- The Jobs Panel should now show the owner of a job as registered with UJS.
-- Canceling a job from an App cell will attempt to delete it, and at least, cancel it.
-- Canceled jobs are treated as Deleted by the App cell.
-- Added configuration for the service_wizard client - mild refactor to how configs get loaded.
+
+**Changes**
+
+-   Pressing the Enter key should trigger a positive reponse on most dialogs (e.g. if there are Yes or No options, it should select Yes)
+-   Only the user who started a job can delete it (except for owners of a narrative... that's all confusing, though, so it's only users who started a job now).
+-   The Jobs Panel should now show the owner of a job as registered with UJS.
+-   Canceling a job from an App cell will attempt to delete it, and at least, cancel it.
+-   Canceled jobs are treated as Deleted by the App cell.
+-   Added configuration for the service_wizard client - mild refactor to how configs get loaded.
 
 ### Version 3.0.0-alpha-9
-__Changes__
-- Restore app and viewer cell icons to their rightful place
-- Minor string tweaks
-- Minor CSS tweaks
-- First pass at setup for optionally using Dynamic services for getting widget subdata
+
+**Changes**
+
+-   Restore app and viewer cell icons to their rightful place
+-   Minor string tweaks
+-   Minor CSS tweaks
+-   First pass at setup for optionally using Dynamic services for getting widget subdata
 
 ### Version 3.0.0-alpha-8
-__Changes__
-- Fix various problems with subdata input widget - selecting multiple when only one should be allowed, pathway issues into data object, etc.
-- Convert execution area back to tabbed items.
-- Add catalog link back to toolbar.
-- Fix launch start time bug.
-- Remove millisecond counts from times.
-- Add icon to tab in tabset.
-- Make use of updated cancel job function in UJS (gonna need some iteration on this once the UJS change goes up)
+
+**Changes**
+
+-   Fix various problems with subdata input widget - selecting multiple when only one should be allowed, pathway issues into data object, etc.
+-   Convert execution area back to tabbed items.
+-   Add catalog link back to toolbar.
+-   Fix launch start time bug.
+-   Remove millisecond counts from times.
+-   Add icon to tab in tabset.
+-   Make use of updated cancel job function in UJS (gonna need some iteration on this once the UJS change goes up)
 
 ### Version 3.0.0-alpha-7
-__Changes__
-- Updated invocation signatures for AppManage.run_app, .run_local_app, WidgetManager.show_output_widget -- inputs to apps (and widgets) must now be a map where the keys are the input ids and the values are the inputs themselves. See this PR for details: https://github.com/kbase/narrative/pull/679
-- Newly generated output cells auto-hide their input areas (still not ideal, since it's the generated widget, but... it's a start).
-- Fixed a couple UI typos
+
+**Changes**
+
+-   Updated invocation signatures for AppManage.run_app, .run_local_app, WidgetManager.show_output_widget -- inputs to apps (and widgets) must now be a map where the keys are the input ids and the values are the inputs themselves. See this PR for details: https://github.com/kbase/narrative/pull/679
+-   Newly generated output cells auto-hide their input areas (still not ideal, since it's the generated widget, but... it's a start).
+-   Fixed a couple UI typos
 
 ### Version 3.0.0-alpha-6
-__Changes__
-- App parameter validation updates:
-  - Empty strings in either text fields or dropdowns get transformed to null before starting the app
-  - Empty strings in checkboxes get transformed to false
-- Log view in App cells has blocky whitespace removed
-- Multiple textarea inputs (currently unused?) has improved support
-- App cell layout has been updated to remove most excess whitespace
-- Improved error and warning handling for Apps. (e.g. pre-existing output object names can be overwritten again, but now there's a warning)
-- '-' characters are not allowed in App parameter ids. They must be representable as variable names (still up for debate, but that's how it is now)
+
+**Changes**
+
+-   App parameter validation updates:
+    -   Empty strings in either text fields or dropdowns get transformed to null before starting the app
+    -   Empty strings in checkboxes get transformed to false
+-   Log view in App cells has blocky whitespace removed
+-   Multiple textarea inputs (currently unused?) has improved support
+-   App cell layout has been updated to remove most excess whitespace
+-   Improved error and warning handling for Apps. (e.g. pre-existing output object names can be overwritten again, but now there's a warning)
+-   '-' characters are not allowed in App parameter ids. They must be representable as variable names (still up for debate, but that's how it is now)
 
 ### Version 3.0.0-alpha-5
-__Changes__
-- Fixed issue when starting SDK jobs from the upload panel with numeric parameters.
-- Fixed crash bug when trying to unpack a finished job that has incomplete inputs.
-- Shut off Jupyter command-mode quick keys when a text parameter input is focused.
+
+**Changes**
+
+-   Fixed issue when starting SDK jobs from the upload panel with numeric parameters.
+-   Fixed crash bug when trying to unpack a finished job that has incomplete inputs.
+-   Shut off Jupyter command-mode quick keys when a text parameter input is focused.
 
 ### Version 3.0.0-alpha-4
-__Changes__
-- Improve error reporting when failing to load a viewer.
+
+**Changes**
+
+-   Improve error reporting when failing to load a viewer.
 
 ### Version 3.0.0-alpha-3
-__Changes__
-- Replace RNA-Seq viewers that had wandered off
-- Display SDK methods for various uploaders
+
+**Changes**
+
+-   Replace RNA-Seq viewers that had wandered off
+-   Display SDK methods for various uploaders
 
 ### Version 3.0.0-alpha-2
-__Changes__
-- Fix updater so that it updates the Markdown cell version of viewer cells into pre-executed code cells that generate viewers. (So, updated viewers should work again)
-- Fix Docker image so that it doesn't spam the annoying SSL errors in all cells.
-- Put code area toggle on all code cells at all times. (Just to give Erik and I something to argue about)
+
+**Changes**
+
+-   Fix updater so that it updates the Markdown cell version of viewer cells into pre-executed code cells that generate viewers. (So, updated viewers should work again)
+-   Fix Docker image so that it doesn't spam the annoying SSL errors in all cells.
+-   Put code area toggle on all code cells at all times. (Just to give Erik and I something to argue about)
 
 ### Version 3.0.0-alpha-1
-__Major Updates__
-- Apps and Methods not made as part of KBase SDK modules are now obsolete and will no longer run. Those apps have been replaced with Markdown cells that note their obsolescence, but still give the name and set of parameters used in the apps for reference. This also gives suggestions for updated apps (that will be available in production eventually...)
-- The distinction between "App" and "Method" has been removed. All cells that execute KBase jobs are now referred to as Apps.
-- All app cells are now based on Jupyter code cells (previously they were based on heavily modified Markdown cells). This means that they generate code that gets executed in the same way that any other code does. This also introduces a KBase Jobs API that gives programmatic access to running Apps. See docs/developer/job_api.md for details.
-- All output and viewer cells are now code cells as well. Existing viewers are still based on Markdown cells, and should work as previously.
-- All visualization widgets had their initialization code slightly modified. See docs/developer/narrative_widgets.md for details.
 
-__Other Changes__
-- Update Jupyter to version 4.2.1.
-- Update IPython kernel to version 5.0.0.
-- Adds a settings menu for editing user options (prototype).
-- App cells tightly validate each input before generating runnable code - until all required inputs are valid, no code can be run.
-- The Jobs panel gets its information pushed from the kernel, and that from communicating with back end servies. Job information is no longer stored in Narrative objects.
-- Running Jobs are associated directly with a Narrative, and inherit its view permissions accordingly; if you can view a Narrative, you can view its running jobs.
-- Copying a shared Narrative no longer copies its Jobs - copying a Narrative with running Jobs will not copy the results.
-- Updated the job log widget to no longer fetch all lines of a running log. It has a limit of 100 lines at a time, with buttons to navigate around the log.
+**Major Updates**
+
+-   Apps and Methods not made as part of KBase SDK modules are now obsolete and will no longer run. Those apps have been replaced with Markdown cells that note their obsolescence, but still give the name and set of parameters used in the apps for reference. This also gives suggestions for updated apps (that will be available in production eventually...)
+-   The distinction between "App" and "Method" has been removed. All cells that execute KBase jobs are now referred to as Apps.
+-   All app cells are now based on Jupyter code cells (previously they were based on heavily modified Markdown cells). This means that they generate code that gets executed in the same way that any other code does. This also introduces a KBase Jobs API that gives programmatic access to running Apps. See docs/developer/job_api.md for details.
+-   All output and viewer cells are now code cells as well. Existing viewers are still based on Markdown cells, and should work as previously.
+-   All visualization widgets had their initialization code slightly modified. See docs/developer/narrative_widgets.md for details.
+
+**Other Changes**
+
+-   Update Jupyter to version 4.2.1.
+-   Update IPython kernel to version 5.0.0.
+-   Adds a settings menu for editing user options (prototype).
+-   App cells tightly validate each input before generating runnable code - until all required inputs are valid, no code can be run.
+-   The Jobs panel gets its information pushed from the kernel, and that from communicating with back end servies. Job information is no longer stored in Narrative objects.
+-   Running Jobs are associated directly with a Narrative, and inherit its view permissions accordingly; if you can view a Narrative, you can view its running jobs.
+-   Copying a shared Narrative no longer copies its Jobs - copying a Narrative with running Jobs will not copy the results.
+-   Updated the job log widget to no longer fetch all lines of a running log. It has a limit of 100 lines at a time, with buttons to navigate around the log.
 
 ### Version 2.0.9
-__Changes__
-- Small changes to viewer widgets - esp. genome viewer and expression data viewer.
-- Fixed overlapping sort icons in tables - JIRA ticket KBASE-4220.
+
+**Changes**
+
+-   Small changes to viewer widgets - esp. genome viewer and expression data viewer.
+-   Fixed overlapping sort icons in tables - JIRA ticket KBASE-4220.
 
 ### Version 2.0.8
-__Changes__
-- Numerous small fixes to text and layout of various widgets.
-- Genome view deals with plants and eukaryota better.
-- Proteome comparison widget uses SVG now.
-- Tree browser widget is properly clickable again.
-- Ontologies, Assemblies, and GenomeAnnotations are uploadable.
-- Fixed several issues with Narrative copying (see JIRA tickets KBASE-2034, KBASE-4140, KBASE-4154, KBASE-4159, NAR-849, and NAR-850).
+
+**Changes**
+
+-   Numerous small fixes to text and layout of various widgets.
+-   Genome view deals with plants and eukaryota better.
+-   Proteome comparison widget uses SVG now.
+-   Tree browser widget is properly clickable again.
+-   Ontologies, Assemblies, and GenomeAnnotations are uploadable.
+-   Fixed several issues with Narrative copying (see JIRA tickets KBASE-2034, KBASE-4140, KBASE-4154, KBASE-4159, NAR-849, and NAR-850).
 
 ### Version 2.0.7
-__Changes__
-- Fixed data subsetting parameter input.
+
+**Changes**
+
+-   Fixed data subsetting parameter input.
 
 ### Version 2.0.6
-__Changes__
-- Fixed local configuration issue with Public and Example data tabs.
-- Updated genome viewer widget to better support eukaryotic genomes.
-- Added sequence category to app catalog.
-- Added Release/Beta method button toggle that should show up in production mode.
-- JIRA NAR-846 - fix problem with Run Time in jobs panel reported as "how long ago"
+
+**Changes**
+
+-   Fixed local configuration issue with Public and Example data tabs.
+-   Updated genome viewer widget to better support eukaryotic genomes.
+-   Added sequence category to app catalog.
+-   Added Release/Beta method button toggle that should show up in production mode.
+-   JIRA NAR-846 - fix problem with Run Time in jobs panel reported as "how long ago"
 
 ### Version 2.0.5
-__Changes__
-- Fixed problems with missing data from Public data tab.
-- Added separate configuration file for Public and Example data tabs.
-- Fixed a few missing vis widget paths.
-- Fixed jitter on data object mouseover.
-- Added 'Shutdown and Restart' option to hamburger menu.
+
+**Changes**
+
+-   Fixed problems with missing data from Public data tab.
+-   Added separate configuration file for Public and Example data tabs.
+-   Fixed a few missing vis widget paths.
+-   Fixed jitter on data object mouseover.
+-   Added 'Shutdown and Restart' option to hamburger menu.
 
 ### Version 2.0.4
-__Changes__
-- Fixed problems with sharing jobs based on SDK-built methods.
-- JIRA KBASE-3725 - renaming narratives should now trigger a save.
-- Updated widgets for some feature-value methods and data types.
-- Fixed problem where pressing 'enter' while filtering the method catalog would refresh the page.
-- Added categories and new icons to various methods.
-- Removed unused data objects from example data tab.
-- Methods can now specify that no output widget should be created.
+
+**Changes**
+
+-   Fixed problems with sharing jobs based on SDK-built methods.
+-   JIRA KBASE-3725 - renaming narratives should now trigger a save.
+-   Updated widgets for some feature-value methods and data types.
+-   Fixed problem where pressing 'enter' while filtering the method catalog would refresh the page.
+-   Added categories and new icons to various methods.
+-   Removed unused data objects from example data tab.
+-   Methods can now specify that no output widget should be created.
 
 ### Version 2.0.3
-__Changes__
-- JIRA KBASE-3388 - fixed problem that caused a crash on save when too many unique methods or apps were in a narrative. The narrative metadata has been reformatted to support this.
-- Fixed problems with funky unicode characters in narrative titles.
-- Updates to various FBA widgets.
+
+**Changes**
+
+-   JIRA KBASE-3388 - fixed problem that caused a crash on save when too many unique methods or apps were in a narrative. The narrative metadata has been reformatted to support this.
+-   Fixed problems with funky unicode characters in narrative titles.
+-   Updates to various FBA widgets.
 
 ### Version 2.0.2
-__Changes__
-- JIRA KBASE-3556 - fixed links from genome widget to gene landing page, made contigs in genome tab clickable.
-- Added tools for editing FBA models.
-- JIRA NAR-838 - delete cell dialog should no longer break when hitting return to trigger it.
-- JIRA NAR-839 - delete cell dialogs should not pollute the DOM (there's only one dialog now, not a new one for each cell).
-- JIRA NAR-589 - change "Copy Narrative" to "Copy This Narrative" for clarity.
-- JIRA NAR-788 - remove light colors from random picker when coloring user names for sharing.
+
+**Changes**
+
+-   JIRA KBASE-3556 - fixed links from genome widget to gene landing page, made contigs in genome tab clickable.
+-   Added tools for editing FBA models.
+-   JIRA NAR-838 - delete cell dialog should no longer break when hitting return to trigger it.
+-   JIRA NAR-839 - delete cell dialogs should not pollute the DOM (there's only one dialog now, not a new one for each cell).
+-   JIRA NAR-589 - change "Copy Narrative" to "Copy This Narrative" for clarity.
+-   JIRA NAR-788 - remove light colors from random picker when coloring user names for sharing.
 
 ### Version 2.0.1
-__Changes__
-- JIRA KBASE-3623 - fixed problem where updating an old version of the Narrative typed object could cause the Narrative title to be lost
-- JIRA KBASE-3624 - fixed links in method input cell subtitles to manual pages
-- JIRA KBASE-3630 - fixed problem with hierarchical clustering widget missing a button
-- Added widget for sequence comparison
-- Added tools for editing FBA model media sets.
+
+**Changes**
+
+-   JIRA KBASE-3623 - fixed problem where updating an old version of the Narrative typed object could cause the Narrative title to be lost
+-   JIRA KBASE-3624 - fixed links in method input cell subtitles to manual pages
+-   JIRA KBASE-3630 - fixed problem with hierarchical clustering widget missing a button
+-   Added widget for sequence comparison
+-   Added tools for editing FBA model media sets.
 
 ### Version 2.0.0
-__Changes__
-- Update IPython Notebook backend to Jupyter 4.1.0.
-- Data Panel slideout should now perform better for users with lots and lots of objects.
-- Fixed problem with copied narratives sometimes referring back to their original workspace.
-- Data Panel slideout dimmer should be in the correct z-position now.
-- Added separate job console for each running method, attached to that cell.
-- Changed style of cells to better show what cell is selected and active.
-- Adjusted Narrative Management tab to be somewhat more performant.
-- Updated Narrative object definition to match the Jupyter notebook object definition more closely.
-- Data panel should no longer hang forever on Narrative startup.
+
+**Changes**
+
+-   Update IPython Notebook backend to Jupyter 4.1.0.
+-   Data Panel slideout should now perform better for users with lots and lots of objects.
+-   Fixed problem with copied narratives sometimes referring back to their original workspace.
+-   Data Panel slideout dimmer should be in the correct z-position now.
+-   Added separate job console for each running method, attached to that cell.
+-   Changed style of cells to better show what cell is selected and active.
+-   Adjusted Narrative Management tab to be somewhat more performant.
+-   Updated Narrative object definition to match the Jupyter notebook object definition more closely.
+-   Data panel should no longer hang forever on Narrative startup.
 
 ### Version 1.1.0
-__Changes__
-- Added "Edit and Re-Run" button to method cells that have already been run.
-- Updated 'filtered' in method panel to 'filtered out'.
-- Added uploaders for Feature-Value pair data.
-- Added viewers for BLAST output.
-- Added bokeh (Python) and Plot.ly (JS) dependencies.
-- Added KBase data_api methods.
-- Added a refresh button to the method panel.
-- Added support for method specs based on namespacing.
-- Added preliminary third party SDK support.
+
+**Changes**
+
+-   Added "Edit and Re-Run" button to method cells that have already been run.
+-   Updated 'filtered' in method panel to 'filtered out'.
+-   Added uploaders for Feature-Value pair data.
+-   Added viewers for BLAST output.
+-   Added bokeh (Python) and Plot.ly (JS) dependencies.
+-   Added KBase data_api methods.
+-   Added a refresh button to the method panel.
+-   Added support for method specs based on namespacing.
+-   Added preliminary third party SDK support.
 
 ### Version 1.0.5
-__Changes__
-- Fix for bugs in saving/loading App state and displaying App step output widgets.
-- Fix for a bug that prevented users with edit privileges from saving a shared narrative.
-- Fixed issue where FBA model comparison widget wasn't showing up properly.
+
+**Changes**
+
+-   Fix for bugs in saving/loading App state and displaying App step output widgets.
+-   Fix for a bug that prevented users with edit privileges from saving a shared narrative.
+-   Fixed issue where FBA model comparison widget wasn't showing up properly.
 
 ### Version 1.0.4
-__Changes__
-- Added widgets and methods to support feature-value analyses
-- JIRA KBASE-2626 - Narrative should no longer crash when the Workspace Service is unavailable, but it will produce a 404 error when trying to fetch a Narrative from that Workspace.
-- JIRA NAR-528 - Narrative method panel now allows filtering by input/output type along with additional
-search terms.
+
+**Changes**
+
+-   Added widgets and methods to support feature-value analyses
+-   JIRA KBASE-2626 - Narrative should no longer crash when the Workspace Service is unavailable, but it will produce a 404 error when trying to fetch a Narrative from that Workspace.
+-   JIRA NAR-528 - Narrative method panel now allows filtering by input/output type along with additional
+    search terms.
 
 ### Version 1.0.3
-__Changes__
-- JIRA KBASE-1672 - updated text in upload dialogs
-- JIRA KBASE-1288 - show prompt when copying a public genome to a Narrative if that genome already exists in the Narrative
-- JIRA NAR-702 - show warning on My Data panel for untitled Narratives
-- JIRA KBASE-1245 - block the Data Uploader's "Import" button while a file is being uploaded.
-- JIRA KBASE-1350 - change reference to "Workspace" to a reference to "Narrative".
-- Refactored all widget code to be loaded asynchronously through Require.js
-- Added initial Selenium test scripts
-- Updated root README, added Travis-CI and Coveralls badges
-- Linked the Narrative Github repo to Travis-CI and Coveralls
 
-__Bugfixes__
-- JIRA KBASE-1671 - fix typo in genome annotation widget
-- JIRA KBASE-2042 - fix errors in the error page that shows up when a Narrative is unavailable.
-- JIRA KBASE-1843/KBASE-1849 - fixed issue where a large narrative object (e.g. a large IPython notebook object) fails to save without a decent error message. The maximum size was bumped to 4MB, and a sensible error message was introduced.
-- Fixed issue where duplicated results can appear in the Public Data tab
-- JIRA NAR-758 - added a horizontal scrollbar to widgets who get too wide (this currenly only affects the OTU Abundance data table widget, but others might get affected in the future).
-- JIRA NAR-814 - added a trailing slash to the service status url.
+**Changes**
+
+-   JIRA KBASE-1672 - updated text in upload dialogs
+-   JIRA KBASE-1288 - show prompt when copying a public genome to a Narrative if that genome already exists in the Narrative
+-   JIRA NAR-702 - show warning on My Data panel for untitled Narratives
+-   JIRA KBASE-1245 - block the Data Uploader's "Import" button while a file is being uploaded.
+-   JIRA KBASE-1350 - change reference to "Workspace" to a reference to "Narrative".
+-   Refactored all widget code to be loaded asynchronously through Require.js
+-   Added initial Selenium test scripts
+-   Updated root README, added Travis-CI and Coveralls badges
+-   Linked the Narrative Github repo to Travis-CI and Coveralls
+
+**Bugfixes**
+
+-   JIRA KBASE-1671 - fix typo in genome annotation widget
+-   JIRA KBASE-2042 - fix errors in the error page that shows up when a Narrative is unavailable.
+-   JIRA KBASE-1843/KBASE-1849 - fixed issue where a large narrative object (e.g. a large IPython notebook object) fails to save without a decent error message. The maximum size was bumped to 4MB, and a sensible error message was introduced.
+-   Fixed issue where duplicated results can appear in the Public Data tab
+-   JIRA NAR-758 - added a horizontal scrollbar to widgets who get too wide (this currenly only affects the OTU Abundance data table widget, but others might get affected in the future).
+-   JIRA NAR-814 - added a trailing slash to the service status url.
 
 ### Version 1.0.2 - 2/19/2015
-__Bugfixes__
-- JIRA NAR-491 - modified public data panel to get metagenomes of the correct type from the updated search interface
-- Fixed problem where Plant transcriptomes weren't properly rendered in the genome browser
-- Fixed problems in domain annotation widget so it displays properly in different error cases
+
+**Bugfixes**
+
+-   JIRA NAR-491 - modified public data panel to get metagenomes of the correct type from the updated search interface
+-   Fixed problem where Plant transcriptomes weren't properly rendered in the genome browser
+-   Fixed problems in domain annotation widget so it displays properly in different error cases
 
 ### Version 1.0.1 - 2/16/2015
-__Changes__
-- JIRA NAR-716 - If a app/method finishes with a non-error status, then the results in the step_errors field of the job status aren't shown.
-- Added Lazy Loading to genome widget. Large genomes shouldn't take a long time to load now.
-- JIRA KBASE-1607 - Sort data types in the data slide out panel
 
-__Bugfixes__
-- Fixed an issue where widgets would occasionally not load.
-- JIRA NAR-699, NAR-700 - Made changes to widgets that were producing confusing or incorrect output based on different context.
-- Fixed issue where data panel list sometimes doesn't load.
+**Changes**
+
+-   JIRA NAR-716 - If a app/method finishes with a non-error status, then the results in the step_errors field of the job status aren't shown.
+-   Added Lazy Loading to genome widget. Large genomes shouldn't take a long time to load now.
+-   JIRA KBASE-1607 - Sort data types in the data slide out panel
+
+**Bugfixes**
+
+-   Fixed an issue where widgets would occasionally not load.
+-   JIRA NAR-699, NAR-700 - Made changes to widgets that were producing confusing or incorrect output based on different context.
+-   Fixed issue where data panel list sometimes doesn't load.
 
 ### Version 1.0.0 - 2/13/2015
+
 ## Production release!
 
 ### Version 0.6.4 - 2/12/2015
-__Changes__
-- Removed most 'View' methods from the Methods panel, except for those required by the Communities tutorials
-- Set the default page title back to "KBase Narrative"
 
-__Bugfixes__
-- In the rename dialog:
-  - Text field wasn't autofocused
-  - Enter button didn't automatically work
-- In other dropdowns, the escape key didn't work properly
-- https://atlassian.kbase.us/browse/KBASE-1586 - fixed parameter checking for min/max ints
-- https://atlassian.kbase.us/browse/NAR-687 - fixed issue with non-loading reactions and compounds for certain gapfilled FBA models
-- https://atlassian.kbase.us/browse/NAR-633 - Rerouted urls to the production site in prep for production release tomorrow. Eep!
+**Changes**
+
+-   Removed most 'View' methods from the Methods panel, except for those required by the Communities tutorials
+-   Set the default page title back to "KBase Narrative"
+
+**Bugfixes**
+
+-   In the rename dialog:
+    -   Text field wasn't autofocused
+    -   Enter button didn't automatically work
+-   In other dropdowns, the escape key didn't work properly
+-   https://atlassian.kbase.us/browse/KBASE-1586 - fixed parameter checking for min/max ints
+-   https://atlassian.kbase.us/browse/NAR-687 - fixed issue with non-loading reactions and compounds for certain gapfilled FBA models
+-   https://atlassian.kbase.us/browse/NAR-633 - Rerouted urls to the production site in prep for production release tomorrow. Eep!
 
 ### Version 0.6.3 - 2/12/2015
-__Bugfixes__
-- https://atlassian.kbase.us/browse/NAR-690 - Missing data types in data panel filter
-- https://atlassian.kbase.us/browse/NAR-692 - Fixed issue that led to drag and drop not working
+
+**Bugfixes**
+
+-   https://atlassian.kbase.us/browse/NAR-690 - Missing data types in data panel filter
+-   https://atlassian.kbase.us/browse/NAR-692 - Fixed issue that led to drag and drop not working
 
 ### Version 0.6.2 - 2/11/2015
-__Changes__
-- Adjustments to readonly mode
-  - Added reduced-functionality side panel
-  - Improved copy dialog
-- Added support for uploading Microsoft Excel files with Media and FBAModels
 
-__Bugfixes__
-- https://atlassian.kbase.us/browse/NAR-681 - loading screen blocks out valid HTTP error pages
-- https://atlassian.kbase.us/browse/NAR-682 - loading screen persists when it shouldn't
-- https://atlassian.kbase.us/browse/NAR-688 - 401 errors when unauthenticated don't redirect to kbase.us
+**Changes**
+
+-   Adjustments to readonly mode
+    -   Added reduced-functionality side panel
+    -   Improved copy dialog
+-   Added support for uploading Microsoft Excel files with Media and FBAModels
+
+**Bugfixes**
+
+-   https://atlassian.kbase.us/browse/NAR-681 - loading screen blocks out valid HTTP error pages
+-   https://atlassian.kbase.us/browse/NAR-682 - loading screen persists when it shouldn't
+-   https://atlassian.kbase.us/browse/NAR-688 - 401 errors when unauthenticated don't redirect to kbase.us
 
 ### Version 0.6.1 - 2/10/2015
-__Changes__
-- Made adjustments to Gapfill viewer widget
-- Added downloaders for PhenotypeSimulationSet and Pangenome
+
+**Changes**
+
+-   Made adjustments to Gapfill viewer widget
+-   Added downloaders for PhenotypeSimulationSet and Pangenome
 
 ### Version 0.6.0 - 2/10/2015
-__Changes__
-- Added a read-only mode for narratives. Users with read-only privileges can only view a narrative, but not change anything, including running functions, since they do not have write privileges anyway. This does come with a copy function that will allow a fork to be made and owned by the user.
-- Header style update, some consistency issues
-- Include old narrative objects under "My Data" and "Shared with me"
-- Show loading icon in communities widgets
-- Renamed CSV Transform API arguments to TSV
 
-__Bugfixes__
-- JIRA KBASE-1411 fix - render issue for protein comparison widget
-- Fixed case where genome object doesn't have any contig info.
+**Changes**
+
+-   Added a read-only mode for narratives. Users with read-only privileges can only view a narrative, but not change anything, including running functions, since they do not have write privileges anyway. This does come with a copy function that will allow a fork to be made and owned by the user.
+-   Header style update, some consistency issues
+-   Include old narrative objects under "My Data" and "Shared with me"
+-   Show loading icon in communities widgets
+-   Renamed CSV Transform API arguments to TSV
+
+**Bugfixes**
+
+-   JIRA KBASE-1411 fix - render issue for protein comparison widget
+-   Fixed case where genome object doesn't have any contig info.
 
 ### Version 0.5.7 - 2/9/2015
-__Changes__
-- Updates to provisioning service to deal with JIRA NAR-660 and overall stability and control
-- Updated urls for FBA service
-- Added new FBAModelSet output viewer
-- Fixed Search API url
-- Adjusted Abundance data table so it can be used as a drag-and-drop widget
-- Updated intro cell text and links from the Narrative side (for this to be actually visible a deploy of ui-common is necessary)
-- Improved genome viewer widget to show all contigs
+
+**Changes**
+
+-   Updates to provisioning service to deal with JIRA NAR-660 and overall stability and control
+-   Updated urls for FBA service
+-   Added new FBAModelSet output viewer
+-   Fixed Search API url
+-   Adjusted Abundance data table so it can be used as a drag-and-drop widget
+-   Updated intro cell text and links from the Narrative side (for this to be actually visible a deploy of ui-common is necessary)
+-   Improved genome viewer widget to show all contigs
 
 ### Version 0.5.6 - 2/7/2015
-__Changes__
-- Updates to FBA model viewer widgets
 
-__Bugfixes__
-- JIRA KBASE-1461 - The config file that contains the Narrative version should no longer be cached in the browser
+**Changes**
+
+-   Updates to FBA model viewer widgets
+
+**Bugfixes**
+
+-   JIRA KBASE-1461 - The config file that contains the Narrative version should no longer be cached in the browser
 
 ### Version 0.5.5 - 2/7/2015
-__Changes__
-- Minor changes to icons
 
-__Bugfixes__
-- JIRA NAR-657, KBASE-1527 - Fixed problem where a new narrative that hasn't had any jobs in it would fail to save.
-- JIRA NAR-651 - Fixed problem where a user with no narratives would see a constant spinner under the Narrative panel
-- Fixed issue where the Narrative panel would refresh twice on startup
+**Changes**
+
+-   Minor changes to icons
+
+**Bugfixes**
+
+-   JIRA NAR-657, KBASE-1527 - Fixed problem where a new narrative that hasn't had any jobs in it would fail to save.
+-   JIRA NAR-651 - Fixed problem where a user with no narratives would see a constant spinner under the Narrative panel
+-   Fixed issue where the Narrative panel would refresh twice on startup
 
 ### Version 0.5.4 - 2/6/2015
-__Changes__
-- JIRA NAR-639, KBASE-1384 - Added completion time, run time, and queue time tracking for jobs
-  - a new 'job_info' property was added to object metadata, containing the following keys:
-    - 'completed', 'error', 'running' = the number of jobs in each state, >= 0
-    - 'queue_time' = total time jobs in this narrative have spent in the 'queued' state
-    - 'run_time' = total runtime reported by jobs in this narrative
-  - these changes become visible in the jobs panel for finished jobs
-- Optimized genome viewer widget
-- Updated Metagenome viewers
-- JIRA NAR-640 - Added autosaving whenever an output or error cells is created by job status change
-- JIRA NAR-650 - Block view of any queue position unless a job is in the 'queued' state.
+
+**Changes**
+
+-   JIRA NAR-639, KBASE-1384 - Added completion time, run time, and queue time tracking for jobs
+    -   a new 'job_info' property was added to object metadata, containing the following keys:
+        -   'completed', 'error', 'running' = the number of jobs in each state, >= 0
+        -   'queue_time' = total time jobs in this narrative have spent in the 'queued' state
+        -   'run_time' = total runtime reported by jobs in this narrative
+    -   these changes become visible in the jobs panel for finished jobs
+-   Optimized genome viewer widget
+-   Updated Metagenome viewers
+-   JIRA NAR-640 - Added autosaving whenever an output or error cells is created by job status change
+-   JIRA NAR-650 - Block view of any queue position unless a job is in the 'queued' state.
 
 ### Version 0.5.3 - 2/5/2015
-__Changes__
-- More minor icon changes.
-- Changed hard-coded urls to be relative to the config file in many widgets.
+
+**Changes**
+
+-   More minor icon changes.
+-   Changed hard-coded urls to be relative to the config file in many widgets.
 
 ### Version 0.5.2 - 2/5/2015
-__Changes__
-- Rerouted landing pages to new endpoint
-- Updated Docker container cleanup script to kill unused containers then images
-- Added new gapfill output widget
-- Added new icons, some code cleanup for setting icons
-- Made "corrupt" narrative labels slightly more obvious
 
-__Bugfixes__
-- Fixed problem where data list filter gets confused when searching and changing type filters
+**Changes**
+
+-   Rerouted landing pages to new endpoint
+-   Updated Docker container cleanup script to kill unused containers then images
+-   Added new gapfill output widget
+-   Added new icons, some code cleanup for setting icons
+-   Made "corrupt" narrative labels slightly more obvious
+
+**Bugfixes**
+
+-   Fixed problem where data list filter gets confused when searching and changing type filters
 
 ### Version 0.5.1 - 2/4/2015
-__Changes__
-- Updated data and app icons, and docs about them
-- Added stats tab to metagenome collection view
-- Fixed minor issue with tab highlighting still being bezeled
-- Hid button for method gallery :(
-- Fixed more inconsistent font issues on buttons
-- Modified text on 3-bar menu, added link to dashboard
+
+**Changes**
+
+-   Updated data and app icons, and docs about them
+-   Added stats tab to metagenome collection view
+-   Fixed minor issue with tab highlighting still being bezeled
+-   Hid button for method gallery :(
+-   Fixed more inconsistent font issues on buttons
+-   Modified text on 3-bar menu, added link to dashboard
 
 ### Version 0.5.0 - 2/3/2015
-__Changes__
-- Refactor to parts of Narrative init module
-  - JIRA NAR-561 Added a version check mechanism - when a new version is deployed, a green button should appear in the header with a prompt to reload
-  - Wired deployment script to emit a version text file that sits in /kb/deployment/ui-common's root
-- Made several style changes - see https://github.com/kbase/narrative/issues/161
-  - Removed edged corners from remaining KBase cells and IPython cells
-  - JIRA NAR-421 - removed header styling from markdown and code cells
-  - KBASE-1196 - changed red ring around running methods to blue ring
-  - Red ring around a cell now only means it's in an error state
-  - Made all separator lines slightly bolder - #CECECE
-  - Added some spacing between login icon and buttons
-  - Updated tab color to a slightly different blue
-  - Added green highlight color as the general use (selected tabs, buttons, etc)
-  - Icons should now be shared between the different data panels and slideout
-  - Added blue color to markdown and code cell buttons, embiggened their icon
-  - Removed superfluous separator line from the top of side panels
-  - Javascript files are now compiled, minified, and tagged with a hash versioning during deployment - the browser should download only one substantial file instead of nearly 100 (!) smallish ones
-  - Cleaned out (commented out) old Javascript widgets that are not necessary for the February release
-  - Added test script for the backend shutdown command to verify it's only possible for an authenticated user to only shut down their own narrative
-  - Added improvements to suggested next steps functionality - now it should pull from the method store instead of being hard-coded
-  - Added custom icons for several datatypes
 
-__Bugfixes__
-- JIRA NAR-586 - fixed error with quotation marks not being used correctly in App info boxes, and links not being rendered properly
-- Fixed several font mismatch issues - in kernel menu, new/copy narrative buttons, error buttons
-- Fixed logic error that led to log proxy causing the CPU to spin
-- Only show job queue position if > 0
-- JIRA KBASE-1304 - fixed race condition that would prevent certain output cells from appearing in apps properly when restarted without saving the output
-- Re-added ability to run the narrative_shutdown command from external hosts
+**Changes**
+
+-   Refactor to parts of Narrative init module
+    -   JIRA NAR-561 Added a version check mechanism - when a new version is deployed, a green button should appear in the header with a prompt to reload
+    -   Wired deployment script to emit a version text file that sits in /kb/deployment/ui-common's root
+-   Made several style changes - see https://github.com/kbase/narrative/issues/161
+    -   Removed edged corners from remaining KBase cells and IPython cells
+    -   JIRA NAR-421 - removed header styling from markdown and code cells
+    -   KBASE-1196 - changed red ring around running methods to blue ring
+    -   Red ring around a cell now only means it's in an error state
+    -   Made all separator lines slightly bolder - #CECECE
+    -   Added some spacing between login icon and buttons
+    -   Updated tab color to a slightly different blue
+    -   Added green highlight color as the general use (selected tabs, buttons, etc)
+    -   Icons should now be shared between the different data panels and slideout
+    -   Added blue color to markdown and code cell buttons, embiggened their icon
+    -   Removed superfluous separator line from the top of side panels
+    -   Javascript files are now compiled, minified, and tagged with a hash versioning during deployment - the browser should download only one substantial file instead of nearly 100 (!) smallish ones
+    -   Cleaned out (commented out) old Javascript widgets that are not necessary for the February release
+    -   Added test script for the backend shutdown command to verify it's only possible for an authenticated user to only shut down their own narrative
+    -   Added improvements to suggested next steps functionality - now it should pull from the method store instead of being hard-coded
+    -   Added custom icons for several datatypes
+
+**Bugfixes**
+
+-   JIRA NAR-586 - fixed error with quotation marks not being used correctly in App info boxes, and links not being rendered properly
+-   Fixed several font mismatch issues - in kernel menu, new/copy narrative buttons, error buttons
+-   Fixed logic error that led to log proxy causing the CPU to spin
+-   Only show job queue position if > 0
+-   JIRA KBASE-1304 - fixed race condition that would prevent certain output cells from appearing in apps properly when restarted without saving the output
+-   Re-added ability to run the narrative_shutdown command from external hosts
 
 ### Version 0.4.9 - 1/30/2015
-__Changes__
-- Added some missing metagenome viewer widgets.
-- Updated all JS client code to their most recent compiled versions.
-- Updated Python Narrative Method Store client.
-- Improved layout and structure of job error modal.
-- Improved styling for data view/selector buttons
-- Added downloaders for FBA models, paired-end reads, and single-end reads.
-- Added a 'Copy Narrative' button to narrative panel
-- Added a friendly and potentially helpful message for narrative fatal errors.
 
-__Bugfixes__
-- JIRA NAR-530 - fixed issue with long object names not wrapping in dropdown selectors.
-- JIRA NAR-579 - fixed problem where short-jobs (e.g. viewers) were improperly treated as long-running.
-- JIRA NAR-582, NAR-514 - added better error status checking for job lookups. Now it covers network errors, unauthorized user errors, missing job errors, and generic AWE errors
+**Changes**
+
+-   Added some missing metagenome viewer widgets.
+-   Updated all JS client code to their most recent compiled versions.
+-   Updated Python Narrative Method Store client.
+-   Improved layout and structure of job error modal.
+-   Improved styling for data view/selector buttons
+-   Added downloaders for FBA models, paired-end reads, and single-end reads.
+-   Added a 'Copy Narrative' button to narrative panel
+-   Added a friendly and potentially helpful message for narrative fatal errors.
+
+**Bugfixes**
+
+-   JIRA NAR-530 - fixed issue with long object names not wrapping in dropdown selectors.
+-   JIRA NAR-579 - fixed problem where short-jobs (e.g. viewers) were improperly treated as long-running.
+-   JIRA NAR-582, NAR-514 - added better error status checking for job lookups. Now it covers network errors, unauthorized user errors, missing job errors, and generic AWE errors
 
 ### Version 0.4.8 - 1/29/2015
-__Changes__
-- Fixed issue with input object type for reads ref-lib uploader.
-- Fixed bug with absent red box around long running UJS method
-- Single file download mode was switched off
-- Zip file mode including provenance info was supported for JSON format download
-- Added lots of new icons for data and apps
-- Updated some of the button styles in the data panels
 
-__Bugfixes__
-- Fixed issue with synchronous methods being treated as asynchronous, and not showing any output.
+**Changes**
+
+-   Fixed issue with input object type for reads ref-lib uploader.
+-   Fixed bug with absent red box around long running UJS method
+-   Single file download mode was switched off
+-   Zip file mode including provenance info was supported for JSON format download
+-   Added lots of new icons for data and apps
+-   Updated some of the button styles in the data panels
+
+**Bugfixes**
+
+-   Fixed issue with synchronous methods being treated as asynchronous, and not showing any output.
 
 ### Version 0.4.7 - 1/28/2015
-__Changes__
-- Changed Narrative tutorial link to the new one on staging.kbase.us
-- JIRA NAR-444 - Changed websocket error dialog to something much more user-readable and KBase-appropriate.
+
+**Changes**
+
+-   Changed Narrative tutorial link to the new one on staging.kbase.us
+-   JIRA NAR-444 - Changed websocket error dialog to something much more user-readable and KBase-appropriate.
 
 ### Version 0.4.6 - 1/28/2015
-__Changes__
-- Added another separate page when a narrative is not found (not just unauthorized)
-- Added support for single file extraction during download
-- Changed "dna" parameter of plant transcriptome uploader to integer value
 
-__Bugfixes__
-- Fixed issue with deployment script not auto-shutting-down all non-attached instances
-- NAR-500 - completed UJS jobs should stay completed
-- NAR-562 - job deletion should work right, and if a deletion fails, it shouldn't break the jobs panel
-- When a user tries to delete a job, it should always remove that job
-- NAR-484 - long job names should wrap now
-- Fixed more issues with FBA model widgets
-- Fixed boolean properties issues in uploaders
+**Changes**
+
+-   Added another separate page when a narrative is not found (not just unauthorized)
+-   Added support for single file extraction during download
+-   Changed "dna" parameter of plant transcriptome uploader to integer value
+
+**Bugfixes**
+
+-   Fixed issue with deployment script not auto-shutting-down all non-attached instances
+-   NAR-500 - completed UJS jobs should stay completed
+-   NAR-562 - job deletion should work right, and if a deletion fails, it shouldn't break the jobs panel
+-   When a user tries to delete a job, it should always remove that job
+-   NAR-484 - long job names should wrap now
+-   Fixed more issues with FBA model widgets
+-   Fixed boolean properties issues in uploaders
 
 ### Version 0.4.5 - 1/28/2015
-__Changes__
-- Changed endpoint URLs for transform service and job service
-- Added better error page when a narrative is either not found or unauthorized
-- Made several adjustments to communities visualization widgets
 
-__Bugfixes__
-- Fixed state checking for long-running job registered with the UJS
-- Fixed issue where FBA service can return unparseable results
-- Fixed various problems with FBA model visualization widgets
+**Changes**
 
+-   Changed endpoint URLs for transform service and job service
+-   Added better error page when a narrative is either not found or unauthorized
+-   Made several adjustments to communities visualization widgets
+
+**Bugfixes**
+
+-   Fixed state checking for long-running job registered with the UJS
+-   Fixed issue where FBA service can return unparseable results
+-   Fixed various problems with FBA model visualization widgets
 
 ### Version 0.4.4 - 1/27/2015
-__Changes__
-- Updated deployment script to auto-init/update submodules and clear out old versions of provisioned (but unattached) containers,
-- Updates to metagenome widgets to prevent crashes.
 
-__Bugfixes__
-- JIRA NAR-541 - fixed problem with missing datatables header images
-- Removed (again?) a dead pointer to a deprecated/moved javascript file.
+**Changes**
+
+-   Updated deployment script to auto-init/update submodules and clear out old versions of provisioned (but unattached) containers,
+-   Updates to metagenome widgets to prevent crashes.
+
+**Bugfixes**
+
+-   JIRA NAR-541 - fixed problem with missing datatables header images
+-   Removed (again?) a dead pointer to a deprecated/moved javascript file.
 
 ### Version 0.4.3 - 1/27/2015
-__Changes__
-- Updated Transform endpoint to the production version
-- Updated Gene Domains endpoint to the production version
-- Added kbaseDomainAnnotation widget
-- Added Media, PhenotypeSet, and PhenotypeSimulationSet widgets
-- Moved downloader panel to a separate widget
-- Updated log testing proxy
 
-__Bugfixes__
-- Fixed issue where some workspace/narrative mappings were lost
+**Changes**
+
+-   Updated Transform endpoint to the production version
+-   Updated Gene Domains endpoint to the production version
+-   Added kbaseDomainAnnotation widget
+-   Added Media, PhenotypeSet, and PhenotypeSimulationSet widgets
+-   Moved downloader panel to a separate widget
+-   Updated log testing proxy
+
+**Bugfixes**
+
+-   Fixed issue where some workspace/narrative mappings were lost
 
 ### Version 0.4.2 - 1/23/2015
-__Changes__
-- JIRA NAR-432 - added little red badge in the Jobs header with the number of running jobs
-- Added support for CSV to PhenotypeSet importer
-- Added support for Media importer
-- Added support for importing FBA Models from CSV or SBML
-- Optional dropdown inputs can now pass no inputs if its spec defaults to an empty string
-- Parameter info mouseover icon only appears if the longer info is different from the short hint
+
+**Changes**
+
+-   JIRA NAR-432 - added little red badge in the Jobs header with the number of running jobs
+-   Added support for CSV to PhenotypeSet importer
+-   Added support for Media importer
+-   Added support for importing FBA Models from CSV or SBML
+-   Optional dropdown inputs can now pass no inputs if its spec defaults to an empty string
+-   Parameter info mouseover icon only appears if the longer info is different from the short hint
 
 ### Version 0.4.1 - 1/23/2015
-__Changes__
-- Added link to app man page from app cell
-- Importer for FASTA/FASTQ files was switched to a new version
 
-__Bugfixes__
-- Error modal that appears while trying to import data should be visible now, and not below the page dimmer
-- JIRA NAR-477 - Propagating parameters to multiple steps should work correctly now
-- JIRA NAR-516 - special characters should be properly escaped while searching for data now
+**Changes**
+
+-   Added link to app man page from app cell
+-   Importer for FASTA/FASTQ files was switched to a new version
+
+**Bugfixes**
+
+-   Error modal that appears while trying to import data should be visible now, and not below the page dimmer
+-   JIRA NAR-477 - Propagating parameters to multiple steps should work correctly now
+-   JIRA NAR-516 - special characters should be properly escaped while searching for data now
 
 ### Version 0.4.0 - 1/23/2015
 
 These are significant enough changes - mainly the improved data upload support and (mostly) feature complete data visualization widgets - to add a minor version number.
 
-__Changes__
-- Updated URL of tutorial page
-- Updated user-icon link to go to user profile page instead of globus
-- Added features to Gene Domains visualization widget
-- Updated FBA model widgets
-- The 'Search Data' menu item should make a new browser window
-- Added refresh button to data slideout
-- Added example transcriptome data
-- Updated import UI for all supported types
-- Improved error messages in data panel and data slideout
+**Changes**
 
-__Bugfixes__
-- Fixed some problems in create_metagenome_set widget
-- JIRA NAR-465 Fixed problem where workspace id wasn't internally available when it should be
-- JIRA KBASE-1610 Fixed issue with selecting multiple genomes for an input to an app
+-   Updated URL of tutorial page
+-   Updated user-icon link to go to user profile page instead of globus
+-   Added features to Gene Domains visualization widget
+-   Updated FBA model widgets
+-   The 'Search Data' menu item should make a new browser window
+-   Added refresh button to data slideout
+-   Added example transcriptome data
+-   Updated import UI for all supported types
+-   Improved error messages in data panel and data slideout
+
+**Bugfixes**
+
+-   Fixed some problems in create_metagenome_set widget
+-   JIRA NAR-465 Fixed problem where workspace id wasn't internally available when it should be
+-   JIRA KBASE-1610 Fixed issue with selecting multiple genomes for an input to an app
 
 ### Version 0.3.18 - 1/22/2015
-__Changes__
-- Added a different FBA model viewer widget
-- Changed communities widgets to properly fetch an auth token
 
-__Bugfixes__
-- JIRA NAR-478 - fixed problem where contig count in genome viewer was incorrect
-- JIRA NAR-487 - plant genomes should be copyable now in data slide out
-- JIRA NAR-441 - corrupted Narratives should be properly handled; deleting a Narrative from a workspace via the API shouldn't break the Narrative loading process
+**Changes**
+
+-   Added a different FBA model viewer widget
+-   Changed communities widgets to properly fetch an auth token
+
+**Bugfixes**
+
+-   JIRA NAR-478 - fixed problem where contig count in genome viewer was incorrect
+-   JIRA NAR-487 - plant genomes should be copyable now in data slide out
+-   JIRA NAR-441 - corrupted Narratives should be properly handled; deleting a Narrative from a workspace via the API shouldn't break the Narrative loading process
 
 ### Version 0.3.17 - 1/22/2015
-__Bugfixes__
-- Repaired link to FBA model visualization widgets
+
+**Bugfixes**
+
+-   Repaired link to FBA model visualization widgets
 
 ### Version 0.3.16 - 1/21/2015
-__Changes__
-- Added link to KBase internal status page.
-- Added programmatic access to workspace id.
-- KBase cells can now be collapsed and restored.
-- App and Method cells now have a spinning icon while running.
-- A traceback should now appear (where applicable) in the Jobs panel.
-- Added "next steps" at bottom of app/method
+
+**Changes**
+
+-   Added link to KBase internal status page.
+-   Added programmatic access to workspace id.
+-   KBase cells can now be collapsed and restored.
+-   App and Method cells now have a spinning icon while running.
+-   A traceback should now appear (where applicable) in the Jobs panel.
+-   Added "next steps" at bottom of app/method
 
 ### Version 0.3.15 - 1/21/2015
-__Changes__
-- Updated type name for Assembly File transform method
-- Added reset button to App cells (method cells still need fixing)
-- Added widgets for metagenome sets
 
-__Bugfixes__
-- JIRA NAR-418 - fixed issue where job error was cleared on panel refresh.
-- Fixed issue where method panel error state wasn't being activated properly.
+**Changes**
+
+-   Updated type name for Assembly File transform method
+-   Added reset button to App cells (method cells still need fixing)
+-   Added widgets for metagenome sets
+
+**Bugfixes**
+
+-   JIRA NAR-418 - fixed issue where job error was cleared on panel refresh.
+-   Fixed issue where method panel error state wasn't being activated properly.
 
 ### Version 0.3.14 - 1/21/2015
-__Changes__
-- Updated server-side Narrative management code to always keep a queue of unattached Narrative containers present. When a user logs on, they already have one ready to connect to.
-- Added visualization widget for microbial community abundance and boxplots.
-- Method details and documentation are visible in a new window now.
-- Added app and method icons for the method panel.
-- Added minimize to app & method panels
+
+**Changes**
+
+-   Updated server-side Narrative management code to always keep a queue of unattached Narrative containers present. When a user logs on, they already have one ready to connect to.
+-   Added visualization widget for microbial community abundance and boxplots.
+-   Method details and documentation are visible in a new window now.
+-   Added app and method icons for the method panel.
+-   Added minimize to app & method panels
 
 ### Version 0.3.13 - 1/20/2015
-__Changes__
-- Added Transform service client code
-- Exposed transform service as a method
-- Added assembly view widget
-- Added icons for Apps and Methods in panel
 
-__Bugfixes__
-- Now inserts a cell instead of freezing when DnD of data onto empty narrative
-- JIRA NAR-388 - fixed a problem where errors on service invocation weren't being stringified properly before logging
-- Github issue #162 fixed - drag and drop data onto an empty Narrative now doesn't lock up
-- JIRA NAR-402 - saving a Narrative updates the Manage panel
-- JIRA KBASE-1199 - newly registered jobs should show a timestamp
-- KBASE-1210 - (not totally fixed) - debug info for launched methods should show up on the console now.
-- NAR-400, KBASE-1202, KBASE-1192, KBASE-1191 - these were all related to the apps not properly catching errors when an output widget fails to render
-- fixed a case where a typespec references a non-existent viewer
+**Changes**
+
+-   Added Transform service client code
+-   Exposed transform service as a method
+-   Added assembly view widget
+-   Added icons for Apps and Methods in panel
+
+**Bugfixes**
+
+-   Now inserts a cell instead of freezing when DnD of data onto empty narrative
+-   JIRA NAR-388 - fixed a problem where errors on service invocation weren't being stringified properly before logging
+-   Github issue #162 fixed - drag and drop data onto an empty Narrative now doesn't lock up
+-   JIRA NAR-402 - saving a Narrative updates the Manage panel
+-   JIRA KBASE-1199 - newly registered jobs should show a timestamp
+-   KBASE-1210 - (not totally fixed) - debug info for launched methods should show up on the console now.
+-   NAR-400, KBASE-1202, KBASE-1192, KBASE-1191 - these were all related to the apps not properly catching errors when an output widget fails to render
+-   fixed a case where a typespec references a non-existent viewer
 
 ### Version 0.3.12 - 1/20/2015
-__Changes__
-- Fixes issue where the Method Gallery overlay panel wouldn't be populated if there were any problematic method/app specs.
-- Added a link to directly submit a JIRA ticket from the pulldown menu.
+
+**Changes**
+
+-   Fixes issue where the Method Gallery overlay panel wouldn't be populated if there were any problematic method/app specs.
+-   Added a link to directly submit a JIRA ticket from the pulldown menu.
 
 ### Version 0.3.11 - 1/16/2015
-__Changes__
-- Running Apps and Methods have a "Cancel" button associated with them. Clicking that will restore the cell to its input state, and cancel (and delete) the running job
-- Deleting App/Method cells now prompts to delete, warning the user that it'll kill any running job (if they've been run before)
-- Deleting jobs now triggers the call to the right back end services to delete the running job itself.
-- Deleting a job from a running cell now unlocks that cell so its inputs can be used again.
-- A dangling job with no associated cell should properly error.
-- A dangling job on the front end that's been deleted on the back should properly error.
-- A job in an error state (not the above, but a runtime error) should now reflect an error on its associated cell (if present)
-- Fixed an error where running a method automatically made an output cell connected to incomplete data.
-- Refactored Jobs panel to only look up jobs that are incomplete (e.g. not 'error', 'completed', 'done', or 'deleted')
-- Toolbars should only appear over IPython cells now (KBase cells have their own menus)
-- Styled app/method control buttons to be closer to the style guide / mockup.
-- Logging of apps and methods is substantially less ugly and made from fewer backslashes.
+
+**Changes**
+
+-   Running Apps and Methods have a "Cancel" button associated with them. Clicking that will restore the cell to its input state, and cancel (and delete) the running job
+-   Deleting App/Method cells now prompts to delete, warning the user that it'll kill any running job (if they've been run before)
+-   Deleting jobs now triggers the call to the right back end services to delete the running job itself.
+-   Deleting a job from a running cell now unlocks that cell so its inputs can be used again.
+-   A dangling job with no associated cell should properly error.
+-   A dangling job on the front end that's been deleted on the back should properly error.
+-   A job in an error state (not the above, but a runtime error) should now reflect an error on its associated cell (if present)
+-   Fixed an error where running a method automatically made an output cell connected to incomplete data.
+-   Refactored Jobs panel to only look up jobs that are incomplete (e.g. not 'error', 'completed', 'done', or 'deleted')
+-   Toolbars should only appear over IPython cells now (KBase cells have their own menus)
+-   Styled app/method control buttons to be closer to the style guide / mockup.
+-   Logging of apps and methods is substantially less ugly and made from fewer backslashes.
 
 ### Version 0.3.10 - 1/16/2015
-__Changes__
-- Narrative panel supports copy/delete/history/revert of narratives.
-- Narrative panel shows apps/methods/description (if exists) for each narrative.
-- Links to LP for genomes and genes were added in Proteome Comparison widget.
-- 'Download as JSON' button was added for objects in narrative data list.
-- Links to LP were added for genes in genome viewer.
-- ContigSet viewer was added.
-- Plant genomes were added into public data tab (and GWAS types were removed).
-- Fixed problem where error cells were not being shown properly.
-- Added several widgets to support communities apps and methods.
+
+**Changes**
+
+-   Narrative panel supports copy/delete/history/revert of narratives.
+-   Narrative panel shows apps/methods/description (if exists) for each narrative.
+-   Links to LP for genomes and genes were added in Proteome Comparison widget.
+-   'Download as JSON' button was added for objects in narrative data list.
+-   Links to LP were added for genes in genome viewer.
+-   ContigSet viewer was added.
+-   Plant genomes were added into public data tab (and GWAS types were removed).
+-   Fixed problem where error cells were not being shown properly.
+-   Added several widgets to support communities apps and methods.
 
 ### Version 0.3.9 - 1/14/2015
-__Changes__
-- Restyled menu bar buttons - 'about' button is now under the dropdown menu on the upper left of the screen, removed the global 'delete cell' button (for now!)
-- Restyled code and markdown cell buttons in the lower right corner of the page
-- Added a debug message that appears in the browser's Javascript console whenever an app/method object is sent to the NJS
-- App and Method specs should be globally available to all elements on the page from the method panel
-- Various styling adjustments on the data panel overlay
-- The 'more' button under each app and method in the methods panel should now link to an external manual page
+
+**Changes**
+
+-   Restyled menu bar buttons - 'about' button is now under the dropdown menu on the upper left of the screen, removed the global 'delete cell' button (for now!)
+-   Restyled code and markdown cell buttons in the lower right corner of the page
+-   Added a debug message that appears in the browser's Javascript console whenever an app/method object is sent to the NJS
+-   App and Method specs should be globally available to all elements on the page from the method panel
+-   Various styling adjustments on the data panel overlay
+-   The 'more' button under each app and method in the methods panel should now link to an external manual page
 
 ### Version 0.3.8 - 1/13/2015
-__Changes__
-- Drag and drop data and data viewer bug fixes.
-- Position of a queued job should now be tracked in the job panel.
-- The Narrative object metadata now tracks the number of each type of cell in that Narrative. Method and App cells are further tracked by their id.
+
+**Changes**
+
+-   Drag and drop data and data viewer bug fixes.
+-   Position of a queued job should now be tracked in the job panel.
+-   The Narrative object metadata now tracks the number of each type of cell in that Narrative. Method and App cells are further tracked by their id.
 
 ### Version 0.3.7 - 1/12/2015
-__Changes__
-- Fix for int, float and array types of input sending to NJS
-- Fix for empty parameter values in import tab
-- Support was added into public data for meta-genomes and 6 types of GWAS
-- Fixed 'Add Data' button in a new Narrative - should properly open the data overlay now
-- Updated layout and styling of Method Gallery overlay to be closer to the mockup
+
+**Changes**
+
+-   Fix for int, float and array types of input sending to NJS
+-   Fix for empty parameter values in import tab
+-   Support was added into public data for meta-genomes and 6 types of GWAS
+-   Fixed 'Add Data' button in a new Narrative - should properly open the data overlay now
+-   Updated layout and styling of Method Gallery overlay to be closer to the mockup
 
 ### Version 0.3.6 - 1/9/2015
-__Changes__
-- Changed install.sh - now it requires an existing Python virtual environment for installation
-- Removed text/code cell buttons from method panel - they've now migrated to the lower right side of the page.
-- Started restyling various elements to match the new style guide (colors, shadows, etc.)
-- Inserted (better) icons than just letters for data objects
-- Public data tab on side panel was redesigned. Genome mode using search API is now the only supported mode there.
-- Method cell changes
-    - Fixed problem where starting a long-running method would immediately show an output cell with broken results
-    - Fixed problem when submitting a method with numerical value inputs
-    - Fixed problem when submitting a method with multiple possible output types for a single parameter
-    - Fixed problem where method cell parameters were not being properly validated before sending the job
-- Added document that details app failure points
-- Data list supports deleting, renaming, reverting objects
+
+**Changes**
+
+-   Changed install.sh - now it requires an existing Python virtual environment for installation
+-   Removed text/code cell buttons from method panel - they've now migrated to the lower right side of the page.
+-   Started restyling various elements to match the new style guide (colors, shadows, etc.)
+-   Inserted (better) icons than just letters for data objects
+-   Public data tab on side panel was redesigned. Genome mode using search API is now the only supported mode there.
+-   Method cell changes
+    -   Fixed problem where starting a long-running method would immediately show an output cell with broken results
+    -   Fixed problem when submitting a method with numerical value inputs
+    -   Fixed problem when submitting a method with multiple possible output types for a single parameter
+    -   Fixed problem where method cell parameters were not being properly validated before sending the job
+-   Added document that details app failure points
+-   Data list supports deleting, renaming, reverting objects
 
 ### Version 0.3.5 - 1/7/2015
-__Changes__
-- Added link to release notes in 'About' dialog.
-- Removed old links from the Navbar menu.
-- Added separate 'Jobs' tab to side panel.
-- Fixed problem with Job errors overflowing the error modal.
-- Method panel changes
-    - The magnifying glass button should now toggle the search input.
-    - Added a 'type:_objecttype_' filter on methods and apps. This filters by their parameters. E.g. putting 'type:genome' or 'type:KBaseGenomes.Genome' in there will only show methods/apps that have a genome as a parameter.
-    - Added an event that can be fired to auto-filter the methods and apps.
-    - Updated the style to a more 'material' look.
-    - All specs are now fetched at Narrative startup. This will speed up some of the in-page population, but any apps with errors in their specs are no longer displayed in the list.
-    - Removed the '+/-' buttons for expanding the tooltip, replaced with '...'
-- Data list changes
-    - Added a big red '+' button to add more data.
-    - Updated the style to a more 'material' look.
-    - Removed the '+/-' buttons for showing metadata info, replaced with '...'
-- Import tab on GetData side panel allows now to upload genome from GBK file, transcriptomes from Fasta and short reads from Fasta and Fastq
-- Viewers can be open for main data types by drag-n-drop objects from Data panel to narrative
-- States of long running methods calling services are now shown on Job panel and Job panel waits for 'Done' state before show output widget
-- Added a 'debug' viewer to the apps. After starting an app's run, click on the gear menu in the app cell and select 'View Job Submission'. This will both emit the returned kernel messages from that app run into your browser's Javascript console, and it will create and run a code cell that will show you the object that gets set to the Job Service.
+
+**Changes**
+
+-   Added link to release notes in 'About' dialog.
+-   Removed old links from the Navbar menu.
+-   Added separate 'Jobs' tab to side panel.
+-   Fixed problem with Job errors overflowing the error modal.
+-   Method panel changes
+    -   The magnifying glass button should now toggle the search input.
+    -   Added a 'type:_objecttype_' filter on methods and apps. This filters by their parameters. E.g. putting 'type:genome' or 'type:KBaseGenomes.Genome' in there will only show methods/apps that have a genome as a parameter.
+    -   Added an event that can be fired to auto-filter the methods and apps.
+    -   Updated the style to a more 'material' look.
+    -   All specs are now fetched at Narrative startup. This will speed up some of the in-page population, but any apps with errors in their specs are no longer displayed in the list.
+    -   Removed the '+/-' buttons for expanding the tooltip, replaced with '...'
+-   Data list changes
+    -   Added a big red '+' button to add more data.
+    -   Updated the style to a more 'material' look.
+    -   Removed the '+/-' buttons for showing metadata info, replaced with '...'
+-   Import tab on GetData side panel allows now to upload genome from GBK file, transcriptomes from Fasta and short reads from Fasta and Fastq
+-   Viewers can be open for main data types by drag-n-drop objects from Data panel to narrative
+-   States of long running methods calling services are now shown on Job panel and Job panel waits for 'Done' state before show output widget
+-   Added a 'debug' viewer to the apps. After starting an app's run, click on the gear menu in the app cell and select 'View Job Submission'. This will both emit the returned kernel messages from that app run into your browser's Javascript console, and it will create and run a code cell that will show you the object that gets set to the Job Service.
 
 ### Version 0.3.4
-__Changes__
-- Redesign of the Method Gallery panel
-- Adjusted Data Panel slideout to maintain its size across each internal tab
-- Added buttons to the footer in the Data Panel slideout
-- Adjustment to data upload panel behavior.
+
+**Changes**
+
+-   Redesign of the Method Gallery panel
+-   Adjusted Data Panel slideout to maintain its size across each internal tab
+-   Added buttons to the footer in the Data Panel slideout
+-   Adjustment to data upload panel behavior.
 
 ### Version 0.3.3
-__Changes__
-- Long running method calls that produce job ids should now be tracked properly
-- Method cells behave closer to App cells now - once they start running, they're 'locked' if they're a long running job
-  - Long running method cells get a red ring, similar to steps inside an app
-  - The next step is to merge their code bases
-- When a long running method cell finishes (the job gets output and is marked 'done' or something similar), an output cell is generated beneath it
-- Method and app jobs should be properly deleteable again.
-- Added global 'delete cell' button back to the menu bar.
-- Made major styling and functionality changes to the 'import' panel attached to 'data'
+
+**Changes**
+
+-   Long running method calls that produce job ids should now be tracked properly
+-   Method cells behave closer to App cells now - once they start running, they're 'locked' if they're a long running job
+    -   Long running method cells get a red ring, similar to steps inside an app
+    -   The next step is to merge their code bases
+-   When a long running method cell finishes (the job gets output and is marked 'done' or something similar), an output cell is generated beneath it
+-   Method and app jobs should be properly deleteable again.
+-   Added global 'delete cell' button back to the menu bar.
+-   Made major styling and functionality changes to the 'import' panel attached to 'data'
 
 ### Version 0.3.2
-__Changes__
-- Steps toward getting long-running methods (not just apps) working.
-- Modified job panel to consume method jobs
-- Method jobs still do not correctly populate their end results.
+
+**Changes**
+
+-   Steps toward getting long-running methods (not just apps) working.
+-   Modified job panel to consume method jobs
+-   Method jobs still do not correctly populate their end results.
 
 ### Version 0.3.1
-__Changes__
-- Changed some text in the data panel, and what appears in the introductory markdown cell in a new Narrative
-- Fixed an issue with infinite scrolling under the "My Data" and "Public" data tabs
+
+**Changes**
+
+-   Changed some text in the data panel, and what appears in the introductory markdown cell in a new Narrative
+-   Fixed an issue with infinite scrolling under the "My Data" and "Public" data tabs
 
 ### Version 0.3.0
-__Changes__
-- Added Method Gallery for browing methods and apps and viewing information
-- Added a manual Narrative Shutdown button (under the 'about' button)
-- Integrated code cells and IPython kernel management
-- Added prototype Narrative Management panel
+
+**Changes**
+
+-   Added Method Gallery for browing methods and apps and viewing information
+-   Added a manual Narrative Shutdown button (under the 'about' button)
+-   Integrated code cells and IPython kernel management
+-   Added prototype Narrative Management panel
 
 ### Version 0.2.2
-__Changes__
-- Restyled Jobs panel, added better management controls, added ability to see Job error statuses
-- Added first pass at data importer
+
+**Changes**
+
+-   Restyled Jobs panel, added better management controls, added ability to see Job error statuses
+-   Added first pass at data importer
 
 ### Version 0.2.1
-__Changes__
-- More improvements to logging - includes more details like user's IP address, Narrative machine, etc.
-- Changed data panel to be able to draw data from all other Narratives and Workspaces
-- Stubs in place for importing data into your Narrative
-- Changed paradigm to one narrative/one workspace for simplicity
+
+**Changes**
+
+-   More improvements to logging - includes more details like user's IP address, Narrative machine, etc.
+-   Changed data panel to be able to draw data from all other Narratives and Workspaces
+-   Stubs in place for importing data into your Narrative
+-   Changed paradigm to one narrative/one workspace for simplicity
 
 ### Version 0.2.0
-__Changes__
-- Switched to semantic versioning - www.semver.org
-- Began massive changes to the UI
-- Improved logging of events and method/app running
-- Introduced App interface
-- Added a Job management panel for tracking App status
-- Switched to fetching lists of Methods and Apps from a centralized method store
+
+**Changes**
+
+-   Switched to semantic versioning - www.semver.org
+-   Began massive changes to the UI
+-   Improved logging of events and method/app running
+-   Introduced App interface
+-   Added a Job management panel for tracking App status
+-   Switched to fetching lists of Methods and Apps from a centralized method store
 
 ### Release 9/25/2014
-__Changes__
-- Fixed a bug that prevented a few Narrative functions from working if the
-user's workspace was empty.
+
+**Changes**
+
+-   Fixed a bug that prevented a few Narrative functions from working if the
+    user's workspace was empty.
 
 ### Release 9/24/2014
-__Changes__
-- Updated workspace URL from the Narrative Interface
+
+**Changes**
+
+-   Updated workspace URL from the Narrative Interface
 
 ### Release 8/14/2014
-__Changes__
-- Added functionality to Communities services
+
+**Changes**
+
+-   Added functionality to Communities services
 
 ### Release 8/8/2014
-__Changes__
-- Fixed problems with loading page in Safari
-- Added genome comparison widget
 
-__Known Issues__
-- R support is problematic
-- Sharing a Narrative with a running job might break
-- Loading a Narrative with a large amount of data in it might be slow
-- Mathjax support is currently out of sync due to version drift
+**Changes**
 
+-   Fixed problems with loading page in Safari
+-   Added genome comparison widget
+
+**Known Issues**
+
+-   R support is problematic
+-   Sharing a Narrative with a running job might break
+-   Loading a Narrative with a large amount of data in it might be slow
+-   Mathjax support is currently out of sync due to version drift
 
 ### Release 8/7/2014
-__Changes__
-- Fixed links to landing pages linked to from the Narrative
-- Fixed problem with KBCacheClient not loading properly
-- Adjusted names of some functions (existing widgets might break!)
-- Fixed 502 Bad Gateway error on Narrative provisioning
 
-__Known Issues__
-- Loading page on Narrative provisioning sometimes loops too much in Safari
-- R support is problematic
-- Sharing a Narrative with a running job might break
-- Loading a Narrative with a large amount of data in it might be slow
-- Mathjax support is currently out of sync due to version drift
+**Changes**
 
+-   Fixed links to landing pages linked to from the Narrative
+-   Fixed problem with KBCacheClient not loading properly
+-   Adjusted names of some functions (existing widgets might break!)
+-   Fixed 502 Bad Gateway error on Narrative provisioning
+
+**Known Issues**
+
+-   Loading page on Narrative provisioning sometimes loops too much in Safari
+-   R support is problematic
+-   Sharing a Narrative with a running job might break
+-   Loading a Narrative with a large amount of data in it might be slow
+-   Mathjax support is currently out of sync due to version drift
 
 ### Release 8/6/2014
-__Changes__
-- Services panel is sorted by service name now
-- Removed old Microbes Service panel
-- Updated Microbes service methods
-- Updates to picrust
-- Added ability to make deprecated services invisible
-- Updates to RNASeq and Jnomics services
-- Updates to plants widget code
-- Visual fixes to how long function names are handed in the Services panel
 
-__Known Issues__
-- R support is problematic
-- Many links to landing pages within the Narrative are broken
-- Sharing a Narrative with a running job might break
-- Loading a Narrative with a large amount of data in it might be slow
-- Mathjax support is currently out of sync due to version drift
+**Changes**
 
+-   Services panel is sorted by service name now
+-   Removed old Microbes Service panel
+-   Updated Microbes service methods
+-   Updates to picrust
+-   Added ability to make deprecated services invisible
+-   Updates to RNASeq and Jnomics services
+-   Updates to plants widget code
+-   Visual fixes to how long function names are handed in the Services panel
+
+**Known Issues**
+
+-   R support is problematic
+-   Many links to landing pages within the Narrative are broken
+-   Sharing a Narrative with a running job might break
+-   Loading a Narrative with a large amount of data in it might be slow
+-   Mathjax support is currently out of sync due to version drift
 
 ### Release 8/5/2014
-__Changes__
-- Added a better fix to the "NoneType object has no attribute get_method" error
-- Updated Microbes services code, split services into 4 separate groups
-- Updates to Jnomics
-- Split picrust widget into qiime and picrust
-- Fixes to plant gene table size and heatmap rendering
 
-__Known Issues__
-- Changing Narrative name in the workspace doesn't propagate inside of the Narrative itself (likely won't fix)
-- R support is problematic
-- Many links to landing pages within the Narrative are broken
-- Sharing a Narrative with a running job might break
-- Loading a Narrative with a large amount of data in it might be slow
-- Services panel should be sorted/sortable
-- Narrative creator and current workspace should be visible in the top panel
-- Mathjax support is currently out of sync due to version drift
+**Changes**
+
+-   Added a better fix to the "NoneType object has no attribute get_method" error
+-   Updated Microbes services code, split services into 4 separate groups
+-   Updates to Jnomics
+-   Split picrust widget into qiime and picrust
+-   Fixes to plant gene table size and heatmap rendering
+
+**Known Issues**
+
+-   Changing Narrative name in the workspace doesn't propagate inside of the Narrative itself (likely won't fix)
+-   R support is problematic
+-   Many links to landing pages within the Narrative are broken
+-   Sharing a Narrative with a running job might break
+-   Loading a Narrative with a large amount of data in it might be slow
+-   Services panel should be sorted/sortable
+-   Narrative creator and current workspace should be visible in the top panel
+-   Mathjax support is currently out of sync due to version drift
 
 ### Release 8/4/2014
-__Changes__
-- Added MathJax.js directly into the repo to combat problems on the back end (this is a temporary fix - we need to install the backend MathJax locally somehow, or update the version)
-- Added a fix where if a call to globusonline fails, the Narrative doesn't initialize properly, leading to broken service panels.
-- Fixed a bug that caused some graphical widgets to time out while loading their script files.
-- Various updates to plants_gwas.py and jnomics.py
+
+**Changes**
+
+-   Added MathJax.js directly into the repo to combat problems on the back end (this is a temporary fix - we need to install the backend MathJax locally somehow, or update the version)
+-   Added a fix where if a call to globusonline fails, the Narrative doesn't initialize properly, leading to broken service panels.
+-   Fixed a bug that caused some graphical widgets to time out while loading their script files.
+-   Various updates to plants_gwas.py and jnomics.py
 
 ### Release 8/1/2014
-__Changes__
-- Addressed issue with auth information getting overridden (leading to the 400 HTTP error)
-- Addressed problems that cause the 502 Bad Gateway error
-- Revised names and descriptions on some widgets
-- Added widget to build a genome set from a tree
-- Revised gapfilling and phenotype view widgets
-- Numerous widgets to GWAS and Plant-specific widgets and functionality
 
-__Known Issues__
-- Current version of jquery.datatables is finicky and can create popup errors. These can be safely ignored.
-- Changing Narrative name doesn't properly update Narrative object name in Workspace Browser and vice-versa.
-- R support is occasionally problematic.
+**Changes**
+
+-   Addressed issue with auth information getting overridden (leading to the 400 HTTP error)
+-   Addressed problems that cause the 502 Bad Gateway error
+-   Revised names and descriptions on some widgets
+-   Added widget to build a genome set from a tree
+-   Revised gapfilling and phenotype view widgets
+-   Numerous widgets to GWAS and Plant-specific widgets and functionality
+
+**Known Issues**
+
+-   Current version of jquery.datatables is finicky and can create popup errors. These can be safely ignored.
+-   Changing Narrative name doesn't properly update Narrative object name in Workspace Browser and vice-versa.
+-   R support is occasionally problematic.
 
 ### Release 7/30/2014
-__Changes__
-- Updated config to make landing page links relative to deployment site
-- Modified provisioning code to address a potential timeout issue (the 502 Bad Gateway error)
-- Adjusted RAST genome loading widget to ignore browser's credentials
-- Updated NCBI genome importer
-- Updated GWAS services endpoints
 
-__Known Issues__
-- Cookie with auth information occasionally gets overwritten with a useless one - logging out and back in will fix this
-- Changing Narrative name doesn't properly update Narrative object name in Workspace Browser and vice-versa.
-- R support is occasionally problematic.
+**Changes**
 
+-   Updated config to make landing page links relative to deployment site
+-   Modified provisioning code to address a potential timeout issue (the 502 Bad Gateway error)
+-   Adjusted RAST genome loading widget to ignore browser's credentials
+-   Updated NCBI genome importer
+-   Updated GWAS services endpoints
+
+**Known Issues**
+
+-   Cookie with auth information occasionally gets overwritten with a useless one - logging out and back in will fix this
+-   Changing Narrative name doesn't properly update Narrative object name in Workspace Browser and vice-versa.
+-   R support is occasionally problematic.
 
 ### Release 7/29/2014
-__Changes__
-- Updated nav bar to match changes to functional site
-- Updated many KBase functions from all domains (Microbes, Communities, and Plants)
-- Added widgets and functions for viewing SEED functional categories
-- Added a version date-stamp
-- Updated look and feel of many elements
-- Updated authentication and token management to behave better
-- Changed Narrative containers to all be named kbase/narrative:datestamp
-- Updated config.json to reference more deployed services
-- Added an input widget type that includes a hidden, untracked, password field
-- Updated references to registered typed objects from the Workspace
-- Fixed a problem where Services panel might get stuck and hang while loading a large Narrative
-- Updated more HTTP errors to have a sensible error page
 
-__Known Issues__
-- Cookie with auth information occasionally gets overwritten with a useless one - logging out and back in will fix this
-- Unaddressed issues from previous release
+**Changes**
 
+-   Updated nav bar to match changes to functional site
+-   Updated many KBase functions from all domains (Microbes, Communities, and Plants)
+-   Added widgets and functions for viewing SEED functional categories
+-   Added a version date-stamp
+-   Updated look and feel of many elements
+-   Updated authentication and token management to behave better
+-   Changed Narrative containers to all be named kbase/narrative:datestamp
+-   Updated config.json to reference more deployed services
+-   Added an input widget type that includes a hidden, untracked, password field
+-   Updated references to registered typed objects from the Workspace
+-   Fixed a problem where Services panel might get stuck and hang while loading a large Narrative
+-   Updated more HTTP errors to have a sensible error page
+
+**Known Issues**
+
+-   Cookie with auth information occasionally gets overwritten with a useless one - logging out and back in will fix this
+-   Unaddressed issues from previous release
 
 ### Release 7/22/2014
-__Changes__
-- Added widgets and functions for viewing phylogenies
 
+**Changes**
+
+-   Added widgets and functions for viewing phylogenies
 
 ### Release 7/21/2014
-__Changes__
-- Updates to Jnomics functions and widgets
-- Updates to Microbes functions and widgets
-- Most errors that were dumped to the browser as ugly stacktraces are now KBase-styled stacktraces that should be slightly more legible.
-- Errors that occur when Narrative saving fails now creates an error modal that communicates the error, instead of just "Autosave Failed!"
-- Deployment of Narrative Docker containers has changed. A base container is built containing most static dependencies (all the apt-get directives, Python and R packages). This container is then updated with the Narrative itself. After building the base container, deployment of subsequent releases should take ~2 minutes.
-- Updated workspace type registry (the kbtypes class) to be up-to-date with the current state of the Workspace.
-- The Narrative should now report unsupported browsers
 
-__Known Issues__
-- Unaddressed issues from previous release
+**Changes**
+
+-   Updates to Jnomics functions and widgets
+-   Updates to Microbes functions and widgets
+-   Most errors that were dumped to the browser as ugly stacktraces are now KBase-styled stacktraces that should be slightly more legible.
+-   Errors that occur when Narrative saving fails now creates an error modal that communicates the error, instead of just "Autosave Failed!"
+-   Deployment of Narrative Docker containers has changed. A base container is built containing most static dependencies (all the apt-get directives, Python and R packages). This container is then updated with the Narrative itself. After building the base container, deployment of subsequent releases should take ~2 minutes.
+-   Updated workspace type registry (the kbtypes class) to be up-to-date with the current state of the Workspace.
+-   The Narrative should now report unsupported browsers
+
+**Known Issues**
+
+-   Unaddressed issues from previous release
 
 ### Release 7/15/2014
-__Changes__
-- Created a service endpoint config file to toggle between dev and prod versions of various services
-- Added Jnomics functions and widgets
-- Added more communities functions and widgets
-- Added KBase-command functions and widgets
-- Authentication should work more logically with the rest of the functional site
-- Updated Narrative typespec to support workspace version 0.2.1
-- Updated Narrative to properly access search
-- Addressed a race condition where saving a Narrative before it completely loads might wipe exiting parameter info out of input fields
-- Added directions on how to deploy the entire Narrative/Nginx provisioning stack.
-- We now have a verified SSL Certificate - Safari should work over HTTPS now.
-- Did some CSS adjustment to GUI cells.
 
-__Known Issues__
-- Unaddressed issues remain from previous release
-- R support is occasionally problematic.
-- Changing Narrative name doesn't properly update Narrative object name in Workspace Browser and vice-versa.
+**Changes**
 
+-   Created a service endpoint config file to toggle between dev and prod versions of various services
+-   Added Jnomics functions and widgets
+-   Added more communities functions and widgets
+-   Added KBase-command functions and widgets
+-   Authentication should work more logically with the rest of the functional site
+-   Updated Narrative typespec to support workspace version 0.2.1
+-   Updated Narrative to properly access search
+-   Addressed a race condition where saving a Narrative before it completely loads might wipe exiting parameter info out of input fields
+-   Added directions on how to deploy the entire Narrative/Nginx provisioning stack.
+-   We now have a verified SSL Certificate - Safari should work over HTTPS now.
+-   Did some CSS adjustment to GUI cells.
+
+**Known Issues**
+
+-   Unaddressed issues remain from previous release
+-   R support is occasionally problematic.
+-   Changing Narrative name doesn't properly update Narrative object name in Workspace Browser and vice-versa.
 
 ### Release 6/20/2014
-__Changes__
 
-- %%inv\_run cell magic should now work properly
-- %inv\_run magic (line and cell) now translate some convenience commands
-    - %inv\_run ls == %inv\_ls
-    - %inv\_run cwd (or pwd) == %inv\_cwd
-    - %inv\_run mkdir == %inv\_make\_directory
-    - %inv\_run rmdir == %inv\_remove_directory
-    - %inv\_run cd == %inv\_cd
-    - %inv\_run rm == %inv\_remove\_files
-    - %inv\_run mv == %inv\_rename\_files
-- The menu bar should remain at the top of the page now, instead of being positioned inline with the rest of the narrative document.
+**Changes**
 
-__Known Issues__
-- %inv\_ls to a directory that doesn't exist will create a generic, not-very-informative error.
-- [NAR-153], [NAR-177] A generic "Autosave failed!" message appears when the narrative fails to save for any reason.
-- [NAR-169] Using Safari through HTTPS will not work with an uncertified SSL credential (which we currently have)
-- [NAR-173] If problems external to the Narrative prevent loading (authentication, Shock or WS downtime), an ugly stacktrace is dumped into the browser instead of a nicely rendered error page.
-- [NAR-180] Copying narratives in the newsfeed can cause errors.
-- [NAR-179] There's a problem that occurs when logged into a narrative for a long time.
+-   %%inv_run cell magic should now work properly
+-   %inv_run magic (line and cell) now translate some convenience commands
+    -   %inv_run ls == %inv_ls
+    -   %inv_run cwd (or pwd) == %inv_cwd
+    -   %inv_run mkdir == %inv_make_directory
+    -   %inv_run rmdir == %inv_remove_directory
+    -   %inv_run cd == %inv_cd
+    -   %inv_run rm == %inv_remove_files
+    -   %inv_run mv == %inv_rename_files
+-   The menu bar should remain at the top of the page now, instead of being positioned inline with the rest of the narrative document.
+
+**Known Issues**
+
+-   %inv_ls to a directory that doesn't exist will create a generic, not-very-informative error.
+-   [NAR-153], [NAR-177] A generic "Autosave failed!" message appears when the narrative fails to save for any reason.
+-   [NAR-169] Using Safari through HTTPS will not work with an uncertified SSL credential (which we currently have)
+-   [NAR-173] If problems external to the Narrative prevent loading (authentication, Shock or WS downtime), an ugly stacktrace is dumped into the browser instead of a nicely rendered error page.
+-   [NAR-180] Copying narratives in the newsfeed can cause errors.
+-   [NAR-179] There's a problem that occurs when logged into a narrative for a long time.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,8 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
 ### Version NEXT
 
--   fix bug in data slideout tab selection (related to PTV-1635)
--   fix data and app slideout button and opening behavior (related to PTV-1635)
+-   PTV-1635: fix bug in data slideout tab selection
+-   PTV-1635: fix data and app slideout button and opening behavior
 
 ### Version 4.3.2
 

--- a/kbase-extension/static/kbase/js/common/html.js
+++ b/kbase-extension/static/kbase/js/common/html.js
@@ -14,57 +14,9 @@ define([
     const div = tag('div'),
         span = tag('span'),
         i = tag('i'),
-        table = tag('table'),
-        thead = tag('thead'),
-        tbody = tag('tbody'),
-        tr = tag('tr'),
-        th = tag('th'),
-        td = tag('td'),
         ul = tag('ul'),
         li = tag('li'),
         a = tag('a');
-
-    function jsonToHTML(node) {
-        const nodeType = typeof node;
-        let out;
-        if (nodeType === 'string') {
-            return node;
-        }
-        if (nodeType === 'boolean') {
-            if (node) {
-                return 'true';
-            }
-            return 'false';
-        }
-        if (nodeType === 'number') {
-            return String(node);
-        }
-        if (Array.isArray(node)) {
-            out = '';
-            node.forEach((item) => {
-                out += jsonToHTML(item);
-            });
-            return out;
-        }
-        if (nodeType === 'object') {
-            if (node === null) {
-                return '';
-            }
-            out = '';
-            out += '<' + nodeType.tag;
-            if (node.attributes) {
-                node.attributes.keys().forEach((key) => {
-                    out += key + '="' + node.attributes[key] + '"';
-                });
-            }
-            out += '>';
-            if (node.children) {
-                out += jsonToHTML(node.children);
-            }
-            out += '</' + node.tag + '>';
-            return out;
-        }
-    }
 
     /**
      * Given a simple object of keys and values, create a string which 
@@ -179,48 +131,44 @@ define([
     }
 
     function renderContent(children) {
-        if (children) {
-            if (typeof children === 'string') {
-                return children;
-            }
-            if (typeof children === 'number') {
-                return String(children);
-            }
-            if (Array.isArray(children)) {
-                return children.map((item) => {
-                    return renderContent(item);
-                }).join('');
-            }
-        } else {
-            return '';
+        switch (typeof children) {
+            case 'string': return children;
+            case 'number': return String(children);
+            case 'boolean': return '';
+            case 'undefined': return '';
+            case 'object':
+                if (Array.isArray(children)) {
+                    return children.map((item) => {
+                        return renderContent(item);
+                    }).join('');
+                } else if (children === null) {
+                    return '';
+                } else {
+                    return '';
+                }
         }
     }
     function merge(obj1, obj2) {
-        function isObject(x) {
-            if (typeof x === 'object' &&
-                x !== null &&
-                !(x instanceof Array)) {
-                return true;
-            }
-            return false;
-        }
         function merger(aObj, bObj) {
             Object.keys(bObj).forEach((key) => {
-                if (isObject(aObj) && isObject(bObj)) {
+                if (isSimpleObject(aObj[key]) && isSimpleObject(bObj[key])) {
                     aObj[key] = merger(aObj[key], bObj[key]);
+                } else {
+                    aObj[key] = bObj[key];
                 }
-                aObj[key] = bObj[key];
             });
             return aObj;
         }
         return merger(obj1, obj2);
     }
+
     function isSimpleObject(obj) {
         if (typeof obj !== 'object' || obj === null) {
             return false;
         }
         return Object.getPrototypeOf(obj) === Object.getPrototypeOf({});
     }
+
     function tag(tagName, options) {
         options = options || {};
         let tagAttribs;
@@ -229,46 +177,14 @@ define([
         }
         const tagFun = function (attribs, children) {
             let node = '<' + tagName;
-            switch (typeof attribs) {
-                case 'string':
-                    // skip attribs, just go to children.
-                    children = attribs;
-                    attribs = null;
-                    break;
-                case 'number':
-                    children = String(attribs);
-                    attribs = null;
-                    break;
-                case 'boolean':
-                    if (attribs) {
-                        children = 'true';
-                    } else {
-                        children = 'false';
-                    }
-                    attribs = null;
-                    break;
-                case 'undefined':
-                    if (!children) {
-                        children = '';
-                    }
-                    break;
-                case 'object':
-                    if (Array.isArray(attribs)) {
-                        // skip attribs, just go to children.
-                        children = attribs;
-                        attribs = null;
-                    } else if (attribs === null) {
-                        if (!children) {
-                            children = '';
-                        }
-                    } else if (isSimpleObject(attribs)) {
-                        if (options.attribs) {
-                            attribs = merge(merge({}, options.attribs), attribs);
-                        }
-                    } else {
-                        throw 'Cannot make tag ' + tagName + ' from a ' + (typeof attribs);
-                    }
-                    break;
+
+            if (isSimpleObject(attribs)) {
+                if (options.attribs) {
+                    attribs = merge(merge({}, options.attribs), attribs);
+                }
+            } else {
+                children = children || attribs;
+                attribs = null;
             }
 
             attribs = attribs || options.attribs;
@@ -291,51 +207,13 @@ define([
         }
         return tagFun;
     }
+
     function genId() {
         return 'kb_html_' + (new Uuid(4)).format();
     }
-    function makeTable(arg) {
-        let id;
-        arg = arg || {};
-        if (arg.id) {
-            id = arg.id;
-        } else {
-            id = genId();
-            arg.generated = { id: id };
-        }
-        const attribs = { id: id };
-        if (arg.class) {
-            attribs.class = arg.class;
-        } else if (arg.classes) {
-            attribs.class = arg.classes.join(' ');
-        }
-        return table(attribs, [
-            thead(tr(arg.columns.map((x) => {
-                return th(x);
-            }))),
-            tbody(arg.rows.map((row) => {
-                return tr(row.map((x) => {
-                    return td(x);
-                }));
-            }))
-        ]);
-    }
-
-    function bsPanel(title, content) {
-        return div({ class: 'panel panel-default' }, [
-            div({ class: 'panel-heading' }, [
-                span({ class: 'panel-title' }, title)
-            ]),
-            div({ class: 'panel-body' }, [
-                content
-            ])
-        ]);
-    }
 
     function makePanel(arg) {
-
         const klass = arg.class || 'default';
-
         return div({ class: 'panel panel-' + klass }, [
             div({ class: 'panel-heading' }, [
                 span({ class: 'panel-title' }, arg.title)
@@ -347,273 +225,11 @@ define([
     }
 
     function loading(msg) {
-        const prompt = msg ? `${msg}... &nbsp &nbsp` : '';
+        const prompt = msg ? `${msg} &nbsp;&nbsp;` : '';
         return span([
             prompt,
             i({ class: 'fa fa-spinner fa-pulse fa-2x fa-fw margin-bottom' })
         ]);
-    }
-
-    /*
-     * 
-     */
-    function makeTableRotated(arg) {
-        function columnLabel(column) {
-            let key;
-            if (typeof column === 'string') {
-                key = column;
-            } else {
-                if (column.label) {
-                    return column.label;
-                }
-                key = column.key;
-            }
-            return key
-                .replace(/(id|Id)/g, 'ID')
-                .split(/_/g).map((word) => {
-                    return word.charAt(0).toUpperCase() + word.slice(1);
-                })
-                .join(' ');
-        }
-        function formatValue(rawValue, column) {
-            if (typeof column === 'string') {
-                return rawValue;
-            }
-            if (column.format) {
-                return column.format(rawValue);
-            }
-            if (column.type) {
-                switch (column.type) {
-                    case 'bool':
-                        // yuck, use truthiness
-                        if (rawValue) {
-                            return 'True';
-                        }
-                        return 'False';
-                    default:
-                        return rawValue;
-                }
-            }
-            return rawValue;
-        }
-
-        const id = genId(),
-            attribs = { id: id };
-        if (arg.class) {
-            attribs.class = arg.class;
-        } else if (arg.classes) {
-            attribs.class = arg.classes.join(' ');
-        }
-
-        return table(attribs,
-            arg.columns.map((column, index) => {
-                return tr([
-                    th(columnLabel(column)),
-                    arg.rows.map((row) => {
-                        return td(formatValue(row[index], column));
-                    })
-                ]);
-            }));
-    }
-
-    function makeRotatedTable(data, columns) {
-        function columnLabel(column) {
-            let key;
-            if (column.label) {
-                return column.label;
-            }
-            if (typeof column === 'string') {
-                key = column;
-            } else {
-                key = column.key;
-            }
-            return key
-                .replace(/(id|Id)/g, 'ID')
-                .split(/_/g).map((word) => {
-                    return word.charAt(0).toUpperCase() + word.slice(1);
-                })
-                .join(' ');
-        }
-        function columnValue(row, column) {
-            const rawValue = row[column.key];
-            if (column.format) {
-                return column.format(rawValue);
-            }
-            if (column.type) {
-                switch (column.type) {
-                    case 'bool':
-                        // yuck, use truthiness
-                        if (rawValue) {
-                            return 'True';
-                        }
-                        return 'False';
-                    default:
-                        return rawValue;
-                }
-            }
-            return rawValue;
-        }
-
-        return table({ class: 'table table-stiped table-bordered' },
-            columns.map((column) => {
-                return tr([
-                    th(columnLabel(column)), data.map((row) => {
-                        return td(columnValue(row, column));
-                    })
-                ]);
-            }));
-    }
-
-    function properCase(string) {
-        return string.charAt(0).toUpperCase() + string.slice(1);
-    }
-
-    function makeObjTable(data, options) {
-        const tableData = (data instanceof Array && data) || [data],
-            columns = (options && options.columns) || Object.keys(tableData[0]).map((key) => {
-                return {
-                    key: key,
-                    label: properCase(key)
-                };
-            }),
-            classes = (options && options.classes) || ['table-striped', 'table-bordered'];
-
-        function columnValue(row, column) {
-            const rawValue = row[column.key];
-            if (column.format) {
-                return column.format(rawValue);
-            }
-            if (column.type) {
-                switch (column.type) {
-                    case 'bool':
-                        // yuck, use truthiness
-                        if (rawValue) {
-                            return 'True';
-                        }
-                        return 'False';
-                    default:
-                        return rawValue;
-                }
-            }
-            return rawValue;
-        }
-        if (options && options.rotated) {
-            return table({ class: 'table ' + classes.join(' ') },
-                columns.map((column) => {
-                    return tr([
-                        th(column.label),
-                        tableData.map((row) => {
-                            return td({ dataElement: column.key }, columnValue(row, column));
-                        })
-                    ]);
-                }));
-        }
-        return table({ class: 'table ' + classes.join(' ') },
-            [tr(columns.map((column) => {
-                return th(column.label);
-            }))].concat(tableData.map((row) => {
-                return tr(columns.map((column) => {
-                    return td({ dataElement: column.key }, columnValue(row, column));
-                }));
-            })));
-    }
-
-    function makeObjectTable(data, options) {
-        function columnLabel(column) {
-            let key;
-            if (column.label) {
-                return column.label;
-            }
-            if (typeof column === 'string') {
-                key = column;
-            } else {
-                key = column.key;
-            }
-            return key
-                .replace(/(id|Id)/g, 'ID')
-                .split(/_/g).map((word) => {
-                    return word.charAt(0).toUpperCase() + word.slice(1);
-                })
-                .join(' ');
-        }
-        function columnValue(row, column) {
-            const rawValue = row[column.key];
-            if (column.format) {
-                return column.format(rawValue);
-            }
-            if (column.type) {
-                switch (column.type) {
-                    case 'bool':
-                        // yuck, use truthiness
-                        if (rawValue) {
-                            return 'True';
-                        }
-                        return 'False';
-                    default:
-                        return rawValue;
-                }
-            }
-            return rawValue;
-        }
-        let columns, classes;
-        if (!options) {
-            options = {};
-        } else if (options.columns) {
-            columns = options.columns;
-        } else {
-            columns = options;
-            options = {};
-        }
-        if (!columns) {
-            columns = Object.keys(data).map((columnName) => {
-                return {
-                    key: columnName
-                };
-            });
-        } else {
-            columns = columns.map((column) => {
-                if (typeof column === 'string') {
-                    return {
-                        key: column
-                    };
-                }
-                return column;
-            });
-        }
-        if (options.classes) {
-            classes = options.classes;
-        } else {
-            classes = ['table-striped', 'table-bordered'];
-        }
-
-        return table({ class: 'table ' + classes.join(' ') },
-            columns.map((column) => {
-                return tr([
-                    th(columnLabel(column)),
-                    td(columnValue(data, column))
-                ]);
-            }));
-    }
-
-    function flatten(html) {
-        if (typeof html === 'string') {
-            return html;
-        }
-        if (Array.isArray(html)) {
-            return html.map((h) => {
-                return flatten(h);
-            }).join('');
-        }
-        throw new Error('Not a valid html representation -- must be string or list');
-    }
-
-    function makeList(arg) {
-        if (Array.isArray(arg.items)) {
-            return ul(arg.items.map((item) => {
-                return li(item);
-            }));
-        }
-        return 'Sorry, cannot make a list from that';
     }
 
     /**
@@ -696,21 +312,13 @@ define([
     }
 
     return Object.freeze({
-        html: jsonToHTML,
         camelToKebab,
-        tag,
-        makeTable,
-        makeTableRotated,
-        makeRotatedTable,
-        makeObjectTable,
-        makeObjTable,
         genId,
-        bsPanel,
-        panel: bsPanel,
-        makePanel,
+        isSimpleObject,
         loading,
-        flatten,
-        makeList,
-        makeTabs
+        makePanel,
+        makeTabs,
+        merge,
+        tag
     });
 });

--- a/kbase-extension/static/kbase/js/common/html.js
+++ b/kbase-extension/static/kbase/js/common/html.js
@@ -85,12 +85,6 @@ define([
         return Object.entries(attribs)
             .map(([key, value]) => {
                 const attribName = camelToKebab(key);
-                // The value may itself be an object, which becomes a special string.
-                // This applies for "style" and "data-bind", each of which have a 
-                // structured string value.
-                // Another special case is an array, useful for space-separated
-                // attributes, esp. "class".
-
                 // We first ensure that values passed as objects are pre-processed.
                 // There are three use cases supported:
                 // - setting the value to null (equivalent to false or undefined)

--- a/kbase-extension/static/kbase/js/common/html.js
+++ b/kbase-extension/static/kbase/js/common/html.js
@@ -146,6 +146,7 @@ define([
                     } else if (Array.isArray(value)) {
                         value = value.join(' ');
                     } else {
+                        // Special handling of specific attribute types.
                         switch (attribName) {
                             case 'style':
                                 value = makeStyleAttribs(value);
@@ -627,8 +628,8 @@ define([
      */
     function reverse(arr) {
         const newArray = [];
-        for (let i = arr.length - 1; i >= 0; i -= 1) {
-            newArray.push(arr[i]);
+        for (let index = arr.length - 1; index >= 0; index -= 1) {
+            newArray.push(arr[index]);
         }
         return newArray;
     }

--- a/kbase-extension/static/kbase/js/common/html.js
+++ b/kbase-extension/static/kbase/js/common/html.js
@@ -1,749 +1,738 @@
-/*global
- define
- */
 /*jslint
  browser: true,
  white: true
  */
 define([
-    'underscore',
     'uuid'
-], function (underscore, Uuid) {
+], (
+    Uuid
+) => {
     'use strict';
-    return (function () {
 
-        function jsonToHTML(node) {
-            var nodeType = typeof node,
-                out;
-            if (nodeType === 'string') {
-                return node;
-            }
-            if (nodeType === 'boolean') {
-                if (node) {
-                    return 'true';
-                }
-                return 'false';
-            }
-            if (nodeType === 'number') {
-                return String(node);
-            }
-            if (nodeType === 'object' && node.push) {
-                out = '';
-                node.forEach(function (item) {
-                    out += jsonToHTML(item);
-                });
-                return out;
-            }
-            if (nodeType === 'object') {
-                out = '';
-                out += '<' + nodeType.tag;
-                if (node.attributes) {
-                    node.attributes.keys().forEach(function (key) {
-                        out += key + '="' + node.attributes[key] + '"';
-                    });
-                }
-                out += '>';
-                if (node.children) {
-                    out += jsonToHTML(node.children);
-                }
-                out += '</' + node.tag + '>';
-                return out;
-            }
+    const TAGS = {}
+
+    const div = tag('div'),
+        span = tag('span'),
+        i = tag('i'),
+        table = tag('table'),
+        thead = tag('thead'),
+        tbody = tag('tbody'),
+        tr = tag('tr'),
+        th = tag('th'),
+        td = tag('td'),
+        ul = tag('ul'),
+        li = tag('li'),
+        a = tag('a');
+
+    function jsonToHTML(node) {
+        const nodeType = typeof node;
+        let out;
+        if (nodeType === 'string') {
+            return node;
         }
-
-        var tags = {};
-        /**
-         * Given a simple object of keys and values, create a string which 
-         * encodes them into a form suitable for the value of a style attribute.
-         * Style attribute values are themselves attributes, but due to the limitation
-         * of html attributes, they are embedded in a string:
-         * The format is
-         * key: value;
-         * Note that values are not quoted, and the separator between fields is
-         * a semicolon
-         * Note that we expect the value to be embedded withing an html attribute
-         * which is quoted with double-qoutes; but we don't do any escaping here.
-         * @param {type} attribs
-         * @returns {String}
-         */
-        function camelToHyphen(s) {
-            return s.replace(/[A-Z]/g, function (m) {
-                return '-' + m.toLowerCase();
+        if (nodeType === 'boolean') {
+            if (node) {
+                return 'true';
+            }
+            return 'false';
+        }
+        if (nodeType === 'number') {
+            return String(node);
+        }
+        if (Array.isArray(node)) {
+            out = '';
+            node.forEach((item) => {
+                out += jsonToHTML(item);
             });
+            return out;
         }
-        function makeStyleAttribs(attribs) {
-            if (attribs) {
-                return Object.keys(attribs)
-                    .map(function (rawKey) {
-                        var value = attribs[rawKey],
-                            key = camelToHyphen(rawKey);
-
-                        if (typeof value === 'string') {
-                            return key + ': ' + value;
-                        }
-                        // just ignore invalid attributes for now
-                        // TODO: what is the proper thing to do?
-                        return '';
-                    })
-                    .filter(function (field) {
-                        return field ? true : false;
-                    })
-                    .join('; ');
-            }
-            return '';
-        }
-
-        /**
-         * The attributes for knockout's data-bind is slightly different than
-         * for style. The syntax is that of a simple javascript object.
-         * property: value, property: "value", property: 123
-         * So, we simply escape double-quotes on the value, so that unquoted values
-         * will remain as raw names/symbols/numbers, and quoted strings will retain
-         * the quotes.
-         * TODO: it would be smarter to detect if it was a quoted string
-         * 
-         * @param {type} attribs
-         * @returns {String}
-         */
-        function makeDataBindAttribs(attribs) {
-            if (attribs) {
-                return Object.keys(attribs)
-                    .map(function (key) {
-                        var value = attribs[key];
-                        if (typeof value === 'string') {
-                            //var escapedValue = value.replace(/\"/g, '\\"');
-                            return key + ':' + value;
-                        }
-                        if (typeof value === 'object') {
-                            return key + ': {' + makeDataBindAttribs(value) + '}';
-                        }
-                        // just ignore invalid attributes for now
-                        // TODO: what is the proper thing to do?
-                        return '';
-                    })
-                    .filter(function (field) {
-                        return field ? true : false;
-                    })
-                    .join(',');
-            }
-            return '';
-        }
-
-        /**
-         * Given a simple object of keys and values, create a string which 
-         * encodes a set of html tag attributes.
-         * String values escape the "
-         * Boolean values either insert the attribute name or not
-         * Object values are interpreted as "embedded attributes" (see above)
-         * @param {type} attribs
-         * @returns {String}
-         */
-        function makeTagAttribs(attribs) {
-            var quoteChar = '"', escapedValue;
-            if (attribs) {
-                return Object.keys(attribs)
-                    .map(function (key) {
-                        var value = attribs[key],
-                            attribName = camelToHyphen(key);
-                        // The value may itself be an object, which becomes a special string.
-                        // This applies for "style" and "data-bind", each of which have a 
-                        // structured string value.
-                        // Another special case is an array, useful for space-separated
-                        // attributes, esp. "class".
-                        if (typeof value === 'object') {
-                            if (value === null) {
-                                // null works just like false.
-                                value = false;
-                            } else if (value instanceof Array) {
-                                value = value.join(' ');
-                            } else {
-                                switch (attribName) {
-                                    case 'style':
-                                        value = makeStyleAttribs(value);
-                                        break;
-                                    case 'data-bind':
-                                        // reverse the quote char, since data-bind attributes 
-                                        // can contain double-quote, which can't itself
-                                        // be quoted.
-                                        quoteChar = "'";
-                                        value = makeDataBindAttribs(value);
-                                        break;
-                                    default:
-                                        value = false;
-                                }
-                            }
-                        }
-                        if (typeof value === 'string') {
-                            escapedValue = value.replace(new RegExp('\\' + quoteChar, 'g'), '\\' + quoteChar);
-                            return attribName + '=' + quoteChar + escapedValue + quoteChar;
-                        }
-                        if (typeof value === 'boolean') {
-                            if (value) {
-                                return attribName;
-                            }
-                            return false;
-                        }
-                        if (typeof value === 'number') {
-                            return attribName + '=' + quoteChar + String(value) + quoteChar;
-                        }
-                        return false;
-                    })
-                    .filter(function (field) {
-                        return field ? true : false;
-                    })
-                    .join(' ');
-            }
-            return '';
-        }
-        function renderContent(children) {
-            if (children) {
-                if (underscore.isString(children)) {
-                    return children;
-                }
-                if (underscore.isNumber(children)) {
-                    return String(children);
-                }
-                if (underscore.isArray(children)) {
-                    return children.map(function (item) {
-                        return renderContent(item);
-                    }).join('');
-                }
-            } else {
+        if (nodeType === 'object') {
+            if (node === null) {
                 return '';
             }
-        }
-        function merge(obj1, obj2) {
-            function isObject(x) {
-                if (typeof x === 'object' &&
-                    x !== null &&
-                    !(x instanceof Array)) {
-                    return true;
-                }
-                return false;
-            }
-            function merger(a, b) {
-                Object.keys(b).forEach(function (key) {
-                    if (isObject(a) && isObject(b)) {
-                        a[key] = merger(a[key], b[key]);
-                    }
-                    a[key] = b[key];
+            out = '';
+            out += '<' + nodeType.tag;
+            if (node.attributes) {
+                node.attributes.keys().forEach((key) => {
+                    out += key + '="' + node.attributes[key] + '"';
                 });
-                return a;
             }
-            return merger(obj1, obj2);
-        }
-        function tag(tagName, options) {
-            options = options || {};
-            var tagAttribs;
-            if (tags[tagName] && !options.ignoreCache) {
-                return tags[tagName];
+            out += '>';
+            if (node.children) {
+                out += jsonToHTML(node.children);
             }
-            var tagFun = function (attribs, children) {
-                var node = '<' + tagName;
-                if (underscore.isArray(attribs)) {
-                    // skip attribs, just go to children.
-                    children = attribs;
-                    attribs = null;
-                } else if (underscore.isString(attribs)) {
-                    // skip attribs, just go to children.
-                    children = attribs;
-                    attribs = null;
-                } else if (underscore.isNull(attribs) || underscore.isUndefined(attribs)) {
-                    if (!children) {
-                        children = '';
-                    }
-                } else if (underscore.isObject(attribs)) {
-                    if (options.attribs) {
-                        attribs = merge(merge({}, options.attribs), attribs);
-                    }
-                } else if (underscore.isNumber(attribs)) {
-                    children = String(attribs);
-                    attribs = null;
-                } else if (underscore.isBoolean(attribs)) {
-                    if (attribs) {
-                        children = 'true';
-                    } else {
-                        children = 'false';
-                    }
-                    attribs = null;
-                } else {
-                    throw 'Cannot make tag ' + tagName + ' from a ' + (typeof attribs);
-                }
-                attribs = attribs || options.attribs;
-                if (attribs) {
-                    tagAttribs = makeTagAttribs(attribs);
-                    if (tagAttribs && tagAttribs.length > 0) {
-                        node += ' ' + tagAttribs;
-                    }
-                }
-
-                node += '>';
-                if (options.close !== false) {
-                    node += renderContent(children);
-                    node += '</' + tagName + '>';
-                }
-                return node;
-            };
-            if (!options.ignoreCache) {
-                tags[tagName] = tagFun;
-            }
-            return tagFun;
+            out += '</' + node.tag + '>';
+            return out;
         }
-        function genId() {
-            return 'kb_html_' + (new Uuid(4)).format();
-        }
-        function makeTable(arg) {
-            var table = tag('table'),
-                thead = tag('thead'),
-                tbody = tag('tbody'),
-                tr = tag('tr'),
-                th = tag('th'),
-                td = tag('td'), id, attribs;
-            arg = arg || {};
-            if (arg.id) {
-                id = arg.id;
-            } else {
-                id = genId();
-                arg.generated = {id: id};
-            }
-            attribs = {id: id};
-            if (arg.class) {
-                attribs.class = arg.class;
-            } else if (arg.classes) {
-                attribs.class = arg.classes.join(' ');
-            }
-            return table(attribs, [
-                thead(tr(arg.columns.map(function (x) {
-                    return th(x);
-                }))),
-                tbody(arg.rows.map(function (row) {
-                    return tr(row.map(function (x) {
-                        return td(x);
-                    }));
-                }))
-            ]);
-        }
+    }
 
-        function bsPanel(title, content) {
-            var div = tag('div'),
-                span = tag('span');
+    /**
+     * Given a simple object of keys and values, create a string which 
+     * encodes them into a form suitable for the value of a style attribute.
+     * Style attribute values are themselves attributes, but due to the limitation
+     * of html attributes, they are embedded in a string:
+     * The format is
+     * key: value;
+     * Note that values are not quoted, and the separator between fields is
+     * a semicolon
+     * Note that we expect the value to be embedded withing an html attribute
+     * which is quoted with double-qoutes; but we don't do any escaping here.
+     * @param {type} attribs
+     * @returns {String}
+     */
+    function camelToKebab(s) {
+        return s.replace(/[A-Z]/g, (m) => {
+            return '-' + m.toLowerCase();
+        });
+    }
+    function makeStyleAttribs(attribs) {
+        return Object.keys(attribs)
+            .map((rawKey) => {
+                const rawValue = attribs[rawKey],
+                    key = camelToKebab(rawKey);
 
-            return div({class: 'panel panel-default'}, [
-                div({class: 'panel-heading'}, [
-                    span({class: 'panel-title'}, title)
-                ]),
-                div({class: 'panel-body'}, [
-                    content
-                ])
-            ]);
-        }
-
-        function makePanel(arg) {
-            var div = tag('div'),
-                span = tag('span'),
-                klass = arg.class || 'default';
-
-            return div({class: 'panel panel-' + klass}, [
-                div({class: 'panel-heading'}, [
-                    span({class: 'panel-title'}, arg.title)
-                ]),
-                div({class: 'panel-body'}, [
-                    arg.content
-                ])
-            ]);
-        }
-
-        function loading(msg) {
-            var span = tag('span'),
-                i = tag('i'),
-                prompt;
-            if (msg) {
-                prompt = msg + '... &nbsp &nbsp';
-            }
-            return span([
-                prompt,
-                i({class: 'fa fa-spinner fa-pulse fa-2x fa-fw margin-bottom'})
-            ]);
-        }
-
-        /*
-         * 
-         */
-        function makeTableRotated(arg) {
-            function columnLabel(column) {
-                var key;
-                if (typeof column === 'string') {
-                    key = column;
-                } else {
-                    if (column.label) {
-                        return column.label;
-                    }
-                    key = column.key;
-                }
-                return key
-                    .replace(/(id|Id)/g, 'ID')
-                    .split(/_/g).map(function (word) {
-                    return word.charAt(0).toUpperCase() + word.slice(1);
-                })
-                    .join(' ');
-            }
-            function formatValue(rawValue, column) {
-                if (typeof column === 'string') {
-                    return rawValue;
-                }
-                if (column.format) {
-                    return column.format(rawValue);
-                }
-                if (column.type) {
-                    switch (column.type) {
-                        case 'bool':
-                            // yuck, use truthiness
-                            if (rawValue) {
-                                return 'True';
-                            }
-                            return 'False';
-                        default:
+                const value = (() => {
+                    switch (typeof rawValue) {
+                        case 'string':
                             return rawValue;
+                        case 'number':
+                            return String(rawValue);
+                        case 'boolean':
+                            return false;
+                        case 'undefined':
+                            return false;
+                        case 'object':
+                            return false;
                     }
-                }
-                return rawValue;
-            }
+                })();
 
-            var table = tag('table'),
-                tr = tag('tr'),
-                th = tag('th'),
-                td = tag('td'),
-                id = genId(),
-                attribs = {id: id};
-            if (arg.class) {
-                attribs.class = arg.class;
-            } else if (arg.classes) {
-                attribs.class = arg.classes.join(' ');
-            }
+                if (typeof value === 'string') {
+                    return `${key}: ${value}`;
+                };
+                return false;
+            })
+            .filter((field) => {
+                return field ? true : false;
+            })
+            .join('; ');
+    }
 
-            return table(attribs,
-                arg.columns.map(function (column, index) {
-                    return tr([
-                        th(columnLabel(column)),
-                        arg.rows.map(function (row) {
-                            return td(formatValue(row[index], column));
-                        })
-                    ]);
-                }));
+    /**
+     * The attributes for knockout's data-bind is slightly different than
+     * for style. The syntax is that of a simple javascript object.
+     * property: value, property: "value", property: 123
+     * So, we simply escape double-quotes on the value, so that unquoted values
+     * will remain as raw names/symbols/numbers, and quoted strings will retain
+     * the quotes.
+     * TODO: it would be smarter to detect if it was a quoted string
+     * 
+     * @param {type} attribs
+     * @returns {String}
+     */
+    function makeDataBindAttribs(attribs) {
+        if (attribs) {
+            return Object.keys(attribs)
+                .map((key) => {
+                    const value = attribs[key];
+                    if (typeof value === 'string') {
+                        //var escapedValue = value.replace(/\"/g, '\\"');
+                        return key + ':' + value;
+                    }
+                    if (typeof value === 'object') {
+                        return key + ': {' + makeDataBindAttribs(value) + '}';
+                    }
+                    // just ignore invalid attributes for now
+                    // TODO: what is the proper thing to do?
+                    return '';
+                })
+                .filter((field) => {
+                    return field ? true : false;
+                })
+                .join(',');
         }
+        return '';
+    }
 
-        function makeRotatedTable(data, columns) {
-            function columnLabel(column) {
-                var key;
+    /**
+     * Given a simple object of keys and values, create a string which 
+     * encodes a set of html tag attributes.
+     * String values escape the "
+     * Boolean values either insert the attribute name or not
+     * Object values are interpreted as "embedded attributes" (see above)
+     * @param {type} attribs
+     * @returns {String}
+     */
+    function makeTagAttribs(attribs) {
+        let quoteChar = '"', escapedValue;
+        if (attribs) {
+            return Object.keys(attribs)
+                .map((key) => {
+                    let value = attribs[key];
+                    const attribName = camelToKebab(key);
+                    // The value may itself be an object, which becomes a special string.
+                    // This applies for "style" and "data-bind", each of which have a 
+                    // structured string value.
+                    // Another special case is an array, useful for space-separated
+                    // attributes, esp. "class".
+                    if (typeof value === 'object') {
+                        if (value === null) {
+                            // null works just like false.
+                            value = false;
+                        } else if (value instanceof Array) {
+                            value = value.join(' ');
+                        } else {
+                            switch (attribName) {
+                                case 'style':
+                                    value = makeStyleAttribs(value);
+                                    break;
+                                case 'data-bind':
+                                    // reverse the quote char, since data-bind attributes 
+                                    // can contain double-quote, which can't itself
+                                    // be quoted.
+                                    quoteChar = "'";
+                                    value = makeDataBindAttribs(value);
+                                    break;
+                                default:
+                                    value = false;
+                            }
+                        }
+                    }
+                    if (typeof value === 'string') {
+                        escapedValue = value.replace(new RegExp('\\' + quoteChar, 'g'), '\\' + quoteChar);
+                        return attribName + '=' + quoteChar + escapedValue + quoteChar;
+                    }
+                    if (typeof value === 'boolean') {
+                        if (value) {
+                            return attribName;
+                        }
+                        return false;
+                    }
+                    if (typeof value === 'number') {
+                        return attribName + '=' + quoteChar + String(value) + quoteChar;
+                    }
+                    return false;
+                })
+                .filter((field) => {
+                    return field ? true : false;
+                })
+                .join(' ');
+        }
+        return '';
+    }
+    function renderContent(children) {
+        if (children) {
+            if (typeof children === 'string') {
+                return children;
+            }
+            if (typeof children === 'number') {
+                return String(children);
+            }
+            if (Array.isArray(children)) {
+                return children.map((item) => {
+                    return renderContent(item);
+                }).join('');
+            }
+        } else {
+            return '';
+        }
+    }
+    function merge(obj1, obj2) {
+        function isObject(x) {
+            if (typeof x === 'object' &&
+                x !== null &&
+                !(x instanceof Array)) {
+                return true;
+            }
+            return false;
+        }
+        function merger(a, b) {
+            Object.keys(b).forEach((key) => {
+                if (isObject(a) && isObject(b)) {
+                    a[key] = merger(a[key], b[key]);
+                }
+                a[key] = b[key];
+            });
+            return a;
+        }
+        return merger(obj1, obj2);
+    }
+    function tag(tagName, options) {
+        options = options || {};
+        let tagAttribs;
+        if (TAGS[tagName] && !options.ignoreCache) {
+            return TAGS[tagName];
+        }
+        const tagFun = function (attribs, children) {
+            let node = '<' + tagName;
+            if (Array.isArray(attribs)) {
+                // skip attribs, just go to children.
+                children = attribs;
+                attribs = null;
+            } else if (typeof attribs === 'string') {
+                // skip attribs, just go to children.
+                children = attribs;
+                attribs = null;
+            } else if ((attribs === null) || (typeof attribs === 'undefined')) {
+                if (!children) {
+                    children = '';
+                }
+            } else if (typeof attribs === 'object') {
+                if (options.attribs) {
+                    attribs = merge(merge({}, options.attribs), attribs);
+                }
+            } else if (typeof attribs === 'number') {
+                children = String(attribs);
+                attribs = null;
+            } else if (typeof attribs === 'boolean') {
+                if (attribs) {
+                    children = 'true';
+                } else {
+                    children = 'false';
+                }
+                attribs = null;
+            } else {
+                throw 'Cannot make tag ' + tagName + ' from a ' + (typeof attribs);
+            }
+            attribs = attribs || options.attribs;
+            if (attribs) {
+                tagAttribs = makeTagAttribs(attribs);
+                if (tagAttribs && tagAttribs.length > 0) {
+                    node += ' ' + tagAttribs;
+                }
+            }
+
+            node += '>';
+            if (options.close !== false) {
+                node += renderContent(children);
+                node += '</' + tagName + '>';
+            }
+            return node;
+        };
+        if (!options.ignoreCache) {
+            TAGS[tagName] = tagFun;
+        }
+        return tagFun;
+    }
+    function genId() {
+        return 'kb_html_' + (new Uuid(4)).format();
+    }
+    function makeTable(arg) {
+        let id;
+        arg = arg || {};
+        if (arg.id) {
+            id = arg.id;
+        } else {
+            id = genId();
+            arg.generated = { id: id };
+        }
+        const attribs = { id: id };
+        if (arg.class) {
+            attribs.class = arg.class;
+        } else if (arg.classes) {
+            attribs.class = arg.classes.join(' ');
+        }
+        return table(attribs, [
+            thead(tr(arg.columns.map((x) => {
+                return th(x);
+            }))),
+            tbody(arg.rows.map((row) => {
+                return tr(row.map((x) => {
+                    return td(x);
+                }));
+            }))
+        ]);
+    }
+
+    function bsPanel(title, content) {
+        return div({ class: 'panel panel-default' }, [
+            div({ class: 'panel-heading' }, [
+                span({ class: 'panel-title' }, title)
+            ]),
+            div({ class: 'panel-body' }, [
+                content
+            ])
+        ]);
+    }
+
+    function makePanel(arg) {
+
+        const klass = arg.class || 'default';
+
+        return div({ class: 'panel panel-' + klass }, [
+            div({ class: 'panel-heading' }, [
+                span({ class: 'panel-title' }, arg.title)
+            ]),
+            div({ class: 'panel-body' }, [
+                arg.content
+            ])
+        ]);
+    }
+
+    function loading(msg) {
+        const prompt = msg ? `${msg}... &nbsp &nbsp` : '';
+        return span([
+            prompt,
+            i({ class: 'fa fa-spinner fa-pulse fa-2x fa-fw margin-bottom' })
+        ]);
+    }
+
+    /*
+     * 
+     */
+    function makeTableRotated(arg) {
+        function columnLabel(column) {
+            let key;
+            if (typeof column === 'string') {
+                key = column;
+            } else {
                 if (column.label) {
                     return column.label;
                 }
-                if (typeof column === 'string') {
-                    key = column;
-                } else {
-                    key = column.key;
-                }
-                return key
-                    .replace(/(id|Id)/g, 'ID')
-                    .split(/_/g).map(function (word) {
+                key = column.key;
+            }
+            return key
+                .replace(/(id|Id)/g, 'ID')
+                .split(/_/g).map((word) => {
                     return word.charAt(0).toUpperCase() + word.slice(1);
                 })
-                    .join(' ');
-            }
-            function columnValue(row, column) {
-                var rawValue = row[column.key];
-                if (column.format) {
-                    return column.format(rawValue);
-                }
-                if (column.type) {
-                    switch (column.type) {
-                        case 'bool':
-                            // yuck, use truthiness
-                            if (rawValue) {
-                                return 'True';
-                            }
-                            return 'False';
-                        default:
-                            return rawValue;
-                    }
-                }
+                .join(' ');
+        }
+        function formatValue(rawValue, column) {
+            if (typeof column === 'string') {
                 return rawValue;
             }
-
-            var table = tag('table'),
-                tr = tag('tr'),
-                th = tag('th'),
-                td = tag('td');
-            return table({class: 'table table-stiped table-bordered'},
-                columns.map(function (column) {
-                    return tr([
-                        th(columnLabel(column)), data.map(function (row) {
-                            return td(columnValue(row, column));
-                        })
-                    ]);
-                }));
+            if (column.format) {
+                return column.format(rawValue);
+            }
+            if (column.type) {
+                switch (column.type) {
+                    case 'bool':
+                        // yuck, use truthiness
+                        if (rawValue) {
+                            return 'True';
+                        }
+                        return 'False';
+                    default:
+                        return rawValue;
+                }
+            }
+            return rawValue;
         }
 
-        function properCase(string) {
-            return string.charAt(0).toUpperCase() + string.slice(1);
+        const id = genId(),
+            attribs = { id: id };
+        if (arg.class) {
+            attribs.class = arg.class;
+        } else if (arg.classes) {
+            attribs.class = arg.classes.join(' ');
         }
 
-        function makeObjTable(data, options) {
-            var tableData = (data instanceof Array && data) || [data],
-                columns = (options && options.columns) || Object.keys(tableData[0]).map(function (key) {
+        return table(attribs,
+            arg.columns.map((column, index) => {
+                return tr([
+                    th(columnLabel(column)),
+                    arg.rows.map((row) => {
+                        return td(formatValue(row[index], column));
+                    })
+                ]);
+            }));
+    }
+
+    function makeRotatedTable(data, columns) {
+        function columnLabel(column) {
+            let key;
+            if (column.label) {
+                return column.label;
+            }
+            if (typeof column === 'string') {
+                key = column;
+            } else {
+                key = column.key;
+            }
+            return key
+                .replace(/(id|Id)/g, 'ID')
+                .split(/_/g).map((word) => {
+                    return word.charAt(0).toUpperCase() + word.slice(1);
+                })
+                .join(' ');
+        }
+        function columnValue(row, column) {
+            const rawValue = row[column.key];
+            if (column.format) {
+                return column.format(rawValue);
+            }
+            if (column.type) {
+                switch (column.type) {
+                    case 'bool':
+                        // yuck, use truthiness
+                        if (rawValue) {
+                            return 'True';
+                        }
+                        return 'False';
+                    default:
+                        return rawValue;
+                }
+            }
+            return rawValue;
+        }
+
+        return table({ class: 'table table-stiped table-bordered' },
+            columns.map((column) => {
+                return tr([
+                    th(columnLabel(column)), data.map((row) => {
+                        return td(columnValue(row, column));
+                    })
+                ]);
+            }));
+    }
+
+    function properCase(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
+    }
+
+    function makeObjTable(data, options) {
+        const tableData = (data instanceof Array && data) || [data],
+            columns = (options && options.columns) || Object.keys(tableData[0]).map((key) => {
                 return {
                     key: key,
                     label: properCase(key)
                 };
             }),
-                classes = (options && options.classes) || ['table-striped', 'table-bordered'],
-                table = tag('table'),
-                tr = tag('tr'),
-                th = tag('th'),
-                td = tag('td');
+            classes = (options && options.classes) || ['table-striped', 'table-bordered'];
 
-            function columnValue(row, column) {
-                var rawValue = row[column.key];
-                if (column.format) {
-                    return column.format(rawValue);
-                }
-                if (column.type) {
-                    switch (column.type) {
-                        case 'bool':
-                            // yuck, use truthiness
-                            if (rawValue) {
-                                return 'True';
-                            }
-                            return 'False';
-                        default:
-                            return rawValue;
-                    }
-                }
-                return rawValue;
+        function columnValue(row, column) {
+            const rawValue = row[column.key];
+            if (column.format) {
+                return column.format(rawValue);
             }
-            if (options && options.rotated) {
-                return table({class: 'table ' + classes.join(' ')},
-                    columns.map(function (column) {
-                        return tr([
-                            th(column.label),
-                            tableData.map(function (row) {
-                                return td({dataElement: column.key}, columnValue(row, column));
-                            })
-                        ]);
-                    }));
+            if (column.type) {
+                switch (column.type) {
+                    case 'bool':
+                        // yuck, use truthiness
+                        if (rawValue) {
+                            return 'True';
+                        }
+                        return 'False';
+                    default:
+                        return rawValue;
+                }
             }
-            return table({class: 'table ' + classes.join(' ')},
-                [tr(columns.map(function (column) {
-                        return th(column.label);
-                    }))].concat(tableData.map(function (row) {
-                return tr(columns.map(function (column) {
-                    return td({dataElement: column.key}, columnValue(row, column));
+            return rawValue;
+        }
+        if (options && options.rotated) {
+            return table({ class: 'table ' + classes.join(' ') },
+                columns.map((column) => {
+                    return tr([
+                        th(column.label),
+                        tableData.map((row) => {
+                            return td({ dataElement: column.key }, columnValue(row, column));
+                        })
+                    ]);
+                }));
+        }
+        return table({ class: 'table ' + classes.join(' ') },
+            [tr(columns.map((column) => {
+                return th(column.label);
+            }))].concat(tableData.map((row) => {
+                return tr(columns.map((column) => {
+                    return td({ dataElement: column.key }, columnValue(row, column));
                 }));
             })));
-        }
+    }
 
-        function makeObjectTable(data, options) {
-            function columnLabel(column) {
-                var key;
-                if (column.label) {
-                    return column.label;
-                }
-                if (typeof column === 'string') {
-                    key = column;
-                } else {
-                    key = column.key;
-                }
-                return key
-                    .replace(/(id|Id)/g, 'ID')
-                    .split(/_/g).map(function (word) {
+    function makeObjectTable(data, options) {
+        function columnLabel(column) {
+            let key;
+            if (column.label) {
+                return column.label;
+            }
+            if (typeof column === 'string') {
+                key = column;
+            } else {
+                key = column.key;
+            }
+            return key
+                .replace(/(id|Id)/g, 'ID')
+                .split(/_/g).map((word) => {
                     return word.charAt(0).toUpperCase() + word.slice(1);
                 })
-                    .join(' ');
+                .join(' ');
+        }
+        function columnValue(row, column) {
+            const rawValue = row[column.key];
+            if (column.format) {
+                return column.format(rawValue);
             }
-            function columnValue(row, column) {
-                var rawValue = row[column.key];
-                if (column.format) {
-                    return column.format(rawValue);
+            if (column.type) {
+                switch (column.type) {
+                    case 'bool':
+                        // yuck, use truthiness
+                        if (rawValue) {
+                            return 'True';
+                        }
+                        return 'False';
+                    default:
+                        return rawValue;
                 }
-                if (column.type) {
-                    switch (column.type) {
-                        case 'bool':
-                            // yuck, use truthiness
-                            if (rawValue) {
-                                return 'True';
-                            }
-                            return 'False';
-                        default:
-                            return rawValue;
-                    }
-                }
-                return rawValue;
             }
-            var columns, classes;
-            if (!options) {
-                options = {};
-            } else if (options.columns) {
-                columns = options.columns;
-            } else {
-                columns = options;
-                options = {};
-            }
-            if (!columns) {
-                columns = Object.keys(data).map(function (columnName) {
-                    return {
-                        key: columnName
-                    };
-                });
-            } else {
-                columns = columns.map(function (column) {
-                    if (typeof column === 'string') {
-                        return {
-                            key: column
-                        };
-                    }
-                    return column;
-                });
-            }
-            if (options.classes) {
-                classes = options.classes;
-            } else {
-                classes = ['table-striped', 'table-bordered'];
-            }
-
-            var table = tag('table'),
-                tr = tag('tr'),
-                th = tag('th'),
-                td = tag('td'),
-                result = table({class: 'table ' + classes.join(' ')},
-                    columns.map(function (column) {
-                        return tr([
-                            th(columnLabel(column)),
-                            td(columnValue(data, column))
-                        ]);
-                    }));
-            return result;
+            return rawValue;
         }
-
-        function flatten(html) {
-            if (underscore.isString(html)) {
-                return html;
-            }
-            if (underscore.isArray(html)) {
-                return html.map(function (h) {
-                    return flatten(h);
-                }).join('');
-            }
-            throw new Error('Not a valid html representation -- must be string or list');
+        let columns, classes;
+        if (!options) {
+            options = {};
+        } else if (options.columns) {
+            columns = options.columns;
+        } else {
+            columns = options;
+            options = {};
         }
-
-        function makeList(arg) {
-            if (underscore.isArray(arg.items)) {
-                var ul = tag('ul'),
-                    li = tag('li');
-                return ul(arg.items.map(function (item) {
-                    return li(item);
-                }));
-            }
-            return 'Sorry, cannot make a list from that';
-        }
-
-        /**
-         * Make a bootsrap tabset:
-         * arg.tabs.id
-         * arg.tabs.label
-         * arg.tabs.name
-         * arg.tabs.content
-         * 
-         * @param {type} arg
-         * @returns {unresolved}
-         */
-        function reverse(arr) {
-            var newArray = [], i, len = arr.length;
-            for (i = len-1; i >= 0; i -= 1) {
-                newArray.push(arr[i]);
-            }
-            return newArray;
-        }
-        
-        function makeTabs(arg) {
-            var ul = tag('ul'),
-                li = tag('li'),
-                a = tag('a'),
-                div = tag('div'),
-                tabsId = arg.id,
-                tabsAttribs = {},
-                tabClasses = ['nav', 'nav-tabs'],
-                tabStyle = {}, activeIndex, tabTabs,
-                tabs = arg.tabs.filter(function (tab) {
-                    return (tab ? true : false);
-                });
-
-            if (tabsId) {
-                tabsAttribs.id = tabsId;
-            }
-            tabs.forEach(function (tab) {
-                tab.id = genId();
+        if (!columns) {
+            columns = Object.keys(data).map((columnName) => {
+                return {
+                    key: columnName
+                };
             });
-            if (arg.alignRight) {
-                tabTabs = reverse(tabs);
-                tabStyle.float = 'right';
-                activeIndex = tabs.length - 1;
-            } else {
-                tabTabs = tabs;
-                activeIndex = 0;
-            }
-            return div(tabsAttribs, [
-                ul({class: tabClasses.join(' '), role: 'tablist'},
-                    tabTabs.map(function (tab, index) {
-                        var attribs = {
-                            role: 'presentation'
-                        };
-                        if (index === activeIndex) {
-                            attribs.class = 'active';
-                        }
-                        attribs.style = tabStyle;
-                        return li(attribs, a({
-                            href: '#' + tab.id,
-                            ariaControls: 'home',
-                            role: 'tab',
-                            dataToggle: 'tab'
-                        }, tab.label));
-                    })),
-                div({class: 'tab-content'},
-                    tabs.map(function (tab, index) {
-                        var attribs = {
-                            role: 'tabpanel',
-                            class: 'tab-pane',
-                            id: tab.id
-                        };
-                        if (tab.name) {
-                            attribs['data-name'] = tab.name;
-                        }
-                        if (index === 0) {
-                            attribs.class += ' active';
-                        }
-                        return div(attribs, tab.content);
-                    })
-                    )
-            ]);
+        } else {
+            columns = columns.map((column) => {
+                if (typeof column === 'string') {
+                    return {
+                        key: column
+                    };
+                }
+                return column;
+            });
+        }
+        if (options.classes) {
+            classes = options.classes;
+        } else {
+            classes = ['table-striped', 'table-bordered'];
         }
 
-        return {
-            html: jsonToHTML,
-            tag: tag,
-            makeTable: makeTable,
-            makeTableRotated: makeTableRotated,
-            makeRotatedTable: makeRotatedTable,
-            makeObjectTable: makeObjectTable,
-            makeObjTable: makeObjTable,
-            genId: genId,
-            bsPanel: bsPanel,
-            panel: bsPanel,
-            makePanel: makePanel,
-            loading: loading,
-            flatten: flatten,
-            makeList: makeList,
-            makeTabs: makeTabs
-        };
-    }());
+        return table({ class: 'table ' + classes.join(' ') },
+            columns.map((column) => {
+                return tr([
+                    th(columnLabel(column)),
+                    td(columnValue(data, column))
+                ]);
+            }));
+    }
+
+    function flatten(html) {
+        if (typeof html === 'string') {
+            return html;
+        }
+        if (Array.isArray(html)) {
+            return html.map((h) => {
+                return flatten(h);
+            }).join('');
+        }
+        throw new Error('Not a valid html representation -- must be string or list');
+    }
+
+    function makeList(arg) {
+        if (Array.isArray(arg.items)) {
+            return ul(arg.items.map((item) => {
+                return li(item);
+            }));
+        }
+        return 'Sorry, cannot make a list from that';
+    }
+
+    /**
+     * Make a bootstrap tabset:
+     * arg.tabs.id
+     * arg.tabs.label
+     * arg.tabs.name
+     * arg.tabs.content
+     * 
+     * @param {type} arg
+     * @returns {unresolved}
+     */
+    function reverse(arr) {
+        const newArray = [];
+        for (let i = arr.length - 1; i >= 0; i -= 1) {
+            newArray.push(arr[i]);
+        }
+        return newArray;
+    }
+
+    function makeTabs(arg) {
+        const tabsId = arg.id,
+            tabsAttribs = {},
+            tabClasses = ['nav', 'nav-tabs'],
+            tabStyle = {},
+            tabs = arg.tabs.filter((tab) => {
+                return (tab ? true : false);
+            });
+
+        let activeIndex, tabTabs;
+
+        if (tabsId) {
+            tabsAttribs.id = tabsId;
+        }
+        tabs.forEach((tab) => {
+            tab.id = genId();
+        });
+        if (arg.alignRight) {
+            tabTabs = reverse(tabs);
+            tabStyle.float = 'right';
+            activeIndex = tabs.length - 1;
+        } else {
+            tabTabs = tabs;
+            activeIndex = 0;
+        }
+        return div(tabsAttribs, [
+            ul({ class: tabClasses.join(' '), role: 'tablist' },
+                tabTabs.map((tab, index) => {
+                    const attribs = {
+                        role: 'presentation'
+                    };
+                    if (index === activeIndex) {
+                        attribs.class = 'active';
+                    }
+                    attribs.style = tabStyle;
+                    return li(attribs, a({
+                        href: '#' + tab.id,
+                        ariaControls: 'home',
+                        role: 'tab',
+                        dataToggle: 'tab'
+                    }, tab.label));
+                })),
+            div({ class: 'tab-content' },
+                tabs.map((tab, index) => {
+                    const attribs = {
+                        role: 'tabpanel',
+                        class: 'tab-pane',
+                        id: tab.id
+                    };
+                    if (tab.name) {
+                        attribs['data-name'] = tab.name;
+                    }
+                    if (index === 0) {
+                        attribs.class += ' active';
+                    }
+                    return div(attribs, tab.content);
+                })
+            )
+        ]);
+    }
+
+    return Object.freeze({
+        html: jsonToHTML,
+        camelToKebab,
+        tag,
+        makeTable,
+        makeTableRotated,
+        makeRotatedTable,
+        makeObjectTable,
+        makeObjTable,
+        genId,
+        bsPanel,
+        panel: bsPanel,
+        makePanel,
+        loading,
+        flatten,
+        makeList,
+        makeTabs
+    });
 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -392,15 +392,10 @@ define([
 
         renderOverlayState: function () {
             if (this.$appCatalogContainer.is(':visible')) {
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', true);
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', false);
                 // Need to rerender (not refresh data) because in some states, the catalog browser looks to see
                 // if things are hidden or not. When this panel is hidden, then refreshed, all sections will
                 // think they have no content and nothing will display.
                 this.appCatalog.rerender();
-            } else {
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', false);
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', true);
             }
         },
 
@@ -702,16 +697,16 @@ define([
                         return b.info.name.localeCompare(a.info.name);
                     }
                 });
-                for (let i = 0; i < appList.length; i++) {
-                    $appPanel.append(this.buildAppItem(appSet[appList[i]]));
+                for (const appId of appList) {
+                    $appPanel.append(this.buildAppItem(appSet[appId]));
                 }
             };
 
             const buildSingleAccordion = (category, appList) => {
                 const $accordionBody = $('<div>');
-                appList.forEach((appId) => {
+                for (const appId of appList) {
                     $accordionBody.append(this.buildAppItem(appSet[appId]));
-                });
+                }
 
                 return {
                     title: category + ' <span class="label label-info pull-right" style="padding-top:0.4em">' + appList.length + '</span>',
@@ -819,8 +814,7 @@ define([
                     filterString = filter[1];
                 }
             }
-            let filteredIds = Object.keys(appSet);
-            filteredIds = Object.keys(appSet).filter((id) => {
+            const filteredIds = Object.keys(appSet).filter((id) => {
                 let searchSet;
                 const app = appSet[id];
                 switch (filterType) {
@@ -948,13 +942,12 @@ define([
                 // we need to fetch some methods, so don't
                 Promise.resolve(this.methClient.get_method_spec({ ids: specSet.methods, tag: this.currentTag }))
                     .then((specs) => {
-                        for (let k = 0; k < specs.length; k++) {
-                            results.methods[specs[k].info.id] = specs[k];
+                        for (const spec of specs) {
+                            results.methods[spec.info.id] = specs;
                         }
                         callback(results);
                     })
                     .catch((err) => {
-
                         console.error('Error in method panel on "getFunctionSpecs" when contacting NMS');
                         console.error(err);
                         callback(results); // still return even if we couldn't get the methods

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -943,7 +943,7 @@ define([
                 Promise.resolve(this.methClient.get_method_spec({ ids: specSet.methods, tag: this.currentTag }))
                     .then((specs) => {
                         for (const spec of specs) {
-                            results.methods[spec.info.id] = specs;
+                            results.methods[spec.info.id] = spec;
                         }
                         callback(results);
                     })

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -327,7 +327,9 @@ define([
             });
             this.addButton(this.$toggleVersionBtn);
 
-            this.$appCatalogBody = $('<div>');
+            this.$appCatalogBody = $('<div>')
+                .attr('data-test-id', 'app-slideout-panel');
+
             this.appCatalog = null;
             this.$appCatalogContainer = $('<div>')
                 .append($('<div>')
@@ -338,6 +340,7 @@ define([
 
             this.$slideoutBtn = $('<button>')
                 .addClass('btn btn-xs btn-default')
+                .attr('data-test-id', 'app-slideout-button')
                 .tooltip({
                     title: 'Hide / Show App Catalog',
                     container: 'body',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -1,4 +1,3 @@
-/*global define*/
 /*jslint white: true*/
 /**
  * A widget that contains functions and function information for the Narrative.
@@ -73,8 +72,7 @@ define([
 
         currentTag: null, // release/dev/beta; which version of the method spec to fetch.  default is release
 
-        init: function(options) {
-            var self = this;
+        init: function (options) {
             this.app_offset = true;
             this._super(options);
             // DOM structure setup here.
@@ -109,8 +107,8 @@ define([
                 .append(this.$methodList);
 
             this.bsSearch = new BootstrapSearch(this.$searchDiv, {
-                inputFunction: function() {
-                    self.refreshPanel(this);
+                inputFunction: () => {
+                    this.refreshPanel(this);
                 },
                 placeholder: 'Search apps'
             });
@@ -136,17 +134,17 @@ define([
                 .append(this.$loadingPanel)
                 .append(this.$errorPanel));
 
-            $(document).on('filterMethods.Narrative', function(e, filterString) {
+            $(document).on('filterMethods.Narrative', (e, filterString) => {
                 if (filterString) {
                     this.$searchDiv.show({ effect: 'blind', duration: 'fast' });
                     this.bsSearch.val(filterString);
                 }
-            }.bind(this));
+            });
 
-            $(document).on('removeFilterMethods.Narrative', function() {
+            $(document).on('removeFilterMethods.Narrative', () => {
                 this.$searchDiv.toggle({ effect: 'blind', duration: 'fast' });
                 this.bsSearch.val('');
-            }.bind(this));
+            });
 
             /* 'request' should be expected to be an object like this:
              * {
@@ -172,7 +170,7 @@ define([
              * If a spec isn't found, then it won't appear in the return values.
              */
             $(document).on('getFunctionSpecs.Narrative',
-                $.proxy(function(e, specSet, callback) {
+                $.proxy(function (e, specSet, callback) {
                     if (callback) {
                         this.getFunctionSpecs(specSet, callback);
                     }
@@ -181,7 +179,7 @@ define([
 
             this.currentPanelStyle = 'category';
             this.$filterLabel = $('<span>').append(this.currentPanelStyle);
-            var $filterMenu = $('<ul>')
+            const $filterMenu = $('<ul>')
                 .addClass('dropdown-menu dropdown-menu-right')
                 .css({
                     'margin-top': '20px'
@@ -197,10 +195,11 @@ define([
                     .append('<a style="cursor:pointer" data-filter="a-z">Name A-Z</a>'))
                 .append($('<li>')
                     .append('<a style="cursor:pointer" data-filter="z-a">Name Z-A</a>'));
-            $filterMenu.find('li a').click(function() {
-                self.currentPanelStyle = $(this).data('filter');
-                self.$filterLabel.text(self.currentPanelStyle);
-                self.refreshPanel();
+
+            $filterMenu.find('li a').click((ev) => {
+                this.currentPanelStyle = $(ev.target).data('filter');
+                this.$filterLabel.text(this.currentPanelStyle);
+                this.refreshPanel();
             });
 
             this.addButton($('<span class="dropdown">')
@@ -229,9 +228,9 @@ define([
                         hide: Config.get('tooltip').hideDelay
                     }
                 })
-                .click(function() {
+                .click(() => {
                     this.$searchDiv.toggle({ effect: 'blind', duration: 'fast' });
-                    var new_height = this.$methodList.height();
+                    let new_height = this.$methodList.height();
                     if (this.app_offset) {
                         new_height = (new_height - 40) + 'px';
                     } else {
@@ -240,7 +239,7 @@ define([
                     this.$methodList.css('height', new_height);
                     this.app_offset = !this.app_offset;
                     this.bsSearch.focus();
-                }.bind(this)));
+                }));
 
             // Refresh button
             this.addButton($('<button>')
@@ -254,8 +253,8 @@ define([
                         hide: Config.get('tooltip').hideDelay
                     }
                 })
-                .click(function() {
-                    var versionTag = 'release';
+                .click(() => {
+                    let versionTag = 'release';
                     if (this.versionState === 'B') { versionTag = 'beta'; } else if (this.versionState === 'D') { versionTag = 'dev'; }
                     this.refreshFromService(versionTag);
                     this.refreshKernelSpecManager();
@@ -263,10 +262,10 @@ define([
                     if (this.appCatalog) {
                         this.appCatalog.refreshAndRender();
                     }
-                }.bind(this)));
+                }));
 
             // Toggle version btn
-            var toggleTooltipText = 'Toggle between Release and Beta Versions';
+            let toggleTooltipText = 'Toggle between Release and Beta Versions';
             if (Config.get('dev_mode'))
                 toggleTooltipText = 'Toggle between Release/Beta/Dev versions';
             this.$toggleVersionBtn = $('<button>')
@@ -282,10 +281,10 @@ define([
                 .append('R');
             this.versionState = 'R';
 
-            var devMode = Config.get('dev_mode');
-            var showBetaWarning = true;
+            const devMode = Config.get('dev_mode');
+            let showBetaWarning = true;
 
-            var betaWarningCompiled = Handlebars.compile(BetaWarningTemplate);
+            const betaWarningCompiled = Handlebars.compile(BetaWarningTemplate);
 
             this.betaWarningDialog = new BootstrapDialog({
                 title: 'Warning - entering beta mode!',
@@ -294,13 +293,13 @@ define([
                 closeButton: true,
                 enterToTrigger: true
             });
-            this.betaWarningDialog.getBody().find('input').change(function() {
+            this.betaWarningDialog.getBody().find('input').change(function () {
                 showBetaWarning = $(this).is(':checked');
             }).prop('checked', showBetaWarning);
 
-            this.$toggleVersionBtn.click(function() {
+            this.$toggleVersionBtn.click(() => {
                 this.$toggleVersionBtn.tooltip('hide');
-                var versionTag = 'release';
+                let versionTag = 'release';
                 if (this.versionState === 'R') {
                     this.versionState = 'B';
                     versionTag = 'beta';
@@ -325,7 +324,7 @@ define([
                 if (this.appCatalog) {
                     this.appCatalog.setTag(versionTag);
                 }
-            }.bind(this));
+            });
             this.addButton(this.$toggleVersionBtn);
 
             this.$appCatalogBody = $('<div>');
@@ -353,8 +352,53 @@ define([
             this.addButton(this.$slideoutBtn);
 
             this.methClient = new NarrativeMethodStore(this.options.methodStoreURL);
+
+            $(document).on('sidePanelOverlayHiding.Narrative', (_, panel) => {
+                if (panel === this.$appCatalogContainer) {
+                    this.preRenderOverlayState();
+                }
+            });
+
+            $(document).on('sidePanelOverlayShowing.Narrative', (_, panel) => {
+                if (panel === this.$appCatalogContainer) {
+                    this.preRenderOverlayState();
+                }
+            });
+
+            $(document).on('sidePanelOverlayHidden.Narrative', () => {
+                this.renderOverlayState();
+            });
+
+            $(document).on('sidePanelOverlayShown.Narrative', () => {
+                this.renderOverlayState();
+            });
+
             this.refreshFromService();
             return this;
+        },
+
+        preRenderOverlayState: function () {
+            if (this.$appCatalogContainer.is(':visible')) {
+                this.$slideoutBtn.children().toggleClass('fa-arrow-left', false);
+                this.$slideoutBtn.children().toggleClass('fa-arrow-right', true);
+            } else {
+                this.$slideoutBtn.children().toggleClass('fa-arrow-left', true);
+                this.$slideoutBtn.children().toggleClass('fa-arrow-right', false);
+            }
+        },
+
+        renderOverlayState: function () {
+            if (this.$appCatalogContainer.is(':visible')) {
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', true);
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', false);
+                // Need to rerender (not refresh data) because in some states, the catalog browser looks to see
+                // if things are hidden or not. When this panel is hidden, then refreshed, all sections will
+                // think they have no content and nothing will display.
+                this.appCatalog.rerender();
+            } else {
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', false);
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', true);
+            }
         },
 
         spawnCatalogBrowser: function () {
@@ -362,19 +406,13 @@ define([
             if (!this.appCatalog) {
                 this.appCatalog = new KBaseCatalogBrowser(
                     this.$appCatalogBody, {
-                        ignoreCategories: this.ignoreCategories,
-                        tag: this.currentTag
-                    }
+                    ignoreCategories: this.ignoreCategories,
+                    tag: this.currentTag
+                }
                 );
             }
-
             this.$slideoutBtn.tooltip('hide');
-            this.trigger('hideGalleryPanelOverlay.Narrative');
-            this.trigger('toggleSidePanelOverlay.Narrative', this.$appCatalogContainer);
-            // Need to rerender (not refresh data) because in some states, the catalog browser looks to see
-            // if things are hidden or not. When this panel is hidden, then refreshed, all sections will
-            // think they have no content and nothing will display.
-            this.appCatalog.rerender();
+            this.trigger('toggleSidePanelOverlay.Narrative', [this.$appCatalogContainer]);
         },
 
         detach: function () {
@@ -384,7 +422,7 @@ define([
             this.$bodyDiv.detach();
         },
 
-        refreshKernelSpecManager: function() {
+        refreshKernelSpecManager: function () {
             try {
                 Jupyter.notebook.kernel.execute(
                     'from biokbase.narrative.jobs.specmanager import SpecManager\n' +
@@ -396,12 +434,12 @@ define([
             }
         },
 
-        setListHeight: function(height, animate) {
+        setListHeight: function (height, animate) {
             if (this.$methodList) {
                 if (animate) {
-                    this.$methodList.animate({'height': height}, this.slideTime); // slideTime comes from kbaseNarrativeControlPanel
+                    this.$methodList.animate({ 'height': height }, this.slideTime); // slideTime comes from kbaseNarrativeControlPanel
                 } else {
-                    this.$methodList.css({'height': height});
+                    this.$methodList.css({ 'height': height });
                 }
             }
         },
@@ -414,20 +452,20 @@ define([
             }
         },
 
-        initMethodTooltip: function() {
+        initMethodTooltip: function () {
             this.help = {};
 
             this.help.$helpPanel = $('<div>')
                 .addClass('kb-function-help-popup alert alert-info')
                 .hide()
-                .click(function() {
+                .click(() => {
                     this.help.$helpPanel.hide();
-                }.bind(this));
+                });
             this.help.$helpTitle = $('<span>');
             this.help.$helpVersion = $('<span>')
                 .addClass('version');
 
-            var $helpHeader = $('<div>')
+            const $helpHeader = $('<div>')
                 .append(
                     $('<h1>')
                         .css({
@@ -454,14 +492,14 @@ define([
         /**
          * Fetch ignored_category from Narrative Service and assign returned value to local ignoreCategories
          */
-        getIgnoreCategories: function() {
+        getIgnoreCategories: function () {
             this.narrativeService.callFunc('get_ignore_categories', [])
                 .then((ignoreCategories) => {
                     this.ignoreCategories = ignoreCategories[0];
                 })
-                .catch((error) => {
+                .catch(() => {
                     // return default ignore categories
-                    this.ignoreCategories =  {
+                    this.ignoreCategories = {
                         inactive: 1,
                         importers: 1,
                         viewers: 1
@@ -472,7 +510,7 @@ define([
         /**
          * Returns a promise that resolves when the app is done refreshing itself.
          */
-        refreshFromService: function(versionTag) {
+        refreshFromService: function (versionTag) {
             this.showLoadingMessage('Loading available Apps...');
             if (versionTag) {
                 this.currentTag = versionTag;
@@ -506,7 +544,7 @@ define([
          * app (should be one of "release", "beta", "dev"). Otherwise, we use the current user-
          * selected tag.
          */
-        triggerApp: function(app, tag, parameters) {
+        triggerApp: function (app, tag, parameters) {
             if (Jupyter.narrative.narrController.uiModeIs('view')) {
                 new BootstrapDialog({
                     type: 'warning',
@@ -516,12 +554,11 @@ define([
                 }).show();
                 return;
             }
-            var self = this;
-            if(!tag) {
-                tag = self.currentTag;
+            if (!tag) {
+                tag = this.currentTag;
             }
-            if (typeof(app) === 'string') {
-                var info = self.methodSpecs[app.toLowerCase()];
+            if (typeof (app) === 'string') {
+                let info = this.methodSpecs[app.toLowerCase()];
                 if (!info) {
                     info = {
                         'info': {
@@ -531,78 +568,80 @@ define([
                 }
                 app = info;
             }
-            if(!app['spec']) {
-                Promise.resolve(self.methClient.get_method_spec({ids: [app.info.id], tag: tag}))
-                    .then(function(spec) {
+            if (!app['spec']) {
+                Promise.resolve(this.methClient.get_method_spec({ ids: [app.info.id], tag: tag }))
+                    .then((spec) => {
                         spec = spec[0];
-                        if (self.moduleVersions[spec.info.module_name]) {
-                            spec.info.ver = self.moduleVersions[spec.info.module_name];
+                        if (this.moduleVersions[spec.info.module_name]) {
+                            spec.info.ver = this.moduleVersions[spec.info.module_name];
                         }
-                        self.trigger('appClicked.Narrative', [spec, tag, parameters]);
+                        this.trigger('appClicked.Narrative', [spec, tag, parameters]);
                     })
-                    .catch(function (err) {
-                        var errorId = new Uuid(4).format();
+                    .catch((err) => {
+                        const errorId = new Uuid(4).format();
                         console.error('Error getting method spec #' + errorId, err, app, tag);
                         alert('Error getting app spec, see console for error info #' + errorId);
                     });
             } else {
-                self.trigger('appClicked.Narrative', [app, tag, parameters]);
+                this.trigger('appClicked.Narrative', [app, tag, parameters]);
             }
         },
 
-        categorizeApps: function(style, appSet) {
+        categorizeApps: function (style, appSet) {
 
             // previously, categories had the first letter of each word uppercased as part of display.
             // now they're uppercased while the cats are built, to map similar cats to the same keyed
             // display name (e.g. "metabolic_modeling" and "metabolic modeling" both go to "Metabolic Modeling")
             // but 'uncategorized' is a hardwired special case. I opted to break it out into a constant defined
             // here instead of use an upper case string as the key throughout later on.
-            var UNCATEGORIZED = 'Uncategorized';
+            const UNCATEGORIZED = 'Uncategorized';
 
-            var allCategories = {
+            const allCategories = {
                 favorites: []
             };
             allCategories[UNCATEGORIZED] = [];  //my kingdom for es6 syntax
 
-            Object.keys(appSet).forEach(function(appId) {
-                var categoryList = [];
+            Object.keys(appSet).forEach((appId) => {
+                let categoryList = [];
                 switch (style) {
-                case 'input':
-                    categoryList = appSet[appId].info.input_types.map(function(input) {
-                        if (input.indexOf('.') !== -1) {
-                            return input.split('.')[1];
-                        }
-                        else {
-                            return input;
-                        }
-                    });
-                    break;
-                case 'output':
-                    categoryList = appSet[appId].info.output_types.map(function(output) {
-                        if (output.indexOf('.') !== -1) {
-                            return output.split('.')[1];
-                        }
-                        else {
-                            return output;
-                        }
-                    });
-                    break;
-                default:
-                case 'category':
-                    categoryList = appSet[appId].info.categories;
-                    var activeIndex = categoryList.indexOf('active');
-                    if (activeIndex !== -1) {
-                        categoryList.splice(activeIndex, 1);
-                    }
-                    break;
+                    case 'input':
+                        categoryList = appSet[appId].info.input_types.map((input) => {
+                            if (input.indexOf('.') !== -1) {
+                                return input.split('.')[1];
+                            }
+                            else {
+                                return input;
+                            }
+                        });
+                        break;
+                    case 'output':
+                        categoryList = appSet[appId].info.output_types.map((output) => {
+                            if (output.indexOf('.') !== -1) {
+                                return output.split('.')[1];
+                            }
+                            else {
+                                return output;
+                            }
+                        });
+                        break;
+                    default:
+                    case 'category':
+                        (() => {
+                            categoryList = appSet[appId].info.categories;
+                            const activeIndex = categoryList.indexOf('active');
+                            if (activeIndex !== -1) {
+                                categoryList.splice(activeIndex, 1);
+                            }
+                        })();
+                        break;
                 }
                 if (categoryList.length === 0) {
                     allCategories[UNCATEGORIZED].push(appId);
                 }
-                categoryList.forEach(function(cat) {
+                categoryList.forEach((cat) => {
                     cat = Categories.categories[cat] || cat;
                     cat = cat.replace('_', ' ')
-                        .replace(/\w\S*/g, function(txt) {
+                        .replace(/\w\S*/g, (txt) => {
                             return txt.charAt(0).toUpperCase() + txt.substr(1);
                         });
                     if (!allCategories[cat]) {
@@ -614,13 +653,13 @@ define([
                     allCategories.favorites.push(appId);
                 }
             });
-            Object.keys(allCategories).forEach(function(cat) {
-                allCategories[cat] = allCategories[cat].filter(function(el, index, arr) {
+            Object.keys(allCategories).forEach((cat) => {
+                allCategories[cat] = allCategories[cat].filter((el, index, arr) => {
                     return index === arr.indexOf(el);
                 });
-                allCategories[cat].sort(function(a, b) {
+                allCategories[cat].sort((a, b) => {
                     a = appSet[a],
-                    b = appSet[b];
+                        b = appSet[b];
                     return a.info.name.localeCompare(b.info.name);
                 });
             });
@@ -633,16 +672,15 @@ define([
             return allCategories;
         },
 
-        refreshPanel: function() {
-            var panelStyle = this.currentPanelStyle,
-                filterString = this.bsSearch.val(),
-                appSet = this.methodSpecs,
-                self = this,
-                $appPanel = $('<div>');
+        refreshPanel: function () {
+            const panelStyle = this.currentPanelStyle;
+            const filterString = this.bsSearch.val();
+            let appSet = this.methodSpecs;
+            const $appPanel = $('<div>');
 
-            var buildFlatPanel = function(ascending) {
-                var appList = Object.keys(appSet);
-                appList.sort(function(a, b) {
+            const buildFlatPanel = (ascending) => {
+                const appList = Object.keys(appSet);
+                appList.sort((a, b) => {
                     a = appSet[a];
                     b = appSet[b];
                     if (a.favorite && b.favorite) {
@@ -661,15 +699,15 @@ define([
                         return b.info.name.localeCompare(a.info.name);
                     }
                 });
-                for (var i=0; i<appList.length; i++) {
-                    $appPanel.append(self.buildAppItem(appSet[appList[i]]));
+                for (let i = 0; i < appList.length; i++) {
+                    $appPanel.append(this.buildAppItem(appSet[appList[i]]));
                 }
             };
 
-            var buildSingleAccordion = function(category, appList) {
-                var $accordionBody = $('<div>');
-                appList.forEach(function(appId) {
-                    $accordionBody.append(self.buildAppItem(appSet[appId]));
+            const buildSingleAccordion = (category, appList) => {
+                const $accordionBody = $('<div>');
+                appList.forEach((appId) => {
+                    $accordionBody.append(this.buildAppItem(appSet[appId]));
                 });
 
                 return {
@@ -678,13 +716,13 @@ define([
                 };
             };
 
-            var assembleAccordion = function(accordion) {
-                var $body = accordion.body;
-                var $toggle = $('<span class="fa fa-chevron-right">')
+            const assembleAccordion = function (accordion) {
+                const $body = accordion.body;
+                const $toggle = $('<span class="fa fa-chevron-right">')
                     .css({
                         'padding-right': '3px'
                     });
-                var $header = $('<div class="row">')
+                const $header = $('<div class="row">')
                     .css({
                         cursor: 'pointer',
                         'font-size': '1.1em',
@@ -694,14 +732,14 @@ define([
                     })
                     .append($toggle)
                     .append(accordion.title)
-                    .click(function() {
+                    .click(() => {
                         if ($toggle.hasClass('fa-chevron-right')) {
-                            $body.slideDown('fast', function() {
+                            $body.slideDown('fast', () => {
                                 $toggle.removeClass('fa-chevron-right')
                                     .addClass('fa-chevron-down');
                             });
                         } else {
-                            $body.slideUp('fast', function() {
+                            $body.slideUp('fast', () => {
                                 $toggle.removeClass('fa-chevron-down')
                                     .addClass('fa-chevron-right');
                             });
@@ -710,21 +748,21 @@ define([
                 return $('<div>').append($header).append($body.hide());
             };
 
-            var withCategories = function(a,b) {
-                var catA = (Categories.categories[a] || a).toLowerCase();
-                var catB = (Categories.categories[b] || b).toLowerCase();
+            const withCategories = function (a, b) {
+                const catA = (Categories.categories[a] || a).toLowerCase();
+                const catB = (Categories.categories[b] || b).toLowerCase();
                 if (catA < catB) { return -1; }
-                else if (catA > catB) { return  1; }
-                else                  { return  0; }
+                else if (catA > catB) { return 1; }
+                else { return 0; }
             };
 
-            var buildAccordionPanel = function(style) {
+            const buildAccordionPanel = (style) => {
                 /* first, get elements in order like this:
                  * { category1: [ appId1, appId2, appId3, ...]}
                  */
-                var categorySet = self.categorizeApps(style, appSet);
-                var accordionList = [];
-                Object.keys(categorySet).sort(withCategories).forEach(function(cat) {
+                const categorySet = this.categorizeApps(style, appSet);
+                const accordionList = [];
+                Object.keys(categorySet).sort(withCategories).forEach((cat) => {
                     if (cat === 'favorites') {
                         return;
                     }
@@ -733,7 +771,7 @@ define([
                 if (categorySet.favorites) {
                     accordionList.unshift(buildSingleAccordion('My Favorites', categorySet.favorites));
                 }
-                accordionList.forEach(function(accordion) {
+                accordionList.forEach((accordion) => {
                     $appPanel.append(assembleAccordion(accordion));
                 });
             };
@@ -743,19 +781,19 @@ define([
 
             // 2. Switch over panelStyle and build the view based on that.
             switch (panelStyle) {
-            case 'a-z':
-                buildFlatPanel(true);
-                break;
-            case 'z-a':
-                buildFlatPanel(false);
-                break;
-            case 'category':
-            case 'input':
-            case 'output':
-                buildAccordionPanel(panelStyle);
-                break;
-            default:
-                break;
+                case 'a-z':
+                    buildFlatPanel(true);
+                    break;
+                case 'z-a':
+                    buildFlatPanel(false);
+                    break;
+                case 'category':
+                case 'input':
+                case 'output':
+                    buildAccordionPanel(panelStyle);
+                    break;
+                default:
+                    break;
             }
             this.$methodList.empty().append($appPanel);
         },
@@ -765,55 +803,55 @@ define([
          * filterString - just a string. includes prefixes in_type:, out_type:
          * appSet - keys=appIds, values=appSpecs
          */
-        filterApps: function(filterString, appSet) {
+        filterApps: function (filterString, appSet) {
             if (!filterString) {
                 return appSet;
             }
-            var filterType = 'name';
+            let filterType = 'name';
             filterString = filterString.toLowerCase();
-            var filter = filterString.split(':');
+            const filter = filterString.split(':');
             if (filter.length === 2) {
                 if (['in_type', 'out_type', 'input', 'output'].indexOf(filter[0]) !== -1) {
                     filterType = filter[0];
                     filterString = filter[1];
                 }
             }
-            var filteredIds = Object.keys(appSet);
-            filteredIds = Object.keys(appSet).filter(function(id) {
-                var searchSet;
-                var app = appSet[id];
+            let filteredIds = Object.keys(appSet);
+            filteredIds = Object.keys(appSet).filter((id) => {
+                let searchSet;
+                const app = appSet[id];
                 switch (filterType) {
-                case 'in_type':
-                case 'input':
-                    if (filterString.indexOf('.') !== -1) {
-                        searchSet = app.info.input_types;
-                    }
-                    else {
-                        searchSet = app.info.short_input_types;
-                    }
-                    break;
-                case 'out_type':
-                case 'output':
-                    if (filterString.indexOf('.') !== -1) {
-                        searchSet = app.info.output_types;
-                    }
-                    else {
-                        searchSet = app.info.short_output_types;
-                    }
-                    break;
-                default:
-                    return [
-                        app.info.name,
-                        app.info.input_types.join(';'),
-                        app.info.output_types.join(';'),
-                        app.info.module_name
-                    ].join(';').toLowerCase().indexOf(filterString) !== -1;
+                    case 'in_type':
+                    case 'input':
+                        if (filterString.indexOf('.') !== -1) {
+                            searchSet = app.info.input_types;
+                        }
+                        else {
+                            searchSet = app.info.short_input_types;
+                        }
+                        break;
+                    case 'out_type':
+                    case 'output':
+                        if (filterString.indexOf('.') !== -1) {
+                            searchSet = app.info.output_types;
+                        }
+                        else {
+                            searchSet = app.info.short_output_types;
+                        }
+                        break;
+                    default:
+                        return [
+                            app.info.name,
+                            app.info.input_types.join(';'),
+                            app.info.output_types.join(';'),
+                            app.info.module_name
+                        ].join(';').toLowerCase().indexOf(filterString) !== -1;
                 }
-                var lowerSearchSet = searchSet.map(function(val) { return val.toLowerCase(); });
+                const lowerSearchSet = searchSet.map((val) => { return val.toLowerCase(); });
                 return lowerSearchSet.indexOf(filterString) !== -1;
             });
-            var filteredSet = {};
-            filteredIds.forEach(function(id) {
+            const filteredSet = {};
+            filteredIds.forEach((id) => {
                 filteredSet[id] = appSet[id];
             });
             return filteredSet;
@@ -829,7 +867,7 @@ define([
          * @param {object} app - the app object that contains app info and spec.
          * @private
          */
-        buildAppItem: function(app) {
+        buildAppItem: function (app) {
             /**
              app.info:
                 authors:["rsutormin"], categories:["annotation"], icon:{url:}, id: str,
@@ -838,18 +876,16 @@ define([
                 subtitle: str, tooltip: str, ver: str
              *
             */
-            var self = this;
-
-            var moreLink = '';
-            if(app.info.module_name) {
+            let moreLink = '';
+            if (app.info.module_name) {
                 moreLink = this.options.methodHelpLink + app.info.id + '/' + this.currentTag;
             } else {
                 moreLink = this.options.methodHelpLink + 'l.m/' + app.info.id;
             }
-            var $more = $('<div>')
+            const $more = $('<div>')
                 .addClass('kb-method-list-more-div');
 
-            if (self.currentTag && self.currentTag !== 'release') {
+            if (this.currentTag && this.currentTag !== 'release') {
                 $more.append($('<div style="font-size:8pt">')
                     .append(app.info.git_commit_hash));
             }
@@ -861,24 +897,22 @@ define([
                         .attr('target', '_blank')
                         .attr('href', moreLink)));
 
-            var $card = kbaseAppCard.apply(this, [
+            const $card = kbaseAppCard.apply(this, [
                 {
-                    createdBy:false,
+                    createdBy: false,
                     moreContent: $more,
                     max_name_length: 50,
-                    self: self,
+                    self: this,
                     app: app,
                 }]);
 
-            //custome click functions;
-            $card.find('.narrative-card-logo , .kb-data-list-name').click(function (e) {
+            //custom click functions;
+            $card.find('.narrative-card-logo .kb-data-list-name').click((e) => {
                 e.stopPropagation();
-                self.triggerApp(app);
+                this.triggerApp(app);
             });
 
             return $card;
-
-
         },
 
         /* 'request' should be expected to be an object like this:
@@ -904,19 +938,19 @@ define([
          *
          * If a spec isn't found, then it won't appear in the return values.
          */
-        getFunctionSpecs: function(specSet, callback) {
-            var results = {};
+        getFunctionSpecs: function (specSet, callback) {
+            const results = {};
             if (specSet.methods && specSet.methods instanceof Array) {
                 results.methods = {};
                 // we need to fetch some methods, so don't
                 Promise.resolve(this.methClient.get_method_spec({ ids: specSet.methods, tag: this.currentTag }))
-                    .then(function(specs) {
-                        for (var k = 0; k < specs.length; k++) {
+                    .then((specs) => {
+                        for (let k = 0; k < specs.length; k++) {
                             results.methods[specs[k].info.id] = specs[k];
                         }
                         callback(results);
                     })
-                    .catch(function(err) {
+                    .catch((err) => {
 
                         console.error('Error in method panel on "getFunctionSpecs" when contacting NMS');
                         console.error(err);
@@ -933,7 +967,7 @@ define([
          * Shows a loading spinner or message on top of the panel.
          * @private
          */
-        showLoadingMessage: function(message) {
+        showLoadingMessage: function (message) {
             this.$loadingPanel.find('#message').empty();
             if (message)
                 this.$loadingPanel.find('#message').html(message);
@@ -946,7 +980,7 @@ define([
          * Shows the main function panel, hiding all others.
          * @private
          */
-        showAppPanel: function() {
+        showAppPanel: function () {
             this.$errorPanel.hide();
             this.$loadingPanel.hide();
             this.$functionPanel.show();
@@ -957,7 +991,7 @@ define([
          * @param {string} error - the text of the error message
          * @private
          */
-        showError: function(title, error) {
+        showError: function (title, error) {
             this.$errorPanel.empty().append(DisplayUtil.createError(title, error));
             this.$functionPanel.hide();
             this.$loadingPanel.hide();

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -792,9 +792,9 @@ define([
                                         })));
                                 history.reverse();
                                 const $tbl = $('<table>').css({ 'width': '100%' });
-                                for (let k = 0; k < history.length; k++) {
-                                    const $revertBtn = $('<button>').append('v' + history[k][4]).addClass('kb-data-list-btn');
-                                    if (k === 0) {
+                                for (const [historyItem, historyIndex] of history.items()) {
+                                    const $revertBtn = $('<button>').append('v' + historyItem[4]).addClass('kb-data-list-btn');
+                                    if (historyIndex === 0) {
                                         $revertBtn.tooltip({
                                             title: 'Current Version',
                                             container: 'body',
@@ -805,7 +805,7 @@ define([
                                             }
                                         });
                                     } else {
-                                        const revertRef = { wsid: history[k][6], objid: history[k][0], ver: history[k][4] };
+                                        const revertRef = { wsid: historyItem[6], objid: historyItem[0], ver: historyItem[4] };
                                         ((revertRefLocal) => {
                                             $revertBtn.tooltip({
                                                 title: 'Revert to this version?',
@@ -831,10 +831,10 @@ define([
                                     }
                                     $tbl.append($('<tr>')
                                         .append($('<td>').append($revertBtn))
-                                        .append($('<td>').append('Saved by ' + history[k][5] + '<br>' + TimeFormat.getTimeStampStr(history[k][3])))
+                                        .append($('<td>').append('Saved by ' + historyItem[5] + '<br>' + TimeFormat.getTimeStampStr(historyItem[3])))
                                         .append($('<td>').append($('<span>').css({ margin: '4px' }).addClass('fa fa-info pull-right'))
                                             .tooltip({
-                                                title: history[k][2] + '<br>' + history[k][8] + '<br>' + history[k][9] + ' bytes',
+                                                title: historyItem[2] + '<br>' + historyItem[8] + '<br>' + historyItem[9] + ' bytes',
                                                 container: 'body',
                                                 html: true,
                                                 placement: 'bottom',
@@ -1892,14 +1892,13 @@ define([
                 const regex = new RegExp(term, 'i');
 
                 this.n_filteredObjsRendered = 0;
-                for (let k = 0; k < this.viewOrder.length; k++) {
-
+                for (const orderedObject of this.viewOrder) {
                     // [0] : obj_id objid // [1] : obj_name name // [2] : type_string type
                     // [3] : timestamp save_date // [4] : int version // [5] : username saved_by
                     // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
                     // [9] : int size // [10] : usermeta meta
                     let match = false;
-                    const info = this.dataObjects[this.viewOrder[k].objId].info;
+                    const info = this.dataObjects[orderedObject.objId].info;
                     if (regex.test(info[1])) {
                         match = true;
                     } // match on name
@@ -1917,10 +1916,8 @@ define([
                             if (!(Object.prototype.hasOwnProperty.call(info[10], metaKey))) {
                                 continue;
                             }
-                            if (regex.test(metaValue)) {
-                                match = true;
-                                break;
-                            } else if (regex.test(metaKey + '::' + metaValue)) {
+                            if (regex.test(metaValue) ||
+                                regex.test(metaKey + '::' + metaValue)) {
                                 match = true;
                                 break;
                             }
@@ -1932,7 +1929,7 @@ define([
                             match = false; // no match if we are not the selected type!
                         }
                     }
-                    this.viewOrder[k].inFilter = match;
+                    orderedObject.inFilter = match;
                 }
             } else {
                 // no new search, so show all and render the list

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1554,6 +1554,7 @@ define([
                     $noDataDiv.append($('<button>')
                         .append('Add Data')
                         .addClass('kb-data-list-add-data-text-button')
+                        .attr('data-test-id', 'add-data-button')
                         .css({ 'margin': '20px' })
                         .click(() => {
                             this.trigger('toggleSidePanelOverlay.Narrative', [this.options.parentControlPanel.$overlayPanel]);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -510,7 +510,7 @@ define([
         fetchWorkspaceData: function () {
             const addObjectInfo = (objInfo, dpInfo) => {
                 // Get the object info
-                const objId = this.itemId(objInfo); //objInfo[6] + '/' + objInfo[0]; // + '/' + objInfo[2]
+                const objId = this.itemId(objInfo);
                 let fullDpReference = null;
                 if (dpInfo && dpInfo.ref) {
                     fullDpReference = dpInfo.ref + ';' + objInfo[6] + '/' + objInfo[0] + '/' + objInfo[4];
@@ -553,9 +553,9 @@ define([
             };
 
             const updateSetInfo = (obj) => {
-                const setId = this.itemId(obj.object_info); //obj.object_info[6] + '/' + obj.object_info[0];
+                const setId = this.itemId(obj.object_info);
                 obj.set_items.set_items_info.forEach((setItem) => {
-                    const itemId = this.itemId(setItem); //setItem[6] + '/' + setItem[0];
+                    const itemId = this.itemId(setItem);
                     if (!this.setInfo[setId]) {
                         this.setInfo[setId] = {
                             div: null,
@@ -604,15 +604,15 @@ define([
          * Returns the available object data for a type.
          * If no type is specified (type is falsy), returns all object data
          */
-        getObjData: function (type) {
-            if (type) {
+        getObjData: function (types) {
+            if (types) {
                 const dataSet = {};
-                if (typeof type === 'string') {
-                    type = [type];
+                if (typeof types === 'string') {
+                    types = [types];
                 }
-                for (let i = 0; i < type.length; i++) {
-                    if (this.objData[type[i]]) {
-                        dataSet[type[i]] = this.objData[type[i]];
+                for (const type of types) {
+                    if (this.objData[type]) {
+                        dataSet[type] = this.objData[type];
                     }
                 }
                 return dataSet;
@@ -755,8 +755,15 @@ define([
         },
 
         openReportButton: function () {
-            const $openReport = this.makeToolbarButton('report');
-            return $openReport;
+            return this.makeToolbarButton('report');
+        },
+
+        renderError: function ($alertContainer, message) {
+            $alertContainer.empty();
+            $alertContainer
+                .append($('<span>')
+                    .css({ 'color': '#F44336' })
+                    .append('Error! ' + message));
         },
 
         openHistoryButton: function (objData, $alertContainer) {
@@ -817,8 +824,7 @@ define([
                                                         },
                                                         (error) => {
                                                             console.error(error);
-                                                            $alertContainer.empty();
-                                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                                            this.renderError($alertContainer, error.error.message);
                                                         });
                                                 });
                                         })(revertRef);
@@ -843,8 +849,7 @@ define([
                             },
                             (error) => {
                                 console.error(error);
-                                $alertContainer.empty();
-                                $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                this.renderError($alertContainer, error.error.message);
                             });
                     }
                 });
@@ -968,8 +973,7 @@ define([
                                         },
                                         (error) => {
                                             console.error(error);
-                                            $alertContainer.empty();
-                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                            this.renderError($alertContainer, error.error.message);
                                         });
                                 }
                             }))
@@ -1026,14 +1030,12 @@ define([
                                                 },
                                                 (error) => {
                                                     console.error(error);
-                                                    $alertContainer.empty();
-                                                    $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                                    this.renderError($alertContainer, error.error.message);
                                                 });
                                         },
                                         (error) => {
                                             console.error(error);
-                                            $alertContainer.empty();
-                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                            this.renderError($alertContainer, error.error.message);
                                         });
 
                                 }
@@ -1123,9 +1125,9 @@ define([
                     return [];
                 }
 
-                const objectsToFetch = result.report_upas.map((reportRef) => {
+                const objectsToFetch = result.report_upas.map((ref) => {
                     return {
-                        ref: reportRef
+                        ref
                     };
                 });
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -29,7 +29,7 @@ define([
     'api/dataProvider',
     'bootstrap',
     'jquery-nearest'
-], function (
+], (
     KBWidget,
     $,
     _,
@@ -54,7 +54,7 @@ define([
     BootstrapSearch,
     kbaseDataCard,
     DataProvider
-) {
+) => {
     'use strict';
 
     return KBWidget({
@@ -123,8 +123,8 @@ define([
         /*
         variables to keep track of current state before workspace refresh
         */
-        selectedType : '',
-        lastSortFunction : null,
+        selectedType: '',
+        lastSortFunction: null,
 
         /**
          * Utility function to portably return the identifier to
@@ -171,7 +171,7 @@ define([
          */
         inAnySet: function (item_info) {
             if (this.setViewMode) {
-                var item_id = this.itemId(item_info);
+                const item_id = this.itemId(item_info);
                 return _.has(this.setItems, item_id);
             } else {
                 return false;
@@ -191,21 +191,20 @@ define([
          *         the keys: (item_id, expanded, div).
          */
         getItemParents: function (item_info) {
-            var item_id = this.itemId(item_info);
+            const item_id = this.itemId(item_info);
             // empty if not in ANY set
             if (!_.has(this.setItems, item_id)) {
                 return [];
             }
-            var _this = this;
             // Construct return value, which is one
             // map for each of the Sets.
             return _.map(
                 _.keys(this.setItems[item_id]),
-                function (key) {
+                (key) => {
                     return {
                         item_id: key,
-                        expanded: _this.setInfo[key].expanded,
-                        div: _this.setInfo[key].div
+                        expanded: this.setInfo[key].expanded,
+                        div: this.setInfo[key].div
                     };
                 }
             );
@@ -240,9 +239,8 @@ define([
          */
         init: function (options) {
             this._super(options);
-            var _this = this;
 
-            var dataConfig = Config.get('data_panel');
+            const dataConfig = Config.get('data_panel');
             // this is the limit of the number of objects to retrieve from the ws on each pass
             // note that if there are more objects than this, then sorts/search filters may
             // not show accurate results
@@ -276,20 +274,19 @@ define([
             this.mainListId = StringUtil.uuid();
             this.$mainListDiv = $('<div id=' + this.mainListId + '>')
                 .css({ 'overflow-x': 'hidden', 'overflow-y': 'auto', 'height': this.mainListPanelHeight })
-                .on('scroll', function () {
+                .on('scroll', () => {
                     if ($(this).scrollTop() + $(this).innerHeight() >= this.scrollHeight) {
-                        _this.renderMore();
+                        this.renderMore();
                     }
                 });
 
             this.$addDataButton = $('<button>').addClass('kb-data-list-add-data-button fa fa-plus fa-2x')
                 .attr('aria-label', 'add data')
                 .css({ 'position': 'absolute', bottom: '15px', right: '25px', 'z-index': '5' })
-                .click(function () {
-                    _this.trigger('hideGalleryPanelOverlay.Narrative');
-                    _this.trigger('toggleSidePanelOverlay.Narrative', _this.options.parentControlPanel.$overlayPanel);
+                .click(() => {
+                    this.trigger('toggleSidePanelOverlay.Narrative', [this.options.parentControlPanel.$overlayPanel]);
                 });
-            var $mainListDivContainer = $('<div>').css({ 'position': 'relative' })
+            const $mainListDivContainer = $('<div>').css({ 'position': 'relative' })
                 .append(this.loadingDiv.div)
                 .append(this.$mainListDiv)
                 .append(this.$addDataButton.hide());
@@ -301,8 +298,8 @@ define([
             }
 
             // listener for refresh
-            $(document).on('updateDataList.Narrative', function () {
-                _this.refresh();
+            $(document).on('updateDataList.Narrative', () => {
+                this.refresh();
             });
 
             if (this.options.ws_name) {
@@ -367,15 +364,15 @@ define([
         },
 
         refresh: function (showError) {
-            if(this.writingLock) {
+            if (this.writingLock) {
                 return;
             }
             // Set the refresh timer on the first refresh. From  here, it'll refresh itself
             // every this.options.refresh_interval (30000) ms
             if (this.refreshTimer === null) {
-                this.refreshTimer = setInterval(function () {
+                this.refreshTimer = setInterval(() => {
                     this.refresh();
-                }.bind(this), this.options.refresh_interval); // check if there is new data every X ms
+                }, this.options.refresh_interval); // check if there is new data every X ms
             }
 
             if (!this.ws_name || !this.ws) {
@@ -387,7 +384,7 @@ define([
             return Promise.resolve(this.ws.get_workspace_info({
                 workspace: this.ws_name
             }))
-                .then(function (wsInfo) {
+                .then((wsInfo) => {
                     if (this.wsLastUpdateTimestamp !== wsInfo[3]) {
                         this.wsLastUpdateTimestamp = wsInfo[3];
                         this.maxWsObjId = wsInfo[4];
@@ -396,22 +393,22 @@ define([
                     } else {
                         this.refreshTimeStrings();
                     }
-                }.bind(this))
-                .catch(function (error) {
+                })
+                .catch((error) => {
                     console.error('DataList: when checking for updates:', error);
                     if (showError) {
                         this.showBlockingError('Sorry, an error occurred while fetching your data.', { 'error': 'Unable to connect to KBase database.' });
                     }
-                }.bind(this));
+                });
         },
 
         refreshTimeStrings: function () {
-            Object.keys(this.dataObjects).forEach(function (i) {
+            Object.keys(this.dataObjects).forEach((i) => {
                 if (this.dataObjects[i].$div) {
-                    var newTime = TimeFormat.getTimeStampStr(this.dataObjects[i].info[3]);
+                    const newTime = TimeFormat.getTimeStampStr(this.dataObjects[i].info[3]);
                     this.dataObjects[i].$div.find('.kb-data-list-date').text(newTime);
                 }
-            }.bind(this));
+            });
         },
 
         reloadWsData: function () {
@@ -425,24 +422,24 @@ define([
             this.clearSets();
 
             this.fetchWorkspaceData()
-                .then(function () {
+                .then(() => {
                     // Signal all data channel listeners that we have new data.
                     // TODO: only signal if there are actual changes
                     // TODO: data fetch and sychronization should live as a ui
                     // service, not in a widget.
-                    var justInfo = Object.keys(this.dataObjects).map(function (objId) {
+                    const justInfo = Object.keys(this.dataObjects).map((objId) => {
                         return this.dataObjects[objId].info;
-                    }.bind(this));
-                    var objectInfoPlus = Object.keys(this.dataObjects).map(function (objId) {
+                    });
+                    const objectInfoPlus = Object.keys(this.dataObjects).map((objId) => {
                         // see code below this function for the format of
                         // items in the dataObjects collection
-                        var dataObject = this.dataObjects[objId];
-                        var info = this.createInfoObject(dataObject.info);
+                        const dataObject = this.dataObjects[objId];
+                        const info = this.createInfoObject(dataObject.info);
                         dataObject.objectInfo = info;
                         info.dataPaletteRef = dataObject.refPath;
                         return info;
-                    }.bind(this));
-                    var data = JSON.parse(JSON.stringify(justInfo));
+                    });
+                    const data = JSON.parse(JSON.stringify(justInfo));
                     this.runtime.bus().set({
                         data: data,
                         timestamp: new Date().getTime(),
@@ -453,17 +450,17 @@ define([
                             type: 'workspace-data-updated'
                         }
                     });
-                }.bind(this))
-                .then(function () {
+                })
+                .then(() => {
                     this.showLoading('Rendering data...');
-                    var numObj = Object.keys(this.dataObjects).length;
+                    const numObj = Object.keys(this.dataObjects).length;
                     if (numObj > this.options.maxObjsToPreventFilterAsYouTypeInSearch) {
                         this.$searchInput.off('input');
                     }
 
                     if (numObj <= this.options.max_objs_to_prevent_initial_sort) {
-                        this.viewOrder.sort(function (a, b) {
-                            var idA = a.objId,
+                        this.viewOrder.sort((a, b) => {
+                            const idA = a.objId,
                                 idB = b.objId;
                             if (this.dataObjects[idA].info[3] > this.dataObjects[idB].info[3]) {
                                 return -1;
@@ -472,26 +469,26 @@ define([
                                 return 1;
                             }
                             return 0;
-                        }.bind(this));
+                        });
                         this.$elem.find('#nar-data-list-default-sort-option').attr('checked');
                     }
 
                     this.populateAvailableTypes();
-                    var typeSelected = this.$filterTypeSelect.val();
-                    if(this.selectedType === 'filterTypeSelect'){
+                    const typeSelected = this.$filterTypeSelect.val();
+                    if (this.selectedType === 'filterTypeSelect') {
                         this.currentMatch = this.viewOrder;
                         this.filterByType(typeSelected);
-                    }else if(this.selectedType === 'sortData'){
+                    } else if (this.selectedType === 'sortData') {
                         this.sortData(this.lastSortFunction);
                     }
-                    else{
+                    else {
                         this.renderList();
                         this.$elem.find('#nar-data-list-default-sort-label').addClass('active');
 
                     }
                     this.hideLoading();
                     this.trigger('dataUpdated.Narrative');
-                }.bind(this));
+                });
         },
 
         /**
@@ -511,17 +508,17 @@ define([
         },
 
         fetchWorkspaceData: function () {
-            var addObjectInfo = function (objInfo, dpInfo) {
+            const addObjectInfo = (objInfo, dpInfo) => {
                 // Get the object info
-                var objId = this.itemId(objInfo); //objInfo[6] + '/' + objInfo[0]; // + '/' + objInfo[2]
-                var fullDpReference = null;
+                const objId = this.itemId(objInfo); //objInfo[6] + '/' + objInfo[0]; // + '/' + objInfo[2]
+                let fullDpReference = null;
                 if (dpInfo && dpInfo.ref) {
                     fullDpReference = dpInfo.ref + ';' + objInfo[6] + '/' + objInfo[0] + '/' + objInfo[4];
                 }
                 if (this.dataObjects[objId]) {
                     return;
                 }
-                var key = StringUtil.uuid();
+                const key = StringUtil.uuid();
                 this.dataObjects[objId] = {
                     key: key,
                     $div: null,
@@ -538,14 +535,14 @@ define([
                 });
 
                 // set the type -> object info structure
-                var typeKey = objInfo[2].split('-')[0];
+                const typeKey = objInfo[2].split('-')[0];
                 if (!(typeKey in this.objData)) {
                     this.objData[typeKey] = [];
                 }
                 this.objData[typeKey].push(objInfo.concat(fullDpReference));
 
                 // get the count of objects for each type
-                var typeName = typeKey.split('.')[1];
+                const typeName = typeKey.split('.')[1];
                 if (!(typeName in this.availableTypes)) {
                     this.availableTypes[typeName] = {
                         type: typeName,
@@ -553,12 +550,12 @@ define([
                     };
                 }
                 this.availableTypes[typeName].count++;
-            }.bind(this);
+            };
 
-            var updateSetInfo = function (obj) {
-                var setId = this.itemId(obj.object_info); //obj.object_info[6] + '/' + obj.object_info[0];
-                obj.set_items.set_items_info.forEach(function (setItem) {
-                    var itemId = this.itemId(setItem); //setItem[6] + '/' + setItem[0];
+            const updateSetInfo = (obj) => {
+                const setId = this.itemId(obj.object_info); //obj.object_info[6] + '/' + obj.object_info[0];
+                obj.set_items.set_items_info.forEach((setItem) => {
+                    const itemId = this.itemId(setItem); //setItem[6] + '/' + setItem[0];
                     if (!this.setInfo[setId]) {
                         this.setInfo[setId] = {
                             div: null,
@@ -574,13 +571,13 @@ define([
                     if (!this.dataObjects[itemId]) {
                         addObjectInfo(setItem, obj.dp_info);
                     }
-                }.bind(this));
-            }.bind(this);
+                });
+            };
 
             return DataProvider.getData(true)
-                .then(function(objects) {
-                    objects.forEach(function (obj) {
-                        var objInfo = obj.object_info;
+                .then((objects) => {
+                    objects.forEach((obj) => {
+                        const objInfo = obj.object_info;
                         if (objInfo[2].indexOf('KBaseNarrative') === 0) {
                             if (objInfo[2].indexOf('KBaseNarrative.Narrative') === 0) {
                                 Jupyter.narrative.checkDocumentVersion(objInfo);
@@ -593,13 +590,13 @@ define([
                             updateSetInfo(obj);
                         }
                     });
-                }.bind(this))
-                .catch(function (error) {
+                })
+                .catch((error) => {
                     this.showBlockingError('Sorry, an error occurred while fetching your data.', error);
                     console.error(error);
                     window.KBError('kbaseNarrativeDataList.fetchWorkspaceData', error.error.message);
                     throw error;
-                }.bind(this));
+                });
 
         },
 
@@ -609,11 +606,11 @@ define([
          */
         getObjData: function (type) {
             if (type) {
-                var dataSet = {};
+                const dataSet = {};
                 if (typeof type === 'string') {
                     type = [type];
                 }
-                for (var i = 0; i < type.length; i++) {
+                for (let i = 0; i < type.length; i++) {
                     if (this.objData[type[i]]) {
                         dataSet[type[i]] = this.objData[type[i]];
                     }
@@ -634,16 +631,16 @@ define([
             }
             // if it's part of a ref chain, just get the last one
             if (ref.indexOf(';') >= 0) {
-                var refSplit = ref.split(';');
+                const refSplit = ref.split(';');
                 ref = refSplit[refSplit.length - 1];
             }
             // carve off the version, if present
-            var refSegments = ref.split('/');
+            const refSegments = ref.split('/');
             if (refSegments.length < 2 || refSegments.length > 3) {
                 return null;
             }
             ref = refSegments[0] + '/' + refSegments[1];
-            var retVal = null;
+            let retVal = null;
             if (this.dataObjects[ref]) {
                 retVal = this.dataObjects[ref].info;
                 if (asObject) {
@@ -657,9 +654,9 @@ define([
 
         getDataObjectByName: function (name, wsId) {
             // means we gotta search. Oof.
-            var objInfo = null;
-            Object.keys(this.dataObjects).forEach(function (id) {
-                var obj = this.dataObjects[id];
+            let objInfo = null;
+            Object.keys(this.dataObjects).forEach((id) => {
+                const obj = this.dataObjects[id];
                 if (obj.info[1] === name) {
                     if (wsId) {
                         if (wsId === obj.info[6]) {
@@ -669,7 +666,7 @@ define([
                         objInfo = obj.info;
                     }
                 }
-            }.bind(this));
+            });
             return objInfo;
         },
 
@@ -677,14 +674,13 @@ define([
         selectedObject: null,
 
         setSelected: function ($selectedRow, object_info) {
-            var _this = this;
-            if (_this.$currentSelectedRow) {
-                _this.$currentSelectedRow.removeClass('kb-data-list-obj-row-selected');
+            if (this.$currentSelectedRow) {
+                this.$currentSelectedRow.removeClass('kb-data-list-obj-row-selected');
             }
-            if (object_info[0] === _this.selectedObject) {
-                _this.$currentSelectedRow = null;
-                _this.selectedObject = null;
-                _this.trigger('removeFilterMethods.Narrative');
+            if (object_info[0] === this.selectedObject) {
+                this.$currentSelectedRow = null;
+                this.selectedObject = null;
+                this.trigger('removeFilterMethods.Narrative');
             }
         },
 
@@ -693,10 +689,10 @@ define([
         },
 
         makeToolbarButton: function (name) {
-            var btnClasses = 'btn btn-xs btn-default';
-            var btnCss = { 'color': '#888' };
+            const btnClasses = 'btn btn-xs btn-default';
+            const btnCss = { 'color': '#888' };
 
-            var $btn = $('<span>')
+            const $btn = $('<span>')
                 .addClass(btnClasses)
                 .css(btnCss);
 
@@ -718,9 +714,9 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-sign-in'))
-                .click(function () {
+                .click(() => {
                     this.trigger('filterMethods.Narrative', 'input:' + objData.objectInfo.type.split('-')[0]);
-                }.bind(this));
+                });
         },
 
         filterMethodOutputButton: function (objData) {
@@ -734,9 +730,9 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-sign-out'))
-                .click(function () {
+                .click(() => {
                     this.trigger('filterMethods.Narrative', 'output:' + objData.objectInfo.type.split('-')[0]);
-                }.bind(this));
+                });
         },
 
         openLandingPageButton: function (objData, $alertContainer) {
@@ -750,21 +746,20 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-binoculars'))
-                .click(function (e) {
+                .click((e) => {
                     e.stopPropagation();
                     $alertContainer.empty();
-                    var landingPageLink = this.options.lp_url + objData.objectInfo.ref;
+                    const landingPageLink = this.options.lp_url + objData.objectInfo.ref;
                     window.open(landingPageLink, '_blank');
-                }.bind(this));
+                });
         },
 
         openReportButton: function () {
-            var $openReport = this.makeToolbarButton('report');
+            const $openReport = this.makeToolbarButton('report');
             return $openReport;
         },
 
         openHistoryButton: function (objData, $alertContainer) {
-            var _this = this;
             return this.makeToolbarButton()
                 .tooltip({
                     title: 'View history to revert changes',
@@ -775,23 +770,23 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-history'))
-                .click(function (e) {
+                .click((e) => {
                     e.stopPropagation();
                     $alertContainer.empty();
 
-                    if (_this.ws_name && _this.ws) {
-                        _this.ws.get_object_history({ ref: objData.objectInfo.wsid + '/' + objData.objectInfo.id },
-                            function (history) {
+                    if (this.ws_name && this.ws) {
+                        this.ws.get_object_history({ ref: objData.objectInfo.wsid + '/' + objData.objectInfo.id },
+                            (history) => {
                                 $alertContainer.append($('<div>')
                                     .append($('<button>').addClass('kb-data-list-cancel-btn')
                                         .append('Hide History')
-                                        .click(function () {
+                                        .click(() => {
                                             $alertContainer.empty();
                                         })));
                                 history.reverse();
-                                var $tbl = $('<table>').css({ 'width': '100%' });
-                                for (var k = 0; k < history.length; k++) {
-                                    var $revertBtn = $('<button>').append('v' + history[k][4]).addClass('kb-data-list-btn');
+                                const $tbl = $('<table>').css({ 'width': '100%' });
+                                for (let k = 0; k < history.length; k++) {
+                                    const $revertBtn = $('<button>').append('v' + history[k][4]).addClass('kb-data-list-btn');
                                     if (k == 0) {
                                         $revertBtn.tooltip({
                                             title: 'Current Version',
@@ -803,8 +798,8 @@ define([
                                             }
                                         });
                                     } else {
-                                        var revertRef = { wsid: history[k][6], objid: history[k][0], ver: history[k][4] };
-                                        (function (revertRefLocal) {
+                                        const revertRef = { wsid: history[k][6], objid: history[k][0], ver: history[k][4] };
+                                        ((revertRefLocal) => {
                                             $revertBtn.tooltip({
                                                 title: 'Revert to this version?',
                                                 container: 'body',
@@ -814,13 +809,13 @@ define([
                                                     hide: Config.get('tooltip').hideDelay
                                                 }
                                             })
-                                                .click(function () {
-                                                    _this.ws.revert_object(revertRefLocal,
-                                                        function () {
-                                                            _this.writingLock = false;
-                                                            _this.refresh();
+                                                .click(() => {
+                                                    this.ws.revert_object(revertRefLocal,
+                                                        () => {
+                                                            this.writingLock = false;
+                                                            this.refresh();
                                                         },
-                                                        function (error) {
+                                                        (error) => {
                                                             console.error(error);
                                                             $alertContainer.empty();
                                                             $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
@@ -846,7 +841,7 @@ define([
                                 }
                                 $alertContainer.append($tbl);
                             },
-                            function (error) {
+                            (error) => {
                                 console.error(error);
                                 $alertContainer.empty();
                                 $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
@@ -866,7 +861,7 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-sitemap fa-rotate-90'))
-                .click(function (e) {
+                .click((e) => {
                     e.stopPropagation();
                     $alertContainer.empty();
                     window.open('/#objgraphview/' + objData.objectInfo.ref);
@@ -874,7 +869,6 @@ define([
         },
 
         downloadButton: function (objData, ref_path, $alertContainer) {
-            var _this = this;
             return this.makeToolbarButton()
                 .tooltip({
                     title: 'Export / Download data',
@@ -885,28 +879,27 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-download'))
-                .click(function (e) {
+                .click((e) => {
                     e.stopPropagation();
                     $alertContainer.empty();
-                    var type = objData.objectInfo.type.split('-')[0];
-                    var wsId = objData.objectInfo.wsid;
-                    var objId = objData.objectInfo.id;
-                    var objRef = objData.fromPalette ? ref_path : (wsId + '/' + objId);
-                    var downloadPanel = $('<div>');
+                    const type = objData.objectInfo.type.split('-')[0];
+                    const wsId = objData.objectInfo.wsid;
+                    const objId = objData.objectInfo.id;
+                    const objRef = objData.fromPalette ? ref_path : (wsId + '/' + objId);
+                    const downloadPanel = $('<div>');
                     $alertContainer.append(downloadPanel);
                     new kbaseNarrativeDownloadPanel(downloadPanel, {
-                        token: _this._attributes.auth.token,
+                        token: this._attributes.auth.token,
                         type: type,
                         objId: objId,
                         ref: objRef,
                         objName: objData.objectInfo.name,
-                        downloadSpecCache: _this.downloadSpecCache
+                        downloadSpecCache: this.downloadSpecCache
                     });
                 });
         },
 
         renameButton: function (objData, $alertContainer) {
-            var _this = this;
             return this.makeToolbarButton()
                 .tooltip({
                     title: 'Rename data',
@@ -917,7 +910,7 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-font'))
-                .click(function (e) {
+                .click((e) => {
                     e.stopPropagation();
                     $alertContainer.empty();
                     if (Jupyter.narrative.readonly) {
@@ -930,67 +923,66 @@ define([
                     }
 
                     //lock on refresh expires after 15 min
-                    var releaseLock = function(){
-                        if(_this.refreshwritingLock !== null) {
-                            clearTimeout(_this.refreshwritingLock);
+                    const releaseLock = () => {
+                        if (this.refreshwritingLock !== null) {
+                            clearTimeout(this.refreshwritingLock);
                         }
 
-                        _this.refreshwritingLock = setTimeout(function () {
-                            _this.writingLock = false;
+                        this.refreshwritingLock = setTimeout(() => {
+                            this.writingLock = false;
                         }, 900000);
                     };
-                    var $newNameInput = $('<input type="text">')
+                    const $newNameInput = $('<input type="text">')
                         .addClass('form-control')
                         .val(objData.objectInfo.name)
-                        .on('focus', function () {
+                        .on('focus', () => {
                             if (Jupyter && Jupyter.narrative) {
-                                _this.writingLock = true;
+                                this.writingLock = true;
                                 Jupyter.narrative.disableKeyboardManager();
                             }
                         })
-                        .on('blur', function () {
+                        .on('blur', () => {
                             if (Jupyter && Jupyter.narrative) {
                                 Jupyter.narrative.enableKeyboardManager();
                             }
                         });
 
-                    $newNameInput.unbind('focus',releaseLock);
-                    $newNameInput.bind('focus',releaseLock);
+                    $newNameInput.unbind('focus', releaseLock);
+                    $newNameInput.bind('focus', releaseLock);
 
                     $alertContainer.append($('<div>')
                         .append($('<div>').append('Warning: Apps using the old name may break.'))
                         .append($('<div>').append($newNameInput))
                         .append($('<button>').addClass('kb-data-list-btn')
                             .append('Rename')
-                            .click(function () {
+                            .click(() => {
 
-                                if (_this.ws_name && _this.ws) {
-                                    _this.ws.rename_object({
+                                if (this.ws_name && this.ws) {
+                                    this.ws.rename_object({
                                         obj: { ref: objData.objectInfo.wsid + '/' + objData.objectInfo.id },
                                         new_name: $newNameInput.val()
                                     },
-                                    function () {
-                                        _this.writingLock = false;
-                                        _this.refresh();
-                                    },
-                                    function (error) {
-                                        console.error(error);
-                                        $alertContainer.empty();
-                                        $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
-                                    });
+                                        () => {
+                                            this.writingLock = false;
+                                            this.refresh();
+                                        },
+                                        (error) => {
+                                            console.error(error);
+                                            $alertContainer.empty();
+                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                        });
                                 }
                             }))
                         .append($('<button>').addClass('kb-data-list-cancel-btn')
                             .append('Cancel')
-                            .click(function () {
-                                _this.writingLock = false;
+                            .click(() => {
+                                this.writingLock = false;
                                 $alertContainer.empty();
                             })));
                 });
         },
 
         deleteButton: function (objData, $alertContainer) {
-            var _this = this;
             return this.makeToolbarButton()
                 .tooltip({
                     title: 'Delete data',
@@ -1001,7 +993,7 @@ define([
                     }
                 })
                 .append($('<span>').addClass('fa fa-trash-o'))
-                .click(function (e) {
+                .click((e) => {
                     e.stopPropagation();
                     $alertContainer.empty();
                     // TODO: The control should actually be disabled. This should be via a listener
@@ -1018,54 +1010,54 @@ define([
                         .append($('<span>').append('Are you sure?'))
                         .append($('<button>').addClass('kb-data-list-btn')
                             .append('Delete')
-                            .click(function () {
-                                if (_this.ws_name && _this.ws) {
-                                    _this.ws.rename_object({
+                            .click(() => {
+                                if (this.ws_name && this.ws) {
+                                    this.ws.rename_object({
                                         obj: { ref: objData.objectInfo.wsid + '/' + objData.objectInfo.id },
                                         new_name: objData.objectInfo.name.split('-deleted-')[0] + '-deleted-' + (new Date()).getTime()
                                     },
-                                    function () {
-                                        _this.ws.delete_objects([{ ref: objData.objectInfo.wsid + '/' + objData.objectInfo.id }],
-                                            function () {
-                                                $(document).trigger('deleteDataList.Narrative', objData.objectInfo.name);
-                                                _this.writingLock = false;
-                                                _this.refresh();
+                                        () => {
+                                            this.ws.delete_objects([{ ref: objData.objectInfo.wsid + '/' + objData.objectInfo.id }],
+                                                () => {
+                                                    $(document).trigger('deleteDataList.Narrative', objData.objectInfo.name);
+                                                    this.writingLock = false;
+                                                    this.refresh();
 
-                                            },
-                                            function (error) {
-                                                console.error(error);
-                                                $alertContainer.empty();
-                                                $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
-                                            });
-                                    },
-                                    function (error) {
-                                        console.error(error);
-                                        $alertContainer.empty();
-                                        $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
-                                    });
+                                                },
+                                                (error) => {
+                                                    console.error(error);
+                                                    $alertContainer.empty();
+                                                    $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                                });
+                                        },
+                                        (error) => {
+                                            console.error(error);
+                                            $alertContainer.empty();
+                                            $alertContainer.append($('<span>').css({ 'color': '#F44336' }).append('Error! ' + error.error.message));
+                                        });
 
                                 }
                             }))
                         .append($('<button>').addClass('kb-data-list-cancel-btn')
                             .append('Cancel')
-                            .click(function () {
+                            .click(() => {
                                 $alertContainer.empty();
                             })));
                 });
         },
 
         addDataControls: function (objData, $alertContainer, ref_path) {
-            var $filterMethodInput = this.filterMethodInputButton(objData);
-            var $filterMethodOutput = this.filterMethodOutputButton(objData);
-            var $openLandingPage = this.openLandingPageButton(objData, $alertContainer);
-            var $openReport = this.openReportButton(objData);
-            var $openHistory = this.openHistoryButton(objData, $alertContainer);
-            var $openProvenance = this.openProvenanceButton(objData, $alertContainer);
-            var $download = this.downloadButton(objData, ref_path, $alertContainer);
-            var $rename = this.renameButton(objData, $alertContainer);
-            var $delete = this.deleteButton(objData, $alertContainer);
+            const $filterMethodInput = this.filterMethodInputButton(objData);
+            const $filterMethodOutput = this.filterMethodOutputButton(objData);
+            const $openLandingPage = this.openLandingPageButton(objData, $alertContainer);
+            const $openReport = this.openReportButton(objData);
+            const $openHistory = this.openHistoryButton(objData, $alertContainer);
+            const $openProvenance = this.openProvenanceButton(objData, $alertContainer);
+            const $download = this.downloadButton(objData, ref_path, $alertContainer);
+            const $rename = this.renameButton(objData, $alertContainer);
+            const $delete = this.deleteButton(objData, $alertContainer);
 
-            var $btnToolbar = $('<span>')
+            const $btnToolbar = $('<span>')
                 .addClass('btn-group');
 
             $btnToolbar.append($filterMethodInput)
@@ -1089,19 +1081,19 @@ define([
         },
 
         toggleSetExpansion: function (objId, $setDiv) {
-            var setInfo = this.setInfo[objId];
-            var setItemsShown, i;
+            const setInfo = this.setInfo[objId];
+            let setItemsShown, i;
             if (!setInfo) {
                 return;
             }
-            var showItems = this.dataObjects[objId].expanded;
+            const showItems = this.dataObjects[objId].expanded;
             if (showItems) {
                 setItemsShown = 0;
                 for (i = 0; i < setInfo.item_ids.length; i++) {
-                    var setItemId = setInfo.item_ids[i];
-                    var viewInfo = _.findWhere(this.viewOrder, { objId: setItemId });
+                    const setItemId = setInfo.item_ids[i];
+                    const viewInfo = _.findWhere(this.viewOrder, { objId: setItemId });
                     if (viewInfo.inFilter) {
-                        var $setItemDiv = this.renderObjectRowDiv(setItemId, 1);
+                        const $setItemDiv = this.renderObjectRowDiv(setItemId, 1);
                         $setDiv.after($setItemDiv);
                         setItemsShown++;
                     }
@@ -1116,7 +1108,7 @@ define([
         },
 
         getReportForObject: function (objectInfo) {
-            var narrativeService = new DynamicServiceClient({
+            const narrativeService = new DynamicServiceClient({
                 module: 'NarrativeService',
                 url: Config.url('service_wizard'),
                 token: this.token
@@ -1125,13 +1117,13 @@ define([
                 {
                     upa: objectInfo.ref
                 }
-            ]).spread(function(result) {
+            ]).spread((result) => {
 
                 if (result.report_upas.length === 0) {
                     return [];
                 }
 
-                var objectsToFetch = result.report_upas.map(function (reportRef) {
+                const objectsToFetch = result.report_upas.map((reportRef) => {
                     return {
                         ref: reportRef
                     };
@@ -1139,13 +1131,13 @@ define([
 
                 // If, after evaluation of the reports, we really don't have any, just
                 // shortcircuit with an array of nulls.
-                if (objectsToFetch.length === 0)  {
+                if (objectsToFetch.length === 0) {
                     return [];
                 }
 
-                var reportRef = result.object_upa;
+                const reportRef = result.object_upa;
 
-                var workspace = new GenericClient({
+                const workspace = new GenericClient({
                     module: 'Workspace',
                     url: Config.url('workspace'),
                     token: this.token
@@ -1155,15 +1147,15 @@ define([
                     objects: objectsToFetch,
                     ignoreErrors: 0
                 }])
-                    .spread(function (result) {
-                        var objectReportsForOutput = result.data.filter(function (reportObject) {
+                    .spread((result) => {
+                        let objectReportsForOutput = result.data.filter((reportObject) => {
                             // pull out found objects which are in the list of objects created in the report.
                             // objects_created looks like {description: .., ref: ..}
-                            return reportObject.data.objects_created.some(function (objectCreated) {
+                            return reportObject.data.objects_created.some((objectCreated) => {
                                 return objectCreated.ref === reportRef;
                             });
                         })
-                            .map(function (reportObject) {
+                            .map((reportObject) => {
                                 return ServiceUtils.objectInfoToObject(reportObject.info);
                             });
 
@@ -1172,14 +1164,14 @@ define([
                         // TODO: otherwise? is it possible to have more than one report and not have
                         //       one in the current workspace????
                         if (objectReportsForOutput.length > 1) {
-                            objectReportsForOutput = objectReportsForOutput.filter(function (reportInfo) {
+                            objectReportsForOutput = objectReportsForOutput.filter((reportInfo) => {
                                 return (reportInfo.wsid === objectInfo.wsid);
                             });
                         }
 
                         return objectReportsForOutput;
                     });
-            }.bind(this));
+            });
         },
 
         onOpenDataListItem: function ($moreRow, objData) {
@@ -1187,18 +1179,16 @@ define([
                 return;
             }
 
-            var _this = this;
-
-            var objectInfo = objData.objectInfo;
+            const objectInfo = objData.objectInfo;
             // The report button needs the report to be found!
-            var $reportButton = $moreRow.find('[data-button="report"]');
+            const $reportButton = $moreRow.find('[data-button="report"]');
 
             $reportButton.empty().append($('<span>')
                 .addClass('fa fa-spinner fa-spin fa-fw fa-sm').css('width', '0.75em'));
 
 
             this.getReportForObject(objectInfo)
-                .then(function (result) {
+                .then((result) => {
                     if (result.length === 0) {
                         $reportButton.addClass('disabled');
                         $reportButton.empty().append($('<span>')
@@ -1207,7 +1197,7 @@ define([
                         $reportButton
                             .tooltip({
                                 title: 'No report associated with this object',
-                                container: '#' + _this.mainListId,
+                                container: '#' + this.mainListId,
                                 delay: {
                                     show: Config.get('tooltip').showDelay,
                                     hide: Config.get('tooltip').hideDelay
@@ -1225,16 +1215,16 @@ define([
                         $reportButton
                             .tooltip({
                                 title: 'View associated report',
-                                container: '#' + _this.mainListId,
+                                container: '#' + this.mainListId,
                                 delay: {
                                     show: Config.get('tooltip').showDelay,
                                     hide: Config.get('tooltip').hideDelay
                                 }
                             })
-                            .click(function (e) {
+                            .click((e) => {
                                 e.stopPropagation();
                                 if (objData.reportRef) {
-                                    _this.showReportLandingPage(objData.reportRef);
+                                    this.showReportLandingPage(objData.reportRef);
                                 }
                             });
                     } else {
@@ -1243,7 +1233,7 @@ define([
                         $reportButton
                             .tooltip({
                                 title: 'Too many reports associated with this object',
-                                container: '#' + _this.mainListId,
+                                container: '#' + this.mainListId,
                                 delay: {
                                     show: Config.get('tooltip').showDelay,
                                     hide: Config.get('tooltip').hideDelay
@@ -1262,52 +1252,51 @@ define([
          * in the data list.
          */
         renderObjectRowDiv: function (objId) {
-            var _this = this;
-            var objData = this.dataObjects[objId];
-            var object_info = objData.info;
-            var ref_path = objData.refPath;
-            var object_key = objData.key;
+            const objData = this.dataObjects[objId];
+            const object_info = objData.info;
+            const ref_path = objData.refPath;
+            const object_key = objData.key;
 
             // object_info:
             // [0] : obj_id objid // [1] : obj_name name // [2] : type_string type
             // [3] : timestamp save_date // [4] : int version // [5] : username saved_by
             // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
             // [9] : int size // [10] : usermeta meta
-            var type_tokens = object_info[2].split('.');
-            var type_module = type_tokens[0];
-            var type = type_tokens[1].split('-')[0];
-            var is_set = this.isASet(object_info);
+            const type_tokens = object_info[2].split('.');
+            const type_module = type_tokens[0];
+            const type = type_tokens[1].split('-')[0];
+            const is_set = this.isASet(object_info);
 
-            var author = ' ';
-            if (object_info[5] !== _this.my_username) {
+            let author = ' ';
+            if (object_info[5] !== this.my_username) {
                 author = ' by ' + object_info[5];
             }
 
-            var metadata = object_info[10] || {};
-            var viewType = type;
+            const metadata = object_info[10] || {};
+            let viewType = type;
             if (type === 'Genome' || type === 'GenomeAnnotation') {
-                if (metadata.hasOwnProperty('Name')) {
+                if ('Name' in metadata) {
                     viewType = type + ': ' + metadata['Name'];
                 }
             }
 
-            var metadataText = '';
-            for (var key in metadata) {
-                if (metadata.hasOwnProperty(key)) {
+            let metadataText = '';
+            for (const key in metadata) {
+                if (Object.prototype.hasOwnProperty.call(metadata, key)) {
                     metadataText += '<tr><th>' + key + '</th><td>' + metadata[key] + '</td></tr>';
                 }
             }
 
             // create more content
-            var $savedByUserSpan = $('<td>').addClass('kb-data-list-username-td');
+            const $savedByUserSpan = $('<td>').addClass('kb-data-list-username-td');
             DisplayUtil.displayRealName(object_info[5], $savedByUserSpan);
 
-            var $alertDiv = $('<div>').css({ 'text-align': 'center', 'margin': '10px 0px' });
-            var typeLink = '<a href="/#spec/module/' + type_module + '" target="_blank">' + type_module + '</a>.<wbr>' +
+            const $alertDiv = $('<div>').css({ 'text-align': 'center', 'margin': '10px 0px' });
+            const typeLink = '<a href="/#spec/module/' + type_module + '" target="_blank">' + type_module + '</a>.<wbr>' +
                 '<a href="/#spec/type/' + object_info[2] + '" target="_blank">' + (type_tokens[1].replace('-', '&#8209;')) + '.' + type_tokens[2] + '</a>';
 
-            var $moreContent = $('<div>').addClass('kb-data-list-more-div')
-                .append(_this.addDataControls(objData, $alertDiv, ref_path)).append($alertDiv)
+            const $moreContent = $('<div>').addClass('kb-data-list-more-div')
+                .append(this.addDataControls(objData, $alertDiv, ref_path)).append($alertDiv)
                 .append(
                     $('<table style="width:100%;">')
                         .append('<tr><th>Permanent Id</th><td>' + object_info[6] + '/' + object_info[0] + '/' + object_info[4] + '</td></tr>')
@@ -1315,20 +1304,20 @@ define([
                         .append($('<tr>').append('<th>Saved by</th>').append($savedByUserSpan))
                         .append(metadataText));
 
-            var $card = kbaseDataCard.apply(this,[{
+            const $card = kbaseDataCard.apply(this, [{
                 viewType: viewType,
                 type: type,
                 editedBy: author,
                 moreContent: $moreContent,
                 is_set: is_set,
                 object_info: object_info,
-                onOpen: function() {
-                    _this.onOpenDataListItem($moreContent, objData);
+                onOpen: () => {
+                    this.onOpenDataListItem($moreContent, objData);
                 }
             }]);
 
             if (objData.fromPalette) {
-                var $paletteIcon = $('<div>')
+                const $paletteIcon = $('<div>')
                     .addClass('pull-right narrative-card-palette-icon')
                     .append($('<i>')
                         .addClass('fa fa-link')
@@ -1347,23 +1336,23 @@ define([
             }
             //add custom click events
 
-            $card.find('.narrative-card-logo , .kb-data-list-name').click(function (e) {
+            $card.find('.narrative-card-logo , .kb-data-list-name').click((e) => {
                 e.stopPropagation();
-                _this.insertViewer(object_key);
+                this.insertViewer(object_key);
             });
 
-            $card.find('.narrative-card-row-main').click(function () {
-                var $node = $(this.parentElement).find('.narrative-card-row-more');
-                if (_this.selectedObject === object_info[0] && $node.is(':visible')) {
+            $card.find('.narrative-card-row-main').click(() => {
+                const $node = $(this.parentElement).find('.narrative-card-row-more');
+                if (this.selectedObject === object_info[0] && $node.is(':visible')) {
                     // assume selection handling occurs before this is called
                     // so if we are now selected and the moreContent is visible, leave it...
                     return;
                 }
 
                 if ($node.is(':visible')) {
-                    _this.writingLock = false;
+                    this.writingLock = false;
                 } else {
-                    _this.getRichData(object_info, $node);
+                    this.getRichData(object_info, $node);
                 }
             });
 
@@ -1377,25 +1366,24 @@ define([
         // ============= DnD ==================
 
         addDropZone: function (container, targetCell, isBelow) {
-            var targetDiv = document.createElement('div'),
-                _this = this;
+            const targetDiv = document.createElement('div');
 
             targetDiv.classList.add('kb-data-list-drag-target');
             targetDiv.innerHTML = '<i>drop data object here</i>';
-            targetDiv.addEventListener('dragover', function (e) {
+            targetDiv.addEventListener('dragover', (e) => {
                 e.target.classList.add('-drag-active');
                 e.preventDefault();
             });
-            targetDiv.addEventListener('dragenter', function (e) {
+            targetDiv.addEventListener('dragenter', (e) => {
                 e.target.classList.add('-drag-hover');
                 e.preventDefault();
             });
-            targetDiv.addEventListener('dragleave', function (e) {
+            targetDiv.addEventListener('dragleave', (e) => {
                 e.target.classList.remove('-drag-hover');
                 e.target.classList.remove('-drag-active');
                 e.preventDefault();
             });
-            targetDiv.addEventListener('drop', function (e) {
+            targetDiv.addEventListener('drop', (e) => {
                 if (Jupyter.narrative.readonly) {
                     new BootstrapDialog({
                         type: 'warning',
@@ -1405,10 +1393,11 @@ define([
                     }).show();
                     return;
                 }
-                var data = JSON.parse(e.dataTransfer.getData('info')),
-                    obj = _this.dataObjects[_this.keyToObjId[data.key]],
-                    info = _this.createInfoObject(obj.info, obj.refPath),
-                    cell, cellIndex, placement;
+                const data = JSON.parse(e.dataTransfer.getData('info'));
+                const obj = this.dataObjects[this.keyToObjId[data.key]];
+                const info = this.createInfoObject(obj.info, obj.refPath);
+
+                let cell, placement;
 
                 if (e.target.getAttribute('cellIs') === 'below') {
                     cell = $(e.target.nextSibling).data().cell;
@@ -1417,7 +1406,7 @@ define([
                     cell = $(e.target.previousSibling).data().cell;
                     placement = 'below';
                 }
-                cellIndex = Jupyter.notebook.find_cell_index(cell);
+                const cellIndex = Jupyter.notebook.find_cell_index(cell);
 
                 $(document).trigger('createViewerCell.Narrative', {
                     nearCellIdx: cellIndex,
@@ -1436,7 +1425,7 @@ define([
         },
 
         addDragAndDrop: function ($row) {
-            var node = $row.children().get(0),
+            const node = $row.children().get(0),
                 key = $row.attr('kb-oid'),
                 obj = this.dataObjects[this.keyToObjId[key]], //_.findWhere(this.objectList, {key: key}),
                 info = this.createInfoObject(obj.info, obj.refPath),
@@ -1445,30 +1434,29 @@ define([
                     info: info,
                     key: key
                 },
-                dataString = JSON.stringify(data),
-                _this = this;
+                dataString = JSON.stringify(data);
 
             node.setAttribute('draggable', true);
 
-            node.addEventListener('dragstart', function (e) {
+            node.addEventListener('dragstart', (e) => {
                 e.dataTransfer.dropEffect = 'copy';
                 e.dataTransfer.setData('info', dataString);
 
-                var targetCells = document.querySelectorAll('#notebook-container .cell');
-                var container = document.querySelector('#notebook-container');
-                for (var i = 0; i < targetCells.length; i += 1) {
-                    _this.addDropZone(container, targetCells.item(i));
+                const targetCells = document.querySelectorAll('#notebook-container .cell');
+                const container = document.querySelector('#notebook-container');
+                for (let i = 0; i < targetCells.length; i += 1) {
+                    this.addDropZone(container, targetCells.item(i));
                     if (i === targetCells.length - 1) {
-                        _this.addDropZone(container, targetCells.item(i), true);
+                        this.addDropZone(container, targetCells.item(i), true);
                     }
                 }
             });
 
-            node.addEventListener('dragend', function () {
-                var container = document.querySelector('#notebook-container'),
+            node.addEventListener('dragend', () => {
+                const container = document.querySelector('#notebook-container'),
                     targetCells = document.querySelectorAll('#notebook-container .kb-data-list-drag-target');
-                for (var i = 0; i < targetCells.length; i += 1) {
-                    var targetCell = targetCells.item(i);
+                for (let i = 0; i < targetCells.length; i += 1) {
+                    const targetCell = targetCells.item(i);
                     container.removeChild(targetCell);
                 }
             });
@@ -1495,7 +1483,7 @@ define([
          * list of fields returned from Workspace service.
          */
         createInfoObject: function (info, refPath) {
-            var ret = ServiceUtils.objectInfoToObject(info);
+            const ret = ServiceUtils.objectInfoToObject(info);
 
             if (refPath) {
                 ret['ref_path'] = refPath;
@@ -1509,9 +1497,9 @@ define([
         },
 
         renderMore: function () {
-            var start = this.lastObjectRendered;
-            var limit = this.n_objs_rendered + this.options.objs_to_render_on_scroll;
-            for (var i = start + 1;
+            const start = this.lastObjectRendered;
+            const limit = this.n_objs_rendered + this.options.objs_to_render_on_scroll;
+            for (let i = start + 1;
                 (i < this.viewOrder.length) && (this.n_objs_rendered < limit); i++) {
                 if (this.shouldRenderObject(this.viewOrder[i])) {
                     this.renderObject(this.viewOrder[i].objId);
@@ -1528,7 +1516,7 @@ define([
         },
 
         shouldRenderObject: function (viewInfo) {
-            var render = viewInfo.inFilter;
+            let render = viewInfo.inFilter;
             if (render) {
                 if (this.setViewMode && this.inAnySet(this.dataObjects[viewInfo.objId].info)) {
                     render = false;
@@ -1544,8 +1532,8 @@ define([
             this.n_objs_rendered = 0;
 
             if (this.viewOrder.length > 0) {
-                var limit = this.options.objs_to_render_to_start;
-                for (var i = 0; i < this.viewOrder.length && (this.n_objs_rendered < limit); i++) {
+                const limit = this.options.objs_to_render_to_start;
+                for (let i = 0; i < this.viewOrder.length && (this.n_objs_rendered < limit); i++) {
                     if (this.shouldRenderObject(this.viewOrder[i])) {
                         this.renderObject(this.viewOrder[i].objId);
                         this.n_objs_rendered++;
@@ -1559,7 +1547,7 @@ define([
                 }
 
             } else {
-                var $noDataDiv = $('<div>')
+                const $noDataDiv = $('<div>')
                     .css({ 'text-align': 'center', 'margin': '20pt' })
                     .append('This Narrative has no data yet.<br><br>');
                 if (Jupyter && Jupyter.narrative && !Jupyter.narrative.readonly) {
@@ -1567,10 +1555,9 @@ define([
                         .append('Add Data')
                         .addClass('kb-data-list-add-data-text-button')
                         .css({ 'margin': '20px' })
-                        .click(function () {
-                            this.trigger('hideGalleryPanelOverlay.Narrative');
-                            this.trigger('toggleSidePanelOverlay.Narrative', this.options.parentControlPanel.$overlayPanel);
-                        }.bind(this)));
+                        .click(() => {
+                            this.trigger('toggleSidePanelOverlay.Narrative', [this.options.parentControlPanel.$overlayPanel]);
+                        }));
                     this.$addDataButton.hide();
                 }
                 this.$mainListDiv.append($noDataDiv);
@@ -1579,7 +1566,7 @@ define([
         },
 
         renderObject: function (objId) {
-            var $renderedDiv = this.renderObjectRowDiv(objId);
+            const $renderedDiv = this.renderObjectRowDiv(objId);
             this.dataObjects[objId].$div = $renderedDiv;
             this.$mainListDiv.append($renderedDiv);
             if (this.setViewMode) {
@@ -1588,14 +1575,12 @@ define([
         },
 
         renderController: function () {
-            var _this = this;
-
-            var $upOrDown = $('<button class="btn btn-default btn-sm" type="button">').css({ 'margin-left': '5px' })
+            const $upOrDown = $('<button class="btn btn-default btn-sm" type="button">').css({ 'margin-left': '5px' })
                 .append('<span class="fa fa-sort-amount-asc" style="color:#777" aria-hidden="true" />')
-                .on('click', function () {
-                    _this.reverseData();
-                    _this.sortOrder *= -1;
-                    var $icon = $upOrDown.find('.fa');
+                .on('click', () => {
+                    this.reverseData();
+                    this.sortOrder *= -1;
+                    const $icon = $upOrDown.find('.fa');
                     if ($icon.is('.fa-sort-amount-desc,.fa-sort-amount-asc')) {
                         $icon.toggleClass('fa-sort-amount-desc fa-sort-amount-asc');
                     }
@@ -1604,49 +1589,49 @@ define([
                     }
                 });
 
-            var setSortIcon = function(newIcon) {
+            const setSortIcon = (newIcon) => {
                 $upOrDown
                     .find('.fa')
                     .removeClass()
                     .addClass('fa ' + newIcon);
             };
 
-            var $byDate = $('<label id="nar-data-list-default-sort-label" class="btn btn-default">').addClass('btn btn-default')
+            const $byDate = $('<label id="nar-data-list-default-sort-label" class="btn btn-default">').addClass('btn btn-default')
                 .append($('<input type="radio" name="options" id="nar-data-list-default-sort-option" autocomplete="off">'))
                 .append('date')
-                .on('click', function () {
-                    _this.sortData(function (a, b) {
-                        return _this.sortOrder * _this.dataObjects[a.objId].info[3]
-                            .localeCompare(_this.dataObjects[b.objId].info[3]);
+                .on('click', () => {
+                    this.sortData((a, b) => {
+                        return this.sortOrder * this.dataObjects[a.objId].info[3]
+                            .localeCompare(this.dataObjects[b.objId].info[3]);
                     });
-                    setSortIcon(_this.sortOrder > 0 ? 'fa-sort-amount-desc' : 'fa-sort-amount-asc');
+                    setSortIcon(this.sortOrder > 0 ? 'fa-sort-amount-desc' : 'fa-sort-amount-asc');
                 });
 
-            var $byName = $('<label class="btn btn-default">')
+            const $byName = $('<label class="btn btn-default">')
                 .append($('<input type="radio" name="options" id="option2" autocomplete="off">'))
                 .append('name')
-                .on('click', function () {
-                    _this.sortData(function (a, b) {
-                        return -1 * _this.sortOrder * _this.dataObjects[a.objId].info[1].toUpperCase()
-                            .localeCompare(_this.dataObjects[b.objId].info[1].toUpperCase());
+                .on('click', () => {
+                    this.sortData((a, b) => {
+                        return -1 * this.sortOrder * this.dataObjects[a.objId].info[1].toUpperCase()
+                            .localeCompare(this.dataObjects[b.objId].info[1].toUpperCase());
                     });
-                    setSortIcon(_this.sortOrder > 0 ? 'fa-sort-alpha-desc' : 'fa-sort-alpha-asc');
+                    setSortIcon(this.sortOrder > 0 ? 'fa-sort-alpha-desc' : 'fa-sort-alpha-asc');
                 });
 
-            var $byType = $('<label class="btn btn-default">')
+            const $byType = $('<label class="btn btn-default">')
                 .append($('<input type="radio" name="options" id="option3" autocomplete="off">'))
                 .append('type')
-                .on('click', function () {
-                    _this.sortData(function (a, b) {
-                        var aType = _this.dataObjects[a.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
-                        var bType = _this.dataObjects[b.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
-                        return -1 * _this.sortOrder * aType.localeCompare(bType);
+                .on('click', () => {
+                    this.sortData((a, b) => {
+                        const aType = this.dataObjects[a.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
+                        const bType = this.dataObjects[b.objId].info[2].toUpperCase().match(/\.(.+)/)[1];
+                        return -1 * this.sortOrder * aType.localeCompare(bType);
                     });
-                    setSortIcon(_this.sortOrder > 0 ? 'fa-sort-alpha-desc' : 'fa-sort-alpha-asc');
+                    setSortIcon(this.sortOrder > 0 ? 'fa-sort-alpha-desc' : 'fa-sort-alpha-asc');
                 });
 
 
-            var $sortByGroup = $('<div data-toggle="buttons">')
+            const $sortByGroup = $('<div data-toggle="buttons">')
                 .addClass('btn-group btn-group-sm')
                 .css({ 'margin': '2px' })
                 .append($byDate)
@@ -1654,8 +1639,8 @@ define([
                 .append($byType);
 
             /** Set view mode toggle */
-            _this.viewModeDisableHnd = {};
-            var $viewMode = $('<span>')
+            this.viewModeDisableHnd = {};
+            const $viewMode = $('<span>')
                 .addClass('btn btn-xs btn-default kb-data-list-ctl')
                 .attr('id', 'kb-data-list-hierctl')
                 .tooltip({
@@ -1667,29 +1652,29 @@ define([
                     }
                 })
                 .append('<span class="fa fa-copy"></span>')
-                .on('click', function () {
-                    _this.setViewMode = !_this.setViewMode;
-                    if (_this.setViewMode) {
+                .on('click', () => {
+                    this.setViewMode = !this.setViewMode;
+                    if (this.setViewMode) {
                         $('#kb-data-list-hierctl').attr('enabled', '1');
                     } else {
                         $('#kb-data-list-hierctl').removeAttr('enabled');
                     }
-                    _this.renderList();
+                    this.renderList();
                 });
 
             // Search control
-            _this.controlClickHnd.search = function () {
-                if (!_this.$searchDiv.is(':visible')) {
-                    _this.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
-                    _this.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
-                    _this.$searchDiv.show({ effect: 'blind', duration: 'fast' });
-                    _this.bsSearch.focus();
+            this.controlClickHnd.search = () => {
+                if (!this.$searchDiv.is(':visible')) {
+                    this.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$searchDiv.show({ effect: 'blind', duration: 'fast' });
+                    this.bsSearch.focus();
                 } else {
-                    _this.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
                 }
             };
 
-            var $openSearch = $('<span>')
+            const $openSearch = $('<span>')
                 .addClass('btn btn-xs btn-default kb-data-list-ctl')
                 .attr('id', 'kb-data-list-searchctl')
                 .tooltip({
@@ -1701,19 +1686,19 @@ define([
                     }
                 })
                 .append('<span class="fa fa-search"></span>')
-                .on('click', _this.controlClickHnd.search);
+                .on('click', this.controlClickHnd.search);
 
             // Sort control
-            _this.controlClickHnd.sort = function () {
-                if (!_this.$sortByDiv.is(':visible')) {
-                    _this.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
-                    _this.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
-                    _this.$sortByDiv.show({ effect: 'blind', duration: 'fast' });
+            this.controlClickHnd.sort = () => {
+                if (!this.$sortByDiv.is(':visible')) {
+                    this.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$sortByDiv.show({ effect: 'blind', duration: 'fast' });
                 } else {
-                    _this.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
                 }
             };
-            var $openSort = $('<span>')
+            const $openSort = $('<span>')
                 .addClass('btn btn-xs btn-default kb-data-list-ctl')
                 .attr('id', 'kb-data-list-sortctl')
                 .tooltip({
@@ -1725,19 +1710,19 @@ define([
                     }
                 })
                 .append('<span class="fa fa-sort-amount-asc"></span>')
-                .on('click', _this.controlClickHnd.sort);
+                .on('click', this.controlClickHnd.sort);
 
             // Filter control
-            _this.controlClickHnd.filter = function () {
-                if (!_this.$filterTypeDiv.is(':visible')) {
-                    _this.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
-                    _this.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
-                    _this.$filterTypeDiv.show({ effect: 'blind', duration: 'fast' });
+            this.controlClickHnd.filter = () => {
+                if (!this.$filterTypeDiv.is(':visible')) {
+                    this.$sortByDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$searchDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$filterTypeDiv.show({ effect: 'blind', duration: 'fast' });
                 } else {
-                    _this.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
+                    this.$filterTypeDiv.hide({ effect: 'blind', duration: 'fast' });
                 }
             };
-            var $openFilter = $('<span>')
+            const $openFilter = $('<span>')
                 .addClass('btn btn-xs btn-default kb-data-list-ctl')
                 .attr('id', 'kb-data-list-filterctl')
                 .tooltip({
@@ -1749,10 +1734,10 @@ define([
                     }
                 })
                 .append('<span class="fa fa-filter"></span>')
-                .on('click', _this.controlClickHnd.filter);
+                .on('click', this.controlClickHnd.filter);
 
             // Refresh control
-            var $refreshBtn = $('<span>')
+            const $refreshBtn = $('<span>')
                 .addClass('btn btn-xs btn-default')
                 .tooltip({
                     title: 'Refresh data list',
@@ -1763,50 +1748,50 @@ define([
                     }
                 })
                 .append('<span class="fa fa-refresh"></span>')
-                .on('click', function () {
+                .on('click', () => {
                     this.writingLock = false;
-                    _this.refresh();
+                    this.refresh();
                 });
-            _this.$searchDiv = $('<div>');
-            _this.bsSearch = new BootstrapSearch(_this.$searchDiv, {
-                inputFunction: function() {
-                    _this.search();
+            this.$searchDiv = $('<div>');
+            this.bsSearch = new BootstrapSearch(this.$searchDiv, {
+                inputFunction: () => {
+                    this.search();
                 },
                 placeholder: 'Search in your data'
             });
 
-            _this.$sortByDiv = $('<div>').css('text-align', 'center')
+            this.$sortByDiv = $('<div>').css('text-align', 'center')
                 .append('<small>sort by: </small>')
                 .append($sortByGroup)
                 .append($upOrDown);
 
-            _this.$filterTypeSelect = $('<select>').addClass('form-control')
+            this.$filterTypeSelect = $('<select>').addClass('form-control')
                 .css('margin', 'inherit')
                 .append($('<option value="">'))
-                .change(function () {
-                    _this.selectedType = 'filterTypeSelect';
-                    var optionSelected = $(this).find('option:selected');
-                    var typeSelected = optionSelected.val();
+                .change(() => {
+                    this.selectedType = 'filterTypeSelect';
+                    const optionSelected = $(this).find('option:selected');
+                    const typeSelected = optionSelected.val();
 
                     // whenever we change the type filter, we need to clear the current match
                     // so that the complete filter can rerun
-                    _this.currentMatch = _this.viewOrder;
+                    this.currentMatch = this.viewOrder;
 
-                    _this.filterByType(typeSelected);
+                    this.filterByType(typeSelected);
                 });
 
-            _this.$filterTypeDiv = $('<div>')
-                .append(_this.$filterTypeSelect);
+            this.$filterTypeDiv = $('<div>')
+                .append(this.$filterTypeSelect);
 
-            var $header = $('<div>');
-            if (_this.options.parentControlPanel) {
+            const $header = $('<div>');
+            if (this.options.parentControlPanel) {
                 if (Config.get('features').hierarchicalDataView) {
-                    _this.options.parentControlPanel.addButtonToControlPanel($viewMode);
+                    this.options.parentControlPanel.addButtonToControlPanel($viewMode);
                 }
-                _this.options.parentControlPanel.addButtonToControlPanel($openSearch);
-                _this.options.parentControlPanel.addButtonToControlPanel($openSort);
-                _this.options.parentControlPanel.addButtonToControlPanel($openFilter);
-                _this.options.parentControlPanel.addButtonToControlPanel($refreshBtn);
+                this.options.parentControlPanel.addButtonToControlPanel($openSearch);
+                this.options.parentControlPanel.addButtonToControlPanel($openSort);
+                this.options.parentControlPanel.addButtonToControlPanel($openFilter);
+                this.options.parentControlPanel.addButtonToControlPanel($refreshBtn);
             } else {
                 $header.addClass('row').css({ 'margin': '5px' })
                     .append($('<div>').addClass('col-xs-12').css({ 'margin': '0px', 'padding': '0px', 'text-align': 'right' })
@@ -1817,35 +1802,35 @@ define([
             }
 
 
-            _this.$sortByDiv.hide();
-            _this.$searchDiv.hide();
-            _this.$filterTypeDiv.hide();
+            this.$sortByDiv.hide();
+            this.$searchDiv.hide();
+            this.$filterTypeDiv.hide();
 
-            var $filterDiv = $('<div>')
-                .append(_this.$sortByDiv)
-                .append(_this.$searchDiv)
-                .append(_this.$filterTypeDiv);
+            const $filterDiv = $('<div>')
+                .append(this.$sortByDiv)
+                .append(this.$searchDiv)
+                .append(this.$filterTypeDiv);
 
-            _this.$controllerDiv.append($header).append($filterDiv);
+            this.$controllerDiv.append($header).append($filterDiv);
         },
         /**
          * Populates the filter set of available types.
          */
         populateAvailableTypes: function () {
             if (this.availableTypes && this.$filterTypeSelect) {
-                var selected = this.$filterTypeSelect.val();
+                const selected = this.$filterTypeSelect.val();
                 this.$filterTypeSelect.empty();
-                var runningCount = 0;
-                Object.keys(this.availableTypes).sort().forEach(function (type) {
-                    var typeInfo = this.availableTypes[type];
-                    var suf = typeInfo.count > 0 ? 's' : '';
+                let runningCount = 0;
+                Object.keys(this.availableTypes).sort().forEach((type) => {
+                    const typeInfo = this.availableTypes[type];
+                    const suf = typeInfo.count > 0 ? 's' : '';
                     this.$filterTypeSelect.append(
                         $('<option value="' + typeInfo.type + '">')
                             .append([typeInfo.type, ' (', typeInfo.count, ' object', suf, ')'].join(''))
                     );
                     runningCount += typeInfo.count;
-                }.bind(this));
-                var suf = runningCount > 0 ? 's' : '';
+                });
+                const suf = runningCount > 0 ? 's' : '';
                 this.$filterTypeSelect
                     .prepend($('<option value="">')
                         .append('Show All Types (' + runningCount + ' object' + suf + ')'))
@@ -1896,17 +1881,17 @@ define([
                 term = term.replace(/\./g, '\\.').replace(/\\\\\./g, '.'); // dots are common in names, so we escape them, but
                 // if a user writes '\\.' we assume they want the regex '.'
 
-                var regex = new RegExp(term, 'i');
+                const regex = new RegExp(term, 'i');
 
                 this.n_filteredObjsRendered = 0;
-                for (var k = 0; k < this.viewOrder.length; k++) {
+                for (let k = 0; k < this.viewOrder.length; k++) {
 
                     // [0] : obj_id objid // [1] : obj_name name // [2] : type_string type
                     // [3] : timestamp save_date // [4] : int version // [5] : username saved_by
                     // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
                     // [9] : int size // [10] : usermeta meta
-                    var match = false;
-                    var info = this.dataObjects[this.viewOrder[k].objId].info;
+                    let match = false;
+                    const info = this.dataObjects[this.viewOrder[k].objId].info;
                     if (regex.test(info[1])) {
                         match = true;
                     } // match on name
@@ -1918,8 +1903,8 @@ define([
                     } // match on saved_by user
 
                     if (!match && info[10]) { // match on metadata values
-                        for (var metaKey in info[10]) {
-                            if (info[10].hasOwnProperty(metaKey)) {
+                        for (const metaKey in info[10]) {
+                            if (Object.prototype.hasOwnProperty.call(info[10], metaKey)) {
                                 if (regex.test(info[10][metaKey])) {
                                     match = true;
                                     break;
@@ -1940,7 +1925,7 @@ define([
                 }
             } else {
                 // no new search, so show all and render the list
-                this.viewOrder.forEach(function (viewInfo) {
+                this.viewOrder.forEach((viewInfo) => {
                     viewInfo.inFilter = true;
                 });
             }
@@ -1957,7 +1942,7 @@ define([
             // e.g. the report button.
 
             // The "Saved by" field needs to lookup that user's real name.
-            var $usernameTd = $moreRow.find('.kb-data-list-username-td');
+            const $usernameTd = $moreRow.find('.kb-data-list-username-td');
             DisplayUtil.displayRealName(object_info[5], $usernameTd);
         }
     });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -424,14 +424,10 @@ define([
 
         renderOverlayState: function () {
             if (this.$overlayPanel.is(':visible')) {
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', true);
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', false);
                 const idx = $('.kb-side-overlay-container').find('.kb-side-header.active').index();
                 this.updateSlideoutRendering(idx);
             } else {
                 this.deactivateLastRenderedPanel();
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', false);
-                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', true);
             }
         },
 
@@ -481,14 +477,13 @@ define([
                 this.renderOverlayState();
             });
 
-
-            $(document).on('sidePanelOverlayHiding.Narrative', (_, panel) => {
+            $(document).on('sidePanelOverlayHiding.Narrative', (_ev, panel) => {
                 if (panel === this.$overlayPanel) {
                     this.preRenderOverlayState();
                 }
             });
 
-            $(document).on('sidePanelOverlayShowing.Narrative', (_, panel) => {
+            $(document).on('sidePanelOverlayShowing.Narrative', (_ev, panel) => {
                 if (panel === this.$overlayPanel) {
                     this.preRenderOverlayState();
                 }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -491,8 +491,7 @@ define([
 
             $(document).on('sidePanelOverlayShown.Narrative', () => {
                 this.renderOverlayState();
-            }
-            );
+            });
 
             closeBtn.click(() => {
                 this.trigger('hideSidePanelOverlay.Narrative');

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataPanel.js
@@ -1,4 +1,3 @@
-/*global define,Workspace*/
 /*jslint white: true*/
 /*eslint-env browser*/
 
@@ -23,29 +22,25 @@ define([
     'kbase/js/widgets/narrative_core/dataBrowser',
     'narrativeConfig',
     'base/js/namespace',
-    'kbaseNarrative',
     'kbaseNarrativeControlPanel',
     'kbaseNarrativeDataList',
     'kbaseNarrativeSidePublicTab',
     'kbaseNarrativeExampleDataTab',
     'kbaseNarrativeStagingDataTab',
-    'api/dataProvider',
     'bootstrap'
-], function (
+], (
     KBWidget,
     $,
     _,
     DataBrowser,
     Config,
     Jupyter,
-    kbaseNarrative,
     kbaseNarrativeControlPanel,
     kbaseNarrativeDataList,
     kbaseNarrativeSidePublicTab,
     kbaseNarrativeExampleDataTab,
-    kbaseNarrativeStagingDataTab,
-    DataProvider
-) {
+    kbaseNarrativeStagingDataTab
+) => {
     'use strict';
 
     /*
@@ -64,8 +59,6 @@ define([
       reflects incorrect data. So in case anybody starts complaining about the list of types not matching their
       data, this is probably the cause and should be revisited. For now, I'm going to sweep it under the rug.
     */
-
-    var knownTypes = [];
 
     return KBWidget({
         name: 'kbaseNarrativeDataPanel',
@@ -104,11 +97,11 @@ define([
 
             this.ws_name = Jupyter.narrative.getWorkspaceName();
 
-            var icons = Config.get('icons');
+            const icons = Config.get('icons');
             this.data_icons = icons.data;
             this.icon_colors = icons.colors;
 
-            var $dataList = $('<div>');
+            const $dataList = $('<div>');
             this.body().append($dataList);
             this.dataListWidget =
                 new kbaseNarrativeDataList($dataList, {
@@ -123,12 +116,12 @@ define([
              */
             $(document).on(
                 'dataLoadedQuery.Narrative', $.proxy(function (e, params, ignoreVersion, callback) {
-                    var obj_data = this.dataListWidget.getObjData(params, ignoreVersion);
+                    const obj_data = this.dataListWidget.getObjData(params, ignoreVersion);
                     if (callback) {
                         callback(obj_data);
                     }
                 },
-                this)
+                    this)
             );
 
 
@@ -137,42 +130,33 @@ define([
              * in the workspace.
              */
             $(document).on(
-                'updateData.Narrative', function () {
+                'updateData.Narrative', () => {
                     this.dataListWidget.refresh();
-                }.bind(this)
+                }
             );
 
             /**
              * This should be triggered when something wants to know what workspace this widget is currently linked to.
              */
             $(document).on(
-                'workspaceQuery.Narrative', function (e, callback) {
+                'workspaceQuery.Narrative', (e, callback) => {
                     if (callback) {
                         callback(this.ws_name);
                     }
-                }.bind(this)
+                }
             );
 
-            $(document).on(
-                'sidePanelOverlayShown.Narrative', function () {
-                    // find the index of what tab is being shown.
-                    if (this.$overlayPanel.is(':visible')) {
-                        var idx = $('.kb-side-overlay-container').find('.kb-side-header.active').index();
-                        this.updateSlideoutRendering(idx);
-                    }
-                }.bind(this)
-            );
 
             $(document).on('deleteDataList.Narrative', $.proxy(function (event, data) {
                 this.loadedData[data] = false;
-                var className = '.' + data.split('.').join('--');
+                const className = '.' + data.split('.').join('--');
                 $(className).html('');
                 $(className).append($('<span>').addClass('fa fa-chevron-circle-left'))
                     .append(' Add');
             }, this));
 
             // note how many times we've clicked on the data browser slideout button.
-            var numDataBrowserClicks = 0;
+            let numDataBrowserClicks = 0;
 
             this.$slideoutBtn = $('<button data-test-id="data-slideout-button">')
                 .addClass('btn btn-xs btn-default')
@@ -185,22 +169,20 @@ define([
                     }
                 })
                 .append('<span class="fa fa-arrow-right"></span>')
-                .click(function () {
-                    this.$slideoutBtn.children().toggleClass('fa-arrow-right fa-arrow-left');
+                .click(() => {
                     this.$slideoutBtn.tooltip('hide');
-                    this.trigger('hideGalleryPanelOverlay.Narrative');
-                    this.trigger('toggleSidePanelOverlay.Narrative', this.$overlayPanel);
+                    this.trigger('toggleSidePanelOverlay.Narrative', [this.$overlayPanel]);
 
                     // NOTE - this will be missed and a widget will remain active if the panel 
                     // is closed by means other than clicking this button.
                     // This should be re-visited at some point.
-                    this.deactivateLastRenderedPanel();
+                    // this.deactivateLastRenderedPanel();
 
                     // once we've clicked it 10 times, meaning we've open and shut the browser 5x, we reveal its TRUE NAME.
                     if (++numDataBrowserClicks >= 10) {
                         this.$slideoutBtn.attr('data-original-title', 'Hide / Show Slidey McSliderface');
                     }
-                }.bind(this));
+                });
 
             this.addButton(this.$slideoutBtn);
 
@@ -233,42 +215,42 @@ define([
          * It associates the new auth token with this widget and refreshes the data panel.
          * @private
          */
-        loggedInCallback: function (event, auth) {
+        loggedInCallback: function () {
             this.isLoggedIn = true;
             if (this.ws_name) {
                 this.tabMapping = [
                     {
-                        widget : this.mineTab,
-                        render : function () {
+                        widget: this.mineTab,
+                        render: function () {
                             this.mineTab.updateView(true, true);
                         }.bind(this),
                     },
                     {
-                        widget : this.sharedTab,
-                        render : function () {
+                        widget: this.sharedTab,
+                        render: function () {
                             this.sharedTab.updateView(true, true);
                         }.bind(this),
                     },
                     {
-                        widget : this.publicTab,
-                        render : function () {
+                        widget: this.publicTab,
+                        render: function () {
                             this.publicTab.render();
                         }.bind(this),
                     },
                     {
-                        widget : this.exampleTab,
-                        render : function () {
+                        widget: this.exampleTab,
+                        render: function () {
                             this.exampleTab.getExampleDataAndRender();
                         }.bind(this),
                     },
-                    { render : function() {} },
+                    { render: function () { } },
                 ];
 
                 if (Config.get('features').stagingDataViewer) {
                     this.tabMapping.push(
                         {
-                            widget : this.stagingTab,
-                            render : function () {
+                            widget: this.stagingTab,
+                            render: function () {
                                 this.stagingTab.updateView();
                             }.bind(this)
                         }
@@ -340,13 +322,13 @@ define([
             }
         },
 
-        getDataObjectByName: function(name) {
+        getDataObjectByName: function (name) {
             if (this.dataListWidget) {
                 return this.dataListWidget.getDataObjectByName(name);
             }
         },
 
-        getDataObjectByRef: function(ref, asObject) {
+        getDataObjectByRef: function (ref, asObject) {
             if (this.dataListWidget) {
                 return this.dataListWidget.getDataObjectByRef(ref, asObject);
             }
@@ -402,7 +384,7 @@ define([
             };
         },
 
-        deactivateLastRenderedPanel : function() {
+        deactivateLastRenderedPanel: function () {
             if (this.$lastRenderedWidget && this.$lastRenderedWidget.deactivate) {
                 this.$lastRenderedWidget.deactivate();
                 this.$lastRenderedWidget = undefined;
@@ -416,7 +398,7 @@ define([
                 this.tabMapping[panelIdx].render();
                 this.renderedTabs[panelIdx] = true;
             }
-            var $widget = this.tabMapping[panelIdx].widget;
+            const $widget = this.tabMapping[panelIdx].widget;
             if ($widget && $widget.activate) {
                 $widget.activate();
             }
@@ -426,57 +408,101 @@ define([
 
         currentWsIsTemp: function () {
             this.$myDataHeader.empty();
-            this.$myDataHeader.css({'color': '#777', 'margin': '10px 10px 0px 10px'});
+            this.$myDataHeader.css({ 'color': '#777', 'margin': '10px 10px 0px 10px' });
             this.$myDataHeader.append(this.myDataTempNarrativeMsg);
+        },
+
+        preRenderOverlayState: function () {
+            if (this.$overlayPanel.is(':visible')) {
+                this.$slideoutBtn.children().toggleClass('fa-arrow-left', false);
+                this.$slideoutBtn.children().toggleClass('fa-arrow-right', true);
+            } else {
+                this.$slideoutBtn.children().toggleClass('fa-arrow-left', true);
+                this.$slideoutBtn.children().toggleClass('fa-arrow-right', false);
+            }
+        },
+
+        renderOverlayState: function () {
+            if (this.$overlayPanel.is(':visible')) {
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', true);
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', false);
+                const idx = $('.kb-side-overlay-container').find('.kb-side-header.active').index();
+                this.updateSlideoutRendering(idx);
+            } else {
+                this.deactivateLastRenderedPanel();
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-left', false);
+                // this.$slideoutBtn.children().toggleClass('fa-arrow-right', true);
+            }
         },
 
         buildSlideoutPanel: function () {
             // tab panels
-            let minePanel = $('<div class="kb-import-content kb-import-mine">'),
+            const minePanel = $('<div class="kb-import-content kb-import-mine">'),
                 sharedPanel = $('<div class="kb-import-content kb-import-shared">'),
                 publicPanel = $('<div class="kb-import-content kb-import-public" data-test-id="panel-public">'),
                 examplePanel = $('<div class="kb-import-content">'),
                 stagingPanel = $('<div class="kb-import-content">');
 
-            let tabList = [
-                {id: 'mydata', tabName: '<small>My Data</small>', content: minePanel},
-                {id: 'sharedwithme', tabName: '<small>Shared With Me</small>', content: sharedPanel},
-                {id: 'public', tabName: '<small>Public</small>', content: publicPanel},
-                {id: 'example', tabName: '<small>Example</small>', content: examplePanel},
+            const tabList = [
+                { id: 'mydata', tabName: '<small>My Data</small>', content: minePanel },
+                { id: 'sharedwithme', tabName: '<small>Shared With Me</small>', content: sharedPanel },
+                { id: 'public', tabName: '<small>Public</small>', content: publicPanel },
+                { id: 'example', tabName: '<small>Example</small>', content: examplePanel },
             ];
 
             if (Config.get('features').stagingDataViewer) {
-                tabList.push({id: 'import', tabName: '<small>Import<small>', content: stagingPanel});
+                tabList.push({ id: 'import', tabName: '<small>Import<small>', content: stagingPanel });
             }
 
             // add tabs
-            let $tabs = this.buildTabs(tabList);
+            const $tabs = this.buildTabs(tabList);
 
-            var body = $('<div>');
-            var footer = $('<div>');
+            const body = $('<div>');
+            const footer = $('<div>');
             body.addClass('kb-side-panel');
             body.attr('data-test-id', 'data-slideout-panel');
             body.append($tabs.header, $tabs.body);
 
             // add footer status container and buttons
-            var importStatus = $('<div class="pull-left kb-import-status">');
+            const importStatus = $('<div class="pull-left kb-import-status">');
             footer.append(importStatus);
-            var btn = $('<button class="btn btn-primary pull-right" disabled>Add to Narrative</button>').css({'margin': '10px'});
-            var closeBtn = $('<button class="kb-default-btn pull-right">Close</button>').css({'margin': '10px'});
+            const closeBtn = $('<button class="kb-default-btn pull-right">Close</button>').css({ 'margin': '10px' });
 
             // Setup the panels that are defined by widgets
-            this.mineTab = new DataBrowser(minePanel, {$importStatus: importStatus, ws_name: this.ws_name, dataSet: 'mine'});
-            this.sharedTab = new DataBrowser(sharedPanel, {$importStatus: importStatus, ws_name: this.ws_name, dataSet: 'shared'});
-            this.publicTab = new kbaseNarrativeSidePublicTab(publicPanel, {$importStatus: importStatus, ws_name: this.ws_name});
-            this.exampleTab = new kbaseNarrativeExampleDataTab(examplePanel, {$importStatus: importStatus, ws_name: this.ws_name});
+            this.mineTab = new DataBrowser(minePanel, { $importStatus: importStatus, ws_name: this.ws_name, dataSet: 'mine' });
+            this.sharedTab = new DataBrowser(sharedPanel, { $importStatus: importStatus, ws_name: this.ws_name, dataSet: 'shared' });
+            this.publicTab = new kbaseNarrativeSidePublicTab(publicPanel, { $importStatus: importStatus, ws_name: this.ws_name });
+            this.exampleTab = new kbaseNarrativeExampleDataTab(examplePanel, { $importStatus: importStatus, ws_name: this.ws_name });
             if (Config.get('features').stagingDataViewer) {
                 this.stagingTab = new kbaseNarrativeStagingDataTab(stagingPanel).render();
             }
 
+            $(document).on('sidePanelOverlayHidden.Narrative', () => {
+                this.renderOverlayState();
+            });
+
+
+            $(document).on('sidePanelOverlayHiding.Narrative', (_, panel) => {
+                if (panel === this.$overlayPanel) {
+                    this.preRenderOverlayState();
+                }
+            });
+
+            $(document).on('sidePanelOverlayShowing.Narrative', (_, panel) => {
+                if (panel === this.$overlayPanel) {
+                    this.preRenderOverlayState();
+                }
+            });
+
+            $(document).on('sidePanelOverlayShown.Narrative', () => {
+                this.renderOverlayState();
+            }
+            );
+
             closeBtn.click(() => {
-                this.$slideoutBtn.children().toggleClass('fa-arrow-right fa-arrow-left');
                 this.trigger('hideSidePanelOverlay.Narrative');
             });
+
             footer.append(closeBtn);
 
             this.$overlayPanel = body.append(footer);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -196,6 +196,7 @@ define([
                 this.$overlayBody = $('<div class="kb-overlay-body">');
                 this.$overlayFooter = $('<div class="kb-overlay-footer">');
                 this.$overlay = $('<div>')
+                    .attr('data-test-id', 'side-overlay-container')
                     .addClass('kb-side-overlay-container');
 
                 $('body').append(this.$overlay);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -3,378 +3,389 @@ define([
     'kbwidget',
     'jquery',
     'base/js/namespace',
-    'narrativeConfig',
     'kbaseNarrativeDataPanel',
     'kbaseNarrativeAppPanel',
     'kbaseNarrativeManagePanel',
 ],
-function(
-    KBWidget,
-    $,
-    Jupyter,
-    Config,
-    kbaseNarrativeDataPanel,
-    kbaseNarrativeAppPanel,
-    kbaseNarrativeManagePanel
-) {
-    'use strict';
-    return KBWidget({
-        name: 'kbaseNarrativeSidePanel',
+    (
+        KBWidget,
+        $,
+        Jupyter,
+        kbaseNarrativeDataPanel,
+        kbaseNarrativeAppPanel,
+        kbaseNarrativeManagePanel
+    ) => {
+        'use strict';
+        return KBWidget({
+            name: 'kbaseNarrativeSidePanel',
 
-        options: {
-            autorender: true,
-        },
-        $dataWidget: null,
-        dataWidgetListHeight: [340, 680], // [height with methods showing, max height], overwritten on window size change
-        $methodsWidget: null,
-        methodsWidgetListHeight: [300, 600], // [height with data showing, max height]
-
-        heightListOffset: 220, // in px, space taken up by titles, header bar, etc.  The rest of the real estate is divided
-        // by half for for the method and data lists
-        heightPanelOffset: 110, // in px, space taken by just the header, the rest is for the full panel size, which is the
-        // case for the narratives/jobs panels
-        $narrativesWidget: null,
-        $overlay: null,
-
-        hideButtonSize: 4, //percent width
-
-        /**
-         * Does the initial panel layout - tabs and spots for each widget
-         * It then instantiates them, but not until told to render (unless autorender = true)
-         */
-        init: function(options) {
-            this._super(options);
-            var analysisWidgets = this.buildPanelSet([{
-                name: 'kbaseNarrativeDataPanel',
-                params: {
-                    collapseCallback: $.proxy(function(isMinimized) {
-                        this.handleMinimizedDataPanel(isMinimized);
-                    }, this)
-                }
+            options: {
+                autorender: true,
             },
-            {
-                name: 'kbaseNarrativeAppPanel',
-                params: {
-                    autopopulate: false,
-                    collapseCallback: $.proxy(function(isMinimized) {
-                        this.handleMinimizedMethodPanel(isMinimized);
-                    }, this)
+            $dataWidget: null,
+            dataWidgetListHeight: [340, 680], // [height with methods showing, max height], overwritten on window size change
+            $methodsWidget: null,
+            methodsWidgetListHeight: [300, 600], // [height with data showing, max height]
+
+            heightListOffset: 220, // in px, space taken up by titles, header bar, etc.  The rest of the real estate is divided
+            // by half for for the method and data lists
+            heightPanelOffset: 110, // in px, space taken by just the header, the rest is for the full panel size, which is the
+            // case for the narratives/jobs panels
+            $narrativesWidget: null,
+            $overlay: null,
+
+            hideButtonSize: 4, //percent width
+
+            /**
+             * Does the initial panel layout - tabs and spots for each widget
+             * It then instantiates them, but not until told to render (unless autorender = true)
+             */
+            init: function (options) {
+                this._super(options);
+                const analysisWidgets = this.buildPanelSet([{
+                    name: 'kbaseNarrativeDataPanel',
+                    params: {
+                        collapseCallback: $.proxy(function (isMinimized) {
+                            this.handleMinimizedDataPanel(isMinimized);
+                        }, this)
+                    }
+                },
+                {
+                    name: 'kbaseNarrativeAppPanel',
+                    params: {
+                        autopopulate: false,
+                        collapseCallback: $.proxy(function (isMinimized) {
+                            this.handleMinimizedMethodPanel(isMinimized);
+                        }, this)
+                    }
+                }]);
+                this.$dataWidget = analysisWidgets['kbaseNarrativeDataPanel'];
+                this.$methodsWidget = analysisWidgets['kbaseNarrativeAppPanel'];
+
+                const $analysisPanel = analysisWidgets['panelSet'];
+
+                const manageWidgets = this.buildPanelSet([{
+                    name: 'kbaseNarrativeManagePanel',
+                    params: { autopopulate: false, showTitle: false }
+                },]);
+
+                this.$narrativesWidget = manageWidgets['kbaseNarrativeManagePanel'];
+                const $managePanel = manageWidgets['panelSet'];
+
+                this.$tabs = this.buildTabs([{
+                    tabName: 'Analyze',
+                    content: $analysisPanel,
+                    widgets: [this.$dataWidget, this.$methodsWidget]
+                }, {
+                    tabName: 'Narratives',
+                    content: $managePanel,
+                    widgets: [this.$narrativesWidget]
+                },
+                ], true);
+
+                this.$elem.addClass('kb-side-panel');
+                this.$elem.append(this.$tabs.header)
+                    .append(this.$tabs.body);
+
+                $(document).on('showSidePanelOverlay.Narrative', (event, $panel) => {
+                    this.showOverlay($panel);
+                });
+
+                $(document).on('hideSidePanelOverlay.Narrative', (event, $panel) => {
+                    this.hideOverlay($panel);
+                });
+
+                $(document).on('toggleSidePanelOverlay.Narrative', (event, $panel) => {
+                    this.toggleOverlay($panel);
+                });
+
+                // handle window size change in left panel, and call it once to set the correct size now
+                $(window).on('resize', $.proxy(function () { this.windowSizeChange(); }, this));
+                this.windowSizeChange();
+
+                if (this.autorender) {
+                    this.render();
                 }
-            }]);
-            this.$dataWidget = analysisWidgets['kbaseNarrativeDataPanel'];
-            this.$methodsWidget = analysisWidgets['kbaseNarrativeAppPanel'];
 
-            var $analysisPanel = analysisWidgets['panelSet'];
-
-            var manageWidgets = this.buildPanelSet([{
-                name: 'kbaseNarrativeManagePanel',
-                params: { autopopulate: false, showTitle: false }
-            }, ]);
-
-            this.$narrativesWidget = manageWidgets['kbaseNarrativeManagePanel'];
-            var $managePanel = manageWidgets['panelSet'];
-
-            this.$tabs = this.buildTabs([{
-                tabName: 'Analyze',
-                content: $analysisPanel,
-                widgets: [this.$dataWidget, this.$methodsWidget]
-            }, {
-                tabName: 'Narratives',
-                content: $managePanel,
-                widgets: [this.$narrativesWidget]
+                return this;
             },
-            ], true);
 
-            this.$elem.addClass('kb-side-panel');
-            this.$elem.append(this.$tabs.header)
-                .append(this.$tabs.body);
+            /**
+             * @method
+             * @public
+             * A bit of a hack. Set a specific read-only mode where we don't see the jobs or methods panel,
+             * only the data panel and narratives panel.
+             * So we need to remove the 'Jobs' header all together, then hide the methods panel,
+             * and expand the data panel to fill the screen
+             */
+            setReadOnlyMode: function (readOnly) {
+                this.$dataWidget.setReadOnlyMode(readOnly);
+                this.$methodsWidget.setReadOnlyMode(readOnly);
+            },
 
-            $(document).on('showSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
-                this.showOverlay(panel);
-            }, this));
+            /**
+             * @method
+             * @private
+             * Builds a very simple set of tabs.
+             * @param {Array} tabs - a list of objects where each has a 'tabName' and 'content' property.
+             * As you might expect, 'tabName' is the name of the tab that goes into the styled header,
+             * and 'content' is the tab content, expected to be something that can be attached via .append()
+             * @param isOuter - if true, treat these tabs as though they belong to the outer side panel,
+             * not to an inner set of tabs. That is, when any new tab is selected, it hides the overlay,
+             * if it's open.
+             */
+            buildTabs: function (tabs, isOuter) {
+                const $header = $('<div>');
+                const $body = $('<div>');
+                $body.addClass('narrative-side-panel-content');
+                $body.css('height', 'calc(100% - 45px)');
 
-            $(document).on('hideSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
-                this.hideOverlay(panel);
-            }, this));
-
-            $(document).on('toggleSidePanelOverlay.Narrative', $.proxy(function(event, panel) {
-                this.toggleOverlay(panel);
-            }, this));
-
-            // handle window size change in left panel, and call it once to set the correct size now
-            $(window).on('resize', $.proxy(function() { this.windowSizeChange(); }, this));
-            this.windowSizeChange();
-
-            if (this.autorender) {
-                this.render();
-            }
-
-            return this;
-        },
-
-        /**
-         * @method
-         * @public
-         * A bit of a hack. Set a specific read-only mode where we don't see the jobs or methods panel,
-         * only the data panel and narratives panel.
-         * So we need to remove the 'Jobs' header all together, then hide the methods panel,
-         * and expand the data panel to fill the screen
-         */
-        setReadOnlyMode: function(readOnly) {
-            this.$dataWidget.setReadOnlyMode(readOnly);
-            this.$methodsWidget.setReadOnlyMode(readOnly);
-        },
-
-        /**
-         * @method
-         * @private
-         * Builds a very simple set of tabs.
-         * @param {Array} tabs - a list of objects where each has a 'tabName' and 'content' property.
-         * As you might expect, 'tabName' is the name of the tab that goes into the styled header,
-         * and 'content' is the tab content, expected to be something that can be attached via .append()
-         * @param isOuter - if true, treat these tabs as though they belong to the outer side panel,
-         * not to an inner set of tabs. That is, when any new tab is selected, it hides the overlay,
-         * if it's open.
-         */
-        buildTabs: function(tabs, isOuter) {
-            var $header = $('<div>');
-            var $body = $('<div>');
-            $body.addClass('narrative-side-panel-content');
-            $body.css('height', 'calc(100% - 45px)');
-
-            $header.append($('<div>')
-                .addClass('kb-side-toggle')
-                .css('width', this.hideButtonSize + '%')
-                .append($('<span>')
-                    .addClass('fa fa-caret-left'))
-                .click(function() {
-                    Jupyter.narrative.toggleSidePanel();
-                }));
-            for (var i = 0; i < tabs.length; i++) {
-                var tab = tabs[i];
                 $header.append($('<div>')
-                    .addClass('kb-side-header')
-                    .css('width', ((100 - this.hideButtonSize) / tabs.length) + '%')
-                    .append(tab.tabName)
-                    .attr('kb-data-id', i));
-                $body.append($('<div>')
-                    .addClass('kb-side-tab')
-                    .append(tab.content)
-                    .attr('kb-data-id', i));
-            }
-
-            $header.find('div[kb-data-id]').click($.proxy(function(event) {
-                var $headerDiv = $(event.currentTarget);
-
-                if (!$headerDiv.hasClass('active')) {
-                    var idx = $headerDiv.attr('kb-data-id');
-                    $header.find('div').removeClass('active');
-                    $headerDiv.addClass('active');
-                    $body.find('div.kb-side-tab').removeClass('active');
-                    $body.find('[kb-data-id=' + idx + ']').addClass('active');
-                    tabs[idx].widgets.forEach(w => {
-                        w.activate();
-                    });
-                    if (isOuter)
-                        this.hideOverlay();
+                    .addClass('kb-side-toggle')
+                    .css('width', this.hideButtonSize + '%')
+                    .append($('<span>')
+                        .addClass('fa fa-caret-left'))
+                    .click(() => {
+                        Jupyter.narrative.toggleSidePanel();
+                    }));
+                for (let i = 0; i < tabs.length; i++) {
+                    const tab = tabs[i];
+                    $header.append($('<div>')
+                        .addClass('kb-side-header')
+                        .css('width', ((100 - this.hideButtonSize) / tabs.length) + '%')
+                        .append(tab.tabName)
+                        .attr('kb-data-id', i));
+                    $body.append($('<div>')
+                        .addClass('kb-side-tab')
+                        .append(tab.content)
+                        .attr('kb-data-id', i));
                 }
-            }, this));
 
-            $header.find('div:nth-child(2)').addClass('active');
-            $body.find('div:first-child.kb-side-tab').addClass('active');
-            tabs[0].widgets.forEach(w => {
-                w.activate();
-            });
+                $header.find('div[kb-data-id]').click($.proxy(function (event) {
+                    const $headerDiv = $(event.currentTarget);
 
-            return {
-                header: $header,
-                body: $body
-            };
-        },
-
-        initOverlay: function() {
-            var self = this;
-
-            this.$overlayBody = $('<div class="kb-overlay-body">');
-            this.$overlayFooter = $('<div class="kb-overlay-footer">');
-            this.$overlay = $('<div>')
-                .addClass('kb-side-overlay-container');
-
-            $('body').append(this.$overlay);
-            this.$overlay.hide();
-
-            this.$narrativeDimmer = $('<div>')
-                .addClass('kb-overlay-dimmer');
-
-            $('body').append(this.$narrativeDimmer);
-            this.$narrativeDimmer.hide();
-            this.updateOverlayPosition();
-
-            // hide panel when clicking outside
-            this.$narrativeDimmer.unbind('click');
-            this.$narrativeDimmer.click(function() {
-                self.hideOverlay();
-            });
-        },
-
-        updateOverlayPosition: function() {
-            this.$overlay.position({ my: 'left top', at: 'right top', of: this.$elem });
-            this.$narrativeDimmer.position({ my: 'left top', at: 'right top', of: this.$elem });
-        },
-
-        /**
-         * @method
-         * @public
-         * Also available through a trigger - 'toggleSidePanelOverlay.Narrative'
-         * The behavior here is done in three cases.
-         * 1. If the overlay is currently visible, it gets hidden.
-         * 1a. If there is a panel given, and it is different from the currently attached panel, then
-         *     the new panel is attached and the overlay is redisplayed.
-         * 2. If the overlay is currently hidden, it is shown with the given panel.
-         */
-        toggleOverlay: function(panel) {
-            if (this.$overlay.is(':visible')) {
-                this.hideOverlay();
-                if (panel && panel !== this.currentPanel) {
-                    this.showOverlay(panel);
-                }
-            } else
-                this.showOverlay(panel);
-        },
-
-        showOverlay: function(panel) {
-            if (this.$overlay) {
-                if (panel) {
-                    if (this.currentPanel)
-                        $(this.currentPanel).detach();
-                    this.$overlay.append(panel);
-                    this.currentPanel = panel;
-                }
-                Jupyter.narrative.disableKeyboardManager();
-                this.$narrativeDimmer.show();
-                this.$elem.find('.kb-side-header, .kb-side-toggle').addClass('kb-overlay-active');
-                this.$overlay.show('slide', 'fast', $.proxy(function() {
-                    this.trigger('sidePanelOverlayShown.Narrative');
+                    if (!$headerDiv.hasClass('active')) {
+                        const idx = $headerDiv.attr('kb-data-id');
+                        $header.find('div').removeClass('active');
+                        $headerDiv.addClass('active');
+                        $body.find('div.kb-side-tab').removeClass('active');
+                        $body.find('[kb-data-id=' + idx + ']').addClass('active');
+                        tabs[idx].widgets.forEach(w => {
+                            w.activate();
+                        });
+                        if (isOuter)
+                            this.hideOverlay();
+                    }
                 }, this));
-            }
-        },
 
-        hideOverlay: function() {
-            if (this.$overlay) {
-                Jupyter.narrative.enableKeyboardManager();
-                this.$narrativeDimmer.hide();
-                this.$elem.find('.kb-side-header, .kb-side-toggle').removeClass('kb-overlay-active');
-                this.$overlay.hide('slide', 'fast', $.proxy(function() {
-                    this.trigger('sidePanelOverlayHidden.Narrative');
-                }, this));
-            }
-        },
+                $header.find('div:nth-child(2)').addClass('active');
+                $body.find('div:first-child.kb-side-tab').addClass('active');
+                tabs[0].widgets.forEach(w => {
+                    w.activate();
+                });
 
-        /**
-         * Builds the general structure for a panel set.
-         * These are intended to start with 2 panels, but we can move from there if needed.
-         *
-         * (I'll jsdoc this up in a bit)
-         * widgets = [
-         *     {
-         *         name: kbaseNarrativeDataPanel (for instance)
-         *         params: {}
-         *     }
-         * ]
-         * @param {object} widgets
-         *
-         */
-        buildPanelSet: function(widgets) {
-            var $panelSet = $('<div>')
-                .addClass('kb-narr-side-panel-set')
-                .css('height', '100%');
-            if (!widgets || Object.prototype.toString.call(widgets) !== '[object Array]' || widgets.length === 0)
-                return $panelSet;
-
-
-            var retObj = {};
-            for (var i = 0; i < widgets.length; i++) {
-                var widgetInfo = widgets[i];
-                var $widgetDiv = $('<div>')
-                    .addClass('kb-side-separator');
-
-                var constructor_mapping = {
-                    'kbaseNarrativeDataPanel': kbaseNarrativeDataPanel,
-                    'kbaseNarrativeAppPanel': kbaseNarrativeAppPanel,
-                    'kbaseNarrativeManagePanel': kbaseNarrativeManagePanel
+                return {
+                    header: $header,
+                    body: $body
                 };
-                retObj[widgetInfo.name] = new constructor_mapping[widgetInfo.name]($widgetDiv, widgetInfo.params);
-                $panelSet.append($widgetDiv);
+            },
+
+            initOverlay: function () {
+                const self = this;
+
+                this.$overlayBody = $('<div class="kb-overlay-body">');
+                this.$overlayFooter = $('<div class="kb-overlay-footer">');
+                this.$overlay = $('<div>')
+                    .addClass('kb-side-overlay-container');
+
+                $('body').append(this.$overlay);
+                this.$overlay.hide();
+
+                this.$narrativeDimmer = $('<div>')
+                    .addClass('kb-overlay-dimmer');
+
+                $('body').append(this.$narrativeDimmer);
+                this.$narrativeDimmer.hide();
+                this.updateOverlayPosition();
+
+                // hide panel when clicking outside
+                this.$narrativeDimmer.unbind('click');
+                this.$narrativeDimmer.click(() => {
+                    self.hideOverlay();
+                });
+            },
+
+            updateOverlayPosition: function () {
+                this.$overlay.position({ my: 'left top', at: 'right top', of: this.$elem });
+                this.$narrativeDimmer.position({ my: 'left top', at: 'right top', of: this.$elem });
+            },
+
+            /**
+             * @method
+             * @public
+             * Also available through a trigger - 'toggleSidePanelOverlay.Narrative'
+             * The behavior here is done in three cases.
+             * 1. If the overlay is currently visible, it gets hidden.
+             * 1a. If there is a panel given, and it is different from the currently attached panel, then
+             *     the new panel is attached and the overlay is redisplayed.
+             * 2. If the overlay is currently hidden, it is shown with the given panel.
+             */
+            toggleOverlay: async function ($panel) {
+                if (this.$overlay.is(':visible')) {
+                    await this.hideOverlay();
+                    if ($panel && $panel !== this.$currentPanel) {
+                        await this.showOverlay($panel);
+                    }
+                } else
+                    await this.showOverlay($panel);
+            },
+
+            showOverlay: function ($panel) {
+                return new Promise((resolve) => {
+                    if (!this.$overlay || this.$overlay.is(':visible')) {
+                        resolve();
+                        return;
+                    }
+                    this.trigger('sidePanelOverlayShowing.Narrative', [$panel]);
+                    if ($panel) {
+                        if (this.$currentPanel) {
+                            this.$currentPanel.detach();
+                        }
+                        this.$overlay.append($panel);
+                        this.$currentPanel = $panel;
+                    }
+                    Jupyter.narrative.disableKeyboardManager();
+                    this.$narrativeDimmer.show();
+                    this.$elem.find('.kb-side-header, .kb-side-toggle').addClass('kb-overlay-active');
+                    this.$overlay.show('slide', 'fast', () => {
+                        this.trigger('sidePanelOverlayShown.Narrative');
+                        resolve();
+                    });
+                });
+            },
+
+            hideOverlay: function () {
+                return new Promise((resolve) => {
+                    if (!this.$overlay || !this.$overlay.is(':visible')) {
+                        resolve();
+                        return;
+                    }
+                    this.trigger('sidePanelOverlayHiding.Narrative', [this.$currentPanel]);
+                    Jupyter.narrative.enableKeyboardManager();
+                    this.$narrativeDimmer.hide();
+                    this.$elem.find('.kb-side-header, .kb-side-toggle').removeClass('kb-overlay-active');
+                    this.$overlay.hide('slide', 'fast', () => {
+                        this.trigger('sidePanelOverlayHidden.Narrative');
+                        resolve();
+                    });
+                })
+            },
+
+            /**
+             * Builds the general structure for a panel set.
+             * These are intended to start with 2 panels, but we can move from there if needed.
+             *
+             * (I'll jsdoc this up in a bit)
+             * widgets = [
+             *     {
+             *         name: kbaseNarrativeDataPanel (for instance)
+             *         params: {}
+             *     }
+             * ]
+             * @param {object} widgets
+             *
+             */
+            buildPanelSet: function (widgets) {
+                const $panelSet = $('<div>')
+                    .addClass('kb-narr-side-panel-set')
+                    .css('height', '100%');
+                if (!widgets || Object.prototype.toString.call(widgets) !== '[object Array]' || widgets.length === 0)
+                    return $panelSet;
+
+
+                const retObj = {};
+                for (let i = 0; i < widgets.length; i++) {
+                    const widgetInfo = widgets[i];
+                    const $widgetDiv = $('<div>')
+                        .addClass('kb-side-separator');
+
+                    const constructor_mapping = {
+                        'kbaseNarrativeDataPanel': kbaseNarrativeDataPanel,
+                        'kbaseNarrativeAppPanel': kbaseNarrativeAppPanel,
+                        'kbaseNarrativeManagePanel': kbaseNarrativeManagePanel
+                    };
+                    retObj[widgetInfo.name] = new constructor_mapping[widgetInfo.name]($widgetDiv, widgetInfo.params);
+                    $panelSet.append($widgetDiv);
+                }
+                retObj['panelSet'] = $panelSet;
+                return retObj;
+            },
+
+
+            /**
+             * Specialized callback controlling heights of panels when data panel is minimized.
+             * Assumes data and method panel are on the same tab.
+             */
+            handleMinimizedDataPanel: function (isMinimized) {
+                if (isMinimized) {
+                    // data panel was minimized
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1], true);
+                } else {
+                    // data panel was maximized
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0], true);
+                }
+            },
+
+            /**
+             * Specialized callback controlling heights of panels when method panel is minimized.
+             * Assumes data and method panel are on the same tab.
+             */
+            handleMinimizedMethodPanel: function (isMinimized) {
+                if (isMinimized) {
+                    // data panel was minimized
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[1], true);
+                } else {
+                    // data panel was maximized
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[0], true);
+                }
+            },
+
+
+            windowSizeChange: function () {
+
+                // determine height of panels, and set the bounds
+                const $window = $(window);
+                let h = $window.height();
+
+                if (h < 300) { // below a height of 300px, don't trim anymore, just let the rest be clipped
+                    h = 300;
+                }
+                const max = h - this.heightListOffset;
+                const min = (h - this.heightListOffset) / 2;
+                this.methodsWidgetListHeight[0] = min;
+                this.methodsWidgetListHeight[1] = max;
+                this.dataWidgetListHeight[0] = min;
+                this.dataWidgetListHeight[1] = max;
+
+                // actually update the sizes
+                if (this.$methodsWidget.isMinimized()) {
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[1]);
+                } else {
+                    this.$dataWidget.setListHeight(this.dataWidgetListHeight[0]);
+                }
+                if (this.$dataWidget.isMinimized()) {
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1]);
+                } else {
+                    this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0]);
+                }
+
+                const fullSize = h - this.heightPanelOffset;
+                this.$narrativesWidget.setHeight(fullSize);
+            },
+
+            render: function () {
+                this.initOverlay();
             }
-            retObj['panelSet'] = $panelSet;
-            return retObj;
-        },
 
-
-        /**
-         * Specialized callback controlling heights of panels when data panel is minimized.
-         * Assumes data and method panel are on the same tab.
-         */
-        handleMinimizedDataPanel: function(isMinimized) {
-            if (isMinimized) {
-                // data panel was minimized
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1], true);
-            } else {
-                // data panel was maximized
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0], true);
-            }
-        },
-
-        /**
-         * Specialized callback controlling heights of panels when method panel is minimized.
-         * Assumes data and method panel are on the same tab.
-         */
-        handleMinimizedMethodPanel: function(isMinimized) {
-            if (isMinimized) {
-                // data panel was minimized
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[1], true);
-            } else {
-                // data panel was maximized
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[0], true);
-            }
-        },
-
-
-        windowSizeChange: function() {
-
-            // determine height of panels, and set the bounds
-            var $window = $(window);
-            var h = $window.height();
-
-            if (h < 300) { // below a height of 300px, don't trim anymore, just let the rest be clipped
-                h = 300;
-            }
-            var max = h - this.heightListOffset;
-            var min = (h - this.heightListOffset) / 2;
-            this.methodsWidgetListHeight[0] = min;
-            this.methodsWidgetListHeight[1] = max;
-            this.dataWidgetListHeight[0] = min;
-            this.dataWidgetListHeight[1] = max;
-
-            // actually update the sizes
-            if (this.$methodsWidget.isMinimized()) {
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[1]);
-            } else {
-                this.$dataWidget.setListHeight(this.dataWidgetListHeight[0]);
-            }
-            if (this.$dataWidget.isMinimized()) {
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[1]);
-            } else {
-                this.$methodsWidget.setListHeight(this.methodsWidgetListHeight[0]);
-            }
-
-            var fullSize = h - this.heightPanelOffset;
-            this.$narrativesWidget.setHeight(fullSize);
-        },
-
-        render: function() {
-            this.initOverlay();
-        }
-
+        });
     });
-});

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeSidePanel.js
@@ -305,8 +305,7 @@ define([
 
 
                 const retObj = {};
-                for (let i = 0; i < widgets.length; i++) {
-                    const widgetInfo = widgets[i];
+                for (const widgetInfo of widgets) {
                     const $widgetDiv = $('<div>')
                         .addClass('kb-side-separator');
 

--- a/test/integration/specs/kbaseNarrativeDataPanel_test.js
+++ b/test/integration/specs/kbaseNarrativeDataPanel_test.js
@@ -197,11 +197,12 @@ describe('Tabbing within the data panel should work', () => {
         const tabs = await slideoutPanel.$$(`[role="tablist"] > [role="tab"]`);
 
         for (const [index, tab] of tabs.entries()) {
-            const testId = await tab.getAttribute('data-test-id');
-            const testLabel = await tab.getText();
-            const {name,  label} = testCase.tabs[index];
-            expect(testId).toEqual(`tab-${name}`);
-            expect(testLabel).toEqual(label);
+            const { name, label } = testCase.tabs[index];
+            await browser.waitUntil(async () => {
+                const testId = await tab.getAttribute('data-test-id');
+                const testLabel = await tab.getText();
+                return testId === `tab-${name}` && testLabel === label;
+            });
         }
     });
 

--- a/test/integration/specs/kbaseNarrativeSidePanel_test.js
+++ b/test/integration/specs/kbaseNarrativeSidePanel_test.js
@@ -119,12 +119,11 @@ async function slideoutPanelToBe(slideout, state) {
                 return !isDisplayed;
             });
         }
-        return;
+    } else {
+        const slideoutContainer = await slideoutToBe('open');
+        const slideoutPanel = await slideoutContainer.$(`[data-test-id="${slideout}-slideout-panel"]`);
+        await slideoutPanel.waitForDisplayed();
     }
-
-    const slideoutContainer = await slideoutToBe('open');
-    const slideoutPanel = await slideoutContainer.$(`[data-test-id="${slideout}-slideout-panel"]`);
-    await slideoutPanel.waitForDisplayed();
 }
 
 describe('Tabbing within the data panel should work', () => {

--- a/test/integration/specs/kbaseNarrativeSidePanel_test.js
+++ b/test/integration/specs/kbaseNarrativeSidePanel_test.js
@@ -1,0 +1,263 @@
+/*global  browser, $ */
+/* eslint {strict: ['error', 'global']} */
+'use strict';
+
+const { login, openNarrative, clickWhenReady } = require('../wdioUtils.js');
+
+// Ideally the test data should be the same, except for narrative id, in each env.
+// But currently CI and prod are indexed differently.
+
+// Note that the narrativeIds used below must be owned or shared with full rights (at least edit) with the narrativetest user.
+// Note that narrativetest is not yet set up in narrative-dev/prod.
+const allTestCases = {
+    common: {
+
+    },
+    envs: {
+        ci: {
+            TEST_CASE_1: {
+                narrativeId: 53983
+            },
+        },
+        'narrative-dev': {
+            TEST_CASE_1: {
+                narrativeId: 78050,
+            }
+        }
+    }
+};
+
+function getTestCase(name) {
+    const envCases = allTestCases.envs[browser.config.testParams.ENV];
+    return Object.assign({}, allTestCases.common, envCases[name]);
+}
+
+async function clickSlideoutButton(slideout) {
+    // Open a slideout by clicking it's toggle button
+    const button = await $(`[data-test-id="${slideout}-slideout-button"]`);
+    await button.waitForDisplayed();
+    await clickWhenReady(button);
+}
+
+async function clickAddDataButton() {
+    // Open a slideout by clicking it's toggle button
+    // const body = await $('body');
+    // console.log('*** body ***', body);
+    // const button = await body.selectByVisibleText('Add Data');
+    const button = await $('[data-test-id="add-data-button"]');
+    await button.waitForDisplayed();
+    await clickWhenReady(button);
+}
+
+
+async function clickOverlayDimmer() {
+    const dimmer = await $('.kb-overlay-dimmer');
+    const slideoutPanel = await $('[data-test-id="data-slideout-panel"]');
+
+    // First just fetch all the dimensions 
+    const { x: spx, y: spy } = await slideoutPanel.getLocation();
+    const { width: spw, height: sph } = await slideoutPanel.getSize();
+
+    const { x: dx, y: dy } = await dimmer.getLocation();
+    const { width: dw, height: dh } = await dimmer.getSize();
+
+    // I find that bottom and right are just easier to reason
+    // about when doing comparisons.
+    const spBottom = (spy + sph);
+    const dBottom = (dy + dh);
+    const spRight = (spx + spw);
+    const dRight = (dx + dw);
+
+    // We'll try to click below the side panel or to the right.
+    // Note that the point of reference for "click" is the 
+    // mid point of the element.
+
+    if (dBottom > spBottom) {
+        // Below
+        const clickOptions = {
+            x: 0,                     // midpoint
+            y: Math.round(dh / 2) - 1 // this should be the last pixel (length - 1)
+        };
+        await dimmer.click(clickOptions);
+    } else if (dRight > spRight) {
+        // To the right
+        const clickOptions = {
+            x: Math.round(dw / 2) - 1,  // this should be the last pixel (length - 1)
+            y: 0                        // midpoint
+        }
+        await dimmer.click(clickOptions);
+    } else {
+        throw new Error('No clickable areas');
+    }
+}
+
+async function getSlideoutContainer() {
+    const slideoutContainer = await $('[data-test-id="side-overlay-container"]');
+    await slideoutContainer.waitForExist();
+    return slideoutContainer;
+}
+
+async function slideoutToBe(state) {
+    const slideoutContainer = await $('[data-test-id="side-overlay-container"]');
+    await slideoutContainer.waitForDisplayed({ reverse: state === 'closed' });
+    return slideoutContainer;
+}
+
+async function slideoutPanelToBe(slideout, state) {
+    // Open the data slideout by clicking it's toggle button
+    const direction = state === 'open' ? 'left' : 'right';
+    const button = await $(`[data-test-id="${slideout}-slideout-button"] .fa-arrow-${direction}`);
+    await button.waitForDisplayed();
+
+    if (state === 'closed') {
+        // slideout  could be open or closed; if open, ensure  not displayed.
+        const slideoutContainer = await getSlideoutContainer();
+        if (await slideoutContainer.isDisplayed()) {
+            await browser.waitUntil(async () => {
+                const slideoutPanel = await slideoutContainer.$(`[data-test-id="${slideout}-slideout-panel"]`);
+                const isDisplayed = await slideoutPanel.isDisplayed();
+                return !isDisplayed;
+            });
+        }
+        return;
+    }
+
+    const slideoutContainer = await slideoutToBe('open');
+    const slideoutPanel = await slideoutContainer.$(`[data-test-id="${slideout}-slideout-panel"]`);
+    await slideoutPanel.waitForDisplayed();
+}
+
+describe('Tabbing within the data panel should work', () => {
+    beforeEach(async () => {
+        await browser.setTimeout({ 'implicit': 30000 });
+        await browser.reloadSession();
+    });
+
+    afterEach(async () => {
+        await browser.deleteCookies();
+    });
+
+    it('Opens and closes the data slideout with the data panel button', async () => {
+        const testCase = getTestCase('TEST_CASE_1');
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickSlideoutButton('data');
+        await slideoutToBe('open');
+        await slideoutPanelToBe('data', 'open');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickSlideoutButton('data');
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+    });
+
+    it('Opens and closes the app slideout with the data panel button', async () => {
+        const testCase = getTestCase('TEST_CASE_1');
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickSlideoutButton('app');
+        await slideoutToBe('open');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'open');
+
+        await clickSlideoutButton('app');
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+    });
+
+    it('Opens data panel, then open app panel', async () => {
+        const testCase = getTestCase('TEST_CASE_1');
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickSlideoutButton('data');
+        await slideoutToBe('open');
+        await slideoutPanelToBe('data', 'open');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickSlideoutButton('app');
+        await slideoutToBe('open');
+
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'open');
+    });
+
+    it('Opens app panel, then open data panel', async () => {
+        const testCase = getTestCase('TEST_CASE_1');
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickSlideoutButton('app');
+        await slideoutToBe('open');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'open');
+
+        await clickSlideoutButton('data');
+        await slideoutToBe('open');
+        await slideoutPanelToBe('data', 'open');
+        await slideoutPanelToBe('app', 'closed');
+    });
+
+    // Test cases for open with "Add Data" button
+    it('Opens and closes the data slideout with the "Add Data" button', async () => {
+        const testCase = getTestCase('TEST_CASE_1');
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickAddDataButton();
+        await slideoutToBe('open');
+        await slideoutPanelToBe('data', 'open');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickAddDataButton();
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+    });
+
+    // Open via button, close by clicking outside the slideout.
+    it('Opens and closes the data slideout with the "Add Data" button', async () => {
+        const testCase = getTestCase('TEST_CASE_1');
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickSlideoutButton('data');
+        await slideoutToBe('open');
+        await slideoutPanelToBe('data', 'open');
+        await slideoutPanelToBe('app', 'closed');
+
+        await clickOverlayDimmer();
+        await slideoutToBe('closed');
+        await slideoutPanelToBe('data', 'closed');
+        await slideoutPanelToBe('app', 'closed');
+    });
+
+});

--- a/test/unit/spec/common/html-Spec.js
+++ b/test/unit/spec/common/html-Spec.js
@@ -5,6 +5,138 @@ define([
     'use strict';
 
     describe('html utility library', () => {
+        // camelToKebab
+        it('Converts camelCaseToHyphen', () => {
+            expect(html.camelToKebab('camelCase')).toEqual('camel-case');
+            expect(html.camelToKebab('CamelCase')).toEqual('-camel-case');
+            expect(html.camelToKebab('camel')).toEqual('camel');
+            expect(html.camelToKebab('CASE')).toEqual('-c-a-s-e');
+        });
+
+        // genId
+        it('Generates an id', () => {
+            expect(html.genId()).toMatch(/^kb_html_.*$/);
+        });
+
+        // Looading
+        it('Makes a loading message', () => {
+            let loading = html.loading();
+            expect(loading).toEqual('<span><i class="fa fa-spinner fa-pulse fa-2x fa-fw margin-bottom"></i></span>');
+
+            loading = html.loading('Loading...');
+            expect(loading).toEqual('<span>Loading... &nbsp;&nbsp;<i class="fa fa-spinner fa-pulse fa-2x fa-fw margin-bottom"></i></span>');
+        });
+
+        // makePanel
+        it('Makes a panel', () => {
+            const panelDef = [{
+                title: 'Panel 1',
+                body: 'This is panel 1'
+            }, {
+                title: 'Panel2',
+                body: 'This is panel 2'
+            }];
+            const panelContent = '<div class="panel panel-default"><div class="panel-heading"><span class="panel-title"></span></div><div class="panel-body"></div></div>';
+            const panel = html.makePanel(panelDef);
+            expect(panel).toEqual(panelContent);
+        });
+
+        // makeTabs
+        it('Makes tabs', () => {
+            const arg = {
+                id: '123',
+                alignRight: false,
+                tabs: [{
+                    name: 'tab1',
+                    label: 'Tab One',
+                    content: 'This is tab one'
+                }, {
+                    name: 'tab2',
+                    label: 'Tab Two',
+                    content: 'This is tab two'
+                }, null]
+            };
+            const expected = new RegExp('<div id="123"><ul class="nav nav-tabs" role="tablist"><li role="presentation" class="active" style=""><a href="#kb_html_[^"]+" aria-controls="home" role="tab" data-toggle="tab">Tab One</a></li><li role="presentation" style=""><a href="#kb_html_[^"]+" aria-controls="home" role="tab" data-toggle="tab">Tab Two</a></li></ul><div class="tab-content"><div role="tabpanel" class="tab-pane active" id="kb_html_[^"]+" data-name="tab1">This is tab one</div><div role="tabpanel" class="tab-pane" id="kb_html_[^"]+" data-name="tab2">This is tab two</div></div></div>');
+            const tabs = html.makeTabs(arg);
+            expect(tabs).toMatch(expected);
+        });
+
+        it('Makes tabs right aligned', () => {
+            const arg = {
+                id: '123',
+                alignRight: true,
+                tabs: [{
+                    name: 'tab1',
+                    label: 'Tab One',
+                    content: 'This is tab one'
+                }, {
+                    name: 'tab2',
+                    label: 'Tab Two',
+                    content: 'This is tab two'
+                }]
+            };
+            const expected = new RegExp('<div id="123"><ul class="nav nav-tabs" role="tablist"><li role="presentation" style="float: right"><a href="#kb_html_[^"]+" aria-controls="home" role="tab" data-toggle="tab">Tab Two</a></li><li role="presentation" class="active" style="float: right"><a href="#kb_html[^"]+" aria-controls="home" role="tab" data-toggle="tab">Tab One</a></li></ul><div class="tab-content"><div role="tabpanel" class="tab-pane active" id="kb_html_[^"]+" data-name="tab1">This is tab one</div><div role="tabpanel" class="tab-pane" id="kb_html_[^"]+" data-name="tab2">This is tab two</div></div></div>');
+
+            const tabs = html.makeTabs(arg);
+
+            expect(tabs).toMatch(expected);
+        });
+
+        // merge
+        it('Merges two simple objects', () => {
+            const x = { foo: 'bar' };
+            const y = { bing: 'bong' };
+            const z = html.merge(x, y);
+            expect(z).toEqual({ foo: 'bar', bing: 'bong' });
+        });
+
+        it('Merges two nested objects', () => {
+            const x = { foo: 'bar', 'name': { middle: 'M' } };
+            const y = { bing: 'bong', 'name': { first: 'Mickey', last: 'Mouse' } };
+            const z = html.merge(x, y);
+            expect(z).toEqual({ foo: 'bar', bing: 'bong', name: { first: 'Mickey', middle: 'M', last: 'Mouse' } });
+        });
+
+        // isSimpleObject
+        it('Determine if a value is a simple object', () => {
+            const cases = [{
+                value: 'hi',
+                expected: false
+            }, {
+                value: 42,
+                expected: false
+            }, {
+                value: true,
+                expected: false
+            }, {
+                value: false,
+                expected: false
+            }, {
+                value: 'hi',
+                expected: false
+            }, {
+                value: null,
+                expected: false
+            }, {
+                value: undefined,
+                expected: false
+            }, {
+                value: new Date(),
+                expected: false
+            }, {
+                value: {},
+                expected: true
+            }, {
+                value: { foo: 'bar' },
+                expected: true
+            }]
+            for (const { value, expected } of cases) {
+                expect(html.isSimpleObject(value)).toEqual(expected);
+            }
+        });
+
+        // tag
+
         it('Creates a simple tag', () => {
             const span = html.tag('span');
             expect(span('hi')).toEqual('<span>hi</span>');
@@ -12,7 +144,7 @@ define([
 
         it('Creates a tag with attributes', () => {
             const div = html.tag('div');
-            expect(div({ class: 'foo' }, 'hello')).toEqual('<div class="foo">hello</div>');
+            expect(div({ class: 'foo', bar: 42 }, 'hello')).toEqual('<div class="foo" bar="42">hello</div>');
         });
 
         it('Creates a tag with empty attributes', () => {
@@ -22,17 +154,17 @@ define([
 
         it('Creates a tag with a string as attributes', () => {
             const div = html.tag('div');
-            expect(div('hi', 'hello')).toEqual('<div>hi</div>');
+            expect(div('hi', 'hello')).toEqual('<div>hello</div>');
         });
 
         it('Creates a tag with false as attributes', () => {
             const div = html.tag('div');
-            expect(div(false, 'hello')).toEqual('<div>false</div>');
+            expect(div(false, 'hello')).toEqual('<div>hello</div>');
         });
 
         it('Creates a tag with true as attributes', () => {
             const div = html.tag('div');
-            expect(div(true, 'hello')).toEqual('<div>true</div>');
+            expect(div(true, 'hello')).toEqual('<div>hello</div>');
         });
 
         it('Creates a tag with null as attributes', () => {
@@ -47,12 +179,34 @@ define([
 
         it('Creates a tag with a  number as attributes', () => {
             const div = html.tag('div');
-            expect(div(42, 'hello')).toEqual('<div>42</div>');
+            expect(div(42, 'hello')).toEqual('<div>hello</div>');
+        });
+
+        it('Creates a tag without a closing tag', () => {
+            const z = html.tag('z', { close: false });
+            expect(z()).toEqual('<z>');
         });
 
         it('Creates a tag with attribute with  number value', () => {
-            const div = html.tag('div');
-            expect(div({ foo: 123 }, 'hello')).toEqual('<div foo="123">hello</div>');
+            const x = html.tag('x', { attribs: { foo: 'bar' } });
+            expect(x({ ping: 'pong' }, 'hello')).toEqual('<x foo="bar" ping="pong">hello</x>');
+        });
+
+        it('Creates a tag with attributes, overrides with and without cached tag', () => {
+            const y = html.tag('y', { attribs: { foo: 'bar' } });
+            expect(y()).toEqual('<y foo="bar"></y>');
+
+            const y1 = html.tag('y');
+            expect(y1()).toEqual('<y foo="bar"></y>');
+
+            const y2 = html.tag('y', { attribs: { foo: 'baz' }, ignoreCache: true });
+            expect(y2()).toEqual('<y foo="baz"></y>');
+
+            const y3 = html.tag('y', { ignoreCache: true });
+            expect(y3({ bee: 'buzz' })).toEqual('<y bee="buzz"></y>');
+
+            const y4 = html.tag('y');
+            expect(y4()).toEqual('<y foo="bar"></y>');
         });
 
         it('Creates a tag with attribute with  null value', () => {
@@ -101,12 +255,45 @@ define([
             expect(div(div(div('hi')))).toEqual('<div><div><div>hi</div></div></div>');
         });
 
-        it('Converts camelCaseToHyphen', () => {
-            expect(html.camelToKebab('camelCase')).toEqual('camel-case');
-            expect(html.camelToKebab('CamelCase')).toEqual('-camel-case');
-            expect(html.camelToKebab('camel')).toEqual('camel');
-            expect(html.camelToKebab('CASE')).toEqual('-c-a-s-e');
+        it('Creates a tag with an array content', () => {
+            const div = html.tag('div');
+            expect(div([])).toEqual('<div></div>');
+            expect(div(['hello', 'there'])).toEqual('<div>hellothere</div>');
+            expect(div([123, 456])).toEqual('<div>123456</div>');
         });
 
+        it('Creates a tag with an array tag content', () => {
+            const div = html.tag('div');
+            expect(div([div('hi'), div('hello')])).toEqual('<div><div>hi</div><div>hello</div></div>');
+        });
+
+        it('Creates a tag with non-string content', () => {
+            const div = html.tag('div');
+            const content = [{
+                value: 42,
+                expected: '42'
+            }, {
+                value: 123.456,
+                expected: '123.456'
+            }, {
+                value: true,
+                expected: ''
+            }, {
+                value: false,
+                expected: ''
+            }, {
+                value: null,
+                expected: ''
+            }, {
+                value: undefined,
+                expected: ''
+            }, {
+                value: new Date(),
+                expected: ''
+            }];
+            for (const { value, expected } of content) {
+                expect(div(value)).toEqual(`<div>${expected}</div>`);
+            }
+        });
     });
 });

--- a/test/unit/spec/common/html-Spec.js
+++ b/test/unit/spec/common/html-Spec.js
@@ -229,12 +229,12 @@ define([
             expect(div({ foo: true }, 'hello')).toEqual('<div foo>hello</div>');
         });
 
-        it('Creates a tag with attribute with array value', () => {
+        it('Creates a tag with a class attribute with array value', () => {
             const div = html.tag('div');
-            expect(div({ foo: ['1', '2', '3'] }, 'hello')).toEqual('<div foo="1 2 3">hello</div>');
+            expect(div({ class: ['1', '2', '3'] }, 'hello')).toEqual('<div class="1 2 3">hello</div>');
         });
 
-        it('Creates a tag with attribute with object value', () => {
+        it('Creates a tag with non-style attribute with object value', () => {
             const div = html.tag('div');
             expect(div({ foo: {} }, 'hello')).toEqual('<div>hello</div>');
         });

--- a/test/unit/spec/common/html-Spec.js
+++ b/test/unit/spec/common/html-Spec.js
@@ -4,7 +4,7 @@ define([
 ], (html) => {
     'use strict';
 
-    fdescribe('html utility library', () => {
+    describe('html utility library', () => {
         it('Creates a simple tag', () => {
             const span = html.tag('span');
             expect(span('hi')).toEqual('<span>hi</span>');
@@ -13,6 +13,76 @@ define([
         it('Creates a tag with attributes', () => {
             const div = html.tag('div');
             expect(div({ class: 'foo' }, 'hello')).toEqual('<div class="foo">hello</div>');
+        });
+
+        it('Creates a tag with empty attributes', () => {
+            const div = html.tag('div');
+            expect(div({}, 'hello')).toEqual('<div>hello</div>');
+        });
+
+        it('Creates a tag with a string as attributes', () => {
+            const div = html.tag('div');
+            expect(div('hi', 'hello')).toEqual('<div>hi</div>');
+        });
+
+        it('Creates a tag with false as attributes', () => {
+            const div = html.tag('div');
+            expect(div(false, 'hello')).toEqual('<div>false</div>');
+        });
+
+        it('Creates a tag with true as attributes', () => {
+            const div = html.tag('div');
+            expect(div(true, 'hello')).toEqual('<div>true</div>');
+        });
+
+        it('Creates a tag with null as attributes', () => {
+            const div = html.tag('div');
+            expect(div(null, 'hello')).toEqual('<div>hello</div>');
+        });
+
+        it('Creates a tag with undefined as attributes', () => {
+            const div = html.tag('div');
+            expect(div(undefined, 'hello')).toEqual('<div>hello</div>');
+        });
+
+        it('Creates a tag with a  number as attributes', () => {
+            const div = html.tag('div');
+            expect(div(42, 'hello')).toEqual('<div>42</div>');
+        });
+
+        it('Creates a tag with attribute with  number value', () => {
+            const div = html.tag('div');
+            expect(div({ foo: 123 }, 'hello')).toEqual('<div foo="123">hello</div>');
+        });
+
+        it('Creates a tag with attribute with  null value', () => {
+            const div = html.tag('div');
+            expect(div({ foo: null }, 'hello')).toEqual('<div>hello</div>');
+        });
+
+        it('Creates a tag with attribute with  undefined value', () => {
+            const div = html.tag('div');
+            expect(div({ foo: undefined }, 'hello')).toEqual('<div>hello</div>');
+        });
+
+        it('Creates a tag with attribute with  false value', () => {
+            const div = html.tag('div');
+            expect(div({ foo: false }, 'hello')).toEqual('<div>hello</div>');
+        });
+
+        it('Creates a tag with attribute with  true value', () => {
+            const div = html.tag('div');
+            expect(div({ foo: true }, 'hello')).toEqual('<div foo>hello</div>');
+        });
+
+        it('Creates a tag with attribute with array value', () => {
+            const div = html.tag('div');
+            expect(div({ foo: ['1', '2', '3'] }, 'hello')).toEqual('<div foo="1 2 3">hello</div>');
+        });
+
+        it('Creates a tag with attribute with object value', () => {
+            const div = html.tag('div');
+            expect(div({ foo: {} }, 'hello')).toEqual('<div>hello</div>');
         });
 
         it('Creates a tag with style', () => {

--- a/test/unit/spec/common/html-Spec.js
+++ b/test/unit/spec/common/html-Spec.js
@@ -1,0 +1,42 @@
+/*jslint white:true,browser:true*/
+define([
+    'common/html'
+], (html) => {
+    'use strict';
+
+    fdescribe('html utility library', () => {
+        it('Creates a simple tag', () => {
+            const span = html.tag('span');
+            expect(span('hi')).toEqual('<span>hi</span>');
+        });
+
+        it('Creates a tag with attributes', () => {
+            const div = html.tag('div');
+            expect(div({ class: 'foo' }, 'hello')).toEqual('<div class="foo">hello</div>');
+        });
+
+        it('Creates a tag with style', () => {
+            const div = html.tag('div');
+            expect(div({ style: { color: 'red', fontWeight: 'bold' } }, 'hello')).toEqual('<div style="color: red; font-weight: bold">hello</div>');
+        });
+
+        it('Creates a tag with various style types', () => {
+            const div = html.tag('div');
+            expect(div({ style: { color: 'red', foo: 1, bar: true, baz: false, a: null, b: {}, c: undefined } }, 'hello'))
+                .toEqual('<div style="color: red; foo: 1">hello</div>');
+        });
+
+        it('Creates a nested tag', () => {
+            const div = html.tag('div');
+            expect(div(div(div('hi')))).toEqual('<div><div><div>hi</div></div></div>');
+        });
+
+        it('Converts camelCaseToHyphen', () => {
+            expect(html.camelToKebab('camelCase')).toEqual('camel-case');
+            expect(html.camelToKebab('CamelCase')).toEqual('-camel-case');
+            expect(html.camelToKebab('camel')).toEqual('camel');
+            expect(html.camelToKebab('CASE')).toEqual('-c-a-s-e');
+        });
+
+    });
+});

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -35,7 +35,7 @@ define([
                         ver: '1.0.0',
                         subtitle: 'Run an app',
                         tooltip: 'Run an app',
-                        icon: {url: 'img?method_id=a_module/an_app&image_name=an_app.png&tag=release'},
+                        icon: { url: 'img?method_id=a_module/an_app&image_name=an_app.png&tag=release' },
                         categories: ['active', CATEGORY_A],
                         authors: [FAKE_USER],
                         input_types: [
@@ -58,7 +58,7 @@ define([
                         ver: '1.0.0',
                         subtitle: 'Run an app',
                         tooltip: 'Run an app',
-                        icon: {url: 'img?method_id=another_module/another_app&image_name=an_app.png&tag=release'},
+                        icon: { url: 'img?method_id=another_module/another_app&image_name=an_app.png&tag=release' },
                         categories: ['active', CATEGORY_B],
                         authors: [FAKE_USER],
                         input_types: [
@@ -75,7 +75,7 @@ define([
             }
         };
 
-    describe('Test the kbaseNarrativeAppPanel widget', function() {
+    describe('Test the kbaseNarrativeAppPanel widget', () => {
         beforeEach(() => {
             Jupyter.narrative = {
                 getAuthToken: () => FAKE_TOKEN,
@@ -88,7 +88,7 @@ define([
             // just a dummy mock so we don't see error messages. Don't actually need a kernel.
             Jupyter.notebook = {
                 kernel: {
-                    execute: () => {}
+                    execute: () => { }
                 }
             };
 
@@ -173,19 +173,19 @@ define([
 
         it('Should have a working filter menu', () => {
             // Should have a filter menu.
-            var dropdownSelector = '#kb-app-panel-filter';
+            const dropdownSelector = '#kb-app-panel-filter';
             expect($panel.find(dropdownSelector).length).not.toBe(0);
             // should have category, input types, output types, name a-z, name z-a
-            var filterList = ['category', 'input types', 'output types', 'name a-z', 'name z-a'];
+            const filterList = ['category', 'input types', 'output types', 'name a-z', 'name z-a'];
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li').each((idx, item) => {
                 expect($(item).text().toLowerCase()).toEqual(filterList[idx]);
             });
             // should default to category
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('category');
-            var appListSel = '.kb-function-body > div:last-child > div > div';
+            const appListSel = '.kb-function-body > div:last-child > div > div';
             // spot check category list.
-            var categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
-                var str = elem.innerText.toLowerCase();
+            let categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
+                const str = elem.innerText.toLowerCase();
                 return str.substring(0, str.lastIndexOf(' '));
             });
             // no "my favorites" because we're not logged in
@@ -196,7 +196,7 @@ define([
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(2) a').click();
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('input');
             categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
-                var str = elem.innerText.toLowerCase();
+                const str = elem.innerText.toLowerCase();
                 return str.substring(0, str.lastIndexOf(' '));
             });
             expect(categoryList.indexOf('type1')).not.toBe(-1);
@@ -206,7 +206,7 @@ define([
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(3) a').click();
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('output');
             categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
-                var str = elem.innerText.toLowerCase();
+                const str = elem.innerText.toLowerCase();
                 return str.substring(0, str.lastIndexOf(' '));
             });
             expect(categoryList.indexOf('typeout')).not.toBe(-1);
@@ -217,7 +217,7 @@ define([
             // show alphabetical names of apps
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(4) a').click();
             expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('a-z');
-            var appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map((item) => {
+            let appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map((item) => {
                 return item.innerText.toLowerCase();
             });
             // sort it, then compare to see if in same order. remember, we don't have favorites that pop to the top.
@@ -235,8 +235,8 @@ define([
         });
 
         it('Should have a working version toggle button', () => {
-            appPanel.$toggleVersionBtn.tooltip = () => {};  // to stop any jquery/bootstrap nonsense that happens in testing.
-            var toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
+            appPanel.$toggleVersionBtn.tooltip = () => { };  // to stop any jquery/bootstrap nonsense that happens in testing.
+            const toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
             expect(toggleBtn.length).toBe(1);
             spyOn(appPanel, 'refreshFromService');
             expect(toggleBtn.text()).toEqual('R');
@@ -252,13 +252,13 @@ define([
         });
 
         it('Should have a working refresh button', () => {
-            var refreshBtn = $panel.find('.btn-toolbar button:nth-child(3)');
+            const refreshBtn = $panel.find('.btn-toolbar button:nth-child(3)');
             spyOn(appPanel, 'refreshFromService');
             refreshBtn.click();
             expect(appPanel.refreshFromService).toHaveBeenCalled();
             expect(appPanel.refreshFromService).toHaveBeenCalledWith('release');
-            var toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
-            appPanel.$toggleVersionBtn.tooltip = () => {};  // to stop any jquery/bootstrap nonsense that happens in testing.
+            const toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
+            appPanel.$toggleVersionBtn.tooltip = () => { };  // to stop any jquery/bootstrap nonsense that happens in testing.
             toggleBtn.click();
             refreshBtn.click();
             expect(appPanel.refreshFromService).toHaveBeenCalledWith('beta');
@@ -301,7 +301,7 @@ define([
             };
             Mocks.mockJsonRpc1Call({
                 url: Config.url('narrative_method_store'),
-                response: {error: 'repository notAModule wasn\'t registered'},
+                response: { error: 'repository notAModule wasn\'t registered' },
                 statusCode: 500
             });
             $(document).trigger('getFunctionSpecs.Narrative', [appRequest, cb]);


### PR DESCRIPTION
# Improves the behavior of the the app and data slideout

This set of changes relates to and is motivated by PTV-1635, which relates to the slideout refusing to close. The issue being fixed is that the button to open the app slideout did not change when the slideout opened, closing the slideout via clicking on the background did not either, and switching between the app and data slideout was visually rough and inconsistent.

The primary means to open the data and app slideout is via the small right-arrow buttons in the data and app side panels. These arrows should switch to a left-pointing arrow when the associated slideout is open. The data slideout button worked correctly, some of the time, and the app slideout button never changed direction. Sometimes the data slideout button would get reversed (due to closing actions which did not affect the button state.)

The opening and closing of the slideouts should be animated. The data slideout animation was working, but the app. panel animation was not smooth, to the point of being unnoticeable, and switching from the app panel to the data panel (e.g. click the data slideout button when the app slideout is open) was also not smooth.

The goal was to make the button state (arrow direction) properly reflect the slideout state. of the associated panel (data or app), and to improve the animation of the slide outs.

The general solution was to ensure the jQuery events were emitted and consumed, whereas originally there was a mix of direct invocation and jQuery events. In addition, the jQuery event triggers were used incorrectly (the message payload should be wrapped in an array) which was confusing and a source of potential. The opening behavior of the  app slideout itself and especially in interaction with the data slideout, was primarily due to the overlapping async tasks within the slideout open and close ... wrapping in promises and awaiting the completion improved this behavior. There is still some roughness to the app slideout, but I think this is primarily due to the work conducted by the rendering of the app panel. That code can be made more efficient, and also utilize lazy loading of app cards, but that work was not attempted within this set of changes.

## JIRA Tickets
- https://kbase-jira.atlassian.net/browse/PTV-1635
- https://kbase-jira.atlassian.net/browse/PUBLIC-1517
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

## Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

## Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

## Updating Version and Release Notes (if applicable)

- [-] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
