### PR TITLE
DATAUP-330: eslint and prettier on tests, plus basic existence tests

### DIFF
--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -7,10 +7,10 @@ module.exports = function (config) {
         client: {
             jasmine: {
                 failFast: false,
-                DEFAULT_TIMEOUT_INTERVAL: 20000
+                DEFAULT_TIMEOUT_INTERVAL: 20000,
             },
             requireJsShowNoTimestampsError: '^(?!.*(^/narrative/))',
-            clearContext: false
+            clearContext: false,
         },
         plugins: [
             'karma-jasmine',
@@ -24,34 +24,53 @@ module.exports = function (config) {
         ],
         preprocessors: {
             'kbase-extension/static/kbase/js/**/!(api)/*.js': ['coverage'],
-            'kbase-extension/static/kbase/js/api/!(*[Cc]lient*|Catalog|KBaseFeatureValues|NarrativeJobServiceWrapper|NewWorkspace)*.js': ['coverage'],
+            'kbase-extension/static/kbase/js/api/!(*[Cc]lient*|Catalog|KBaseFeatureValues|NarrativeJobServiceWrapper|NewWorkspace)*.js': [
+                'coverage',
+            ],
             'kbase-extension/static/kbase/js/api/RestAPIClient.js': ['coverage'],
             'nbextensions/appcell2/widgets/tabs/*.js': ['coverage'],
-            'kbase-extension/static/kbase/js/*.js': ['coverage']
+            'kbase-extension/static/kbase/js/*.js': ['coverage'],
         },
         files: [
             'kbase-extension/static/narrative_paths.js',
-            {pattern: 'test/unit/spec/**/*.js', included: false},
-            {pattern: 'node_modules/jasmine-ajax/lib/mock-ajax.js', included: true},
-            {pattern: 'kbase-extension/static/ext_components/kbase-ui-plugin-catalog/src/plugin/modules/data/categories.yml', included: false, served: true},
-            {pattern: 'kbase-extension/static/**/*.css', included: false, served: true},
-            {pattern: 'kbase-extension/static/kbase/templates/**/*.html', included: false, served: true},
-            {pattern: 'kbase-extension/static/kbase/config/**/*.json', included: false, served: true},
-            {pattern: 'kbase-extension/static/kbase/config/**/*.yaml', included: false, served: true},
-            {pattern: 'kbase-extension/static/**/*.js', included: false, served: true},
-            {pattern: 'kbase-extension/static/**/*.gif', included: false, served: true},
-            {pattern: 'nbextensions/appcell2/widgets/tabs/*.js', included: false},
-            {pattern: 'test/testConfig.json', included: false, served: true, nocache: true},
-            {pattern: 'test/*.tok', included: false, served: true, nocache: true},
-            {pattern: 'test/data/**/*', included: false, served: true},
+            { pattern: 'test/unit/spec/**/*.js', included: false },
+            { pattern: 'node_modules/jasmine-ajax/lib/mock-ajax.js', included: true },
+            {
+                pattern:
+                    'kbase-extension/static/ext_components/kbase-ui-plugin-catalog/src/plugin/modules/data/categories.yml',
+                included: false,
+                served: true,
+            },
+            { pattern: 'kbase-extension/static/**/*.css', included: false, served: true },
+            {
+                pattern: 'kbase-extension/static/kbase/templates/**/*.html',
+                included: false,
+                served: true,
+            },
+            {
+                pattern: 'kbase-extension/static/kbase/config/**/*.json',
+                included: false,
+                served: true,
+            },
+            {
+                pattern: 'kbase-extension/static/kbase/config/**/*.yaml',
+                included: false,
+                served: true,
+            },
+            { pattern: 'kbase-extension/static/**/*.js', included: false, served: true },
+            { pattern: 'kbase-extension/static/**/*.gif', included: false, served: true },
+            { pattern: 'nbextensions/appcell2/widgets/tabs/*.js', included: false },
+            { pattern: 'test/testConfig.json', included: false, served: true, nocache: true },
+            { pattern: 'test/*.tok', included: false, served: true, nocache: true },
+            { pattern: 'test/data/**/*', included: false, served: true },
             'test/unit/testUtil.js',
             'test/unit/mocks.js',
-            'test/unit/test-main.js'
+            'test/unit/test-main.js',
         ],
         exclude: [
             'kbase-extension/static/buildTools/*.js',
             'kbase-extension/static/ext_components/**/test/**/*.js',
-            'kbase-extension/static/kbase/js/patched-components/**/*'
+            'kbase-extension/static/kbase/js/patched-components/**/*',
         ],
         // test results reporter to use
         // possible values: 'dots', 'progress'
@@ -60,14 +79,17 @@ module.exports = function (config) {
         coverageReporter: {
             type: 'html',
             dir: 'js-coverage/',
-            reporters: [{
-                type: 'html',
-                subdir: 'html'
-            }, {
-                type: 'lcov',
-                subdir: 'lcov'
-            }],
-            includeAllSources: true
+            reporters: [
+                {
+                    type: 'html',
+                    subdir: 'html',
+                },
+                {
+                    type: 'lcov',
+                    subdir: 'lcov',
+                },
+            ],
+            includeAllSources: true,
         },
         mochaReporter: {
             ignoreSkipped: true,
@@ -98,9 +120,8 @@ module.exports = function (config) {
             '/narrative/static/services': 'http://localhost:32323/narrative/static/services',
             '/narrative/static/bidi': 'http://localhost:32323/narrative/static/bidi',
             '/static/kbase/config': '/base/kbase-extension/static/kbase/config',
-            '/test/': '/base/test/'
+            '/test/': '/base/test/',
         },
-        concurrency: Infinity
-
+        concurrency: Infinity,
     });
 };

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -10,15 +10,7 @@
  * })
  */
 
-define('narrativeMocks', [
-    'jquery',
-    'uuid',
-    'narrativeConfig'
-], (
-    $,
-    UUID,
-    Config
-) => {
+define('narrativeMocks', ['jquery', 'uuid', 'narrativeConfig'], ($, UUID, Config) => {
     'use strict';
     /**
      * Creates a mock Jupyter notebook cell of some type.
@@ -33,21 +25,18 @@ define('narrativeMocks', [
         $toolbar.append($icon);
         const metadata = kbaseCellType ? buildMockExtensionCellMetadata(kbaseCellType, data) : {};
         const mockCell = {
-            metadata: {kbase: metadata},
+            metadata: { kbase: metadata },
             cell_type: cellType,
             renderMinMax: () => {},
             element: $cellContainer,
             input: $('<div>').addClass('input').append('<div>').addClass('input_area'),
             output: $('<div>').addClass('output_wrapper').append('<div>').addClass('output'),
             celltoolbar: {
-                rebuild: () => {}
-            }
+                rebuild: () => {},
+            },
         };
 
-        $cellContainer
-            .append($toolbar)
-            .append(mockCell.input)
-            .append(mockCell.output);
+        $cellContainer.append($toolbar).append(mockCell.input).append(mockCell.output);
         $('body').append($cellContainer);
         return mockCell;
     }
@@ -72,19 +61,19 @@ define('narrativeMocks', [
             attributes: {
                 id: new UUID(4).format(),
                 status: 'new',
-                created: (new Date()).toUTCString(),
+                created: new Date().toUTCString(),
                 title: '',
-                subtitle: ''
+                subtitle: '',
             },
-            data: data
+            data: data,
         };
-        switch(kbaseCellType) {
+        switch (kbaseCellType) {
             case 'app-bulk-import':
                 meta.bulkImportCell = {
                     'user-settings': {
-                        showCodeInputArea: false
+                        showCodeInputArea: false,
                     },
-                    inputs: {}
+                    inputs: {},
                 };
                 meta.attributes.title = 'Import from Staging Area';
                 meta.attributes.subtitle = 'Import files into your Narrative as data objects';
@@ -92,21 +81,21 @@ define('narrativeMocks', [
             case 'app':
                 meta.appCell = {
                     'user-settings': {
-                        showCodeInputArea: false
+                        showCodeInputArea: false,
                     },
                 };
                 break;
             case 'code':
                 meta.codeCell = {
                     'user-settings': {
-                        showCodeInputArea: false
+                        showCodeInputArea: false,
                     },
                 };
                 break;
             case 'codeWithUserSettings':
                 meta.codeCell = {
-                    'userSettings': {
-                        showCodeInputArea: true
+                    userSettings: {
+                        showCodeInputArea: true,
                     },
                 };
                 break;
@@ -133,7 +122,7 @@ define('narrativeMocks', [
         const cells = options.cells || [];
 
         function insertCell(type, index, data) {
-            let cell = buildMockCell(type, '', data);
+            const cell = buildMockCell(type, '', data);
             if (index <= 0) {
                 index = 0;
             }
@@ -141,8 +130,8 @@ define('narrativeMocks', [
             return cell;
         }
 
-        let mockNotebook = {
-            delete_cell: () => options.deleteCallback ? options.deleteCallback() : null,
+        const mockNotebook = {
+            delete_cell: () => (options.deleteCallback ? options.deleteCallback() : null),
             find_cell_index: () => 1,
             get_cells: () => cells,
             get_cell: (index) => {
@@ -151,8 +140,7 @@ define('narrativeMocks', [
                 }
                 if (index <= 0) {
                     return cells[0];
-                }
-                else if (index >= cells.length) {
+                } else if (index >= cells.length) {
                     return null;
                 }
                 return cells[index];
@@ -160,8 +148,8 @@ define('narrativeMocks', [
             _fully_loaded: options.fullyLoaded,
             cells: cells,
             writable: !options.readOnly,
-            insert_cell_above: (type, index, data) => insertCell(type, index-1, data),
-            insert_cell_below: (type, index, data) => insertCell(type, index+1, data),
+            insert_cell_above: (type, index, data) => insertCell(type, index - 1, data),
+            insert_cell_below: (type, index, data) => insertCell(type, index + 1, data),
         };
 
         return mockNotebook;
@@ -187,7 +175,7 @@ define('narrativeMocks', [
             hash: 'another_fake_hash',
             health: 'healthy',
             module_name: args.module,
-            url: args.url
+            url: args.url,
         };
 
         mockJsonRpc1Call({
@@ -195,7 +183,7 @@ define('narrativeMocks', [
             body: new RegExp(args.module),
             statusCode: args.statusCode || 200,
             statusText: args.statusText || 'HTTP/1.1 200 OK',
-            response: wizardResponse
+            response: wizardResponse,
         });
     }
 
@@ -226,16 +214,15 @@ define('narrativeMocks', [
         const jsonRpcResponse = {
             version: '1.1',
             id: '12345',
-            result: [args.response]
+            result: [args.response],
         };
         const serviceResponse = {
             status: args.statusCode || 200,
             statusText: args.statusText || 'HTTP/1.1 200 OK',
             contentType: 'application/json',
-            responseText: JSON.stringify(jsonRpcResponse)
+            responseText: JSON.stringify(jsonRpcResponse),
         };
-        jasmine.Ajax.stubRequest(args.url, requestBody)
-            .andReturn(serviceResponse);
+        jasmine.Ajax.stubRequest(args.url, requestBody).andReturn(serviceResponse);
     }
 
     /**
@@ -247,13 +234,12 @@ define('narrativeMocks', [
      * @param {int} status the status code to return
      */
     function mockAuthRequest(request, responseObj, status) {
-        let reqUrl = `${Config.url('auth')}/api/V2/${request}`;
-        jasmine.Ajax.stubRequest(reqUrl)
-            .andReturn({
-                status: status,
-                contentType: 'application/json',
-                responseText: JSON.stringify(responseObj)
-            });
+        const reqUrl = `${Config.url('auth')}/api/V2/${request}`;
+        jasmine.Ajax.stubRequest(reqUrl).andReturn({
+            status: status,
+            contentType: 'application/json',
+            responseText: JSON.stringify(responseObj),
+        });
     }
 
     const cookieKeys = ['kbase_session'];
@@ -270,7 +256,6 @@ define('narrativeMocks', [
         });
     }
 
-
     return {
         buildMockCell: buildMockCell,
         buildMockNotebook: buildMockNotebook,
@@ -278,7 +263,6 @@ define('narrativeMocks', [
         mockJsonRpc1Call: mockJsonRpc1Call,
         mockAuthRequest: mockAuthRequest,
         setAuthToken: setAuthToken,
-        clearAuthToken: clearAuthToken
+        clearAuthToken: clearAuthToken,
     };
-
 });

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -1,4 +1,3 @@
-/* global jasmine */
 /**
  * This module contains several mock objects that can be reused throughout unit tests.
  * General usage is as per other AMD modules, e.g.:

--- a/test/unit/spec/Util/BootstrapDialogSpec.js
+++ b/test/unit/spec/Util/BootstrapDialogSpec.js
@@ -4,42 +4,40 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
-    'jquery',
-    'util/bootstrapDialog'
-], function(
-    $,
-    Dialog
-) {
+define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
     'use strict';
-    var $simpleBody = $('<div>').append('This is a body text'),
+    let $simpleBody = $('<div>').append('This is a body text'),
         simpleTitle = 'Title',
         simpleButtons = [
-            $('<button>').append('b1').click(function() { }),
-            $('<button>').append('b2').click(function() { })
+            $('<button>')
+                .append('b1')
+                .click(() => {}),
+            $('<button>')
+                .append('b2')
+                .click(() => {}),
         ],
         simpleDialog;
 
-    beforeEach(function() {
+    beforeEach(() => {
         simpleDialog = new Dialog({
             title: simpleTitle,
             body: $simpleBody,
-            buttons: simpleButtons
+            buttons: simpleButtons,
         });
         // simpleDialog.getElement().appendTo('body');
     });
 
-    describe('Test the BootstrapDialog module', function() {
-        it('Should create a new dialog object', function() {
+    describe('Test the BootstrapDialog module', () => {
+        it('Should create a new dialog object', () => {
             expect(simpleDialog).toEqual(jasmine.any(Object));
         });
 
-        it('Should show on command', function() {
+        it('Should show on command', () => {
             simpleDialog.show();
             expect($($.find('.fade.in')).is(':visible')).toBeTruthy();
         });
 
-        it('Should hide on command', function() {
+        it('Should hide on command', () => {
             simpleDialog.show();
             simpleDialog.hide();
             simpleDialog.$modal.on('hidden.bs.modal', () => {
@@ -47,54 +45,54 @@ define ([
             });
         });
 
-        it('Should get a title string back', function() {
-            var title = simpleDialog.getTitle();
+        it('Should get a title string back', () => {
+            const title = simpleDialog.getTitle();
             expect(title).toBe(simpleTitle);
         });
 
-        it('Should get the body div back', function() {
-            var body = simpleDialog.getBody();
+        it('Should get the body div back', () => {
+            const body = simpleDialog.getBody();
             expect(body.html()).toBe($simpleBody.html());
         });
 
-        it('Should give the buttons back', function() {
-            var buttons = simpleDialog.getButtons();
+        it('Should give the buttons back', () => {
+            const buttons = simpleDialog.getButtons();
             expect(buttons.length).toBe(2);
             expect(buttons[0].innerHTML).toBe('b1');
             expect(buttons[1].innerHTML).toBe('b2');
         });
 
-        it('Should get the whole modal object back', function() {
-            var $modal = simpleDialog.getElement();
+        it('Should get the whole modal object back', () => {
+            const $modal = simpleDialog.getElement();
             expect($modal[0].tagName).toBe('DIV');
         });
 
-        it('Should write over the title', function() {
-            var newTitle = 'A new title!';
+        it('Should write over the title', () => {
+            const newTitle = 'A new title!';
             simpleDialog.setTitle(newTitle);
             expect(simpleDialog.getTitle()).toBe(newTitle);
         });
 
-        it('Should create a new body', function() {
-            var $newBody = $('<div>').append('The new body');
+        it('Should create a new body', () => {
+            const $newBody = $('<div>').append('The new body');
             simpleDialog.setBody($newBody);
             expect(simpleDialog.getBody().html()).toBe($newBody.html());
         });
 
-        it('Should trigger a command on enter key', function() {
-            var wasTriggered = false;
-            var btnFn = function() {
+        it('Should trigger a command on enter key', () => {
+            let wasTriggered = false;
+            const btnFn = function () {
                 wasTriggered = true;
             };
-            var dialog = new Dialog({
+            const dialog = new Dialog({
                 title: 'test',
                 body: $('<div>'),
                 buttons: [$('<button>').append('foo').click(btnFn)],
-                enterToTrigger: true
+                enterToTrigger: true,
             });
             dialog.show();
             expect(wasTriggered).toBe(false);
-            var e = $.Event('keypress');
+            const e = $.Event('keypress');
             e.which = 13;
             e.keyCode = 13;
             dialog.getElement().trigger(e);
@@ -103,31 +101,30 @@ define ([
             dialog.destroy();
         });
 
-        it('Should create a simple alert', function() {
-            var alert = new Dialog({
+        it('Should create a simple alert', () => {
+            const alert = new Dialog({
                 title: 'Alert',
                 body: $('<div>').append('an alert'),
-                alertOnly: true
+                alertOnly: true,
             });
 
-            var btns = alert.getButtons();
+            const btns = alert.getButtons();
             expect(btns.length).toBe(1);
             expect(btns[0].innerHTML).toBe('Close');
         });
 
-        it('Should set the title based on type', function() {
-            var d = new Dialog({
+        it('Should set the title based on type', () => {
+            const d = new Dialog({
                 title: 'Foo',
-                type: 'warning'
+                type: 'warning',
             });
             expect(d.$headerTitle.hasClass('text-warning')).toBe(true);
         });
 
-        it('Should destroy the modal on command', function() {
-            var ret = simpleDialog.destroy();
+        it('Should destroy the modal on command', () => {
+            const ret = simpleDialog.destroy();
             expect(ret).toBe(null);
             expect(simpleDialog.getElement()).toBe(null);
         });
-
     });
 });

--- a/test/unit/spec/Util/BootstrapDialogSpec.js
+++ b/test/unit/spec/Util/BootstrapDialogSpec.js
@@ -1,12 +1,6 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
     'use strict';
-    let $simpleBody = $('<div>').append('This is a body text'),
+    const $simpleBody = $('<div>').append('This is a body text'),
         simpleTitle = 'Title',
         simpleButtons = [
             $('<button>')
@@ -15,8 +9,8 @@ define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
             $('<button>')
                 .append('b2')
                 .click(() => {}),
-        ],
-        simpleDialog;
+        ];
+    let simpleDialog;
 
     beforeEach(() => {
         simpleDialog = new Dialog({

--- a/test/unit/spec/Util/BootstrapSearchSpec.js
+++ b/test/unit/spec/Util/BootstrapSearchSpec.js
@@ -1,20 +1,12 @@
-define ([
-    'jquery',
-    'util/bootstrapSearch',
-    'base/js/namespace'
-], function(
-    $,
-    BootstrapSearch,
-    Jupyter
-) {
+define(['jquery', 'util/bootstrapSearch', 'base/js/namespace'], ($, BootstrapSearch, Jupyter) => {
     'use strict';
-    var $targetElem;
+    let $targetElem;
 
     describe('Test the BootstrapSearch module', () => {
         beforeEach(() => {
             $targetElem = $('<div>');
             Jupyter.narrative = {
-                disableKeyboardManager: () => {}
+                disableKeyboardManager: () => {},
             };
         });
 
@@ -31,7 +23,7 @@ define ([
             const bsSearch = new BootstrapSearch($targetElem, {
                 inputFunction: () => {
                     done();
-                }
+                },
             });
             bsSearch.val('stuff');
         });
@@ -42,7 +34,7 @@ define ([
 
             const bsSearch = new BootstrapSearch($targetElem, {
                 emptyIcon: emptyFa,
-                filledIcon: filledFa
+                filledIcon: filledFa,
             });
             const addon = $targetElem.find('span.input-group-addon > span');
             expect(addon.hasClass(emptyFa)).toBe(true);
@@ -60,7 +52,7 @@ define ([
 
             const bsSearch = new BootstrapSearch($targetElem, {
                 emptyIcon: empty,
-                filledIcon: filled
+                filledIcon: filled,
             });
             const addon = $targetElem.find('span.input-group-addon > span');
             expect(addon.hasClass(emptyFa)).toBe(true);
@@ -82,7 +74,7 @@ define ([
                 addonFunction: () => {
                     expect(bsSearch.val()).toEqual('stuff');
                     done();
-                }
+                },
             });
             bsSearch.val('stuff');
             $targetElem.find('span.input-group-addon').click();
@@ -106,7 +98,7 @@ define ([
         it('Should set placeholder text', () => {
             const placeholder = 'some text';
             const bsSearch = new BootstrapSearch($targetElem, {
-                placeholder: placeholder
+                placeholder: placeholder,
             });
             expect($targetElem.find('input.form-control').attr('placeholder')).toEqual(placeholder);
         });
@@ -116,7 +108,7 @@ define ([
             const bsSearch = new BootstrapSearch($targetElem, {
                 escFunction: () => {
                     done();
-                }
+                },
             });
             const e = $.Event('keyup');
             e.which = 27;

--- a/test/unit/spec/Util/DisplaySpec.js
+++ b/test/unit/spec/Util/DisplaySpec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['jquery', 'util/display', 'narrativeConfig', 'util/string'], (
     $,
     DisplayUtil,
@@ -28,8 +22,8 @@ define(['jquery', 'util/display', 'narrativeConfig', 'util/string'], (
 
         it('displayRealName should display a real name with link to user page', (done) => {
             const userId = 'testuser',
-                fullName = 'Test User';
-            const response = {};
+                fullName = 'Test User',
+                response = {};
             response[userId] = fullName;
             jasmine.Ajax.stubRequest(/.*\/auth\/api\/V2\/users\/\?list=testuser/).andReturn({
                 status: 200,
@@ -50,8 +44,8 @@ define(['jquery', 'util/display', 'narrativeConfig', 'util/string'], (
 
         it('displayRealName should display whatever text name it gets back', (done) => {
             const userId = 'haxxor',
-                fullName = '<script>alert("I am so clever")</script>';
-            const response = {};
+                fullName = '<script>alert("I am so clever")</script>',
+                response = {};
             response[userId] = fullName;
 
             jasmine.Ajax.stubRequest(/.*\/auth\/api\/V2\/users\/\?list=haxxor/).andReturn({
@@ -114,8 +108,8 @@ define(['jquery', 'util/display', 'narrativeConfig', 'util/string'], (
 
         it('displayRealName should deal with hackery usernames', (done) => {
             const userId = "<script>alert('Bad actor')</script>",
-                fullName = 'Really Bad Actor';
-            const response = {};
+                fullName = 'Really Bad Actor',
+                response = {};
             response[StringUtil.escape(userId)] = fullName;
             jasmine.Ajax.stubRequest(/.*\/auth\/api\/V2\/users\/\?list/).andReturn({
                 status: 200,

--- a/test/unit/spec/Util/DisplaySpec.js
+++ b/test/unit/spec/Util/DisplaySpec.js
@@ -4,20 +4,15 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
-    'jquery',
-    'util/display',
-    'narrativeConfig',
-    'util/string'
-], function(
+define(['jquery', 'util/display', 'narrativeConfig', 'util/string'], (
     $,
     DisplayUtil,
     Config,
     StringUtil
-) {
+) => {
     'use strict';
 
-    describe('KBase Display Utility function module', function() {
+    describe('KBase Display Utility function module', () => {
         let $nameTarget;
         const profilePageUrl = Config.url('profile_page');
 
@@ -33,29 +28,30 @@ define ([
 
         it('displayRealName should display a real name with link to user page', (done) => {
             const userId = 'testuser',
-                  fullName = 'Test User';
-            let response = {};
+                fullName = 'Test User';
+            const response = {};
             response[userId] = fullName;
             jasmine.Ajax.stubRequest(/.*\/auth\/api\/V2\/users\/\?list=testuser/).andReturn({
                 status: 200,
                 statusText: 'success',
                 contentType: 'text/plain',
                 responseHeaders: '',
-                responseText: JSON.stringify(response)
+                responseText: JSON.stringify(response),
             });
-            DisplayUtil.displayRealName(userId, $nameTarget)
-                .then(() => {
-                    expect($nameTarget.html()).toContain(userId);
-                    expect($nameTarget.html()).toContain(fullName);
-                    expect($nameTarget.html()).toContain('(<a href="' + profilePageUrl + userId + '" target="_blank">' + userId + '</a>)');
-                    done();
-                });
+            DisplayUtil.displayRealName(userId, $nameTarget).then(() => {
+                expect($nameTarget.html()).toContain(userId);
+                expect($nameTarget.html()).toContain(fullName);
+                expect($nameTarget.html()).toContain(
+                    '(<a href="' + profilePageUrl + userId + '" target="_blank">' + userId + '</a>)'
+                );
+                done();
+            });
         });
 
         it('displayRealName should display whatever text name it gets back', (done) => {
             const userId = 'haxxor',
-                  fullName = '<script>alert("I am so clever")</script>';
-            let response = {};
+                fullName = '<script>alert("I am so clever")</script>';
+            const response = {};
             response[userId] = fullName;
 
             jasmine.Ajax.stubRequest(/.*\/auth\/api\/V2\/users\/\?list=haxxor/).andReturn({
@@ -63,15 +59,21 @@ define ([
                 statusText: 'success',
                 contentType: 'text/plain',
                 responseHeaders: '',
-                responseText: JSON.stringify(response)
+                responseText: JSON.stringify(response),
             });
-            DisplayUtil.displayRealName(userId, $nameTarget)
-                .then(() => {
-                    expect($nameTarget.html()).toContain(userId);
-                    expect($nameTarget.html()).toContain($('<div>').text(fullName).html());
-                    expect($nameTarget.html()).toContain(' (<a href="' + profilePageUrl + userId + '" target="_blank">' + userId + '</a>)');
-                    done();
-                });
+            DisplayUtil.displayRealName(userId, $nameTarget).then(() => {
+                expect($nameTarget.html()).toContain(userId);
+                expect($nameTarget.html()).toContain($('<div>').text(fullName).html());
+                expect($nameTarget.html()).toContain(
+                    ' (<a href="' +
+                        profilePageUrl +
+                        userId +
+                        '" target="_blank">' +
+                        userId +
+                        '</a>)'
+                );
+                done();
+            });
         });
 
         it('displayRealName should skip displaying full name when not available', (done) => {
@@ -82,13 +84,14 @@ define ([
                 statusText: 'success',
                 contentType: 'text/plain',
                 responseHeaders: '',
-                responseText: JSON.stringify({})
+                responseText: JSON.stringify({}),
             });
-            DisplayUtil.displayRealName(userId, $nameTarget)
-                .then(() => {
-                    expect($nameTarget.html()).toEqual('<a href="' + profilePageUrl + userId + '" target="_blank">' + userId + '</a>');
-                    done();
-                });
+            DisplayUtil.displayRealName(userId, $nameTarget).then(() => {
+                expect($nameTarget.html()).toEqual(
+                    '<a href="' + profilePageUrl + userId + '" target="_blank">' + userId + '</a>'
+                );
+                done();
+            });
         });
 
         it('displayRealName should display just the username if the auth call fails', (done) => {
@@ -99,49 +102,56 @@ define ([
                 statusText: 'fail',
                 contentType: 'text/plain',
                 responseHeaders: '',
-                responseText: JSON.stringify({})
+                responseText: JSON.stringify({}),
             });
-            DisplayUtil.displayRealName(userId, $nameTarget)
-                .finally(() => {
-                    expect($nameTarget.html()).toEqual('<a href="' + profilePageUrl + userId + '" target="_blank">' + userId + '</a>');
-                    done();
-                });
+            DisplayUtil.displayRealName(userId, $nameTarget).finally(() => {
+                expect($nameTarget.html()).toEqual(
+                    '<a href="' + profilePageUrl + userId + '" target="_blank">' + userId + '</a>'
+                );
+                done();
+            });
         });
 
         it('displayRealName should deal with hackery usernames', (done) => {
             const userId = "<script>alert('Bad actor')</script>",
-                  fullName = 'Really Bad Actor';
-            let response = {};
+                fullName = 'Really Bad Actor';
+            const response = {};
             response[StringUtil.escape(userId)] = fullName;
             jasmine.Ajax.stubRequest(/.*\/auth\/api\/V2\/users\/\?list/).andReturn({
                 status: 200,
                 statusText: 'success',
                 contentType: 'text/plain',
                 responseHeaders: '',
-                responseText: JSON.stringify(response)
+                responseText: JSON.stringify(response),
             });
-            DisplayUtil.displayRealName(userId, $nameTarget)
-                .finally(() => {
-                    const properId = $('<div>').text(userId).html();
-                    expect($nameTarget[0].innerHTML).toContain(fullName);
-                    expect($nameTarget[0].innerHTML).toContain(properId);
-                    expect($nameTarget[0].innerHTML).toContain(' (<a href="' + profilePageUrl + userId + '" target="_blank">' + properId + '</a>)');
-                    done();
-                });
+            DisplayUtil.displayRealName(userId, $nameTarget).finally(() => {
+                const properId = $('<div>').text(userId).html();
+                expect($nameTarget[0].innerHTML).toContain(fullName);
+                expect($nameTarget[0].innerHTML).toContain(properId);
+                expect($nameTarget[0].innerHTML).toContain(
+                    ' (<a href="' +
+                        profilePageUrl +
+                        userId +
+                        '" target="_blank">' +
+                        properId +
+                        '</a>)'
+                );
+                done();
+            });
         });
 
-        it('getAppIcon() should create a default icons for methods and apps', function() {
+        it('getAppIcon() should create a default icons for methods and apps', () => {
             let $icon = DisplayUtil.getAppIcon({});
             expect($icon.html()).toContain('method-icon');
             expect($icon.html()).not.toContain('app-icon');
 
-            $icon = DisplayUtil.getAppIcon({isApp:true});
+            $icon = DisplayUtil.getAppIcon({ isApp: true });
             expect($icon.html()).toContain('app-icon');
             expect($icon.html()).not.toContain('method-icon');
         });
 
-        it('getAppIcon() should create a default icons with urls', function() {
-            const $icon = DisplayUtil.getAppIcon({url:'https://kbase.us/someimg.png'});
+        it('getAppIcon() should create a default icons with urls', () => {
+            const $icon = DisplayUtil.getAppIcon({ url: 'https://kbase.us/someimg.png' });
             // right now icon is directly an image, but might not always be the case, so
             // test that we can find the url
             expect($('<div>').append($icon).html()).toContain('https://kbase.us/someimg.png');
@@ -150,18 +160,20 @@ define ([
             expect($('<div>').append($icon).html()).not.toContain('app-icon');
         });
 
-        it('getAppIcon() should use the cursor option', function() {
-            let $icon = DisplayUtil.getAppIcon({url:'https://kbase.us/someimg.png', cursor:'pointer'});
+        it('getAppIcon() should use the cursor option', () => {
+            let $icon = DisplayUtil.getAppIcon({
+                url: 'https://kbase.us/someimg.png',
+                cursor: 'pointer',
+            });
             expect($('<div>').append($icon).html()).toContain('https://kbase.us/someimg.png');
             expect($('<div>').append($icon).html()).toContain('pointer');
             expect($('<div>').append($icon).html()).not.toContain('method-icon');
             expect($('<div>').append($icon).html()).not.toContain('app-icon');
 
-            $icon = DisplayUtil.getAppIcon({cursor:'pointer'});
+            $icon = DisplayUtil.getAppIcon({ cursor: 'pointer' });
             expect($('<div>').append($icon).html()).toContain('pointer');
             expect($('<div>').append($icon).html()).toContain('method-icon');
             expect($('<div>').append($icon).html()).not.toContain('app-icon');
         });
-
     });
 });

--- a/test/unit/spec/Util/StringSpec.js
+++ b/test/unit/spec/Util/StringSpec.js
@@ -4,52 +4,48 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
-    'util/string'
-], function(
-    StringUtil
-) {
+define(['util/string'], (StringUtil) => {
     'use strict';
 
-    describe('KBase String Utility function module', function() {
-        it('uuid() should create a uuid', function() {
-            var uuid = StringUtil.uuid();
+    describe('KBase String Utility function module', () => {
+        it('uuid() should create a uuid', () => {
+            const uuid = StringUtil.uuid();
             expect(uuid.length).toBe(36);
         });
 
-        it('uuid() should create a unique uuid', function() {
-            var uuid1 = StringUtil.uuid();
-            var uuid2 = StringUtil.uuid();
+        it('uuid() should create a unique uuid', () => {
+            const uuid1 = StringUtil.uuid();
+            const uuid2 = StringUtil.uuid();
             expect(uuid1).not.toBe(uuid2);
         });
 
-        it('safeJSONStringify should stringify a normal object', function() {
-            var plainObj = {
+        it('safeJSONStringify should stringify a normal object', () => {
+            const plainObj = {
                 a: 1,
-                b: 'a string'
+                b: 'a string',
             };
 
-            var jsonified = StringUtil.safeJSONStringify(plainObj);
+            const jsonified = StringUtil.safeJSONStringify(plainObj);
             // by the JSON spec, we can't count on the order -
             // so look for keys individually
             expect(jsonified).toContain('"a":1');
             expect(jsonified).toContain('"b":"a string"');
         });
 
-        it('safeJSONStringify should HTML-escape quotes', function() {
-            var quoteObj = {
+        it('safeJSONStringify should HTML-escape quotes', () => {
+            const quoteObj = {
                 a: 1,
                 b: 'a "string"',
-                c: "another 'string'"
+                c: "another 'string'",
             };
 
-            var jsonified = StringUtil.safeJSONStringify(quoteObj);
+            const jsonified = StringUtil.safeJSONStringify(quoteObj);
             expect(jsonified).toContain('"a":1');
             expect(jsonified).toContain('"b":"a &quot;string&quot;"');
             expect(jsonified).toContain('"c":"another &apos;string&apos;"');
         });
 
-        it('readableBytes should return reasonable values', function() {
+        it('readableBytes should return reasonable values', () => {
             expect(StringUtil.readableBytes(1000)).toBe('1000 B');
             expect(StringUtil.readableBytes(0)).toBe('0 B');
             expect(StringUtil.readableBytes(10000)).toBe('9.77 KB');
@@ -59,54 +55,55 @@ define ([
             expect(StringUtil.readableBytes(99999999999999999999999999999)).toBe('82718.06 YB');
         });
 
-        it('pretty print JSON should do exactly that', function() {
-            var obj = {
+        it('pretty print JSON should do exactly that', () => {
+            const obj = {
                 a: 1,
                 b: true,
                 c: [1, 2, 3],
                 d: {
-                    e: "foo",
-                    f: null
-                }
+                    e: 'foo',
+                    f: null,
+                },
             };
-            var result = '{\n' +
-                         '  <span class="key">"a":</span> <span class="number">1</span>,\n' +
-                         '  <span class="key">"b":</span> <span class="boolean">true</span>,\n' +
-                         '  <span class="key">"c":</span> [\n' +
-                         '    <span class="number">1</span>,\n' +
-                         '    <span class="number">2</span>,\n' +
-                         '    <span class="number">3</span>\n' +
-                         '  ],\n' +
-                         '  <span class="key">"d":</span> {\n' +
-                         '    <span class="key">"e":</span> <span class="string">"foo"</span>,\n' +
-                         '    <span class="key">"f":</span> <span class="null">null</span>\n' +
-                         '  }\n' +
-                         '}';
+            const result =
+                '{\n' +
+                '  <span class="key">"a":</span> <span class="number">1</span>,\n' +
+                '  <span class="key">"b":</span> <span class="boolean">true</span>,\n' +
+                '  <span class="key">"c":</span> [\n' +
+                '    <span class="number">1</span>,\n' +
+                '    <span class="number">2</span>,\n' +
+                '    <span class="number">3</span>\n' +
+                '  ],\n' +
+                '  <span class="key">"d":</span> {\n' +
+                '    <span class="key">"e":</span> <span class="string">"foo"</span>,\n' +
+                '    <span class="key">"f":</span> <span class="null">null</span>\n' +
+                '  }\n' +
+                '}';
             expect(StringUtil.prettyPrintJSON(obj)).toBe(result);
         });
 
         it('escape should turn nasty HTML into printable HTML', () => {
-            let tests = [
+            const tests = [
                 ['foo', 'foo'],
                 ['<script>', '&lt;script&gt;'],
                 ['&<>"\'', '&amp;&lt;&gt;&quot;&#39;'],
-                ['some string', 'some string']
+                ['some string', 'some string'],
             ];
-            tests.forEach(t => {
+            tests.forEach((t) => {
                 expect(StringUtil.escape(t[0])).toEqual(t[1]);
             });
         });
 
         it('escape should do nothing if passed a falsy str', () => {
-            let tests = [
+            const tests = [
                 ['', ''],
                 [false, false],
                 [undefined, undefined],
-                [null, null]
+                [null, null],
             ];
-            tests.forEach(t => {
+            tests.forEach((t) => {
                 expect(StringUtil.escape(t[0])).toEqual(t[1]);
             });
-        })
+        });
     });
 });

--- a/test/unit/spec/Util/StringSpec.js
+++ b/test/unit/spec/Util/StringSpec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['util/string'], (StringUtil) => {
     'use strict';
 
@@ -36,6 +30,7 @@ define(['util/string'], (StringUtil) => {
             const quoteObj = {
                 a: 1,
                 b: 'a "string"',
+                // eslint-disable-next-line quotes
                 c: "another 'string'",
             };
 

--- a/test/unit/spec/Util/TimeFormatSpec.js
+++ b/test/unit/spec/Util/TimeFormatSpec.js
@@ -4,172 +4,161 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
-    'bootstrap',
-    'jquery',
-    'util/timeFormat',
-], function(
-    bootstrap,
-    $,
-    TF,
-) {
+define(['bootstrap', 'jquery', 'util/timeFormat'], (bootstrap, $, TF) => {
     'use strict';
-    var testISOTime = '2015-12-09T21:58:22.202Z';
-    var testISOTime2 = '2016-01-06T00:48:43.196Z';
-    var testOutputString = 'Wed Dec 09 2015';
-    var reformattedString = '2015-12-09 13:58:22';
-    var testExactDayStr = 'Dec 9, 2015';
+    const testISOTime = '2015-12-09T21:58:22.202Z';
+    const testISOTime2 = '2016-01-06T00:48:43.196Z';
+    const testOutputString = 'Wed Dec 09 2015';
+    const reformattedString = '2015-12-09 13:58:22';
+    const testExactDayStr = 'Dec 9, 2015';
 
-    describe('KBase Time Formatting Utility function module', function() {
-        it('getTimeStampStr should properly output an exact time string', function() {
-            var d = TF.getTimeStampStr(testISOTime, true);
+    describe('KBase Time Formatting Utility function module', () => {
+        it('getTimeStampStr should properly output an exact time string', () => {
+            const d = TF.getTimeStampStr(testISOTime, true);
             expect(d).toBe(testExactDayStr);
         });
 
-        it('getTimeStampStr should return a fuzzy relative time string', function() {
-            var prevDay = new Date();
-            prevDay.setDate(prevDay.getDate()-2);
-            var d = TF.getTimeStampStr(prevDay, false);
+        it('getTimeStampStr should return a fuzzy relative time string', () => {
+            const prevDay = new Date();
+            prevDay.setDate(prevDay.getDate() - 2);
+            const d = TF.getTimeStampStr(prevDay, false);
             expect(d).toBe('2 days ago');
         });
 
-        it('getTimeStampStr should return a fuzzy relative time string @ 2 days 2 hours', function() {
-            var prevDay = new Date();
-            prevDay.setDate(prevDay.getDate()-2);
-            prevDay.setHours(prevDay.getHours()-2);
-            var d = TF.getTimeStampStr(prevDay, false);
+        it('getTimeStampStr should return a fuzzy relative time string @ 2 days 2 hours', () => {
+            const prevDay = new Date();
+            prevDay.setDate(prevDay.getDate() - 2);
+            prevDay.setHours(prevDay.getHours() - 2);
+            const d = TF.getTimeStampStr(prevDay, false);
             expect(d).toBe('2 days ago');
         });
 
-        it('getTimeStampStr should return a fuzzy relative time string @ 1 day', function() {
-            var prevDay = new Date();
-            prevDay.setDate(prevDay.getDate()-1);
-            var d = TF.getTimeStampStr(prevDay, false);
+        it('getTimeStampStr should return a fuzzy relative time string @ 1 day', () => {
+            const prevDay = new Date();
+            prevDay.setDate(prevDay.getDate() - 1);
+            const d = TF.getTimeStampStr(prevDay, false);
             expect(d).toBe('1 day ago');
         });
 
-        it('getTimeStampStr should return a fuzzy relative time string @ 1 hour', function() {
-            var prevDay = new Date();
-            prevDay.setHours(prevDay.getHours()-1);
-            var d = TF.getTimeStampStr(prevDay, false);
+        it('getTimeStampStr should return a fuzzy relative time string @ 1 hour', () => {
+            const prevDay = new Date();
+            prevDay.setHours(prevDay.getHours() - 1);
+            const d = TF.getTimeStampStr(prevDay, false);
             expect(d).toBe('1 hour ago');
         });
 
-        it('getTimeStampStr should return a fuzzy relative time string @ 1 minute', function() {
-            var prevDay = new Date();
-            prevDay.setMinutes(prevDay.getMinutes()-1);
-            var d = TF.getTimeStampStr(prevDay, false);
+        it('getTimeStampStr should return a fuzzy relative time string @ 1 minute', () => {
+            const prevDay = new Date();
+            prevDay.setMinutes(prevDay.getMinutes() - 1);
+            const d = TF.getTimeStampStr(prevDay, false);
             expect(d).toBe('1 minute ago');
         });
 
-        it('getShortTimeStampStr should properly output an exact time string', function() {
-            var d = TF.getShortTimeStampStr(testISOTime, true);
+        it('getShortTimeStampStr should properly output an exact time string', () => {
+            const d = TF.getShortTimeStampStr(testISOTime, true);
             expect(d).toBe(testExactDayStr);
         });
 
-        it('getShortTimeStampStr should return a fuzzy relative time string [ 2 mons ]', function() {
-            var prevDay = new Date();
-            prevDay.setDate(prevDay.getDate()-5);
-            prevDay.setMonth(prevDay.getMonth()-2);
-            var d = TF.getShortTimeStampStr(prevDay, false);
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 2 mons ]', () => {
+            const prevDay = new Date();
+            prevDay.setDate(prevDay.getDate() - 5);
+            prevDay.setMonth(prevDay.getMonth() - 2);
+            const d = TF.getShortTimeStampStr(prevDay, false);
             expect(d).toBe('2 mons');
         });
 
-        it('getShortTimeStampStr should return a fuzzy relative time string [ 1 hr ]', function() {
-            var prevDay = new Date();
-            prevDay.setHours(prevDay.getHours()-1);
-            var d = TF.getShortTimeStampStr(prevDay, false);
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 1 hr ]', () => {
+            const prevDay = new Date();
+            prevDay.setHours(prevDay.getHours() - 1);
+            const d = TF.getShortTimeStampStr(prevDay, false);
             expect(d).toBe('1 hr');
         });
 
-        it('getShortTimeStampStr should return a fuzzy relative time string [ 3 mins ]', function() {
-            var prevDay = new Date();
-            prevDay.setSeconds(prevDay.getSeconds()-5);
-            var d = TF.getShortTimeStampStr(prevDay, false);
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 3 mins ]', () => {
+            const prevDay = new Date();
+            prevDay.setSeconds(prevDay.getSeconds() - 5);
+            const d = TF.getShortTimeStampStr(prevDay, false);
             expect(d).toBe('5 secs');
         });
 
-        it('getShortTimeStampStr should return a fuzzy relative time string [ 5 secs ]', function() {
-            var prevDay = new Date();
-            prevDay.setMinutes(prevDay.getMinutes()-3);
-            var d = TF.getShortTimeStampStr(prevDay, false);
+        it('getShortTimeStampStr should return a fuzzy relative time string [ 5 secs ]', () => {
+            const prevDay = new Date();
+            prevDay.setMinutes(prevDay.getMinutes() - 3);
+            const d = TF.getShortTimeStampStr(prevDay, false);
             expect(d).toBe('3 mins');
         });
 
-
-        it('parseDate should properly parse an ISO date string', function() {
-            var d = TF.parseDate(testISOTime);
+        it('parseDate should properly parse an ISO date string', () => {
+            const d = TF.parseDate(testISOTime);
             expect(d).toEqual(jasmine.any(Object));
             expect(d.toDateString()).toBe(testOutputString);
         });
 
-        it('parseDate should properly return null with a bad date', function() {
+        it('parseDate should properly return null with a bad date', () => {
             expect(TF.parseDate('not an iso string!')).toBeNull();
         });
 
-        it('prettyTimestamp should create a span from a good timestamp', function() {
-            var tsDiv = TF.prettyTimestamp(testISOTime);
+        it('prettyTimestamp should create a span from a good timestamp', () => {
+            let tsDiv = TF.prettyTimestamp(testISOTime);
             tsDiv = $(tsDiv);
             expect(tsDiv.is('span')).toBe(true);
 
-            var title = tsDiv.attr('title');
+            const title = tsDiv.attr('title');
             expect(new Date(title).toUTCString()).toBe(new Date(testISOTime).toUTCString());
             // expect(tsDiv.attr('title')).toBe(reformattedString);
         });
 
-        it('prettyTimestamp should throw an error with a bad timestamp', function() {
+        it('prettyTimestamp should throw an error with a bad timestamp', () => {
             try {
                 TF.prettyTimestamp('bad time');
-            }
-            catch (error) {
+            } catch (error) {
                 expect(error).not.toBeNull();
             }
         });
 
-        it('reformatISOTimeString should work with a good ISO string', function() {
-            var newTimeStr = TF.reformatISOTimeString(testISOTime);
+        it('reformatISOTimeString should work with a good ISO string', () => {
+            const newTimeStr = TF.reformatISOTimeString(testISOTime);
             // expect(newTimeStr).toEqual(reformattedString);
-            expect(new Date(newTimeStr).toUTCString())
-                  .toBe(new Date(testISOTime).toUTCString());
+            expect(new Date(newTimeStr).toUTCString()).toBe(new Date(testISOTime).toUTCString());
         });
 
-        it('reformatISOTimeString should not reformat a bad timestamp', function() {
-            var testStr = 'bad time';
-            var newTimeStr = TF.reformatISOTimeString(testStr);
+        it('reformatISOTimeString should not reformat a bad timestamp', () => {
+            const testStr = 'bad time';
+            const newTimeStr = TF.reformatISOTimeString(testStr);
             expect(newTimeStr).toBe(testStr);
         });
 
-        it('reformatDate should reformat a date object into a good string', function() {
-            var d = new Date(testISOTime);
-            var retDate = TF.reformatDate(d);
+        it('reformatDate should reformat a date object into a good string', () => {
+            const d = new Date(testISOTime);
+            const retDate = TF.reformatDate(d);
             expect(new Date(retDate).toUTCString()).toBe(new Date(testISOTime).toUTCString());
         });
 
-        it('reformatDate should return the same input with a bad date', function() {
+        it('reformatDate should return the same input with a bad date', () => {
             expect(TF.reformatDate('blah!')).toBe('blah!');
         });
 
-        it('calcTimeFromNow should have no change when done immediately', function() {
-            var curTime = new Date();
-            var curISO = curTime.toISOString();
+        it('calcTimeFromNow should have no change when done immediately', () => {
+            const curTime = new Date();
+            const curISO = curTime.toISOString();
 
-            var timeDiff = TF.calcTimeFromNow(curISO);
+            const timeDiff = TF.calcTimeFromNow(curISO);
             expect(timeDiff).toBe('0.0 sec ago');
         });
 
-        it('calcTimeDifference should get the diff between two times', function() {
-            var time1 = new Date(testISOTime);
-            var time2 = new Date(testISOTime2);
+        it('calcTimeDifference should get the diff between two times', () => {
+            const time1 = new Date(testISOTime);
+            const time2 = new Date(testISOTime2);
 
-            var diff = TF.calcTimeDifference(time1, time2);
+            const diff = TF.calcTimeDifference(time1, time2);
             expect(diff).toBe('27.1 days');
         });
 
-        it('calcTimeDifference should be the same in both directions', function() {
-            var time1 = new Date(testISOTime);
-            var time2 = new Date(testISOTime2);
+        it('calcTimeDifference should be the same in both directions', () => {
+            const time1 = new Date(testISOTime);
+            const time2 = new Date(testISOTime2);
 
-            var diff = TF.calcTimeDifference(time1, time2);
+            const diff = TF.calcTimeDifference(time1, time2);
             expect(diff).toBe(TF.calcTimeDifference(time2, time1));
         });
     });

--- a/test/unit/spec/Util/TimeFormatSpec.js
+++ b/test/unit/spec/Util/TimeFormatSpec.js
@@ -1,15 +1,8 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['bootstrap', 'jquery', 'util/timeFormat'], (bootstrap, $, TF) => {
     'use strict';
     const testISOTime = '2015-12-09T21:58:22.202Z';
     const testISOTime2 = '2016-01-06T00:48:43.196Z';
     const testOutputString = 'Wed Dec 09 2015';
-    const reformattedString = '2015-12-09 13:58:22';
     const testExactDayStr = 'Dec 9, 2015';
 
     describe('KBase Time Formatting Utility function module', () => {
@@ -105,7 +98,6 @@ define(['bootstrap', 'jquery', 'util/timeFormat'], (bootstrap, $, TF) => {
 
             const title = tsDiv.attr('title');
             expect(new Date(title).toUTCString()).toBe(new Date(testISOTime).toUTCString());
-            // expect(tsDiv.attr('title')).toBe(reformattedString);
         });
 
         it('prettyTimestamp should throw an error with a bad timestamp', () => {
@@ -118,7 +110,6 @@ define(['bootstrap', 'jquery', 'util/timeFormat'], (bootstrap, $, TF) => {
 
         it('reformatISOTimeString should work with a good ISO string', () => {
             const newTimeStr = TF.reformatISOTimeString(testISOTime);
-            // expect(newTimeStr).toEqual(reformattedString);
             expect(new Date(newTimeStr).toUTCString()).toBe(new Date(testISOTime).toUTCString());
         });
 

--- a/test/unit/spec/Util/jobLogViewerSpec.js
+++ b/test/unit/spec/Util/jobLogViewerSpec.js
@@ -1,11 +1,5 @@
 /*jslint white: true*/
-define([
-    'util/jobLogViewer',
-    'common/runtime'
-], (
-    JobLogViewer,
-    Runtime
-) => {
+define(['util/jobLogViewer', 'common/runtime'], (JobLogViewer, Runtime) => {
     'use strict';
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     describe('Test the job log viewer module', () => {
@@ -36,34 +30,34 @@ define([
         });
 
         it('Should be created', () => {
-            let viewer = JobLogViewer.make();
-            ['start', 'stop', 'detach'].forEach(fn => {
+            const viewer = JobLogViewer.make();
+            ['start', 'stop', 'detach'].forEach((fn) => {
                 expect(viewer[fn]).toEqual(jasmine.any(Function));
             });
         });
 
         it('Should fail to start without a node', () => {
-            let viewer = JobLogViewer.make();
+            const viewer = JobLogViewer.make();
             const jobId = 'fakejob';
-            let arg = {
-                jobId: jobId
+            const arg = {
+                jobId: jobId,
             };
             expect(() => viewer.start(arg)).toThrow(new Error('Requires a node to start'));
         });
 
         it('Should fail to start without a jobId', () => {
-            let viewer = JobLogViewer.make();
-            let arg = {
-                node: hostNode
+            const viewer = JobLogViewer.make();
+            const arg = {
+                node: hostNode,
             };
             expect(() => viewer.start(arg)).toThrow(new Error('Requires a job id to start'));
         });
 
         it('Should start as expected with inputs, and be stoppable and detachable', () => {
-            let viewer = JobLogViewer.make();
-            let arg = {
+            const viewer = JobLogViewer.make();
+            const arg = {
                 node: hostNode,
-                jobId: 'someFakeJob'
+                jobId: 'someFakeJob',
             };
             viewer.start(arg);
             expect(hostNode.querySelector('div[data-element="kb-log"]')).toBeDefined();
@@ -72,14 +66,14 @@ define([
         });
 
         it('Should send a bus messages requesting job status information at startup', (done) => {
-            let viewer = JobLogViewer.make();
+            const viewer = JobLogViewer.make();
             const jobId = 'testJob1';
             const arg = {
                 node: hostNode,
-                jobId: jobId
+                jobId: jobId,
             };
             runtimeBus.on('request-job-status', (msg) => {
-                expect(msg).toEqual({jobId: jobId});
+                expect(msg).toEqual({ jobId: jobId });
                 viewer.detach();
                 done();
             });
@@ -87,28 +81,28 @@ define([
         });
 
         it('Should react to job status messages', (done) => {
-            let viewer = JobLogViewer.make();
+            const viewer = JobLogViewer.make();
             const jobId = 'testJobStatusMsg';
             const arg = {
                 node: hostNode,
-                jobId: jobId
+                jobId: jobId,
             };
             runtimeBus.on('request-job-status', (msg) => {
-                expect(msg).toEqual({jobId: jobId});
+                expect(msg).toEqual({ jobId: jobId });
                 runtimeBus.send(
                     {
                         jobId: jobId,
                         jobState: {
-                            status: 'running'
-                        }
+                            status: 'running',
+                        },
                     },
                     {
                         channel: {
-                            jobId: jobId
+                            jobId: jobId,
                         },
                         key: {
-                            type: 'job-status'
-                        }
+                            type: 'job-status',
+                        },
                     }
                 );
                 viewer.detach();
@@ -118,49 +112,49 @@ define([
         });
 
         it('Should start with all buttons disabled', () => {
-            let viewer = JobLogViewer.make();
+            const viewer = JobLogViewer.make();
             const jobId = 'testBtnState';
             const arg = {
                 node: hostNode,
-                jobId: jobId
+                jobId: jobId,
             };
             viewer.start(arg);
-            let btns = hostNode.querySelectorAll('div[data-element="header"] button');
-            btns.forEach(btn => {
+            const btns = hostNode.querySelectorAll('div[data-element="header"] button');
+            btns.forEach((btn) => {
                 expect(btn.classList.contains('disabled')).toBeTruthy();
             });
             viewer.detach();
         });
 
         it('Should render on job-logs messages immediately on startup', (done) => {
-            let viewer = JobLogViewer.make();
+            const viewer = JobLogViewer.make();
             const jobId = 'testJobLogMsgResp';
             const arg = {
                 node: hostNode,
-                jobId: jobId
+                jobId: jobId,
             };
             runtimeBus.on('request-job-status', (msg) => {
-                expect(msg).toEqual({jobId: jobId});
+                expect(msg).toEqual({ jobId: jobId });
                 runtimeBus.send(
                     {
                         jobId: jobId,
                         jobState: {
-                            status: 'running'
-                        }
+                            status: 'running',
+                        },
                     },
                     {
                         channel: {
-                            jobId: jobId
+                            jobId: jobId,
                         },
                         key: {
-                            type: 'job-status'
-                        }
+                            type: 'job-status',
+                        },
                     }
                 );
             });
 
             runtimeBus.on('request-latest-job-log', (msg) => {
-                expect(msg).toEqual({jobId: jobId, options: {}});
+                expect(msg).toEqual({ jobId: jobId, options: {} });
                 runtimeBus.send(
                     {
                         jobId: jobId,
@@ -170,26 +164,29 @@ define([
                             job_id: jobId,
                             latest: true,
                             max_lines: 2,
-                            lines: [{
-                                is_error: 0,
-                                line: 'line 1 - log',
-                                linepos: 1,
-                                ts: 123456789
-                            }, {
-                                is_error: 1,
-                                line: 'line 2 - error',
-                                linepos: 1,
-                                ts: 123456790
-                            }]
-                        }
+                            lines: [
+                                {
+                                    is_error: 0,
+                                    line: 'line 1 - log',
+                                    linepos: 1,
+                                    ts: 123456789,
+                                },
+                                {
+                                    is_error: 1,
+                                    line: 'line 2 - error',
+                                    linepos: 1,
+                                    ts: 123456790,
+                                },
+                            ],
+                        },
                     },
                     {
                         channel: {
-                            jobId: jobId
+                            jobId: jobId,
                         },
                         key: {
-                            type: 'job-logs'
-                        }
+                            type: 'job-logs',
+                        },
                     }
                 );
                 setTimeout(() => {
@@ -209,47 +206,47 @@ define([
         });
 
         it('Should render a queued message for queued jobs', (done) => {
-            let viewer = JobLogViewer.make();
+            const viewer = JobLogViewer.make();
             const jobId = 'testJobQueued';
             const arg = {
                 node: hostNode,
-                jobId: jobId
+                jobId: jobId,
             };
             runtimeBus.on('request-job-status', (msg) => {
-                expect(msg).toEqual({jobId: jobId});
+                expect(msg).toEqual({ jobId: jobId });
                 runtimeBus.send(
                     {
                         jobId: jobId,
                         jobState: {
-                            status: 'queued'
-                        }
+                            status: 'queued',
+                        },
                     },
                     {
                         channel: {
-                            jobId: jobId
+                            jobId: jobId,
                         },
                         key: {
-                            type: 'job-status'
-                        }
+                            type: 'job-status',
+                        },
                     }
                 );
             });
             runtimeBus.on('request-job-update', (msg) => {
-                expect(msg).toEqual({jobId: jobId});
+                expect(msg).toEqual({ jobId: jobId });
                 runtimeBus.send(
                     {
                         jobId: jobId,
                         jobState: {
-                            status: 'queued'
-                        }
+                            status: 'queued',
+                        },
                     },
                     {
                         channel: {
-                            jobId: jobId
+                            jobId: jobId,
                         },
                         key: {
-                            type: 'job-status'
-                        }
+                            type: 'job-status',
+                        },
                     }
                 );
                 setTimeout(() => {
@@ -263,23 +260,14 @@ define([
             viewer.start(arg);
         });
 
-        xit('Should render a canceled message for canceled jobs', (done) => {
-        });
+        xit('Should render a canceled message for canceled jobs', (done) => {});
 
-        xit('Should render an error message for errored jobs', (done) => {
+        xit('Should render an error message for errored jobs', (done) => {});
 
-        });
+        xit('Should have the top button go to the top', (done) => {});
 
-        xit('Should have the top button go to the top', (done) => {
+        xit('Should have the bottom button go to the end', (done) => {});
 
-        });
-
-        xit('Should have the bottom button go to the end', (done) => {
-
-        });
-
-        xit('Should have the stop button make sure it stops', (done) => {
-
-        });
+        xit('Should have the stop button make sure it stops', (done) => {});
     });
-})
+});

--- a/test/unit/spec/Util/jobLogViewerSpec.js
+++ b/test/unit/spec/Util/jobLogViewerSpec.js
@@ -1,4 +1,3 @@
-/*jslint white: true*/
 define(['util/jobLogViewer', 'common/runtime'], (JobLogViewer, Runtime) => {
     'use strict';
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;

--- a/test/unit/spec/api/authSpec.js
+++ b/test/unit/spec/api/authSpec.js
@@ -4,15 +4,7 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define([
-    'api/auth',
-    'narrativeConfig',
-    'uuid'
-], function (
-    Auth,
-    Config,
-    Uuid
-) {
+define(['api/auth', 'narrativeConfig', 'uuid'], (Auth, Config, Uuid) => {
     'use strict';
 
     let authClient;
@@ -30,8 +22,8 @@ define([
             apperror: 'Invalid token',
             message: '10020 Invalid token',
             callid: 'some_call_id',
-            time: 1612476968817
-        }
+            time: 1612476968817,
+        },
     };
 
     const NO_TOKEN_ERROR = {
@@ -42,8 +34,8 @@ define([
             apperror: 'No authentication token',
             message: '10010 No authentication token: No user token provided',
             callid: '4979935107294962',
-            time: 1612477725701
-        }
+            time: 1612477725701,
+        },
     };
 
     const USER_PROFILE = {
@@ -55,7 +47,7 @@ define([
         user: FAKE_USER,
         local: false,
         email: `${FAKE_NAME}@kbase.us`,
-        idents: []
+        idents: [],
     };
 
     function setToken(token) {
@@ -77,13 +69,12 @@ define([
      * @param {int} status the status code to return
      */
     function mockAuthRequest(request, responseObj, status) {
-        let reqUrl = `${Config.url('auth')}/api/${VERSION}/${request}`;
-        jasmine.Ajax.stubRequest(reqUrl)
-            .andReturn({
-                status: status,
-                contentType: 'application/json',
-                responseText: JSON.stringify(responseObj)
-            });
+        const reqUrl = `${Config.url('auth')}/api/${VERSION}/${request}`;
+        jasmine.Ajax.stubRequest(reqUrl).andReturn({
+            status: status,
+            contentType: 'application/json',
+            responseText: JSON.stringify(responseObj),
+        });
     }
 
     /*
@@ -94,27 +85,33 @@ define([
      * - the auth service api request endpoint
      * These will then all be tested when no token is available.
      */
-    const noTokenCases = [{
-        method: 'getTokenInfo',
-        inputs: [],
-        request: 'token'
-    }, {
-        method: 'getUserProfile',
-        inputs: [],
-        request: 'me'
-    }, {
-        method: 'getCurrentProfile',
-        inputs: [],
-        request: 'me'
-    }, {
-        method: 'getUserNames',
-        inputs: [undefined, ['userId', 'nonUserId']],
-        request: 'users/?list=userId,nonUserId'
-    }, {
-        method: 'searchUserNames',
-        inputs: [undefined, 'foo'],
-        request: 'users/search/foo'
-    }];
+    const noTokenCases = [
+        {
+            method: 'getTokenInfo',
+            inputs: [],
+            request: 'token',
+        },
+        {
+            method: 'getUserProfile',
+            inputs: [],
+            request: 'me',
+        },
+        {
+            method: 'getCurrentProfile',
+            inputs: [],
+            request: 'me',
+        },
+        {
+            method: 'getUserNames',
+            inputs: [undefined, ['userId', 'nonUserId']],
+            request: 'users/?list=userId,nonUserId',
+        },
+        {
+            method: 'searchUserNames',
+            inputs: [undefined, 'foo'],
+            request: 'users/search/foo',
+        },
+    ];
 
     /*
      * Each case here represents the following:
@@ -129,20 +126,23 @@ define([
         {
             method: 'getTokenInfo',
             inputs: [FAKE_TOKEN],
-            request: 'token'
-        }, {
+            request: 'token',
+        },
+        {
             method: 'getUserNames',
             inputs: [FAKE_TOKEN, ['userId', 'nonUserId']],
-            request: 'users/?list=userId,nonUserId'
-        }, {
+            request: 'users/?list=userId,nonUserId',
+        },
+        {
             method: 'searchUserNames',
             inputs: [FAKE_TOKEN, 'foo'],
-            request: 'users/search/foo'
-        }, {
+            request: 'users/search/foo',
+        },
+        {
             method: 'searchUserNames',
             inputs: [FAKE_TOKEN, 'foo', ['username', 'displayname']],
-            request: 'users/search/foo/?fields=username,displayname'
-        }
+            request: 'users/search/foo/?fields=username,displayname',
+        },
     ];
 
     describe('Test the Auth API module', () => {
@@ -151,7 +151,7 @@ define([
             authClient = Auth.make({
                 url: Config.url('auth'),
                 // Can't use secure cookies for testing.
-                secureCookies: false
+                secureCookies: false,
             });
             jasmine.Ajax.install();
         });
@@ -162,7 +162,7 @@ define([
         });
 
         it('Should make a new Auth client that has the expected functions', () => {
-            const auth = Auth.make({url: Config.url('auth')});
+            const auth = Auth.make({ url: Config.url('auth') });
             expect(auth).not.toBeNull();
             [
                 'putCurrentProfile',
@@ -177,8 +177,8 @@ define([
                 'searchUserNames',
                 'validateToken',
                 'setCookie',
-                'getCookie'
-            ].forEach(fn => {
+                'getCookie',
+            ].forEach((fn) => {
                 expect(auth[fn]).toBeDefined();
             });
         });
@@ -240,28 +240,26 @@ define([
                 id: 'some_uuid',
                 type: 'Login',
                 user: FAKE_USER,
-                cachefor: 500000
+                cachefor: 500000,
             };
             mockAuthRequest('token', tokenInfo, 200);
-            return authClient.getTokenInfo(FAKE_TOKEN)
-                .then((response) => {
-                    Object.keys(tokenInfo).forEach(tokenKey => {
-                        expect(response[tokenKey]).toEqual(tokenInfo[tokenKey]);
-                    });
-                    const request = jasmine.Ajax.requests.mostRecent();
-                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+            return authClient.getTokenInfo(FAKE_TOKEN).then((response) => {
+                Object.keys(tokenInfo).forEach((tokenKey) => {
+                    expect(response[tokenKey]).toEqual(tokenInfo[tokenKey]);
                 });
+                const request = jasmine.Ajax.requests.mostRecent();
+                expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+            });
         });
 
         it('Should return my profile', () => {
             mockAuthRequest('me', USER_PROFILE, 200);
-            return authClient.getUserProfile()
-                .then((response) => {
-                    expect(response).not.toBeNull();
-                    expect(response).toEqual(USER_PROFILE);
-                    const request = jasmine.Ajax.requests.mostRecent();
-                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
-                });
+            return authClient.getUserProfile().then((response) => {
+                expect(response).not.toBeNull();
+                expect(response).toEqual(USER_PROFILE);
+                const request = jasmine.Ajax.requests.mostRecent();
+                expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+            });
         });
 
         it('Should return a list of users', () => {
@@ -271,25 +269,23 @@ define([
             response[FAKE_USER] = FAKE_NAME;
             mockAuthRequest(`users/?list=${FAKE_USER},${nonUser}`, response, 200);
 
-            return authClient.getUserNames(FAKE_TOKEN, userIds)
-                .then((names) => {
-                    expect(names[FAKE_USER]).toEqual(FAKE_NAME);
-                    expect(Object.keys(names)).not.toContain(nonUser);
-                    const request = jasmine.Ajax.requests.mostRecent();
-                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
-                });
+            return authClient.getUserNames(FAKE_TOKEN, userIds).then((names) => {
+                expect(names[FAKE_USER]).toEqual(FAKE_NAME);
+                expect(Object.keys(names)).not.toContain(nonUser);
+                const request = jasmine.Ajax.requests.mostRecent();
+                expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+            });
         });
 
         it('Should search for users', () => {
             const query = 'us',
-                result = {user1: 'User 1'};
+                result = { user1: 'User 1' };
             mockAuthRequest(`users/search/${query}`, result, 200);
-            return authClient.searchUserNames(FAKE_TOKEN, query)
-                .then((results) => {
-                    expect(results).toEqual(result);
-                    const request = jasmine.Ajax.requests.mostRecent();
-                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
-                });
+            return authClient.searchUserNames(FAKE_TOKEN, query).then((results) => {
+                expect(results).toEqual(result);
+                const request = jasmine.Ajax.requests.mostRecent();
+                expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+            });
         });
 
         it('Should search for users with extra options', () => {
@@ -298,15 +294,14 @@ define([
                 result = {
                     user1: 'User 1',
                     otherperson: 'User 2',
-                    user3: 'Another Person'
+                    user3: 'Another Person',
                 };
             mockAuthRequest(`users/search/${query}/?fields=${options.join(',')}`, result, 200);
-            return authClient.searchUserNames(FAKE_TOKEN, query, options)
-                .then((results) => {
-                    expect(results).toEqual(result);
-                    const request = jasmine.Ajax.requests.mostRecent();
-                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
-                });
+            return authClient.searchUserNames(FAKE_TOKEN, query, options).then((results) => {
+                expect(results).toEqual(result);
+                const request = jasmine.Ajax.requests.mostRecent();
+                expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+            });
         });
 
         it('Should set an auth token cookie', () => {
@@ -317,21 +312,25 @@ define([
         });
 
         // test validateToken with either good or invalid tokens
-        const validationTrials = [{
-            label: ' null',
-            token: null,
-            isValid: true  // should get it from cookie
-        }, {
-            label: 'n undefined',
-            token: undefined,
-            isValid: true  // should get from cookie
-        }, {
-            label: 'n old',
-            token: FAKE_TOKEN,
-            isValid: false
-        }];
+        const validationTrials = [
+            {
+                label: ' null',
+                token: null,
+                isValid: true, // should get it from cookie
+            },
+            {
+                label: 'n undefined',
+                token: undefined,
+                isValid: true, // should get from cookie
+            },
+            {
+                label: 'n old',
+                token: FAKE_TOKEN,
+                isValid: false,
+            },
+        ];
         validationTrials.forEach((trial) => {
-            it(`Should ${!trial.isValid ? 'in': ''}validate a${trial.label} token`, () => {
+            it(`Should ${!trial.isValid ? 'in' : ''}validate a${trial.label} token`, () => {
                 const tokenInfo = {
                     expires: Date.now() + (trial.isValid ? 10000 : -10000),
                     created: Date.now(),
@@ -339,26 +338,24 @@ define([
                     id: 'some_uuid',
                     type: 'Login',
                     user: FAKE_USER,
-                    cachefor: 500000
+                    cachefor: 500000,
                 };
                 mockAuthRequest('token', tokenInfo, 200);
-                return authClient.validateToken(trial.token)
-                    .then((isValid) => {
-                        expect(isValid).toBe(trial.isValid);
-                        const request = jasmine.Ajax.requests.mostRecent();
-                        expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
-                    });
+                return authClient.validateToken(trial.token).then((isValid) => {
+                    expect(isValid).toBe(trial.isValid);
+                    const request = jasmine.Ajax.requests.mostRecent();
+                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+                });
             });
         });
 
         it('Should invalidate an invalid token', () => {
             mockAuthRequest('token', UNAUTH_ERROR, 401);
-            return authClient.validateToken()
-                .then((isValid) => {
-                    expect(isValid).toBe(false);
-                    const request = jasmine.Ajax.requests.mostRecent();
-                    expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
-                });
+            return authClient.validateToken().then((isValid) => {
+                expect(isValid).toBe(false);
+                const request = jasmine.Ajax.requests.mostRecent();
+                expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
+            });
         });
 
         it('Should clear auth token cookie on request', () => {
@@ -407,7 +404,7 @@ define([
             authClient.setCookie({
                 name: backupCookieName,
                 value: backupCookieValue,
-                domain: 'localhost'
+                domain: 'localhost',
             });
 
             // The backup cookie should be set.
@@ -454,7 +451,7 @@ define([
             authClient.setCookie({
                 name: 'narrative_session',
                 value: cookieValue,
-                expires: 14
+                expires: 14,
             });
 
             // Okay, it should be set.

--- a/test/unit/spec/api/authSpec.js
+++ b/test/unit/spec/api/authSpec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine, pending*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['api/auth', 'narrativeConfig', 'uuid'], (Auth, Config, Uuid) => {
     'use strict';
 

--- a/test/unit/spec/api/upaApiSpec.js
+++ b/test/unit/spec/api/upaApiSpec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect fail*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['api/upa', 'narrativeConfig'], (UpaApi, Config) => {
     'use strict';
     describe('Test the UPA API', () => {

--- a/test/unit/spec/api/upaApiSpec.js
+++ b/test/unit/spec/api/upaApiSpec.js
@@ -4,42 +4,46 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
-    'api/upa',
-    'narrativeConfig'
-], function(
-    UpaApi,
-    Config
-) {
+define(['api/upa', 'narrativeConfig'], (UpaApi, Config) => {
     'use strict';
-    describe('Test the UPA API', function() {
-        var upaApi = new UpaApi(),
-            serializeTestData = [{
-                upa: '31/2/3',
-                serial: '[31]/2/3'
-            }, {
-                upa: '31/2/3;4/5/6',
-                serial: '[31]/2/3;4/5/6'
-            }, {
-                upa: '31/2/3;4/5/6;7/8/9',
-                serial: '[31]/2/3;4/5/6;7/8/9'
-            }, {
-                upa: ['31/2/3', '4/5/6', '7/8/9'],
-                serial: '[31]/2/3;4/5/6;7/8/9'
-            }, {
-                upa: '31/31/31;31/31/31',
-                serial: '[31]/31/31;31/31/31'
-            }],
-            serializeExternalTestData = [{
-                upa: '5/1/2',
-                serial: upaApi.externalTag + '5/1/2'
-            }, {
-                upa: '5/1/2;1/2/3',
-                serial: upaApi.externalTag + '5/1/2;1/2/3'
-            }, {
-                upa: '5/5/5;1/1/1',
-                serial: upaApi.externalTag + '5/5/5;1/1/1'
-            }],
+    describe('Test the UPA API', () => {
+        const upaApi = new UpaApi(),
+            serializeTestData = [
+                {
+                    upa: '31/2/3',
+                    serial: '[31]/2/3',
+                },
+                {
+                    upa: '31/2/3;4/5/6',
+                    serial: '[31]/2/3;4/5/6',
+                },
+                {
+                    upa: '31/2/3;4/5/6;7/8/9',
+                    serial: '[31]/2/3;4/5/6;7/8/9',
+                },
+                {
+                    upa: ['31/2/3', '4/5/6', '7/8/9'],
+                    serial: '[31]/2/3;4/5/6;7/8/9',
+                },
+                {
+                    upa: '31/31/31;31/31/31',
+                    serial: '[31]/31/31;31/31/31',
+                },
+            ],
+            serializeExternalTestData = [
+                {
+                    upa: '5/1/2',
+                    serial: upaApi.externalTag + '5/1/2',
+                },
+                {
+                    upa: '5/1/2;1/2/3',
+                    serial: upaApi.externalTag + '5/1/2;1/2/3',
+                },
+                {
+                    upa: '5/5/5;1/1/1',
+                    serial: upaApi.externalTag + '5/5/5;1/1/1',
+                },
+            ],
             badUpas = [
                 '1/2',
                 '1/2/3;4/5/',
@@ -53,7 +57,7 @@ define ([
                 '1;2;3',
                 'foo/bar;baz/frobozz',
                 'myws/myobj/myver;otherws/otherobj/otherver',
-                'myws/myobj/myver'
+                'myws/myobj/myver',
             ],
             badSerials = [
                 '[1]/2',
@@ -70,87 +74,85 @@ define ([
                 '[myws]/myobj/myver;otherws/otherobj/otherver',
                 '[myws]/myobj/myver',
                 '[1]2/23/4',
-                '[1]2/3/4;5/6/7'
+                '[1]2/3/4;5/6/7',
             ],
             upaStruct = {
                 foo: '1/2/3',
                 bar: ['4/5/6', '7/8/9'],
                 baz: {
                     a: '1/2/3',
-                    b: '1/2/3'
-                }
+                    b: '1/2/3',
+                },
             },
             upaStructSerial = {
                 foo: '[1]/2/3',
                 bar: ['[4]/5/6', '[7]/8/9'],
                 baz: {
                     a: '[1]/2/3',
-                    b: '[1]/2/3'
-                }
+                    b: '[1]/2/3',
+                },
             };
 
-        beforeEach(function () {
+        beforeEach(() => {
             history.pushState(null, null, '/narrative/ws.31.obj.1');
             Config.config.workspaceId = 31;
         });
 
-        it('Should properly serialize an UPA from this workspace', function () {
-            serializeTestData.forEach(function(pair) {
+        it('Should properly serialize an UPA from this workspace', () => {
+            serializeTestData.forEach((pair) => {
                 expect(upaApi.serialize(pair.upa)).toBe(pair.serial);
             });
         });
 
-        it('Should properly deserialize an UPA from this workspace', function () {
-            serializeTestData.forEach(function(pair) {
+        it('Should properly deserialize an UPA from this workspace', () => {
+            serializeTestData.forEach((pair) => {
                 if (typeof pair.upa === 'string') {
                     expect(upaApi.deserialize(pair.serial)).toBe(pair.upa);
                 }
             });
         });
 
-        it('Should serialize an UPA from a different workspace', function () {
-            serializeExternalTestData.forEach(function(pair) {
+        it('Should serialize an UPA from a different workspace', () => {
+            serializeExternalTestData.forEach((pair) => {
                 expect(upaApi.serializeExternal(pair.upa)).toBe(pair.serial);
             });
         });
 
-        it('Should deserialize an UPA from a different workspace', function() {
-            serializeExternalTestData.forEach(function(pair) {
+        it('Should deserialize an UPA from a different workspace', () => {
+            serializeExternalTestData.forEach((pair) => {
                 expect(upaApi.deserialize(pair.serial)).toBe(pair.upa);
             });
         });
 
-        it('Should fail to serialize a bad UPA', function () {
-            badUpas.forEach(function(badUpa) {
+        it('Should fail to serialize a bad UPA', () => {
+            badUpas.forEach((badUpa) => {
                 try {
                     upaApi.serialize(badUpa);
                     fail('Should have thrown an error here!');
                 } catch (error) {
                     expect(error).not.toBeNull();
-                    expect(error.error).toEqual('"' + badUpa + '" is not a valid UPA. It may already have been serialized.');
+                    expect(error.error).toEqual(
+                        '"' + badUpa + '" is not a valid UPA. It may already have been serialized.'
+                    );
                 }
             });
         });
 
-        it('Should fail to deserialize a bad UPA', function () {
-            badSerials.forEach(function(badSerial) {
+        it('Should fail to deserialize a bad UPA', () => {
+            badSerials.forEach((badSerial) => {
                 try {
                     upaApi.deserialize(badSerial);
                     fail('Should have thrown an error here!');
-                } catch(error) {
+                } catch (error) {
                     expect(error).not.toBeNull();
                     expect(error.error).toMatch(/Deserialized UPA: .+ is invalid!$/);
                 }
             });
         });
 
-        it('Should fail to deserialize an UPA that is not a string', function () {
-            var badTypes = [
-                ['123/4/5', '6/7/8'],
-                {'123': '456'},
-                null
-            ];
-            badTypes.forEach(function(badType) {
+        it('Should fail to deserialize an UPA that is not a string', () => {
+            const badTypes = [['123/4/5', '6/7/8'], { 123: '456' }, null];
+            badTypes.forEach((badType) => {
                 try {
                     upaApi.deserialize(badType);
                     fail('Should have thrown an error here!');
@@ -161,7 +163,7 @@ define ([
             });
         });
 
-        it('Should fail if the workspace id cannot be found.', function () {
+        it('Should fail if the workspace id cannot be found.', () => {
             history.pushState(null, null, '/narrative/');
             Config.config.workspaceId = undefined;
             try {
@@ -169,49 +171,54 @@ define ([
                 fail('Should have failed here!');
             } catch (error) {
                 expect(error).not.toBeNull();
-                expect(error.error).toEqual('Currently loaded workspace is unknown! Unable to deserialize UPA.');
+                expect(error.error).toEqual(
+                    'Currently loaded workspace is unknown! Unable to deserialize UPA.'
+                );
             }
         });
 
-        it('Should fail to serialize an object', function () {
+        it('Should fail to serialize an object', () => {
             try {
-                upaApi.serialize({foo: 'bar'});
+                upaApi.serialize({ foo: 'bar' });
                 fail('Should have failed here!');
             } catch (error) {
                 expect(error).not.toBeNull();
-                expect(error.error).toEqual('Can only serialize UPA strings or Arrays of UPA paths');
+                expect(error.error).toEqual(
+                    'Can only serialize UPA strings or Arrays of UPA paths'
+                );
             }
         });
 
-        it('Should serialize all elements of a structure', function () {
-            var serialized = upaApi.serializeAll(upaStruct);
-            Object.keys(serialized).forEach(function(key) {
+        it('Should serialize all elements of a structure', () => {
+            const serialized = upaApi.serializeAll(upaStruct);
+            Object.keys(serialized).forEach((key) => {
                 if (typeof upaStructSerial[key] === 'string') {
                     expect(serialized[key]).toEqual(upaStructSerial[key]);
-                }
-                else if (Array.isArray(upaStructSerial[key])) {
-                    upaStructSerial[key].forEach(function(serialUpa) {
+                } else if (Array.isArray(upaStructSerial[key])) {
+                    upaStructSerial[key].forEach((serialUpa) => {
                         expect(serialized[key].indexOf(serialUpa)).toBeGreaterThan(-1);
                     });
                 }
             });
         });
 
-        it('Should throw an error when changing the version of an UPA that isn\t an UPA', function () {
+        it('Should throw an error when changing the version of an UPA that isn\t an UPA', () => {
             try {
                 upaApi.changeUpaVersion('not an upa', 'no new version');
                 fail('Should have failed here!');
             } catch (error) {
                 expect(error).not.toBeNull();
-                expect(error.error).toContain('is not a valid upa, so its version cannot be changed!');
+                expect(error.error).toContain(
+                    'is not a valid upa, so its version cannot be changed!'
+                );
             }
         });
 
-        it('Should throw an error when changing the version of an UPA to a bad value', function () {
-            var badVersionValues = [0, -1, '-1', '0', 'abc', '12V', 'V12', '1v3'];
-            badVersionValues.forEach(function(badVal) {
+        it('Should throw an error when changing the version of an UPA to a bad value', () => {
+            const badVersionValues = [0, -1, '-1', '0', 'abc', '12V', 'V12', '1v3'];
+            badVersionValues.forEach((badVal) => {
                 try {
-                    var newUpa = upaApi.changeUpaVersion('1/2/3', badVal);
+                    const newUpa = upaApi.changeUpaVersion('1/2/3', badVal);
                     fail(newUpa + ' -- Should have failed here!');
                 } catch (error) {
                     expect(error).not.toBeNull();

--- a/test/unit/spec/appWidgets/commonSpec.js
+++ b/test/unit/spec/appWidgets/commonSpec.js
@@ -1,7 +1,3 @@
-/*global define*/ // eslint-disable-line no-redeclare
-/*global describe, expect, it*/
-/*jslint white: true*/
-
 define(['common/events', 'common/ui', 'kb_common/html', 'widgets/appWidgets2/common'], (
     Events,
     UI,

--- a/test/unit/spec/appWidgets/commonSpec.js
+++ b/test/unit/spec/appWidgets/commonSpec.js
@@ -2,16 +2,11 @@
 /*global describe, expect, it*/
 /*jslint white: true*/
 
-define([
-    'common/events',
-    'common/ui',
-    'kb_common/html',
-    'widgets/appWidgets2/common',
-], (
+define(['common/events', 'common/ui', 'kb_common/html', 'widgets/appWidgets2/common'], (
     Events,
     UI,
     html,
-    WidgetCommon,
+    WidgetCommon
 ) => {
     'use strict';
     const div = html.tag('div');
@@ -29,23 +24,34 @@ define([
         it('Should be able to produce content with a clipboard icon', () => {
             const input = document.createElement('div');
             const content = WidgetCommon.containerContent(
-                div, button, events, ui, container, input
+                div,
+                button,
+                events,
+                ui,
+                container,
+                input
             );
             container.innerHTML = content;
-            expect(container
-                .querySelectorAll('[data-element=icon]')[0]
-                .classList.contains('fa-clipboard')
+            expect(
+                container
+                    .querySelectorAll('[data-element=icon]')[0]
+                    .classList.contains('fa-clipboard')
             ).toBeTrue();
         });
 
         it('Should be able to create the clipboard icon', () => {
             const clipboardButton = WidgetCommon.clipboardButton(
-                div, button, events, ui, container
+                div,
+                button,
+                events,
+                ui,
+                container
             );
             container.innerHTML = clipboardButton;
-            expect(container
-                .querySelectorAll('[data-element=icon]')[0]
-                .classList.contains('fa-clipboard')
+            expect(
+                container
+                    .querySelectorAll('[data-element=icon]')[0]
+                    .classList.contains('fa-clipboard')
             ).toBeTrue();
         });
     });

--- a/test/unit/spec/appWidgets/infoPanelSpec.js
+++ b/test/unit/spec/appWidgets/infoPanelSpec.js
@@ -4,88 +4,90 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define([
-    'jquery',
-    'narrativeConfig',
-    'kbase/js/widgets/appInfoPanel'
-], function(
-    $,
-    Config,
-    InfoPanel
-) {
+define(['jquery', 'narrativeConfig', 'kbase/js/widgets/appInfoPanel'], ($, Config, InfoPanel) => {
     'use strict';
 
     function makeDummyPanel() {
         return InfoPanel.make({
             appId: 'SomeModule/some_app',
             appModule: 'SomeModule',
-            tag: 'release'
+            tag: 'release',
         });
     }
 
     /**
      * Mock data for the NMS.get_method_full_info call.
      */
-    const methodFullInfoMock = [[{
-        description: 'This is a KBase wrapper for SomeModule.',
-        authors: ['author1', 'author2']
-    }]];
+    const methodFullInfoMock = [
+        [
+            {
+                description: 'This is a KBase wrapper for SomeModule.',
+                authors: ['author1', 'author2'],
+            },
+        ],
+    ];
 
     /**
      * Mock data for the Catalog.get_exec_aggr_stats call.
      */
-    const getExecAggrStatsMock = [[{
-        number_of_calls: 5
-    }]];
+    const getExecAggrStatsMock = [
+        [
+            {
+                number_of_calls: 5,
+            },
+        ],
+    ];
 
     /**
      * Mock data for the Catalog.get_module_info call.
      */
-    const getModuleInfoMock = [{
-        module_name: 'SomeModule',
-        release: {
-            timestamp: 1555098756211
-        }
-    }];
+    const getModuleInfoMock = [
+        {
+            module_name: 'SomeModule',
+            release: {
+                timestamp: 1555098756211,
+            },
+        },
+    ];
 
     describe('Test the App Info Panel module', () => {
         beforeEach(() => {
             jasmine.Ajax.install();
-            jasmine.Ajax.stubRequest(Config.url('narrative_method_store'), /get_method_full_info/)
-                .andReturn({
-                    status: 200,
-                    statusText: 'HTTP/1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({
-                        version: '1.1',
-                        id: '12345',
-                        result: methodFullInfoMock
-                    })
-                });
+            jasmine.Ajax.stubRequest(
+                Config.url('narrative_method_store'),
+                /get_method_full_info/
+            ).andReturn({
+                status: 200,
+                statusText: 'HTTP/1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify({
+                    version: '1.1',
+                    id: '12345',
+                    result: methodFullInfoMock,
+                }),
+            });
 
-            jasmine.Ajax.stubRequest(Config.url('catalog'), /get_exec_aggr_stats/)
-                .andReturn({
-                    status: 200,
-                    statusText: 'HTTP/1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({
-                        version: '1.1',
-                        id: '12345',
-                        result: getExecAggrStatsMock
-                    })
-                });
+            jasmine.Ajax.stubRequest(Config.url('catalog'), /get_exec_aggr_stats/).andReturn({
+                status: 200,
+                statusText: 'HTTP/1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify({
+                    version: '1.1',
+                    id: '12345',
+                    result: getExecAggrStatsMock,
+                }),
+            });
 
-            jasmine.Ajax.stubRequest(Config.url('catalog'), /get_module_info/)
-                .andReturn({
-                    status: 200,
-                    statusText: 'HTTP/1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({
-                        version: '1.1',
-                        id: '12345',
-                        result: getModuleInfoMock
-                    })
-                });
+            jasmine.Ajax.stubRequest(Config.url('catalog'), /get_module_info/).andReturn({
+                status: 200,
+                statusText: 'HTTP/1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify({
+                    version: '1.1',
+                    id: '12345',
+                    result: getModuleInfoMock,
+                }),
+            });
         });
 
         afterEach(() => {
@@ -99,7 +101,7 @@ define([
 
         it('Has expected functions when instantiated', () => {
             const panel = makeDummyPanel();
-            ['start', 'stop'].forEach(fn => {
+            ['start', 'stop'].forEach((fn) => {
                 expect(panel[fn]).toBeDefined();
             });
         });
@@ -107,16 +109,18 @@ define([
         it('Can render with "start" and return a Promise', () => {
             const panel = makeDummyPanel();
             const myNode = $('<div>');
-            return panel.start({ node: myNode })
-                .then(() => {
-                    expect(myNode.find('.kb-app-cell-info-desc').text()).toContain('This is a KBase wrapper for SomeModule.');
-                });
+            return panel.start({ node: myNode }).then(() => {
+                expect(myNode.find('.kb-app-cell-info-desc').text()).toContain(
+                    'This is a KBase wrapper for SomeModule.'
+                );
+            });
         });
 
         it('Can unrender with "stop" and return a Promise', () => {
             const panel = makeDummyPanel();
             const myNode = $('<div>');
-            return panel.start({ node: myNode })
+            return panel
+                .start({ node: myNode })
                 .then(() => {
                     return panel.stop();
                 })

--- a/test/unit/spec/appWidgets/infoPanelSpec.js
+++ b/test/unit/spec/appWidgets/infoPanelSpec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['jquery', 'narrativeConfig', 'kbase/js/widgets/appInfoPanel'], ($, Config, InfoPanel) => {
     'use strict';
 

--- a/test/unit/spec/appWidgets/infoTabSpec.js
+++ b/test/unit/spec/appWidgets/infoTabSpec.js
@@ -1,8 +1,3 @@
-/*global beforeEach */
-/*global define*/ // eslint-disable-line no-redeclare
-/*global describe, expect, it*/
-/*jslint white: true*/
-
 define(['../../../../../narrative/nbextensions/appCell2/widgets/tabs/infoTab'], (infoTabWidget) => {
     'use strict';
 

--- a/test/unit/spec/appWidgets/infoTabSpec.js
+++ b/test/unit/spec/appWidgets/infoTabSpec.js
@@ -3,109 +3,96 @@
 /*global describe, expect, it*/
 /*jslint white: true*/
 
-define([
-    '../../../../../narrative/nbextensions/appCell2/widgets/tabs/infoTab',
-], function(
-    infoTabWidget
-) {
+define(['../../../../../narrative/nbextensions/appCell2/widgets/tabs/infoTab'], (infoTabWidget) => {
     'use strict';
 
-    describe('The App Info Tab module', function() {
-        it('loads', function() {
+    describe('The App Info Tab module', () => {
+        it('loads', () => {
             expect(infoTabWidget).not.toBe(null);
         });
 
-        it('has expected functions', function() {
+        it('has expected functions', () => {
             expect(infoTabWidget.make).toBeDefined();
         });
-
     });
 
-    describe('The App Info Tab instance', function() {
+    describe('The App Info Tab instance', () => {
         const model = {
             getItem: (item) => model[item],
-            'app': {'tag': 'Mock App'},
+            app: { tag: 'Mock App' },
             'app.spec': {
-                'full_info' : {
-                    'description': 'Details about this mock app'
+                full_info: {
+                    description: 'Details about this mock app',
                 },
-                'info': {
-                    'authors': ['Abraham', 'Martin', 'John'],
-                    'id': 0,
-                    'subtitle': 'A mock app for testing purposes',
-                    'ver': '1.0.1',
+                info: {
+                    authors: ['Abraham', 'Martin', 'John'],
+                    id: 0,
+                    subtitle: 'A mock app for testing purposes',
+                    ver: '1.0.1',
                 },
-                'parameters': [{
-                    'text_options': {
-                        'valid_ws_types': ['KBaseRNASeq.RNASeqSampleSet']},
-                    'ui_name': 'RNA sequence object <font color=red>*</font>',
-                }, {
-                    'ui_name': 'Adapters',
-                }],
+                parameters: [
+                    {
+                        text_options: {
+                            valid_ws_types: ['KBaseRNASeq.RNASeqSampleSet'],
+                        },
+                        ui_name: 'RNA sequence object <font color=red>*</font>',
+                    },
+                    {
+                        ui_name: 'Adapters',
+                    },
+                ],
             },
-            'executionStats': {
-                'number_of_calls': 1729,
-                'total_exec_time': 9001,
+            executionStats: {
+                number_of_calls: 1729,
+                total_exec_time: 9001,
             },
         };
         const appSpec = model.getItem('app.spec');
-        const mockInfoTab = infoTabWidget.make({model});
+        const mockInfoTab = infoTabWidget.make({ model });
         let node, infoTabPromise, infoTab;
 
-        beforeEach(async function () {
+        beforeEach(async () => {
             node = document.createElement('div');
-            infoTabPromise = mockInfoTab.start({node});
+            infoTabPromise = mockInfoTab.start({ node });
             infoTab = await infoTabPromise;
             return infoTab; // to use infoTab for linter
         });
 
-        it('has a factory which can be invoked', function() {
+        it('has a factory which can be invoked', () => {
             expect(mockInfoTab).not.toBe(null);
         });
 
-        it('has the required methods', function() {
+        it('has the required methods', () => {
             expect(mockInfoTab.start).toBeDefined();
             expect(mockInfoTab.stop).toBeDefined();
         });
 
-        it('has a method "start" which returns a Promise',
-            function() {
-                expect(infoTabPromise instanceof Promise).toBeTrue();
-            }
-        );
-
-        it('has a method "stop" which returns a Promise',
-            function() {
-                const result = mockInfoTab.stop();
-                expect(result instanceof Promise).toBeTrue();
-            }
-        );
-
-        it('returns the defined description', function() {
-            expect(infoTab.firstChild.textContent).toBe(
-                appSpec.full_info.description
-            );
+        it('has a method "start" which returns a Promise', () => {
+            expect(infoTabPromise instanceof Promise).toBeTrue();
         });
 
-        it('returns an item for each parameter', function() {
+        it('has a method "stop" which returns a Promise', () => {
+            const result = mockInfoTab.stop();
+            expect(result instanceof Promise).toBeTrue();
+        });
+
+        it('returns the defined description', () => {
+            expect(infoTab.firstChild.textContent).toBe(appSpec.full_info.description);
+        });
+
+        it('returns an item for each parameter', () => {
             const listItems = Array.from(infoTab.querySelectorAll('li li'));
             expect(listItems.length).toBe(appSpec.parameters.length);
         });
 
-        it('renders parameter with formatting correctly', function() {
-            const RNASeqFormat = infoTab.querySelectorAll(
-                'li li:nth-child(1) font'
-            );
+        it('renders parameter with formatting correctly', () => {
+            const RNASeqFormat = infoTab.querySelectorAll('li li:nth-child(1) font');
             expect(RNASeqFormat.length).toBeGreaterThan(0);
         });
 
-        it('renders parameter with no formatting correctly', function() {
-            const AdaptersFormat = infoTab.querySelectorAll(
-                'li li:nth-child(2)'
-            )[0];
-            expect(AdaptersFormat.innerText).toBe(
-                appSpec.parameters[1].ui_name
-            );
+        it('renders parameter with no formatting correctly', () => {
+            const AdaptersFormat = infoTab.querySelectorAll('li li:nth-child(2)')[0];
+            expect(AdaptersFormat.innerText).toBe(appSpec.parameters[1].ui_name);
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/checkboxInputSpec.js
+++ b/test/unit/spec/appWidgets/input/checkboxInputSpec.js
@@ -4,26 +4,20 @@ define([
     'common/runtime',
     'base/js/namespace',
     'kbaseNarrative',
-    'testUtil'
-], function(
-    CheckboxInput,
-    Runtime,
-    Jupyter,
-    Narrative,
-    TestUtil
-) {
+    'testUtil',
+], (CheckboxInput, Runtime, Jupyter, Narrative, TestUtil) => {
     'use strict';
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-    describe('Test checkbox data input widget', function() {
+    describe('Test checkbox data input widget', () => {
         let testConfig = {},
             runtime,
             bus;
 
-        beforeEach(function() {
+        beforeEach(() => {
             runtime = Runtime.make();
             bus = runtime.bus().makeChannelBus({
-                description: 'checkbox testing'
+                description: 'checkbox testing',
             });
             testConfig = {
                 bus: bus,
@@ -32,13 +26,12 @@ define([
                         defaultValue: '',
                         nullValue: '',
                         constraints: {
-                            required: false
-                        }
-
+                            required: false,
+                        },
                     },
                     original: {
-                        text_subdata_options: {}
-                    }
+                        text_subdata_options: {},
+                    },
                 },
                 channelName: bus.channelName,
             };
@@ -55,20 +48,21 @@ define([
             window.kbaseRuntime = null;
         });
 
-        it('should be real!', function() {
+        it('should be real!', () => {
             expect(CheckboxInput).not.toBeNull();
         });
 
-        it('should instantiate with a test config', function() {
+        it('should instantiate with a test config', () => {
             TestUtil.pendingIfNoToken();
-            var widget = CheckboxInput.make(testConfig);
+            const widget = CheckboxInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
         });
 
         it('should start and stop properly without initial value', () => {
-            let widget = CheckboxInput.make(testConfig);
-            let node = document.createElement('div');
-            return widget.start({node: node})
+            const widget = CheckboxInput.make(testConfig);
+            const node = document.createElement('div');
+            return widget
+                .start({ node: node })
                 .then(() => {
                     expect(node.childElementCount).toBeGreaterThan(0);
                     const input = node.querySelector('input[type="checkbox"]');
@@ -83,9 +77,10 @@ define([
 
         it('should start and stop properly with initial value', () => {
             testConfig.initialValue = 1;
-            let widget = CheckboxInput.make(testConfig);
-            let node = document.createElement('div');
-            return widget.start({node: node})
+            const widget = CheckboxInput.make(testConfig);
+            const node = document.createElement('div');
+            return widget
+                .start({ node: node })
                 .then(() => {
                     expect(node.childElementCount).toBeGreaterThan(0);
                     const input = node.querySelector('input[type="checkbox"]');
@@ -100,32 +95,30 @@ define([
 
         it('should update model properly', (done) => {
             bus.on('changed', (value) => {
-                expect(value).toEqual({newValue: 1});
+                expect(value).toEqual({ newValue: 1 });
                 done();
             });
-            let widget = CheckboxInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
-                .then(() => {
-                    const input = node.querySelector('input[type="checkbox"]');
-                    input.setAttribute('checked', true);
-                    input.dispatchEvent(new Event('change'));
-                });
+            const widget = CheckboxInput.make(testConfig);
+            const node = document.createElement('div');
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[type="checkbox"]');
+                input.setAttribute('checked', true);
+                input.dispatchEvent(new Event('change'));
+            });
         });
 
         it('should show message when configured', (done) => {
             testConfig.showOwnMessaged = true;
-            let widget = CheckboxInput.make(testConfig);
-            let node = document.createElement('div');
+            const widget = CheckboxInput.make(testConfig);
+            const node = document.createElement('div');
             bus.on('changed', (value) => {
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    const input = node.querySelector('input[type="checkbox"]');
-                    input.setAttribute('checked', true);
-                    input.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[type="checkbox"]');
+                input.setAttribute('checked', true);
+                input.dispatchEvent(new Event('change'));
+            });
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/checkboxInputSpec.js
+++ b/test/unit/spec/appWidgets/input/checkboxInputSpec.js
@@ -1,4 +1,3 @@
-/*eslint-env jasmine*/
 define([
     'widgets/appWidgets2/input/checkboxInput',
     'common/runtime',

--- a/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
+++ b/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
@@ -3,34 +3,28 @@ define([
     'widgets/appWidgets2/input/dynamicDropdownInput',
     'base/js/namespace',
     'kbaseNarrative',
-    'testUtil'
-], function(
-    DynamicDropdownInput,
-    Jupyter,
-    Narrative,
-    TestUtil
-) {
+    'testUtil',
+], (DynamicDropdownInput, Jupyter, Narrative, TestUtil) => {
     'use strict';
 
-    describe('Test dynamic dropdown input widget', function() {
-        var testConfig = {
+    describe('Test dynamic dropdown input widget', () => {
+        const testConfig = {
             parameterSpec: {
                 data: {
                     defaultValue: '',
                     nullValue: '',
                     constraints: {
-                        required: false
-                    }
-
+                        required: false,
+                    },
                 },
                 original: {
-                    dynamic_dropdown_options: {}
-                }
+                    dynamic_dropdown_options: {},
+                },
             },
-            channelName: 'foo'
+            channelName: 'foo',
         };
 
-        beforeEach(function() {
+        beforeEach(() => {
             Jupyter.narrative = new Narrative();
             if (TestUtil.getAuthToken()) {
                 document.cookie = 'kbase_session=' + TestUtil.getAuthToken();
@@ -39,32 +33,33 @@ define([
             }
         });
 
-        it('should be real!', function() {
+        it('should be real!', () => {
             expect(DynamicDropdownInput).not.toBeNull();
         });
 
-        it('should instantiate with a test config', function() {
+        it('should instantiate with a test config', () => {
             TestUtil.pendingIfNoToken();
-            var widget = DynamicDropdownInput.make(testConfig);
+            const widget = DynamicDropdownInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
         });
 
-        it('should start up and stop correctly', function(done) {
+        it('should start up and stop correctly', (done) => {
             TestUtil.pendingIfNoToken();
-            var widget = DynamicDropdownInput.make(testConfig);
-            widget.start({node: document.createElement('div')})
-                .then(function() {
+            const widget = DynamicDropdownInput.make(testConfig);
+            widget
+                .start({ node: document.createElement('div') })
+                .then(() => {
                     return widget.stop();
                 })
-                .then(function() {
+                .then(() => {
                     // no-op
                 })
-                .catch(function(error) {
+                .catch((error) => {
                     console.error(JSON.stringify(error, null, 4));
                     console.error(error.stack);
                     done.fail();
                 })
-                .finally(function() {
+                .finally(() => {
                     done();
                 });
         });

--- a/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
+++ b/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
@@ -1,4 +1,3 @@
-/*eslint-env jasmine*/
 define([
     'widgets/appWidgets2/input/dynamicDropdownInput',
     'base/js/namespace',

--- a/test/unit/spec/appWidgets/input/floatInputSpec.js
+++ b/test/unit/spec/appWidgets/input/floatInputSpec.js
@@ -1,22 +1,18 @@
 /*eslint-env jasmine*/
-define([
-    'widgets/appWidgets2/input/floatInput',
-    'common/runtime',
-    'testUtil'
-], function(
+define(['widgets/appWidgets2/input/floatInput', 'common/runtime', 'testUtil'], (
     FloatInput,
     Runtime,
     TestUtil
-) {
+) => {
     'use strict';
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-    describe('Test float data input widget', function() {
+    describe('Test float data input widget', () => {
         let testConfig = {},
             runtime,
             bus;
 
-        beforeEach(function() {
+        beforeEach(() => {
             runtime = Runtime.make();
             bus = runtime.bus().makeChannelBus({
                 description: 'float testing',
@@ -31,13 +27,12 @@ define([
                         constraints: {
                             required: false,
                             min: -1000,
-                            max: 1000
-                        }
-
+                            max: 1000,
+                        },
                     },
                     original: {
-                        text_subdata_options: {}
-                    }
+                        text_subdata_options: {},
+                    },
                 },
                 channelName: bus.channelName,
             };
@@ -48,20 +43,21 @@ define([
             window.kbaseRuntime = null;
         });
 
-        it('should be real!', function() {
+        it('should be real!', () => {
             expect(FloatInput).not.toBeNull();
         });
 
-        it('should instantiate with a test config', function() {
+        it('should instantiate with a test config', () => {
             TestUtil.pendingIfNoToken();
-            var widget = FloatInput.make(testConfig);
+            const widget = FloatInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
         });
 
         it('should start and stop properly without initial value', (done) => {
-            let widget = FloatInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
+            const widget = FloatInput.make(testConfig);
+            const node = document.createElement('div');
+            widget
+                .start({ node: node })
                 .then(() => {
                     expect(node.childElementCount).toBeGreaterThan(0);
                     const input = node.querySelector('input[data-type="float"]');
@@ -77,9 +73,10 @@ define([
 
         it('should start and stop properly with initial value', (done) => {
             testConfig.initialValue = 10.0;
-            let widget = FloatInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
+            const widget = FloatInput.make(testConfig);
+            const node = document.createElement('div');
+            widget
+                .start({ node: node })
                 .then(() => {
                     expect(node.childElementCount).toBeGreaterThan(0);
                     const input = node.querySelector('input[data-type="float"]');
@@ -95,55 +92,51 @@ define([
 
         it('should update model properly with change event', (done) => {
             bus.on('changed', (value) => {
-                expect(value).toEqual({newValue: 1.2});
+                expect(value).toEqual({ newValue: 1.2 });
                 done();
             });
-            let widget = FloatInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
-                .then(() => {
-                    const input = node.querySelector('input[data-type="float"]');
-                    input.setAttribute('value', 1.2);
-                    input.dispatchEvent(new Event('change'));
-                })
+            const widget = FloatInput.make(testConfig);
+            const node = document.createElement('div');
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="float"]');
+                input.setAttribute('value', 1.2);
+                input.dispatchEvent(new Event('change'));
+            });
         });
 
         xit('should update model properly with keyup/touch event', (done) => {
-            let widget = FloatInput.make(testConfig);
-            let node = document.createElement('div');
+            const widget = FloatInput.make(testConfig);
+            const node = document.createElement('div');
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    const input = node.querySelector('input[data-type="float"]');
-                    input.setAttribute('value', 1.23);
-                    input.dispatchEvent(new Event('keyup'));
-                });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="float"]');
+                input.setAttribute('value', 1.23);
+                input.dispatchEvent(new Event('keyup'));
+            });
         });
 
         it('should show message when configured', (done) => {
             testConfig.showOwnMessages = true;
-            let widget = FloatInput.make(testConfig);
-            let node = document.createElement('div');
+            const widget = FloatInput.make(testConfig);
+            const node = document.createElement('div');
             bus.on('validation', done);
-            widget.start({node: node})
-                .then(() => {
-                    const input = node.querySelector('input[data-type="float"]');
-                    input.setAttribute('value', 5);
-                    input.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="float"]');
+                input.setAttribute('value', 5);
+                input.dispatchEvent(new Event('change'));
+            });
         });
 
         it('should respond to bus commands', (done) => {
             bus.on('validation', done);
-            let widget = FloatInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('update', {value: '12345.6'});
-                });
+            const widget = FloatInput.make(testConfig);
+            const node = document.createElement('div');
+            widget.start({ node: node }).then(() => {
+                bus.emit('update', { value: '12345.6' });
+            });
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/floatInputSpec.js
+++ b/test/unit/spec/appWidgets/input/floatInputSpec.js
@@ -1,4 +1,3 @@
-/*eslint-env jasmine*/
 define(['widgets/appWidgets2/input/floatInput', 'common/runtime', 'testUtil'], (
     FloatInput,
     Runtime,

--- a/test/unit/spec/appWidgets/input/intInputSpec.js
+++ b/test/unit/spec/appWidgets/input/intInputSpec.js
@@ -1,22 +1,18 @@
 /*eslint-env jasmine*/
-define([
-    'widgets/appWidgets2/input/intInput',
-    'common/runtime',
-    'testUtil'
-], function(
+define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
     IntInput,
     Runtime,
     TestUtil
-) {
+) => {
     'use strict';
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-    describe('Test int data input widget', function() {
+    describe('Test int data input widget', () => {
         let testConfig = {},
             runtime,
             bus;
 
-        beforeEach(function() {
+        beforeEach(() => {
             runtime = Runtime.make();
             bus = runtime.bus().makeChannelBus({
                 description: 'int input testing',
@@ -30,13 +26,12 @@ define([
                         constraints: {
                             required: false,
                             min: -1000,
-                            max: 1000
-                        }
-
+                            max: 1000,
+                        },
                     },
                     original: {
-                        text_subdata_options: {}
-                    }
+                        text_subdata_options: {},
+                    },
                 },
                 channelName: bus.channelName,
             };
@@ -47,20 +42,21 @@ define([
             window.kbaseRuntime = null;
         });
 
-        it('should be real!', function() {
+        it('should be real!', () => {
             expect(IntInput).not.toBeNull();
         });
 
-        it('should instantiate with a test config', function() {
+        it('should instantiate with a test config', () => {
             TestUtil.pendingIfNoToken();
-            var widget = IntInput.make(testConfig);
+            const widget = IntInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
         });
 
         it('should start and stop properly without initial value', (done) => {
-            let widget = IntInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            widget
+                .start({ node: node })
                 .then(() => {
                     expect(node.childElementCount).toBeGreaterThan(0);
                     const input = node.querySelector('input[data-type="int"]');
@@ -76,9 +72,10 @@ define([
 
         it('should start and stop properly with initial value', (done) => {
             testConfig.initialValue = 10;
-            let widget = IntInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            widget
+                .start({ node: node })
                 .then(() => {
                     expect(node.childElementCount).toBeGreaterThan(0);
                     const input = node.querySelector('input[data-type="int"]');
@@ -94,66 +91,62 @@ define([
 
         it('should update model properly with change event', (done) => {
             bus.on('changed', (value) => {
-                expect(value).toEqual({newValue: 1});
+                expect(value).toEqual({ newValue: 1 });
                 done();
             });
-            let widget = IntInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
-                .then(() => {
-                    const input = node.querySelector('input[data-type="int"]');
-                    input.setAttribute('value', 1);
-                    input.dispatchEvent(new Event('change'));
-                })
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="int"]');
+                input.setAttribute('value', 1);
+                input.dispatchEvent(new Event('change'));
+            });
         });
 
         xit('should update model properly with keyup/touch event', (done) => {
-            let widget = IntInput.make(testConfig);
-            let node = document.createElement('div');
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeFalsy();
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let input = node.querySelector('input[data-type="int"]');
-                    input.value = 'foo';
-                    input.setAttribute('value', 'foo');
-                    input.dispatchEvent(new KeyboardEvent('keyup', {key: 3}));
-                });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="int"]');
+                input.value = 'foo';
+                input.setAttribute('value', 'foo');
+                input.dispatchEvent(new KeyboardEvent('keyup', { key: 3 }));
+            });
         });
 
         it('should show message when configured', (done) => {
             testConfig.showOwnMessages = true;
-            let widget = IntInput.make(testConfig);
-            let node = document.createElement('div');
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
             bus.on('validation', done);
-            widget.start({node: node})
-                .then(() => {
-                    const input = node.querySelector('input[data-type="int"]');
-                    input.setAttribute('value', 5);
-                    input.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="int"]');
+                input.setAttribute('value', 5);
+                input.dispatchEvent(new Event('change'));
+            });
         });
 
         it('should respond to update command', (done) => {
             bus.on('validation', done);
-            let widget = IntInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('update', {value: 12345});
-                });
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            widget.start({ node: node }).then(() => {
+                bus.emit('update', { value: 12345 });
+            });
         });
 
-        it('should respond to reset command'), (done) => {
-            bus.on('validation', done);
-            let widget = IntInput.make(testConfig);
-            let node = document.createElement('div');
-            widget.start({node: node})
-                .then(() => {
+        it('should respond to reset command'),
+            (done) => {
+                bus.on('validation', done);
+                const widget = IntInput.make(testConfig);
+                const node = document.createElement('div');
+                widget.start({ node: node }).then(() => {
                     bus.emit('reset-to-defaults');
                 });
-        }
+            };
     });
 });

--- a/test/unit/spec/appWidgets/input/intInputSpec.js
+++ b/test/unit/spec/appWidgets/input/intInputSpec.js
@@ -1,4 +1,3 @@
-/*eslint-env jasmine*/
 define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
     IntInput,
     Runtime,

--- a/test/unit/spec/appWidgets/input/newObjectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/newObjectInputSpec.js
@@ -3,14 +3,8 @@ define([
     'common/runtime',
     'widgets/appWidgets2/input/newObjectInput',
     'base/js/namespace',
-    'kbaseNarrative'
-], (
-    TestUtil,
-    Runtime,
-    NewObjectInput,
-    Jupyter,
-    Narrative
-) => {
+    'kbaseNarrative',
+], (TestUtil, Runtime, NewObjectInput, Jupyter, Narrative) => {
     'use strict';
     let bus,
         testConfig,
@@ -21,9 +15,37 @@ define([
     const wsObjName = 'SomeObject',
         wsObjType = 'SomeModule.SomeType',
         wsObjMapping = {
-            '1': [null],
-            '2': [[1, wsObjName, wsObjType, '2019-07-23T22:42:44+0000', 1, 'someuser', 2, 'someworkspace', 'somehash', 123, null]],
-            '3': [[1, wsObjName, 'SomeOtherModule.SomeOtherType', '2019-07-23T22:42:44+0000', 1, 'someotheruser', 3, 'someotherworkspace', 'somehash', 123, null]]
+            1: [null],
+            2: [
+                [
+                    1,
+                    wsObjName,
+                    wsObjType,
+                    '2019-07-23T22:42:44+0000',
+                    1,
+                    'someuser',
+                    2,
+                    'someworkspace',
+                    'somehash',
+                    123,
+                    null,
+                ],
+            ],
+            3: [
+                [
+                    1,
+                    wsObjName,
+                    'SomeOtherModule.SomeOtherType',
+                    '2019-07-23T22:42:44+0000',
+                    1,
+                    'someotheruser',
+                    3,
+                    'someotherworkspace',
+                    'somehash',
+                    123,
+                    null,
+                ],
+            ],
         };
 
     function buildTestConfig(required, defaultValue, bus) {
@@ -36,13 +58,13 @@ define([
                     constraints: {
                         required: required,
                         defaultValue: defaultValue,
-                        types: ['SomeModule.SomeType']
-                    }
-                }
+                        types: ['SomeModule.SomeType'],
+                    },
+                },
             },
             channelName: bus.channelName,
             closeParameters: [],
-            workspaceId: 777
+            workspaceId: 777,
         };
     }
 
@@ -59,7 +81,7 @@ define([
 
             node = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
-                description: 'select input testing - ' + Math.random().toString(36).substring(2)
+                description: 'select input testing - ' + Math.random().toString(36).substring(2),
             });
             testConfig = buildTestConfig(required, defaultValue, bus);
 
@@ -68,15 +90,16 @@ define([
             jasmine.Ajax.stubRequest(
                 runtime.config('services.workspace.url'),
                 /wsid.\s*\:\s*777\s*,/
-            ).andReturn((function() {
-                return {
-                    status: 200,
-                    statusText: 'HTTP/1.1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({'result': [wsObjMapping['2']]})
-                }
-            })());
-
+            ).andReturn(
+                (function () {
+                    return {
+                        status: 200,
+                        statusText: 'HTTP/1.1 200 OK',
+                        contentType: 'application/json',
+                        responseText: JSON.stringify({ result: [wsObjMapping['2']] }),
+                    };
+                })()
+            );
         });
 
         afterEach(() => {
@@ -90,16 +113,18 @@ define([
         });
 
         it('Should start and stop a widget', (done) => {
-            let widget = NewObjectInput.make(testConfig);
+            const widget = NewObjectInput.make(testConfig);
             expect(widget).toBeDefined();
             expect(widget.start).toBeDefined();
 
             bus.on('sync', () => {
-                let inputElem = node.querySelector('input');
+                const inputElem = node.querySelector('input');
                 expect(inputElem).toBeDefined();
                 done();
             });
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should update value via bus', (done) => {
@@ -107,20 +132,20 @@ define([
             // check along the way.
             bus.respond({
                 key: {
-                    type: 'get-parameters'
+                    type: 'get-parameters',
                 },
                 handle: () => {
                     return {
                         p1: null,
                         p2: 'banana',
-                        p3: 'bar2'
-                    }
-                }
+                        p3: 'bar2',
+                    };
+                },
             });
 
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
-                let inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = node.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     expect(inputElem.value).toBe('foo');
                     done();
@@ -128,10 +153,12 @@ define([
             });
 
             bus.on('sync', () => {
-                bus.emit('update', {value: 'foo'});
+                bus.emit('update', { value: 'foo' });
             });
-            let widget = NewObjectInput.make(testConfig);
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            const widget = NewObjectInput.make(testConfig);
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should reset to default via bus', (done) => {
@@ -139,37 +166,38 @@ define([
 
             bus.respond({
                 key: {
-                    type: 'get-parameters'
+                    type: 'get-parameters',
                 },
                 handle: () => {
                     return {
                         p1: null,
                         p2: 'banana',
-                        p3: 'bar2'
-                    }
-                }
+                        p3: 'bar2',
+                    };
+                },
             });
 
             bus.on('validation', (message) => {
-                let inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = node.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     if (validationCount < 1) {
                         expect(inputElem.value).toBe('foobarbaz');
                         validationCount++;
                         bus.emit('reset-to-defaults');
-                    }
-                    else {
+                    } else {
                         expect(inputElem.value).toBe('apple');
                         done();
                     }
                 }
             });
             bus.on('sync', () => {
-                bus.emit('update', {value: 'foobarbaz'});
+                bus.emit('update', { value: 'foobarbaz' });
             });
 
-            let widget = NewObjectInput.make(testConfig);
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            const widget = NewObjectInput.make(testConfig);
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should reset to empty string via bus without default', (done) => {
@@ -177,26 +205,25 @@ define([
             let validationCount = 0;
             bus.respond({
                 key: {
-                    type: 'get-parameters'
+                    type: 'get-parameters',
                 },
                 handle: () => {
                     return {
                         p1: null,
                         p2: 'banana',
-                        p3: 'bar2'
-                    }
-                }
+                        p3: 'bar2',
+                    };
+                },
             });
 
             bus.on('validation', (message) => {
-                let inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = node.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     if (validationCount < 1) {
                         expect(inputElem.value).toBe('foobarbaz');
                         validationCount++;
                         bus.emit('reset-to-defaults');
-                    }
-                    else {
+                    } else {
                         expect(inputElem.value).toBe('');
                         done();
                     }
@@ -204,26 +231,28 @@ define([
             });
 
             bus.on('sync', () => {
-                bus.emit('update', {value: 'foobarbaz'});
+                bus.emit('update', { value: 'foobarbaz' });
             });
-            let widget = NewObjectInput.make(testConfig);
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            const widget = NewObjectInput.make(testConfig);
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should respond to duplicate parameter change events with "validation"', (done) => {
-            let widget = NewObjectInput.make(testConfig);
+            const widget = NewObjectInput.make(testConfig);
             const inputStr = 'banana';
             bus.respond({
                 key: {
-                    type: 'get-parameters'
+                    type: 'get-parameters',
                 },
                 handle: () => {
                     return {
                         p1: null,
                         p2: 'banana',
-                        p3: 'bar2'
-                    }
-                }
+                        p3: 'bar2',
+                    };
+                },
             });
 
             bus.on('validation', (message) => {
@@ -233,82 +262,87 @@ define([
                 done();
             });
             bus.on('sync', () => {
-                bus.emit('update', {value: inputStr});
+                bus.emit('update', { value: inputStr });
                 // TestUtil.wait(500)
                 //     .then(() => {
                 //         let inputElem = node.querySelector('input[data-element="input"]');
                 //         inputElem.dispatchEvent(new Event('change'));
                 //     });
             });
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should respond to non-unique parameter change events with "validation"', (done) => {
             TestUtil.pendingIfNoToken();
-            let widget = NewObjectInput.make(testConfig);
+            const widget = NewObjectInput.make(testConfig);
             const inputStr = 'banana';
             bus.respond({
                 key: {
-                    type: 'get-parameters'
+                    type: 'get-parameters',
                 },
                 handle: () => {
                     return {
                         p1: null,
                         p2: 'foo2',
-                        p3: 'bar2'
-                    }
-                }
+                        p3: 'bar2',
+                    };
+                },
             });
 
             bus.on('validation', (message) => {
-                let inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = node.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     inputElem.dispatchEvent(new Event('change'));
                 }
             });
             bus.on('sync', () => {
-                bus.emit('update', {value: inputStr});
+                bus.emit('update', { value: inputStr });
             });
             bus.on('changed', (message) => {
                 expect(message.newValue).toBe('banana');
                 done();
             });
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should validate against workspace with non-unique parameter change events with "validation"', (done) => {
             TestUtil.pendingIfNoToken();
-            let widget = NewObjectInput.make(testConfig);
+            const widget = NewObjectInput.make(testConfig);
             const inputStr = wsObjName;
             bus.respond({
                 key: {
-                    type: 'get-parameters'
+                    type: 'get-parameters',
                 },
                 handle: () => {
                     return {
                         p1: null,
                         p2: 'foo2',
-                        p3: 'bar2'
-                    }
-                }
+                        p3: 'bar2',
+                    };
+                },
             });
 
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
-                expect(message.shortMessage).toBe('an object already exists with this name')
+                expect(message.shortMessage).toBe('an object already exists with this name');
                 expect(message.diagnosis).toBe('suspect');
                 done();
             });
             bus.on('sync', () => {
-                bus.emit('update', {value: inputStr});
+                bus.emit('update', { value: inputStr });
                 // TestUtil.wait(500)
                 //     .then(() => {
                 //         let inputElem = node.querySelector('input[data-element="input"]');
                 //         inputElem.dispatchEvent(new Event('change'));
                 //     });
             });
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
-
     });
 });

--- a/test/unit/spec/appWidgets/input/select2ObjectinputSpec.js
+++ b/test/unit/spec/appWidgets/input/select2ObjectinputSpec.js
@@ -5,30 +5,43 @@ define([
     'common/runtime',
     'widgets/appWidgets2/input/select2ObjectInput',
     'base/js/namespace',
-    'kbaseNarrative'
-], (
-    $,
-    TestUtil,
-    Runtime,
-    Select2ObjectInput,
-    Jupyter,
-    Narrative
-) => {
+    'kbaseNarrative',
+], ($, TestUtil, Runtime, Select2ObjectInput, Jupyter, Narrative) => {
     'use strict';
 
     const readsItem = [
-        3, 'small.fq_reads', 'KBaseFile.SingleEndLibrary-2.2', '2018-01-18T22:26:25+0000', 1, 'wjriehl', 25022, 'wjriehl:narrative12345', '4161234123', 628, {}
-    ],
+            3,
+            'small.fq_reads',
+            'KBaseFile.SingleEndLibrary-2.2',
+            '2018-01-18T22:26:25+0000',
+            1,
+            'wjriehl',
+            25022,
+            'wjriehl:narrative12345',
+            '4161234123',
+            628,
+            {},
+        ],
         readsItem2 = [
-            4, 'other_small.fq_reads', 'KBaseFile.SingleEndLibrary-2.2', '2018-01-19T22:26:25+0000', 1, 'wjriehl', 25022, 'wjriehl:narrative12345', '5161234123', 628, {}
+            4,
+            'other_small.fq_reads',
+            'KBaseFile.SingleEndLibrary-2.2',
+            '2018-01-19T22:26:25+0000',
+            1,
+            'wjriehl',
+            25022,
+            'wjriehl:narrative12345',
+            '5161234123',
+            628,
+            {},
         ],
         dummyData = [readsItem, readsItem2],
         dummyObjInfo = [objectify(readsItem), objectify(readsItem2)];
     let runtime;
 
     function objectify(infoArr) {
-        let splitType = infoArr[2].split('-');
-        let moduleAndType = splitType[0].split('.');
+        const splitType = infoArr[2].split('-');
+        const moduleAndType = splitType[0].split('.');
         return {
             id: infoArr[0],
             name: infoArr[1],
@@ -41,8 +54,7 @@ define([
             wsid: infoArr[6],
             saveDate: new Date(infoArr[3]),
             typeModule: moduleAndType[0],
-            typeName: moduleAndType[1]
-
+            typeName: moduleAndType[1],
         };
     }
 
@@ -56,9 +68,9 @@ define([
                     constraints: {
                         required: required,
                         defaultValue: defaultValue,
-                        types: ['KBaseFile.SingleEndLibrary']
-                    }
-                }
+                        types: ['KBaseFile.SingleEndLibrary'],
+                    },
+                },
             },
             channelName: bus.channelName,
         };
@@ -68,17 +80,19 @@ define([
         dataset = dataset || dummyData;
         objectInfo = objectInfo || dummyObjInfo;
 
-        runtime.bus().set({
-            data: dataset,
-            timestamp: new Date().getTime(),
-            objectInfo: objectInfo
-        }, {
-            channel: 'data',
-            key: {
-                type: 'workspace-data-updated'
+        runtime.bus().set(
+            {
+                data: dataset,
+                timestamp: new Date().getTime(),
+                objectInfo: objectInfo,
+            },
+            {
+                channel: 'data',
+                key: {
+                    type: 'workspace-data-updated',
+                },
             }
-        });
-
+        );
     }
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
@@ -110,17 +124,17 @@ define([
             const taxonServiceInfo = {
                 version: '1.1',
                 id: '12345',
-                result: [{
-                    git_commit_hash: 'blahblahblah',
-                    hash: 'blahblahblah',
-                    health: 'healthy',
-                    module_name: 'taxonomy_service',
-                    url: fakeServiceUrl
-                }]
-            }
-            jasmine.Ajax.stubRequest(
-                runtime.config('services.service_wizard.url')
-            ).andReturn({
+                result: [
+                    {
+                        git_commit_hash: 'blahblahblah',
+                        hash: 'blahblahblah',
+                        health: 'healthy',
+                        module_name: 'taxonomy_service',
+                        url: fakeServiceUrl,
+                    },
+                ],
+            };
+            jasmine.Ajax.stubRequest(runtime.config('services.service_wizard.url')).andReturn({
                 status: 200,
                 statusText: 'HTTP/1.1 200 OK',
                 contentType: 'application/json',
@@ -131,25 +145,28 @@ define([
             const taxonSearchInfo = {
                 version: '1.1',
                 id: '67890',
-                result: [{
-                    hits: [{
-                        label: 'A Hit',
-                        id: '1',
-                        category: 'generic',
-                        parent: null,
-                        parent_ref: null
-                    }],
-                    num_of_hits: 1
-                }]
+                result: [
+                    {
+                        hits: [
+                            {
+                                label: 'A Hit',
+                                id: '1',
+                                category: 'generic',
+                                parent: null,
+                                parent_ref: null,
+                            },
+                        ],
+                        num_of_hits: 1,
+                    },
+                ],
             };
-            jasmine.Ajax.stubRequest(fakeServiceUrl)
-                .andReturn({
-                    status: 200,
-                    statusText: 'HTTP/1.1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify(taxonSearchInfo),
-                    response: JSON.stringify(taxonSearchInfo)
-                });
+            jasmine.Ajax.stubRequest(fakeServiceUrl).andReturn({
+                status: 200,
+                statusText: 'HTTP/1.1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify(taxonSearchInfo),
+                response: JSON.stringify(taxonSearchInfo),
+            });
 
             updateData();
         });
@@ -165,15 +182,16 @@ define([
         });
 
         it('Should be instantiable', () => {
-            let widget = Select2ObjectInput.make(testConfig);
+            const widget = Select2ObjectInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
             expect(widget.start).toBeDefined();
             expect(widget.stop).toBeDefined();
         });
 
         it('Should start and stop', (done) => {
-            let widget = Select2ObjectInput.make(testConfig);
-            widget.start({node: node})
+            const widget = Select2ObjectInput.make(testConfig);
+            widget
+                .start({ node: node })
                 .then(() => {
                     return widget.stop();
                 })
@@ -183,44 +201,44 @@ define([
         });
 
         it('Should set model value by bus', (done) => {
-            let widget = Select2ObjectInput.make(testConfig);
+            const widget = Select2ObjectInput.make(testConfig);
             bus.on('validation', (msg) => {
                 expect(msg.errorMessage).toBeUndefined();
                 expect(msg.diagnosis).toBe('optional-empty');
                 done();
             });
 
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('update', {value: 'foo'})
-                });
+            widget.start({ node: node }).then(() => {
+                bus.emit('update', { value: 'foo' });
+            });
         });
 
         it('Should reset model value by bus', (done) => {
-            let widget = Select2ObjectInput.make(testConfig);
+            const widget = Select2ObjectInput.make(testConfig);
             bus.on('validation', (msg) => {
                 expect(msg.errorMessage).toBeUndefined();
                 expect(msg.diagnosis).toBe('optional-empty');
                 done();
             });
 
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('reset-to-defaults');
-                });
+            widget.start({ node: node }).then(() => {
+                bus.emit('reset-to-defaults');
+            });
         });
 
         it('Should respond to changed select2 option', (done) => {
-            let widget = Select2ObjectInput.make(testConfig);
-            bus.on('validation', (msg) => {
-            })
+            const widget = Select2ObjectInput.make(testConfig);
+            bus.on('validation', (msg) => {});
             bus.on('changed', (msg) => {
                 done();
             });
-            widget.start({node: node})
+            widget
+                .start({ node: node })
                 .then(() => {
-                    let $select = $(node).find('select');
-                    let $search = $select.data('select2').dropdown.$search || $select.data('select2').selection.$search;
+                    const $select = $(node).find('select');
+                    const $search =
+                        $select.data('select2').dropdown.$search ||
+                        $select.data('select2').selection.$search;
 
                     $search.val('small');
                     $search.trigger('input');
@@ -228,14 +246,13 @@ define([
                     $select.trigger({
                         type: 'select2: select',
                         params: {
-                            data: {
-                            }
-                        }
-                    })
+                            data: {},
+                        },
+                    });
                     return TestUtil.wait(1000);
                 })
                 .then(() => {
-                    let $select = $(node).find('select');
+                    const $select = $(node).find('select');
                     $select.val('stuff').trigger('change');
                 });
         });

--- a/test/unit/spec/appWidgets/input/select2ObjectinputSpec.js
+++ b/test/unit/spec/appWidgets/input/select2ObjectinputSpec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 define([
     'jquery',
     'testUtil',

--- a/test/unit/spec/appWidgets/input/selectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/selectInputSpec.js
@@ -1,10 +1,4 @@
-define([
-    'common/runtime',
-    'widgets/appWidgets2/input/selectInput'
-], (
-    Runtime,
-    SelectInput
-) => {
+define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, SelectInput) => {
     'use strict';
     let bus,
         testConfig,
@@ -23,21 +17,25 @@ define([
                     constraints: {
                         required: required,
                         defaultValue: defaultValue,
-                        options: [{
-                            value: 'apple',
-                            display: 'Apple'
-                        }, {
-                            value: 'banana',
-                            display: 'Banana'
-                        }, {
-                            value: 'carrot',
-                            display: 'Carrot'
-                        }]
-                    }
-                }
+                        options: [
+                            {
+                                value: 'apple',
+                                display: 'Apple',
+                            },
+                            {
+                                value: 'banana',
+                                display: 'Banana',
+                            },
+                            {
+                                value: 'carrot',
+                                display: 'Carrot',
+                            },
+                        ],
+                    },
+                },
             },
             channelName: bus.channelName,
-            initialValue: 'apple'
+            initialValue: 'apple',
         };
     }
 
@@ -62,14 +60,15 @@ define([
         });
 
         it('Should start and stop a widget', (done) => {
-            let widget = SelectInput.make(testConfig);
+            const widget = SelectInput.make(testConfig);
             expect(widget).toBeDefined();
             expect(widget.start).toBeDefined();
 
-            widget.start({node: node})
+            widget
+                .start({ node: node })
                 .then(() => {
                     // verify it's there.
-                    let inputElem = node.querySelector('select[data-element="input"]');
+                    const inputElem = node.querySelector('select[data-element="input"]');
                     expect(inputElem).toBeDefined();
                     return widget.stop();
                 })
@@ -80,18 +79,18 @@ define([
                 });
         });
 
-        it('Should update value via bus', (done) => { //and reset model properly via bus', (done) => {
+        it('Should update value via bus', (done) => {
+            //and reset model properly via bus', (done) => {
             // start with one value, change it, then reset.
             // check along the way.
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            let widget = SelectInput.make(testConfig);
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('update', {value: 'banana'});
-                });
+            const widget = SelectInput.make(testConfig);
+            widget.start({ node: node }).then(() => {
+                bus.emit('update', { value: 'banana' });
+            });
         });
 
         it('Should reset to default via bus', (done) => {
@@ -99,62 +98,58 @@ define([
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            let widget = SelectInput.make(testConfig);
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('reset-to-defaults');
-                });
+            const widget = SelectInput.make(testConfig);
+            widget.start({ node: node }).then(() => {
+                bus.emit('reset-to-defaults');
+            });
         });
 
         it('Should respond to input change events with "changed"', (done) => {
-            let widget = SelectInput.make(testConfig);
+            const widget = SelectInput.make(testConfig);
             bus.on('changed', (message) => {
                 expect(message.newValue).toEqual('banana');
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('select[data-element="input"]');
-                    inputElem.selectedIndex=2;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('select[data-element="input"]');
+                inputElem.selectedIndex = 2;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         it('Should respond to input change events with "validation"', (done) => {
-            let widget = SelectInput.make(testConfig);
+            const widget = SelectInput.make(testConfig);
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('select[data-element="input"]');
-                    inputElem.selectedIndex = 1
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('select[data-element="input"]');
+                inputElem.selectedIndex = 1;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         it('Should show message when configured', (done) => {
             testConfig.showOwnMessages = true;
-            let widget = SelectInput.make(testConfig);
+            const widget = SelectInput.make(testConfig);
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 // ...detect something?
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('select[data-element="input"]');
-                    inputElem.value = 'banana';
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('select[data-element="input"]');
+                inputElem.value = 'banana';
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         it('Should return a diagnosis of required-missing if so', (done, fail) => {
             bus = runtime.bus().makeChannelBus();
             testConfig = buildTestConfig(true, '', bus);
-            let widget = SelectInput.make(testConfig);
+            const widget = SelectInput.make(testConfig);
             const inputText = null;
             let msgCount = 0,
                 okCount = 0;
@@ -173,12 +168,11 @@ define([
                     done();
                 }
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('select[data-element="input"]');
-                    inputElem.selectedIndex = -1;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('select[data-element="input"]');
+                inputElem.selectedIndex = -1;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
     });
-})
+});

--- a/test/unit/spec/appWidgets/input/subdataInputSpec.js
+++ b/test/unit/spec/appWidgets/input/subdataInputSpec.js
@@ -3,34 +3,28 @@ define([
     'widgets/appWidgets2/input/subdataInput',
     'base/js/namespace',
     'kbaseNarrative',
-    'testUtil'
-], function(
-    SubdataInput,
-    Jupyter,
-    Narrative,
-    TestUtil
-) {
+    'testUtil',
+], (SubdataInput, Jupyter, Narrative, TestUtil) => {
     'use strict';
 
-    describe('Test subobject data input widget', function() {
-        var testConfig = {
+    describe('Test subobject data input widget', () => {
+        const testConfig = {
             parameterSpec: {
                 data: {
                     defaultValue: '',
                     nullValue: '',
                     constraints: {
-                        required: false
-                    }
-
+                        required: false,
+                    },
                 },
                 original: {
-                    text_subdata_options: {}
-                }
+                    text_subdata_options: {},
+                },
             },
-            channelName: 'foo'
+            channelName: 'foo',
         };
 
-        beforeEach(function() {
+        beforeEach(() => {
             Jupyter.narrative = new Narrative();
             if (TestUtil.getAuthToken()) {
                 document.cookie = 'kbase_session=' + TestUtil.getAuthToken();
@@ -39,13 +33,13 @@ define([
             }
         });
 
-        it('should be real!', function() {
+        it('should be real!', () => {
             expect(SubdataInput).not.toBeNull();
         });
 
-        it('should instantiate with a test config', function() {
+        it('should instantiate with a test config', () => {
             TestUtil.pendingIfNoToken();
-            var widget = SubdataInput.make(testConfig);
+            const widget = SubdataInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
         });
     });

--- a/test/unit/spec/appWidgets/input/subdataInputSpec.js
+++ b/test/unit/spec/appWidgets/input/subdataInputSpec.js
@@ -1,4 +1,3 @@
-/*eslint-env jasmine*/
 define([
     'widgets/appWidgets2/input/subdataInput',
     'base/js/namespace',

--- a/test/unit/spec/appWidgets/input/taxonomyRefInputSpec.js
+++ b/test/unit/spec/appWidgets/input/taxonomyRefInputSpec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 define([
     'jquery',
     'testUtil',

--- a/test/unit/spec/appWidgets/input/taxonomyRefInputSpec.js
+++ b/test/unit/spec/appWidgets/input/taxonomyRefInputSpec.js
@@ -5,15 +5,8 @@ define([
     'common/runtime',
     'widgets/appWidgets2/input/taxonomyRefInput',
     'base/js/namespace',
-    'kbaseNarrative'
-], (
-    $,
-    TestUtil,
-    Runtime,
-    TaxonomyRefInput,
-    Jupyter,
-    Narrative
-) => {
+    'kbaseNarrative',
+], ($, TestUtil, Runtime, TaxonomyRefInput, Jupyter, Narrative) => {
     'use strict';
 
     function buildTestConfig(required, defaultValue, bus) {
@@ -26,9 +19,9 @@ define([
                     constraints: {
                         required: required,
                         defaultValue: defaultValue,
-                        types: ['SomeModule.SomeType']
-                    }
-                }
+                        types: ['SomeModule.SomeType'],
+                    },
+                },
             },
             channelName: bus.channelName,
         };
@@ -43,7 +36,6 @@ define([
             node,
             defaultValue = 'apple',
             fakeServiceUrl = 'https://ci.kbase.us/services/fake_taxonomy_service';
-
 
         beforeEach(() => {
             runtime = Runtime.make();
@@ -65,17 +57,17 @@ define([
             const taxonServiceInfo = {
                 version: '1.1',
                 id: '12345',
-                result: [{
-                    git_commit_hash: 'blahblahblah',
-                    hash: 'blahblahblah',
-                    health: 'healthy',
-                    module_name: 'taxonomy_service',
-                    url: fakeServiceUrl
-                }]
-            }
-            jasmine.Ajax.stubRequest(
-                runtime.config('services.service_wizard.url')
-            ).andReturn({
+                result: [
+                    {
+                        git_commit_hash: 'blahblahblah',
+                        hash: 'blahblahblah',
+                        health: 'healthy',
+                        module_name: 'taxonomy_service',
+                        url: fakeServiceUrl,
+                    },
+                ],
+            };
+            jasmine.Ajax.stubRequest(runtime.config('services.service_wizard.url')).andReturn({
                 status: 200,
                 statusText: 'HTTP/1.1 200 OK',
                 contentType: 'application/json',
@@ -86,25 +78,28 @@ define([
             const taxonSearchInfo = {
                 version: '1.1',
                 id: '67890',
-                result: [{
-                    hits: [{
-                        label: 'A Hit',
-                        id: '1',
-                        category: 'generic',
-                        parent: null,
-                        parent_ref: null
-                    }],
-                    num_of_hits: 1
-                }]
+                result: [
+                    {
+                        hits: [
+                            {
+                                label: 'A Hit',
+                                id: '1',
+                                category: 'generic',
+                                parent: null,
+                                parent_ref: null,
+                            },
+                        ],
+                        num_of_hits: 1,
+                    },
+                ],
             };
-            jasmine.Ajax.stubRequest(fakeServiceUrl)
-                .andReturn({
-                    status: 200,
-                    statusText: 'HTTP/1.1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify(taxonSearchInfo),
-                    response: JSON.stringify(taxonSearchInfo)
-                });
+            jasmine.Ajax.stubRequest(fakeServiceUrl).andReturn({
+                status: 200,
+                statusText: 'HTTP/1.1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify(taxonSearchInfo),
+                response: JSON.stringify(taxonSearchInfo),
+            });
         });
 
         afterEach(() => {
@@ -118,60 +113,62 @@ define([
         });
 
         it('Should be instantiable', () => {
-            let widget = TaxonomyRefInput.make(testConfig);
+            const widget = TaxonomyRefInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
             expect(widget.start).toBeDefined();
             expect(widget.stop).toBeDefined();
         });
 
         it('Should start and stop', (done) => {
-            let widget = TaxonomyRefInput.make(testConfig);
-            widget.start({node: node})
+            const widget = TaxonomyRefInput.make(testConfig);
+            widget
+                .start({ node: node })
                 .then(() => {
                     return widget.stop();
                 })
                 .then(() => {
-                    done()
+                    done();
                 });
         });
 
         it('Should set model value by bus', (done) => {
-            let widget = TaxonomyRefInput.make(testConfig);
+            const widget = TaxonomyRefInput.make(testConfig);
             bus.on('validation', (msg) => {
                 expect(msg.errorMessage).toBeNull();
                 expect(msg.diagnosis).toBe('valid');
                 done();
             });
 
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('update', {value: 'foo'})
-                });
+            widget.start({ node: node }).then(() => {
+                bus.emit('update', { value: 'foo' });
+            });
         });
 
         it('Should reset model value by bus', (done) => {
-            let widget = TaxonomyRefInput.make(testConfig);
+            const widget = TaxonomyRefInput.make(testConfig);
             bus.on('validation', (msg) => {
                 expect(msg.errorMessage).toBeNull();
                 expect(msg.diagnosis).toBe('valid');
                 done();
             });
 
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('reset-to-defaults');
-                });
+            widget.start({ node: node }).then(() => {
+                bus.emit('reset-to-defaults');
+            });
         });
 
         it('Should respond to changed select2 option', (done) => {
-            let widget = TaxonomyRefInput.make(testConfig);
+            const widget = TaxonomyRefInput.make(testConfig);
             bus.on('changed', (msg) => {
                 done();
             });
-            widget.start({node: node})
+            widget
+                .start({ node: node })
                 .then(() => {
-                    let $select = $(node).find('select');
-                    let $search = $select.data('select2').dropdown.$search || $select.data('select2').selection.$search;
+                    const $select = $(node).find('select');
+                    const $search =
+                        $select.data('select2').dropdown.$search ||
+                        $select.data('select2').selection.$search;
 
                     $search.val('stuff');
                     $search.trigger('input');
@@ -179,10 +176,9 @@ define([
                     $select.trigger({
                         type: 'select2: select',
                         params: {
-                            data: {
-                            }
-                        }
-                    })
+                            data: {},
+                        },
+                    });
                     return TestUtil.wait(1000);
                     // $select.val('something').trigger({
                     //     type: 'select2:select',
@@ -195,7 +191,7 @@ define([
                     // });
                 })
                 .then(() => {
-                    let $select = $(node).find('select');
+                    const $select = $(node).find('select');
                     $select.val('stuff').trigger('change');
                 });
         });

--- a/test/unit/spec/appWidgets/input/textInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textInputSpec.js
@@ -1,10 +1,4 @@
-define([
-    'common/runtime',
-    'widgets/appWidgets2/input/textInput'
-], (
-    Runtime,
-    TextInput
-) => {
+define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, TextInput) => {
     'use strict';
     let bus,
         testConfig,
@@ -22,11 +16,11 @@ define([
                     nullValue: '',
                     constraints: {
                         required: required,
-                        defaultValue: defaultValue
-                    }
-                }
+                        defaultValue: defaultValue,
+                    },
+                },
             },
-            channelName: bus.channelName
+            channelName: bus.channelName,
         };
     }
 
@@ -51,14 +45,15 @@ define([
         });
 
         it('Should start and stop a widget', (done) => {
-            let widget = TextInput.make(testConfig);
+            const widget = TextInput.make(testConfig);
             expect(widget).toBeDefined();
             expect(widget.start).toBeDefined();
 
-            widget.start({node: node})
+            widget
+                .start({ node: node })
                 .then(() => {
                     // verify it's there.
-                    let inputElem = node.querySelector('input[data-element="input"]');
+                    const inputElem = node.querySelector('input[data-element="input"]');
                     expect(inputElem).toBeDefined();
                     return widget.stop();
                 })
@@ -76,11 +71,10 @@ define([
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            let widget = TextInput.make(testConfig);
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('update', {value: 'some text'});
-                });
+            const widget = TextInput.make(testConfig);
+            widget.start({ node: node }).then(() => {
+                bus.emit('update', { value: 'some text' });
+            });
         });
 
         it('Should reset to default via bus', (done) => {
@@ -88,80 +82,75 @@ define([
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            let widget = TextInput.make(testConfig);
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('reset-to-defaults');
-                });
+            const widget = TextInput.make(testConfig);
+            widget.start({ node: node }).then(() => {
+                bus.emit('reset-to-defaults');
+            });
         });
 
         it('Should respond to input change events with "changed"', (done) => {
-            let widget = TextInput.make(testConfig);
+            const widget = TextInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('changed', (message) => {
                 expect(message.newValue).toEqual(inputText);
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('input[data-element="input"]');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('input[data-element="input"]');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         it('Should respond to input change events with "validation"', (done) => {
-            let widget = TextInput.make(testConfig);
+            const widget = TextInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('input[data-element="input"]');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('input[data-element="input"]');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         xit('Should respond to keyup change events with "validation"', (done) => {
-            let widget = TextInput.make(testConfig);
+            const widget = TextInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('input[data-element="input"]');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('keyup'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('input[data-element="input"]');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('keyup'));
+            });
         });
 
         it('Should show message when configured', (done) => {
             testConfig.showOwnMessages = true;
-            let widget = TextInput.make(testConfig);
+            const widget = TextInput.make(testConfig);
             const inputText = 'some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 // ...detect something?
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('input[data-element="input"]');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('input[data-element="input"]');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         it('Should return a diagnosis of required-missing if so', (done) => {
             testConfig = buildTestConfig(true, '', bus);
-            let widget = TextInput.make(testConfig);
+            const widget = TextInput.make(testConfig);
             const inputText = null;
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeFalsy();
@@ -169,13 +158,11 @@ define([
                 // ...detect something?
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('input[data-element="input"]');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('input[data-element="input"]');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
-
     });
-})
+});

--- a/test/unit/spec/appWidgets/input/textareaInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textareaInputSpec.js
@@ -1,10 +1,4 @@
-define([
-    'common/runtime',
-    'widgets/appWidgets2/input/textareaInput'
-], (
-    Runtime,
-    TextareaInput
-) => {
+define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, TextareaInput) => {
     'use strict';
     let bus,
         testConfig,
@@ -23,14 +17,14 @@ define([
                     nullValue: null,
                     constraints: {
                         required: required,
-                        defaultValue: defaultValue
-                    }
+                        defaultValue: defaultValue,
+                    },
                 },
                 ui: {
-                    nRows: numRows
-                }
+                    nRows: numRows,
+                },
             },
-            channelName: bus.channelName
+            channelName: bus.channelName,
         };
     }
 
@@ -55,14 +49,15 @@ define([
         });
 
         it('Should start and stop a widget', (done) => {
-            let widget = TextareaInput.make(testConfig);
+            const widget = TextareaInput.make(testConfig);
             expect(widget).toBeDefined();
             expect(widget.start).toBeDefined();
 
-            widget.start({node: node})
+            widget
+                .start({ node: node })
                 .then(() => {
                     // verify it's there.
-                    let textarea = node.querySelector('textarea');
+                    const textarea = node.querySelector('textarea');
                     expect(textarea).toBeDefined();
                     expect(textarea.getAttribute('rows')).toBe(String(numRows));
                     return widget.stop();
@@ -81,11 +76,10 @@ define([
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            let widget = TextareaInput.make(testConfig);
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('update', {value: 'some text'});
-                });
+            const widget = TextareaInput.make(testConfig);
+            widget.start({ node: node }).then(() => {
+                bus.emit('update', { value: 'some text' });
+            });
         });
 
         it('Should reset to default via bus', (done) => {
@@ -93,47 +87,43 @@ define([
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            let widget = TextareaInput.make(testConfig);
-            widget.start({node: node})
-                .then(() => {
-                    bus.emit('reset-to-defaults');
-                });
+            const widget = TextareaInput.make(testConfig);
+            widget.start({ node: node }).then(() => {
+                bus.emit('reset-to-defaults');
+            });
         });
 
-
         it('Should respond to input change events with "changed"', (done) => {
-            let widget = TextareaInput.make(testConfig);
+            const widget = TextareaInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('changed', (message) => {
                 expect(message.newValue).toEqual(inputText);
                 widget.stop().then(done);
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('textarea');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('textarea');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         it('Should respond to input change events with "validation"', (done) => {
-            let widget = TextareaInput.make(testConfig);
+            const widget = TextareaInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('textarea');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('textarea');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         xit('Should respond to keyup change events with "changed"', (done) => {
-            let widget = TextareaInput.make(testConfig);
+            const widget = TextareaInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('changed', (message) => {
                 // expect(message.newValue).toBe(inputText);
@@ -142,35 +132,33 @@ define([
                 console.log('Caught a change message!');
                 // done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('textarea');
-                    console.log('here is the elem', inputElem);
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('keyup'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('textarea');
+                console.log('here is the elem', inputElem);
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('keyup'));
+            });
         });
 
         it('Should show message when configured', (done) => {
             testConfig.showOwnMessages = true;
-            let widget = TextareaInput.make(testConfig);
+            const widget = TextareaInput.make(testConfig);
             const inputText = 'some text';
             bus.on('changed', (message) => {
                 expect(message.newValue).toBe(inputText);
                 // ...detect something?
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('textarea');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('textarea');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
 
         it('Should return a diagnosis of required-missing if so', (done) => {
             testConfig = buildTestConfig(true, '', bus);
-            let widget = TextareaInput.make(testConfig);
+            const widget = TextareaInput.make(testConfig);
             const inputText = null;
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeFalsy();
@@ -178,12 +166,11 @@ define([
                 // ...detect something?
                 done();
             });
-            widget.start({node: node})
-                .then(() => {
-                    let inputElem = node.querySelector('textarea');
-                    inputElem.value = inputText;
-                    inputElem.dispatchEvent(new Event('change'));
-                });
+            widget.start({ node: node }).then(() => {
+                const inputElem = node.querySelector('textarea');
+                inputElem.value = inputText;
+                inputElem.dispatchEvent(new Event('change'));
+            });
         });
     });
-})
+});

--- a/test/unit/spec/appWidgets/input/toggleButtonInputSpec.js
+++ b/test/unit/spec/appWidgets/input/toggleButtonInputSpec.js
@@ -1,7 +1,4 @@
-define([
-    'common/runtime',
-    'widgets/appWidgets2/input/toggleButtonInput'
-], (
+define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
     Runtime,
     ToggleButtonInput
 ) => {
@@ -21,13 +18,13 @@ define([
                     defaultValue: defaultValue,
                     nullValue: null,
                     constraints: {
-                        required: required
-                    }
+                        required: required,
+                    },
                 },
                 defaultValue: () => defaultValue,
-                required: () => required
+                required: () => required,
             },
-            channelName: bus.channelName
+            channelName: bus.channelName,
         };
     }
 
@@ -54,7 +51,7 @@ define([
         });
 
         it('Should instantiate a widget', (done) => {
-            let widget = ToggleButtonInput.make(testConfig);
+            const widget = ToggleButtonInput.make(testConfig);
             expect(widget).toBeDefined();
             expect(widget.start).toBeDefined();
 
@@ -62,69 +59,71 @@ define([
             // which does the rendering. THEN we can examine that it's rendered right.
             bus.on('sync', () => {
                 expect(node.querySelector('[data-element="main-panel"]')).toBeDefined();
-                bus.emit('update', {value: true});
+                bus.emit('update', { value: true });
                 setTimeout(() => {
-                    let inputElem = node.querySelector('input[type="checkbox"]');
+                    const inputElem = node.querySelector('input[type="checkbox"]');
                     expect(inputElem).toBeDefined();
                     expect(inputElem.getAttribute('checked')).not.toBeNull();
                     done();
                 }, 1000);
             });
 
-            widget.start()
-                .then(() => {
-                    bus.emit('run', {node: node});
-                });
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should update value via bus', (done) => {
             // start with one value, change it, then reset.
             // check along the way.
-            let widget = ToggleButtonInput.make(testConfig);
+            const widget = ToggleButtonInput.make(testConfig);
 
             bus.on('validation', () => {
-                let inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = node.querySelector('input[type="checkbox"]');
                 expect(inputElem.getAttribute('checked')).not.toBeNull();
                 done();
             });
 
             bus.on('sync', () => {
-                bus.emit('update', {value: defaultValue}); // no change, just verify it's there.
+                bus.emit('update', { value: defaultValue }); // no change, just verify it's there.
             });
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('should reset value via bus', (done) => {
-            let widget = ToggleButtonInput.make(testConfig);
+            const widget = ToggleButtonInput.make(testConfig);
             let validationCount = 0;
             bus.on('validation', () => {
-                let inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = node.querySelector('input[type="checkbox"]');
                 if (inputElem) {
                     if (validationCount < 1) {
                         expect(inputElem.getAttribute('checked')).toBeNull();
                         validationCount++;
                         bus.emit('reset-to-defaults');
-                    }
-                    else {
+                    } else {
                         expect(inputElem.getAttribute('checked')).not.toBeNull();
                         done();
                     }
                 }
             });
             bus.on('sync', () => {
-                bus.emit('update', {value: false});
+                bus.emit('update', { value: false });
             });
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should respond to input change events with "changed"', (done) => {
-            let widget = ToggleButtonInput.make(testConfig);
+            const widget = ToggleButtonInput.make(testConfig);
 
             bus.on('sync', () => {
-                bus.emit('update', {value: defaultValue});
+                bus.emit('update', { value: defaultValue });
             });
             bus.on('validation', () => {
-                let inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = node.querySelector('input[type="checkbox"]');
                 if (inputElem) {
                     expect(inputElem.getAttribute('checked')).not.toBeNull();
                     inputElem.dispatchEvent(new Event('change'));
@@ -135,16 +134,18 @@ define([
                 done();
             });
 
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
 
         it('Should respond to input change events', (done) => {
-            let widget = ToggleButtonInput.make(testConfig);
+            const widget = ToggleButtonInput.make(testConfig);
 
             bus.on('validation', (message) => {
                 expect(message.errorMessage).toBeUndefined();
                 expect(message.diagnosis).toBe('valid');
-                let inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = node.querySelector('input[type="checkbox"]');
                 if (inputElem) {
                     expect(inputElem.getAttribute('checked')).not.toBeNull();
                     inputElem.dispatchEvent(new Event('change'));
@@ -157,10 +158,12 @@ define([
             });
 
             bus.on('sync', () => {
-                bus.emit('update', {value: defaultValue});
+                bus.emit('update', { value: defaultValue });
             });
 
-            widget.start().then(() => {bus.emit('run', {node: node})});
+            widget.start().then(() => {
+                bus.emit('run', { node: node });
+            });
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/undefinedInputSpec.js
+++ b/test/unit/spec/appWidgets/input/undefinedInputSpec.js
@@ -1,6 +1,4 @@
-define([
-    'widgets/appWidgets2/input/undefinedInput'
-], (UndefinedInput) => {
+define(['widgets/appWidgets2/input/undefinedInput'], (UndefinedInput) => {
     'use strict';
 
     describe('Undefined Input Widget test', () => {
@@ -9,10 +7,10 @@ define([
         });
 
         it('Should be instantiable and have an element', () => {
-            let widget = UndefinedInput.make({});
-            let node = document.createElement('div');
+            const widget = UndefinedInput.make({});
+            const node = document.createElement('div');
             widget.attach(node);
             expect(node.innerHTML).toContain('Undefined widget');
         });
-    })
-})
+    });
+});

--- a/test/unit/spec/common/appState-Spec.js
+++ b/test/unit/spec/common/appState-Spec.js
@@ -1,5 +1,3 @@
-/*global define,describe,it,expect*/
-/*jslint white:true,browser:true*/
 define(['common/fsm'], (Fsm) => {
     'use strict';
     const appStates = [

--- a/test/unit/spec/common/appState-Spec.js
+++ b/test/unit/spec/common/appState-Spec.js
@@ -1,245 +1,240 @@
 /*global define,describe,it,expect*/
 /*jslint white:true,browser:true*/
-define([
-    'common/fsm'
-], function (Fsm) {
+define(['common/fsm'], (Fsm) => {
     'use strict';
-    var appStates = [
-        {
-            state: {
-                mode: 'editing',
-                params: 'incomplete'
+    const appStates = [
+            {
+                state: {
+                    mode: 'editing',
+                    params: 'incomplete',
+                },
+                next: [
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                    {
+                        mode: 'editing',
+                        params: 'incomplete',
+                    },
+                ],
             },
-            next: [
-                {
+            {
+                state: {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
+                    code: 'built',
                 },
-                {
-                    mode: 'editing',
-                    params: 'incomplete'
-                }
-            ]
-        },
-        {
-            state: {
-                mode: 'editing',
-                params: 'complete',
-                code: 'built'
+                next: [
+                    {
+                        mode: 'editing',
+                        params: 'incomplete',
+                    },
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                    {
+                        mode: 'processing',
+                        stage: 'launching',
+                    },
+                ],
             },
-            next: [
-                {
-                    mode: 'editing',
-                    params: 'incomplete'
-                },
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                },
-                {
+            {
+                state: {
                     mode: 'processing',
-                    stage: 'launching'
-                }
-            ]
-        },
-        {
-            state: {
-                mode: 'processing',
-                stage: 'launching'
+                    stage: 'launching',
+                },
+                next: [
+                    {
+                        mode: 'processing',
+                        stage: 'queued',
+                    },
+                    {
+                        mode: 'processing',
+                        stage: 'launching',
+                    },
+                    {
+                        mode: 'error',
+                        stage: 'launching',
+                    },
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                ],
             },
-            next: [
-                {
+            {
+                state: {
                     mode: 'processing',
-                    stage: 'queued'
+                    stage: 'queued',
                 },
-                {
+                next: [
+                    {
+                        mode: 'processing',
+                        stage: 'running',
+                    },
+                    {
+                        mode: 'processing',
+                        stage: 'queued',
+                    },
+                    {
+                        mode: 'error',
+                        stage: 'queued',
+                    },
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                ],
+            },
+            {
+                state: {
                     mode: 'processing',
-                    stage: 'launching'
+                    stage: 'running',
                 },
-                {
+                next: [
+                    {
+                        mode: 'success',
+                    },
+                    {
+                        mode: 'error',
+                        stage: 'running',
+                    },
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                ],
+            },
+            {
+                state: {
+                    mode: 'success',
+                },
+                next: [
+                    {
+                        mode: 'success',
+                    },
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                ],
+            },
+            {
+                state: {
                     mode: 'error',
-                    stage: 'launching'
+                    stage: 'launching',
                 },
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                }
-            ]
-        },
-        {
-            state: {
-                mode: 'processing',
-                stage: 'queued'
+                next: [
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                ],
             },
-            next: [
-                {
-                    mode: 'processing',
-                    stage: 'running'
-                },
-                {
-                    mode: 'processing',
-                    stage: 'queued'
-                },
-                {
+            {
+                state: {
                     mode: 'error',
-                    stage: 'queued'
+                    stage: 'queued',
                 },
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                }
-            ]
-        },
-        {
-            state: {
-                mode: 'processing',
-                stage: 'running'
+                next: [
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                ],
             },
-            next: [
-                {
-                    mode: 'success'
-                },
-                {
+            {
+                state: {
                     mode: 'error',
-                    stage: 'running'
+                    stage: 'running',
                 },
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                }
-            ]
-        },
-        {
-            state: {
-                mode: 'success'
+                next: [
+                    {
+                        mode: 'editing',
+                        params: 'complete',
+                        code: 'built',
+                    },
+                ],
             },
-            next: [
-                {
-                    mode: 'success'
-                },
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                }
-            ]
-        },
-        {
-            state: {
-                mode: 'error',
-                stage: 'launching'
-            },
-            next: [
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                }
-            ]
-
-        },
-        {
-            state: {
-                mode: 'error',
-                stage: 'queued'
-            },
-            next: [
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                }
-            ]
-
-        },
-        {
-            state: {
-                mode: 'error',
-                stage: 'running'
-            },
-            next: [
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built'
-                }
-            ]
-
-        }
-    ],
+        ],
         testFindState = {
             state: {
                 mode: 'processing',
-                stage: 'launching'
+                stage: 'launching',
             },
             next: [
                 {
                     mode: 'processing',
-                    stage: 'queued'
+                    stage: 'queued',
                 },
                 {
                     mode: 'processing',
-                    stage: 'launching'
+                    stage: 'launching',
                 },
                 {
                     mode: 'error',
-                    stage: 'launching'
+                    stage: 'launching',
                 },
                 {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
-                }
-            ]
+                    code: 'built',
+                },
+            ],
         },
-    initialState = {
-        state: {
-            mode: 'editing',
-            params: 'incomplete'
-        },
-        next: [
-            {
-                mode: 'editing',
-                params: 'complete',
-                code: 'built'
-            },
-            {
-                mode: 'editing',
-                params: 'incomplete'
-            }
-        ]
-    },
-        nextStateTest =   {
+        initialState = {
             state: {
                 mode: 'editing',
-                params: 'complete',
-                code: 'built'
+                params: 'incomplete',
             },
             next: [
                 {
                     mode: 'editing',
-                    params: 'incomplete'
+                    params: 'complete',
+                    code: 'built',
+                },
+                {
+                    mode: 'editing',
+                    params: 'incomplete',
+                },
+            ],
+        },
+        nextStateTest = {
+            state: {
+                mode: 'editing',
+                params: 'complete',
+                code: 'built',
+            },
+            next: [
+                {
+                    mode: 'editing',
+                    params: 'incomplete',
                 },
                 {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
+                    code: 'built',
                 },
                 {
                     mode: 'processing',
-                    stage: 'launching'
-                }
-            ]
+                    stage: 'launching',
+                },
+            ],
         };
 
-    describe('FSM core functions', function () {
-        it('Is alive', function () {
-            var alive;
+    describe('FSM core functions', () => {
+        it('Is alive', () => {
+            let alive;
             if (Fsm) {
                 alive = true;
             } else {
@@ -247,184 +242,182 @@ define([
             }
             expect(alive).toBeTruthy();
         });
-//        it('Two simple objects equal', function () {
-//            var a = {
-//                name: 'erik'
-//            },
-//            b = {
-//                name: 'erik'
-//            };
-//            expect(Fsm.test.objectEqual(a, b)).toBeTruthy();
-//        });
-//        it('Two simple objects not equal', function () {
-//            var a = {
-//                name: 'erik'
-//            },
-//            b = {
-//                name: 'alex'
-//            };
-//            expect(Fsm.test.objectEqual(a, b)).not.toBeTruthy();
-//        });
+        //        it('Two simple objects equal', function () {
+        //            var a = {
+        //                name: 'erik'
+        //            },
+        //            b = {
+        //                name: 'erik'
+        //            };
+        //            expect(Fsm.test.objectEqual(a, b)).toBeTruthy();
+        //        });
+        //        it('Two simple objects not equal', function () {
+        //            var a = {
+        //                name: 'erik'
+        //            },
+        //            b = {
+        //                name: 'alex'
+        //            };
+        //            expect(Fsm.test.objectEqual(a, b)).not.toBeTruthy();
+        //        });
     });
 
-    describe('Operations on the app state FSM', function () {
-        it('Create with an FSM', function () {
-            var states = appStates,
+    describe('Operations on the app state FSM', () => {
+        it('Create with an FSM', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 });
             expect(fsm).toBeTruthy();
         });
 
-        it('Find a state', function () {
-            var states = appStates,
+        it('Find a state', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 }),
                 toFind = {
                     mode: 'processing',
-                    stage: 'launching'
+                    stage: 'launching',
                 },
-            found = fsm.findState(toFind);
+                found = fsm.findState(toFind);
 
             expect(found).toEqual(testFindState);
         });
 
-        it('Initialize the state machine, should be on initial state.', function () {
-            var states = appStates,
+        it('Initialize the state machine, should be on initial state.', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 });
             fsm.start();
             expect(fsm.getCurrentState()).toEqual(initialState);
         });
 
-
-        it('Move to another state.', function () {
-            var states = appStates,
+        it('Move to another state.', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 }),
                 nextState = {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
+                    code: 'built',
                 };
             fsm.start();
             fsm.newState(nextState);
-            
+
             expect(fsm.getCurrentState()).toEqual(nextStateTest);
         });
 
-        it('Move through a sequence of states.', function () {
-            var states = appStates,
+        it('Move through a sequence of states.', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 });
             fsm.start();
-            fsm.newState({mode: 'editing', params: 'complete', code: 'built'});
-            fsm.newState({mode: 'editing', params: 'complete', code: 'built'});
-            fsm.newState({mode: 'editing', params: 'incomplete'});
-            fsm.newState({mode: 'editing', params: 'complete', code: 'built'});
+            fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
+            fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
+            fsm.newState({ mode: 'editing', params: 'incomplete' });
+            fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
 
             expect(fsm.getCurrentState()).toEqual(nextStateTest);
         });
 
-        it('Move into an invalid state.', function () {
-            var states = appStates,
+        it('Move into an invalid state.', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 });
             fsm.start();
 
             function invalid() {
-                fsm.newState({mode: 'tired'});
+                fsm.newState({ mode: 'tired' });
             }
 
             expect(invalid).toThrow();
         });
-        
-        it('Move through the normal sequence of states.', function () {
-            var states = appStates,
+
+        it('Move through the normal sequence of states.', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 });
             fsm.start();
-            
-            fsm.newState({mode: 'editing', params: 'complete', code: 'built'});
-            fsm.newState({mode: 'processing', stage: 'launching'});
-            fsm.newState({mode: 'processing', stage: 'queued'});
-            fsm.newState({mode: 'processing', stage: 'running'});
-            fsm.newState({mode: 'success'});
 
-            expect(fsm.getCurrentState().state).toEqual({mode: 'success'});
+            fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
+            fsm.newState({ mode: 'processing', stage: 'launching' });
+            fsm.newState({ mode: 'processing', stage: 'queued' });
+            fsm.newState({ mode: 'processing', stage: 'running' });
+            fsm.newState({ mode: 'success' });
+
+            expect(fsm.getCurrentState().state).toEqual({ mode: 'success' });
         });
-        
-         it('Move through the normal sequence of states which ends in an error.', function () {
-            var states = appStates,
+
+        it('Move through the normal sequence of states which ends in an error.', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 });
             fsm.start();
-            
-            fsm.newState({mode: 'editing', params: 'complete', code: 'built'});
-            fsm.newState({mode: 'processing', stage: 'launching'});
-            fsm.newState({mode: 'processing', stage: 'queued'});
-            fsm.newState({mode: 'processing', stage: 'running'});
-            fsm.newState({mode: 'error', stage: 'running'});
 
-            expect(fsm.getCurrentState().state).toEqual({mode: 'error', stage: 'running'});
+            fsm.newState({ mode: 'editing', params: 'complete', code: 'built' });
+            fsm.newState({ mode: 'processing', stage: 'launching' });
+            fsm.newState({ mode: 'processing', stage: 'queued' });
+            fsm.newState({ mode: 'processing', stage: 'running' });
+            fsm.newState({ mode: 'error', stage: 'running' });
+
+            expect(fsm.getCurrentState().state).toEqual({ mode: 'error', stage: 'running' });
         });
-        
-         it('Try to move to a state which is not available', function () {
-            var states = appStates,
+
+        it('Try to move to a state which is not available', () => {
+            const states = appStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: {
                         mode: 'editing',
-                        params: 'incomplete'
-                    }
+                        params: 'incomplete',
+                    },
                 });
             fsm.start();
 
             function invalidStateChange() {
-                fsm.newState({mode: 'processing', stage: 'launching'});
+                fsm.newState({ mode: 'processing', stage: 'launching' });
             }
 
             expect(invalidStateChange).toThrow();
         });
     });
-
 });

--- a/test/unit/spec/common/fsm-Spec.js
+++ b/test/unit/spec/common/fsm-Spec.js
@@ -1,5 +1,3 @@
-/*global define,describe,it,expect*/
-/*jslint white:true,browser:true*/
 define(['common/fsm'], (Fsm) => {
     'use strict';
 

--- a/test/unit/spec/common/fsm-Spec.js
+++ b/test/unit/spec/common/fsm-Spec.js
@@ -1,322 +1,358 @@
 /*global define,describe,it,expect*/
 /*jslint white:true,browser:true*/
-define([
-    'common/fsm'
-], function (Fsm) {
+define(['common/fsm'], (Fsm) => {
     'use strict';
 
-    var simpleStates = [{
+    const simpleStates = [
+            {
                 state: {
-                    mode: 'awake'
+                    mode: 'awake',
                 },
-                next: [{
-                        mode: 'awake'
+                next: [
+                    {
+                        mode: 'awake',
                     },
                     {
-                        mode: 'asleep'
-                    }
-                ]
+                        mode: 'asleep',
+                    },
+                ],
             },
             {
                 state: {
-                    mode: 'asleep'
+                    mode: 'asleep',
                 },
-                next: [{
-                        mode: 'asleep'
+                next: [
+                    {
+                        mode: 'asleep',
                     },
                     {
-                        mode: 'awake'
-                    }
-                ]
-            }
+                        mode: 'awake',
+                    },
+                ],
+            },
         ],
         awakeState = {
             state: {
-                mode: 'awake'
+                mode: 'awake',
             },
-            next: [{
-                    mode: 'awake'
+            next: [
+                {
+                    mode: 'awake',
                 },
                 {
-                    mode: 'asleep'
-                }
-            ]
+                    mode: 'asleep',
+                },
+            ],
         },
         asleepState = {
             state: {
-                mode: 'asleep'
+                mode: 'asleep',
             },
-            next: [{
-                    mode: 'asleep'
+            next: [
+                {
+                    mode: 'asleep',
                 },
                 {
-                    mode: 'awake'
-                }
-            ]
+                    mode: 'awake',
+                },
+            ],
         };
 
-    var statesWithEvents = [{
+    const statesWithEvents = [
+        {
             state: {
-                mode: 'first'
+                mode: 'first',
             },
-            next: [{
-                mode: 'second'
-            }]
+            next: [
+                {
+                    mode: 'second',
+                },
+            ],
         },
         {
             state: {
-                mode: 'second'
+                mode: 'second',
             },
-            next: [{
-                mode: 'last'
-            }],
+            next: [
+                {
+                    mode: 'last',
+                },
+            ],
             on: {
                 enter: {
-                    messages: [{
-                        emit: 'in-second',
-                        message: { test: 'second' }
-                    }]
-                }
-            }
+                    messages: [
+                        {
+                            emit: 'in-second',
+                            message: { test: 'second' },
+                        },
+                    ],
+                },
+            },
         },
         {
             state: {
-                mode: 'last'
-            }
-        }
+                mode: 'last',
+            },
+        },
     ];
 
-    var statesWithEvents2 = [{
+    const statesWithEvents2 = [
+        {
             state: {
-                mode: 'first'
+                mode: 'first',
             },
-            next: [{
-                mode: 'second'
-            }]
+            next: [
+                {
+                    mode: 'second',
+                },
+            ],
         },
         {
             state: {
-                mode: 'second'
+                mode: 'second',
             },
-            next: [{
-                mode: 'last'
-            }],
+            next: [
+                {
+                    mode: 'last',
+                },
+            ],
             on: {
                 exit: {
-                    messages: [{
-                        emit: 'leaving-second',
-                        message: { test: 'second' }
-                    }]
-                }
-            }
+                    messages: [
+                        {
+                            emit: 'leaving-second',
+                            message: { test: 'second' },
+                        },
+                    ],
+                },
+            },
         },
         {
             state: {
-                mode: 'last'
-            }
-        }
+                mode: 'last',
+            },
+        },
     ];
 
-    var statesWithEvents3 = [{
+    const statesWithEvents3 = [
+        {
             state: {
-                mode: 'first'
+                mode: 'first',
             },
-            next: [{
-                mode: 'second'
-            }]
+            next: [
+                {
+                    mode: 'second',
+                },
+            ],
         },
         {
             state: {
-                mode: 'second'
+                mode: 'second',
             },
-            next: [{
-                mode: 'last'
-            }],
+            next: [
+                {
+                    mode: 'last',
+                },
+            ],
             on: {
                 resume: {
-                    messages: [{
-                        emit: 'back-in-second',
-                        message: { test: 'second' }
-                    }]
-                }
-            }
+                    messages: [
+                        {
+                            emit: 'back-in-second',
+                            message: { test: 'second' },
+                        },
+                    ],
+                },
+            },
         },
         {
             state: {
-                mode: 'last'
-            }
-        }
+                mode: 'last',
+            },
+        },
     ];
 
-    var appStates = [{
+    const appStates = [
+        {
             state: {
                 mode: 'editing',
-                params: 'incomplete'
+                params: 'incomplete',
             },
-            next: [{
+            next: [
+                {
                     mode: 'editing',
-                    params: 'complete'
+                    params: 'complete',
                 },
                 {
                     mode: 'editing',
-                    params: 'incomplete'
-                }
-            ]
-        },
-        {
-            state: {
-                mode: 'editing',
-                params: 'complete'
-            },
-            next: [{
-                mode: 'editing',
-                params: 'complete',
-                code: 'built'
-            }]
+                    params: 'incomplete',
+                },
+            ],
         },
         {
             state: {
                 mode: 'editing',
                 params: 'complete',
-                code: 'built'
             },
-            next: [{
+            next: [
+                {
                     mode: 'editing',
-                    params: 'incomplete'
+                    params: 'complete',
+                    code: 'built',
+                },
+            ],
+        },
+        {
+            state: {
+                mode: 'editing',
+                params: 'complete',
+                code: 'built',
+            },
+            next: [
+                {
+                    mode: 'editing',
+                    params: 'incomplete',
                 },
                 {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
+                    code: 'built',
                 },
                 {
                     mode: 'processing',
-                    stage: 'launching'
-                }
-            ]
+                    stage: 'launching',
+                },
+            ],
         },
         {
             state: {
                 mode: 'processing',
-                stage: 'launching'
+                stage: 'launching',
             },
-            next: [{
+            next: [
+                {
                     mode: 'processing',
-                    stage: 'queued'
+                    stage: 'queued',
                 },
                 {
                     mode: 'processing',
-                    stage: 'launching'
+                    stage: 'launching',
                 },
                 {
                     mode: 'error',
-                    stage: 'launching'
+                    stage: 'launching',
                 },
                 {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
-                }
-            ]
+                    code: 'built',
+                },
+            ],
         },
         {
             state: {
                 mode: 'processing',
-                stage: 'queued'
+                stage: 'queued',
             },
-            next: [{
+            next: [
+                {
                     mode: 'processing',
-                    stage: 'running'
+                    stage: 'running',
                 },
                 {
                     mode: 'processing',
-                    stage: 'queued'
+                    stage: 'queued',
                 },
                 {
                     mode: 'error',
-                    stage: 'queued'
+                    stage: 'queued',
                 },
                 {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
-                }
-            ]
+                    code: 'built',
+                },
+            ],
         },
         {
             state: {
                 mode: 'processing',
-                stage: 'running'
+                stage: 'running',
             },
-            next: [{
-                    mode: 'success'
+            next: [
+                {
+                    mode: 'success',
                 },
                 {
                     mode: 'error',
-                    stage: 'running'
+                    stage: 'running',
                 },
                 {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
-                }
-            ]
+                    code: 'built',
+                },
+            ],
         },
         {
             state: {
-                mode: 'success'
+                mode: 'success',
             },
-            next: [{
-                    mode: 'success'
+            next: [
+                {
+                    mode: 'success',
                 },
                 {
                     mode: 'editing',
                     params: 'complete',
-                    code: 'built'
-                }
-            ]
+                    code: 'built',
+                },
+            ],
         },
         {
             state: {
                 mode: 'error',
-                stage: 'launching'
+                stage: 'launching',
             },
-            next: [{
-                mode: 'editing',
-                params: 'complete',
-                code: 'built'
-            }]
-
+            next: [
+                {
+                    mode: 'editing',
+                    params: 'complete',
+                    code: 'built',
+                },
+            ],
         },
         {
             state: {
                 mode: 'error',
-                stage: 'queued'
+                stage: 'queued',
             },
-            next: [{
-                mode: 'editing',
-                params: 'complete',
-                code: 'built'
-            }]
-
+            next: [
+                {
+                    mode: 'editing',
+                    params: 'complete',
+                    code: 'built',
+                },
+            ],
         },
         {
             state: {
                 mode: 'error',
-                stage: 'running'
+                stage: 'running',
             },
-            next: [{
-                mode: 'editing',
-                params: 'complete',
-                code: 'built'
-            }]
-
-        }
+            next: [
+                {
+                    mode: 'editing',
+                    params: 'complete',
+                    code: 'built',
+                },
+            ],
+        },
     ];
 
-    describe('FSM core functions', function () {
-        it('Is alive', function () {
-            var alive;
+    describe('FSM core functions', () => {
+        it('Is alive', () => {
+            let alive;
             if (Fsm) {
                 alive = true;
             } else {
@@ -344,57 +380,54 @@ define([
         //        });
     });
 
-    describe('Operations on a simple FSM', function () {
-        it('Create with an FSM', function () {
-            var states = simpleStates,
+    describe('Operations on a simple FSM', () => {
+        it('Create with an FSM', () => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
-                    initialState: { mode: 'asleep' }
+                    initialState: { mode: 'asleep' },
                 });
             expect(fsm).toBeTruthy();
         });
 
-        it('Find a state', function () {
-            var states = simpleStates,
+        it('Find a state', () => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
-                    initialState: { mode: 'awake' }
+                    initialState: { mode: 'awake' },
                 }),
                 found = fsm.findState({ mode: 'awake' });
 
             expect(found).toEqual(awakeState);
         });
 
-        it('Initialize the state machine, should be on initial state.', function () {
-            var states = simpleStates,
+        it('Initialize the state machine, should be on initial state.', () => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
-                    initialState: { mode: 'awake' }
+                    initialState: { mode: 'awake' },
                 });
             fsm.start();
-
 
             expect(fsm.getCurrentState()).toEqual(awakeState);
         });
 
-        it('Initialize the state machine, start on a different state.', function () {
-            var states = simpleStates,
+        it('Initialize the state machine, start on a different state.', () => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
-                    initialState: { mode: 'awake' }
+                    initialState: { mode: 'awake' },
                 });
             fsm.start({ mode: 'asleep' });
 
-
             expect(fsm.getCurrentState()).toEqual(asleepState);
         });
 
-
-        it('Move to another state.', function () {
-            var states = simpleStates,
+        it('Move to another state.', () => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
-                    initialState: { mode: 'awake' }
+                    initialState: { mode: 'awake' },
                 });
             fsm.start();
             fsm.newState({ mode: 'asleep' });
@@ -402,11 +435,11 @@ define([
             expect(fsm.getCurrentState()).toEqual(asleepState);
         });
 
-        it('Move through a sequence of states.', function () {
-            var states = simpleStates,
+        it('Move through a sequence of states.', () => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
-                    initialState: { mode: 'awake' }
+                    initialState: { mode: 'awake' },
                 });
             fsm.start();
             fsm.newState({ mode: 'asleep' });
@@ -417,11 +450,11 @@ define([
             expect(fsm.getCurrentState()).toEqual(awakeState);
         });
 
-        it('Move into an invalid state.', function () {
-            var states = simpleStates,
+        it('Move into an invalid state.', () => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
-                    initialState: { mode: 'awake' }
+                    initialState: { mode: 'awake' },
                 });
             fsm.start();
 
@@ -432,15 +465,15 @@ define([
             expect(invalid).toThrow();
         });
 
-        it('Move to another state with notification.', function (done) {
-            var states = simpleStates,
+        it('Move to another state with notification.', (done) => {
+            const states = simpleStates,
                 fsm = Fsm.make({
                     states: states,
                     initialState: { mode: 'awake' },
                     onNewState: function (fsm) {
                         expect(fsm.getCurrentState()).toEqual(asleepState);
                         done();
-                    }
+                    },
                 });
             fsm.start();
             fsm.newState({ mode: 'asleep' });
@@ -448,24 +481,24 @@ define([
             // expect(fsm.getCurrentState()).toEqual(asleepState);
         });
 
-        it('Sends a message when entering a state', function (done) {
-            var fsm = Fsm.make({
-                    states: statesWithEvents,
-                    initialState: { mode: 'first' }
-                });
-            fsm.bus.on('in-second', function (message) {
+        it('Sends a message when entering a state', (done) => {
+            const fsm = Fsm.make({
+                states: statesWithEvents,
+                initialState: { mode: 'first' },
+            });
+            fsm.bus.on('in-second', (message) => {
                 expect(message.test).toEqual('second');
                 done();
             });
             fsm.start();
             fsm.newState({ mode: 'second' });
         });
-        it('Sends a message when exiting a state', function (done) {
-            var fsm = Fsm.make({
+        it('Sends a message when exiting a state', (done) => {
+            const fsm = Fsm.make({
                 states: statesWithEvents2,
-                initialState: { mode: 'first' }
+                initialState: { mode: 'first' },
             });
-            fsm.bus.on('leaving-second', function (message) {
+            fsm.bus.on('leaving-second', (message) => {
                 expect(message.test).toEqual('second');
                 done();
             });
@@ -473,19 +506,16 @@ define([
             fsm.newState({ mode: 'second' });
             fsm.newState({ mode: 'last' });
         });
-        it('Sends a message when resuming a state', function (done) {
-            var fsm = Fsm.make({
-                    states: statesWithEvents3,
-                    initialState: { mode: 'second' }
-                });
-            fsm.bus.on('back-in-second', function (message) {
+        it('Sends a message when resuming a state', (done) => {
+            const fsm = Fsm.make({
+                states: statesWithEvents3,
+                initialState: { mode: 'second' },
+            });
+            fsm.bus.on('back-in-second', (message) => {
                 expect(message.test).toEqual('second');
                 done();
             });
             fsm.start();
         });
-
-
     });
-
 });

--- a/test/unit/spec/common/jobsSpec.js
+++ b/test/unit/spec/common/jobsSpec.js
@@ -1,4 +1,5 @@
 define(['common/jobs'], (Jobs) => {
+    'use strict';
     describe('Test Jobs module', () => {
         it('Should be loaded with the right functions', () => {
             expect(Jobs).toBeDefined();

--- a/test/unit/spec/common/jobsSpec.js
+++ b/test/unit/spec/common/jobsSpec.js
@@ -1,6 +1,4 @@
-define([
-    'common/jobs'
-], (Jobs) => {
+define(['common/jobs'], (Jobs) => {
     describe('Test Jobs module', () => {
         it('Should be loaded with the right functions', () => {
             expect(Jobs).toBeDefined();
@@ -12,7 +10,7 @@ define([
                 job_id: 'foo',
                 created: 12345,
                 other: 'key',
-                another: 'key'
+                another: 'key',
             };
             expect(Jobs.isValidJobState(goodJs)).toBeTrue();
         });
@@ -24,19 +22,19 @@ define([
                 ['a', 'list'],
                 {
                     job_id: 'somejob',
-                    other: 'key'
+                    other: 'key',
                 },
                 {
                     created: 'at_some_point',
-                    other: 'key'
+                    other: 'key',
                 },
                 {
-                    foobar: 'baz'
+                    foobar: 'baz',
                 },
                 null,
-                undefined
+                undefined,
             ];
-            badJsList.forEach(elem => {
+            badJsList.forEach((elem) => {
                 expect(Jobs.isValidJobState(elem)).toBeFalse();
             });
         });

--- a/test/unit/spec/common/monoBus-Spec.js
+++ b/test/unit/spec/common/monoBus-Spec.js
@@ -1,5 +1,3 @@
-/*global define,jasmine,describe,it,expect*/
-/*jslint white:true,browser:true*/
 define(['common/monoBus'], (Bus) => {
     'use strict';
 

--- a/test/unit/spec/common/monoBus-Spec.js
+++ b/test/unit/spec/common/monoBus-Spec.js
@@ -1,18 +1,16 @@
 /*global define,jasmine,describe,it,expect*/
 /*jslint white:true,browser:true*/
-define([
-    'common/monoBus'
-], function(Bus) {
+define(['common/monoBus'], (Bus) => {
     'use strict';
 
     // Setting a shorter timeout pretty much forces us to set a timeout explicitly
     // per async test which falls outside of this reasonable setting for "normal"
-    // async code. When we simulate async failures, or chained async calls, we 
+    // async code. When we simulate async failures, or chained async calls, we
     // need to controle the timing expectations within the test itself.
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-    describe('Bus core functions', function() {
-        it('Is alive', function() {
-            var alive;
+    describe('Bus core functions', () => {
+        it('Is alive', () => {
+            let alive;
             if (Bus) {
                 alive = true;
             } else {
@@ -21,70 +19,78 @@ define([
             expect(alive).toBeTruthy();
         });
 
-        it('Send and receive a test based message', function(done) {
-            var bus = Bus.make();
+        it('Send and receive a test based message', (done) => {
+            const bus = Bus.make();
             bus.listen({
-                test: function(message) {
-                    return (message.type === 'test');
+                test: function (message) {
+                    return message.type === 'test';
                 },
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.type).toEqual('test');
                     done();
-                }
+                },
             });
             bus.send({
-                type: 'test'
+                type: 'test',
             });
         });
 
-        it('Send and receive a string key based message', function(done) {
-            var bus = Bus.make();
+        it('Send and receive a string key based message', (done) => {
+            const bus = Bus.make();
             bus.listen({
                 key: 'mykey',
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.prop).toEqual('test2');
                     done();
+                },
+            });
+            bus.send(
+                { prop: 'test2' },
+                {
+                    key: 'mykey',
                 }
-            });
-            bus.send({ prop: 'test2' }, {
-                key: 'mykey'
-            });
+            );
         });
 
-        it('Send and receive an object key based message', function(done) {
-            var bus = Bus.make();
+        it('Send and receive an object key based message', (done) => {
+            const bus = Bus.make();
             bus.listen({
                 key: { type: 'test' },
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.prop).toEqual('test2');
                     done();
+                },
+            });
+            bus.send(
+                { prop: 'test2' },
+                {
+                    key: { type: 'test' },
                 }
-            });
-            bus.send({ prop: 'test2' }, {
-                key: { type: 'test' }
-            });
+            );
         });
 
-        it('Request/response', function(done) {
-            var bus = Bus.make();
+        it('Request/response', (done) => {
+            const bus = Bus.make();
             bus.respond({
                 key: { type: 'test' },
-                handle: function(message) {
+                handle: function (message) {
                     return { reply: 'this is my reply' };
-                }
+                },
             });
-            bus.request({}, {
-                    key: { type: 'test' }
-                })
-                .then(function(response) {
-                    expect(response.reply).toEqual('this is my reply');
-                    done();
-                });
+            bus.request(
+                {},
+                {
+                    key: { type: 'test' },
+                }
+            ).then((response) => {
+                expect(response.reply).toEqual('this is my reply');
+                done();
+            });
         });
 
-        it('Send and receive a message using the simple api', function(done) {
-            var bus = Bus.make();
-            bus.on('test', function(message) {
+        it('Send and receive a message using the simple api', (done) => {
+            const bus = Bus.make();
+            bus.on('test', (message) => {
                 expect(message.say).toEqual('hi');
                 done();
             });
@@ -93,413 +99,439 @@ define([
 
         // CHANNELS
 
-        it('Send and receive a test based message over a new channel', function(done) {
-            var bus = Bus.make();
+        it('Send and receive a test based message over a new channel', (done) => {
+            const bus = Bus.make();
             bus.listen({
                 channel: 'my-test-channel',
-                test: function(message) {
-                    return (message.type === 'test');
+                test: function (message) {
+                    return message.type === 'test';
                 },
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.type).toEqual('test');
                     done();
+                },
+            });
+            bus.send(
+                {
+                    type: 'test',
+                },
+                {
+                    channel: 'my-test-channel',
                 }
-            });
-            bus.send({
-                type: 'test'
-            }, {
-                channel: 'my-test-channel'
-            });
+            );
         });
 
-        it('Send and receive a test based message over a new channel with object name', function(done) {
-            var bus = Bus.make();
+        it('Send and receive a test based message over a new channel with object name', (done) => {
+            const bus = Bus.make();
             bus.listen({
                 channel: {
-                    name: 'my-test-channel'
+                    name: 'my-test-channel',
                 },
-                test: function(message) {
-                    return (message.type === 'test');
+                test: function (message) {
+                    return message.type === 'test';
                 },
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.type).toEqual('test');
                     done();
-                }
+                },
             });
-            bus.send({
-                type: 'test'
-            }, {
-                channel: {
-                    name: 'my-test-channel'
+            bus.send(
+                {
+                    type: 'test',
+                },
+                {
+                    channel: {
+                        name: 'my-test-channel',
+                    },
                 }
-            });
+            );
         });
 
-        it('Send and receive a test based message over a channel bus', function(done) {
-            var bus = Bus.make(),
+        it('Send and receive a test based message over a channel bus', (done) => {
+            const bus = Bus.make(),
                 myBus = bus.makeChannelBus();
 
-            myBus.on('talk', function(message) {
+            myBus.on('talk', (message) => {
                 expect(message.say).toEqual('hello');
                 done();
             });
             myBus.emit('talk', { say: 'hello' });
         });
 
-        it('Send and receive a test based message over a channel bus', function(done) {
-            var bus = Bus.make(),
+        it('Send and receive a test based message over a channel bus', (done) => {
+            const bus = Bus.make(),
                 myBus = bus.makeChannelBus();
 
-            myBus.on('talk', function(message) {
+            myBus.on('talk', (message) => {
                 expect(message.say).toEqual('hello');
                 done();
             });
             myBus.emit('talk', { say: 'hello' });
         });
 
-        it('Send and receive a test based message over the main bus from a channel bus', function(done) {
-            var bus = Bus.make(),
+        it('Send and receive a test based message over the main bus from a channel bus', (done) => {
+            const bus = Bus.make(),
                 myBus = bus.makeChannelBus();
 
-            myBus.bus().on('talk', function(message) {
+            myBus.bus().on('talk', (message) => {
                 expect(message.say).toEqual('hello');
                 done();
             });
             myBus.bus().emit('talk', { say: 'hello' });
         });
 
-        it('Send and receive a test based message over the main bus on a new channel from a channel bus', function(done) {
-            var bus = Bus.make(),
+        it('Send and receive a test based message over the main bus on a new channel from a channel bus', (done) => {
+            const bus = Bus.make(),
                 myBus = bus.makeChannelBus();
 
             myBus.bus().listen({
                 channel: 'my-new-channel',
-                test: function(message) {
+                test: function (message) {
                     return true;
                 },
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.test).toEqual('123');
                     done();
+                },
+            });
+            myBus.bus().send(
+                {
+                    test: '123',
+                },
+                {
+                    channel: 'my-new-channel',
                 }
-            });
-            myBus.bus().send({
-                test: '123'
-            }, {
-                channel: 'my-new-channel'
-            });
+            );
         });
 
-        it('Send and receive a test based message over a channel bus', function(done) {
-            var bus = Bus.make(),
+        it('Send and receive a test based message over a channel bus', (done) => {
+            const bus = Bus.make(),
                 myBus = bus.makeChannelBus();
 
             myBus.listen({
-                test: function(message) {
-                    return (message.language === 'english');
+                test: function (message) {
+                    return message.language === 'english';
                 },
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.greeting).toEqual('hello');
                     done();
-                }
+                },
             });
             myBus.send({
                 language: 'english',
-                greeting: 'hello'
+                greeting: 'hello',
             });
         });
 
-        it('Channel bus Request/response', function(done) {
-            var bus = Bus.make(),
+        it('Channel bus Request/response', (done) => {
+            const bus = Bus.make(),
                 bus1 = bus.makeChannelBus(),
                 bus2 = bus.makeChannelBus(),
                 data = {
-                    key1: 'value1'
+                    key1: 'value1',
                 };
             // responder 1
 
             bus1.respond({
                 key: {
-                    type: 'get-value'
+                    type: 'get-value',
                 },
-                handle: function(message) {
+                handle: function (message) {
                     return {
-                        value: data[message.propertyName]
+                        value: data[message.propertyName],
                     };
-                }
+                },
             });
-            bus1.request({
-                    propertyName: 'key1'
-                }, {
+            bus1.request(
+                {
+                    propertyName: 'key1',
+                },
+                {
                     key: {
-                        type: 'get-value'
-                    }
-                })
-                .then(function(response) {
-                    expect(response.value).toEqual('value1');
-                    done();
-                });
+                        type: 'get-value',
+                    },
+                }
+            ).then((response) => {
+                expect(response.value).toEqual('value1');
+                done();
+            });
         });
 
-        it('Nested bus Request/response', function(done) {
-            var bus = Bus.make(),
+        it('Nested bus Request/response', (done) => {
+            const bus = Bus.make(),
                 bus1 = bus.makeChannelBus(),
                 bus2 = bus.makeChannelBus(),
                 data = {
-                    key1: 'value1'
+                    key1: 'value1',
                 };
             // responder 1
 
             bus1.respond({
                 key: {
-                    type: 'get-value'
+                    type: 'get-value',
                 },
-                handle: function(message) {
+                handle: function (message) {
                     return {
-                        value: data[message.propertyName]
+                        value: data[message.propertyName],
                     };
-                }
+                },
             });
             bus2.respond({
                 key: {
-                    type: 'get-value'
+                    type: 'get-value',
                 },
-                handle: function(message) {
-                    return bus1.request({
-                        propertyName: 'key1'
-                    }, {
-                        key: {
-                            type: 'get-value'
+                handle: function (message) {
+                    return bus1.request(
+                        {
+                            propertyName: 'key1',
+                        },
+                        {
+                            key: {
+                                type: 'get-value',
+                            },
                         }
-                    });
-                }
+                    );
+                },
             });
 
-
-            bus2.request({
-                    propertyName: 'key1'
-                }, {
+            bus2.request(
+                {
+                    propertyName: 'key1',
+                },
+                {
                     key: {
-                        type: 'get-value'
-                    }
-                })
-                .then(function(response) {
-                    expect(response.value).toEqual('value1');
-                    done();
-                });
+                        type: 'get-value',
+                    },
+                }
+            ).then((response) => {
+                expect(response.value).toEqual('value1');
+                done();
+            });
         });
 
-        it('Send and receive a keyed, persistent message over a channel, listen first', function(done) {
-            var bus = Bus.make();
+        it('Send and receive a keyed, persistent message over a channel, listen first', (done) => {
+            const bus = Bus.make();
             bus.listen({
                 channel: 'my-test-channel',
                 key: 'my-test-key',
-                handle: function(message) {
+                handle: function (message) {
                     expect(message.name).toEqual('Winnie');
                     done();
+                },
+            });
+            bus.send(
+                {
+                    name: 'Winnie',
+                },
+                {
+                    channel: 'my-test-channel',
+                    key: 'my-test-key',
+                    persistent: true,
                 }
-            });
-            bus.send({
-                name: 'Winnie'
-            }, {
-                channel: 'my-test-channel',
-                key: 'my-test-key',
-                persistent: true
-            });
+            );
         });
 
-        it('Send and receive a keyed, persistent message over a channel, send first', function(done) {
-            var bus = Bus.make();
-            bus.set({
-                name: 'Winnie'
-            }, {
-                channel: 'my-test-channel',
-                key: 'my-test-key'
-            });
-            window.setTimeout(function() {
+        it('Send and receive a keyed, persistent message over a channel, send first', (done) => {
+            const bus = Bus.make();
+            bus.set(
+                {
+                    name: 'Winnie',
+                },
+                {
+                    channel: 'my-test-channel',
+                    key: 'my-test-key',
+                }
+            );
+            window.setTimeout(() => {
                 bus.listen({
                     channel: 'my-test-channel',
                     key: 'my-test-key',
-                    handle: function(message) {
+                    handle: function (message) {
                         expect(message.name).toEqual('Winnie');
                         done();
-                    }
+                    },
                 });
             }, 1000);
         }, 5000);
 
-        it('Send and receive a keyed, persistent message over a channel, send first, then update', function(done) {
-            var bus = Bus.make(),
+        it('Send and receive a keyed, persistent message over a channel, send first, then update', (done) => {
+            let bus = Bus.make(),
                 times = 0;
-            bus.set({
-                name: 'Winnie'
-            }, {
-                channel: 'my-test-channel',
-                key: 'my-test-key'
-            });
-            window.setTimeout(function() {
+            bus.set(
+                {
+                    name: 'Winnie',
+                },
+                {
+                    channel: 'my-test-channel',
+                    key: 'my-test-key',
+                }
+            );
+            window.setTimeout(() => {
                 bus.listen({
                     channel: 'my-test-channel',
                     key: 'my-test-key',
-                    handle: function(message) {
+                    handle: function (message) {
                         if (times === 0) {
                             times += 1;
-                            bus.set({
-                                name: 'Tigger'
-                            }, {
-                                channel: 'my-test-channel',
-                                key: 'my-test-key'
-                            });
+                            bus.set(
+                                {
+                                    name: 'Tigger',
+                                },
+                                {
+                                    channel: 'my-test-channel',
+                                    key: 'my-test-key',
+                                }
+                            );
                         } else {
                             expect(message.name).toEqual('Tigger');
                             done();
                         }
-                    }
+                    },
                 });
             }, 1000);
         }, 5000);
 
-
-
-        it('Create a working test based message route, then remove the listener, should fail.', function(done) {
+        it('Create a working test based message route, then remove the listener, should fail.', (done) => {
             var bus = Bus.make(),
                 count = 0,
                 listener = bus.listen({
-                    test: function(message) {
-                        return (message.what === 'test');
+                    test: function (message) {
+                        return message.what === 'test';
                     },
-                    handle: function(message) {
+                    handle: function (message) {
                         if (count === 0) {
                             count += 1;
                             bus.removeListener(listener);
                             expect(message.what).toEqual('test');
                             bus.send({ what: 'test' });
-                            window.setTimeout(function() {
+                            window.setTimeout(() => {
                                 expect(count).toEqual(1);
                                 done();
                             }, 3000);
                         } else if (count === 1) {
                             count += 1;
                         }
-                    }
+                    },
                 });
             bus.send({
-                what: 'test'
+                what: 'test',
             });
         }, 5000);
     });
 
-    it('Send and receive a test based message over a named channel using a connection', function(done) {
-        var bus = Bus.make(),
+    it('Send and receive a test based message over a named channel using a connection', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
-        connection.channel('test').on('my-message', function(message) {
+        connection.channel('test').on('my-message', (message) => {
             expect(message.msg).toEqual('greetings');
             done();
         });
         connection.channel('test').emit('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
-
     });
 
-    it('A connection should destroy all listenrs upon stop', function(done) {
-        var bus = Bus.make(),
+    it('A connection should destroy all listenrs upon stop', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
-        connection.channel('test').on('test', function(message) {
+        connection.channel('test').on('test', (message) => {
             // do nothing...
         });
 
-        connection.channel('test').on('my-message', function(message) {
+        connection.channel('test').on('my-message', (message) => {
             // expect(message.msg).toEqual('greetings');
             expect(connection.stats().listeners.active).toEqual(2);
             connection.stop();
-            var stats = connection.stats();
+            const stats = connection.stats();
             expect(stats.listeners.active).toEqual(0);
             done();
         });
         connection.channel('test').emit('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
-
     });
 
-    it('Send and receive an async message over a named channel using a connection', function(done) {
-        var bus = Bus.make(),
+    it('Send and receive an async message over a named channel using a connection', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
-        connection.channel('test').when('my-message')
-            .then(function(message) {
+        connection
+            .channel('test')
+            .when('my-message')
+            .then((message) => {
                 expect(message.msg).toEqual('greetings');
                 done();
             });
 
         connection.channel('test').set('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
     });
 
-    it('Send and receive an async message over a named channel using a connection, then another', function(done) {
-        var bus = Bus.make(),
+    it('Send and receive an async message over a named channel using a connection, then another', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
-        connection.channel('test').when('my-message')
-            .then(function(message) {
+        connection
+            .channel('test')
+            .when('my-message')
+            .then((message) => {
                 expect(message.msg).toEqual('greetings');
-                connection.channel('test').on('my-message', function(message) {
+                connection.channel('test').on('my-message', (message) => {
                     expect(message.msg).toEqual('goodbye');
                     connection.stop();
                     done();
-                })
+                });
             });
 
         connection.channel('test').set('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
         connection.channel('test').set('my-message', {
-            msg: 'goodbye'
+            msg: 'goodbye',
         });
     });
 
-    it('Set a persistent message and get it syncronously', function(done) {
-        var bus = Bus.make(),
+    it('Set a persistent message and get it syncronously', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
         connection.channel('test').set('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
 
-        var message = connection.channel('test').get('my-message');
+        const message = connection.channel('test').get('my-message');
 
         expect(message.msg).toEqual('greetings');
         done();
         connection.stop();
     });
 
-    it('Set a persistent message and get it syncronously, failed', function(done) {
-        var bus = Bus.make(),
+    it('Set a persistent message and get it syncronously, failed', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
         connection.channel('test').set('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
 
-        var message = connection.channel('test').get('my-messagex', { msg: 'goodbye' });
+        const message = connection.channel('test').get('my-messagex', { msg: 'goodbye' });
 
         expect(message.msg).toEqual('goodbye');
         done();
         connection.stop();
     });
 
-    it('Set a persistent message and get it syncronously, set after get, should get default value', function(done) {
-        var bus = Bus.make(),
+    it('Set a persistent message and get it syncronously, set after get, should get default value', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
-
-        var message = connection.channel('test').get('my-messagex', { msg: 'goodbye' });
+        const message = connection.channel('test').get('my-messagex', { msg: 'goodbye' });
 
         connection.channel('test').set('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
 
         expect(message.msg).toEqual('goodbye');
@@ -507,23 +539,22 @@ define([
         connection.stop();
     });
 
-    it('Send and receive an async message over a named channel using a connection, then another', function(done) {
-        var bus = Bus.make(),
+    it('Send and receive an async message over a named channel using a connection, then another', (done) => {
+        const bus = Bus.make(),
             connection = bus.connect();
 
-        var started = new Date().getTime();
+        const started = new Date().getTime();
 
         // var test2Called = 0;
 
-        var test2 = connection.channel('test').plisten({
+        const test2 = connection.channel('test').plisten({
             key: {
-                type: 'my-message'
+                type: 'my-message',
             },
-            handle: function(message) {
+            handle: function (message) {
                 done.fail();
-            }
+            },
         });
-
 
         // var test3 = connection.channel('test').plisten({
         //     key: {
@@ -549,16 +580,16 @@ define([
         //     done.fail();
         // });
 
-        var result = connection.channel('test').plisten({
+        const result = connection.channel('test').plisten({
             key: {
-                type: 'my-message'
+                type: 'my-message',
             },
-            handle: function(message) {
-                var elapsed = new Date().getTime() - started;
+            handle: function (message) {
+                const elapsed = new Date().getTime() - started;
                 expect(elapsed > 1000).toBeTruthy();
                 expect(message.msg).toEqual('goodbye');
                 done();
-            }
+            },
         });
 
         // test2.promise
@@ -573,14 +604,13 @@ define([
         //     msg: 'hi!'
         // });
 
-        result.promise
-            .then(function(message) {
-                expect(message.msg).toEqual('greetings');
-                done();
-            });
+        result.promise.then((message) => {
+            expect(message.msg).toEqual('greetings');
+            done();
+        });
 
         connection.channel('test').set('my-message', {
-            msg: 'greetings'
+            msg: 'greetings',
         });
         // window.setTimeout(function() {
         //     connection.channel('test').set('my-message', {
@@ -588,7 +618,4 @@ define([
         //     });
         // }, 2000);
     });
-
-
-
 });

--- a/test/unit/spec/common/props-Spec.js
+++ b/test/unit/spec/common/props-Spec.js
@@ -1,13 +1,11 @@
 /*global define,describe,it,expect*/
 /*jslint white:true,browser:true*/
-define([
-    'common/props'
-], function (Props) {
+define(['common/props'], (Props) => {
     'use strict';
 
-    describe('Props core functions', function () {
-        it('Is alive', function () {
-            var alive;
+    describe('Props core functions', () => {
+        it('Is alive', () => {
+            let alive;
             if (Props) {
                 alive = true;
             } else {
@@ -15,118 +13,115 @@ define([
             }
             expect(alive).toBeTruthy();
         });
-        it('Set and get a simple string property', function () {
-            var props = Props.make();
+        it('Set and get a simple string property', () => {
+            const props = Props.make();
             props.setItem('color', 'green');
             expect(props.getItem('color')).toEqual('green');
         });
-        it('Set and reset a simple string property', function () {
-            var props = Props.make();
+        it('Set and reset a simple string property', () => {
+            const props = Props.make();
             props.setItem('color', 'green');
             expect(props.getItem('color')).toEqual('green');
             props.reset();
             expect(props.getItem('color')).toBeUndefined();
         });
-        it('Set and get a simple number property', function () {
-            var props = Props.make();
+        it('Set and get a simple number property', () => {
+            const props = Props.make();
             props.setItem('themeaningoflife', 42);
             expect(props.getItem('themeaningoflife')).toEqual(42);
         });
-        it('Set and get a simple boolean property', function () {
-            var props = Props.make();
+        it('Set and get a simple boolean property', () => {
+            const props = Props.make();
             props.setItem('buggy', true);
             expect(props.getItem('buggy')).toEqual(true);
         });
 
-        it('Set and get a simple object property', function () {
-            var props = Props.make();
-            props.setItem('pet', {type: 'dog', name: 'peet'});
-            expect(props.getItem('pet')).toEqual({type: 'dog', name: 'peet'});
-        });       
-        it('Set two object propertyes', function () {
-            var props = Props.make();
+        it('Set and get a simple object property', () => {
+            const props = Props.make();
+            props.setItem('pet', { type: 'dog', name: 'peet' });
+            expect(props.getItem('pet')).toEqual({ type: 'dog', name: 'peet' });
+        });
+        it('Set two object propertyes', () => {
+            const props = Props.make();
             props.setItem(['pet', 'coco'], 'yellow');
             props.setItem(['pet', 'peet'], 'black');
             expect(props.getItem('pet.coco')).toEqual('yellow');
             expect(props.getItem('pet.peet')).toEqual('black');
         });
-        
-        it('Push a value onto a property', function () {
-            var props = Props.make();
+
+        it('Push a value onto a property', () => {
+            const props = Props.make();
             props.setItem('array.prop', []);
             props.pushItem('array.prop', 123);
             expect(props.getItem('array.prop')).toEqual([123]);
             expect(props.popItem('array.prop')).toEqual(123);
             expect(props.getItem('array.prop')).toEqual([]);
         });
-        
-        it('Push a value onto an empty', function () {
-            var props = Props.make();
+
+        it('Push a value onto an empty', () => {
+            const props = Props.make();
             props.pushItem('array.prop', 123);
             expect(props.getItem('array.prop')).toEqual([123]);
             expect(props.popItem('array.prop')).toEqual(123);
             expect(props.getItem('array.prop')).toEqual([]);
         });
-        
-        
-        it('History should undefined', function () {
-            var props = Props.make();
+
+        it('History should undefined', () => {
+            const props = Props.make();
             expect(props.getHistoryCount()).toBeUndefined;
         });
-//        it('History should be 1 after one change', function() {
-//            var props = Props.make();
-//            props.setItem('color', 'red');
-//            expect(props.getHistoryCount()).toEqual(1);
-//        });
+        //        it('History should be 1 after one change', function() {
+        //            var props = Props.make();
+        //            props.setItem('color', 'red');
+        //            expect(props.getHistoryCount()).toEqual(1);
+        //        });
 
-        it('Update callback should be called', function (done) {
-            var props = Props.make({
+        it('Update callback should be called', (done) => {
+            const props = Props.make({
                 onUpdate: function (props) {
                     expect(true).toEqual(true);
                     done();
-                }
+                },
             });
             props.setItem('color', 'red');
-
         });
 
-        it('History should be 1 after one change', function (done) {
-            var props = Props.make({
+        it('History should be 1 after one change', (done) => {
+            const props = Props.make({
                 onUpdate: function (props) {
                     if (props.getHistoryCount() === 1) {
                         expect(props.getHistoryCount()).toEqual(1);
                         done();
                     }
-                }
+                },
             });
             props.setItem('color', 'red');
-
         });
-        it('Set and get a simple string property, check last value', function (done) {
-            var props = Props.make({
+        it('Set and get a simple string property, check last value', (done) => {
+            const props = Props.make({
                 onUpdate: function (props) {
                     if (props.getHistoryCount() === 1) {
                         props.setItem('color', 'green');
                         return;
                     }
-                    var raw = props.getRawObject(),
+                    const raw = props.getRawObject(),
                         last = props.getLastRawObject();
 
                     expect(last.color).toEqual('red');
                     done();
-                }
+                },
             });
             props.setItem('color', 'red');
         });
 
-        it('Copy a property -- it unaffected by changes to the original', function () {
-            var props = Props.make({
-                data: {
-                    prop1: {
-                        propA: 42
-                    }
-                }
-            }),
+        it('Copy a property -- it unaffected by changes to the original', () => {
+            const props = Props.make({
+                    data: {
+                        prop1: {
+                            propA: 42,
+                        },
+                    },
+                }),
                 propCopy = props.copyItem('prop1');
 
             props.setItem('prop1.propA', 53);
@@ -134,11 +129,10 @@ define([
             expect(propCopy.propA).toEqual(42);
             expect(props.getItem('prop1.propA')).toEqual(53);
         });
-        it('Set and get a simple string property using data methods', function () {
-            var data = {};
+        it('Set and get a simple string property using data methods', () => {
+            const data = {};
             Props.setDataItem(data, 'color', 'green');
             expect(Props.getDataItem(data, 'color')).toEqual('green');
         });
     });
-
 });

--- a/test/unit/spec/common/props-Spec.js
+++ b/test/unit/spec/common/props-Spec.js
@@ -1,5 +1,3 @@
-/*global define,describe,it,expect*/
-/*jslint white:true,browser:true*/
 define(['common/props'], (Props) => {
     'use strict';
 
@@ -66,19 +64,14 @@ define(['common/props'], (Props) => {
             expect(props.getItem('array.prop')).toEqual([]);
         });
 
-        it('History should undefined', () => {
+        it('History should be undefined', () => {
             const props = Props.make();
-            expect(props.getHistoryCount()).toBeUndefined;
+            expect(props.getHistoryCount()).toBeUndefined();
         });
-        //        it('History should be 1 after one change', function() {
-        //            var props = Props.make();
-        //            props.setItem('color', 'red');
-        //            expect(props.getHistoryCount()).toEqual(1);
-        //        });
 
         it('Update callback should be called', (done) => {
             const props = Props.make({
-                onUpdate: function (props) {
+                onUpdate: function () {
                     expect(true).toEqual(true);
                     done();
                 },
@@ -88,24 +81,21 @@ define(['common/props'], (Props) => {
 
         it('History should be 1 after one change', (done) => {
             const props = Props.make({
-                onUpdate: function (props) {
-                    if (props.getHistoryCount() === 1) {
-                        expect(props.getHistoryCount()).toEqual(1);
+                onUpdate: function (_props) {
+                    expect(_props.getHistoryCount()).toEqual(1);
                         done();
-                    }
                 },
             });
             props.setItem('color', 'red');
         });
         it('Set and get a simple string property, check last value', (done) => {
             const props = Props.make({
-                onUpdate: function (props) {
-                    if (props.getHistoryCount() === 1) {
-                        props.setItem('color', 'green');
+                onUpdate: function (_props) {
+                    if (_props.getHistoryCount() === 1) {
+                        _props.setItem('color', 'green');
                         return;
                     }
-                    const raw = props.getRawObject(),
-                        last = props.getLastRawObject();
+                    const last = _props.getLastRawObject();
 
                     expect(last.color).toEqual('red');
                     done();
@@ -114,7 +104,7 @@ define(['common/props'], (Props) => {
             props.setItem('color', 'red');
         });
 
-        it('Copy a property -- it unaffected by changes to the original', () => {
+        it('Copy a property -- it is unaffected by changes to the original', () => {
             const props = Props.make({
                     data: {
                         prop1: {

--- a/test/unit/spec/common/pythonInterop-Spec.js
+++ b/test/unit/spec/common/pythonInterop-Spec.js
@@ -1,5 +1,3 @@
-/*global define,describe,it,expect*/
-/*jslint white:true,browser:true*/
 define(['common/pythonInterop'], (PythonInterop) => {
     'use strict';
 

--- a/test/unit/spec/common/pythonInterop-Spec.js
+++ b/test/unit/spec/common/pythonInterop-Spec.js
@@ -1,13 +1,11 @@
 /*global define,describe,it,expect*/
 /*jslint white:true,browser:true*/
-define([
-    'common/pythonInterop'
-], function(PythonInterop) {
+define(['common/pythonInterop'], (PythonInterop) => {
     'use strict';
 
-    describe('Props core functions', function() {
-        it('Is alive', function() {
-            var alive;
+    describe('Props core functions', () => {
+        it('Is alive', () => {
+            let alive;
             if (PythonInterop) {
                 alive = true;
             } else {
@@ -15,183 +13,201 @@ define([
             }
             expect(alive).toBeTruthy();
         });
-        it('Pythonify an undefined value fails properly', function () {
+        it('Pythonify an undefined value fails properly', () => {
             // expect(PythonInterop.pythonifyValue).toThrow();
-            var foo;
-            expect(function() { PythonInterop.pythonifyValue(foo); }).toThrow(new Error('Unsupported parameter type undefined'));
+            let foo;
+            expect(() => {
+                PythonInterop.pythonifyValue(foo);
+            }).toThrow(new Error('Unsupported parameter type undefined'));
         });
-        it('Pythonify a boolean value', function () {
+        it('Pythonify a boolean value', () => {
             expect(PythonInterop.pythonifyValue(true)).toEqual('True');
             expect(PythonInterop.pythonifyValue(false)).toEqual('False');
         });
-        it('Pythonify a null value', function() {
-            var jsValue = null,
+        it('Pythonify a null value', () => {
+            const jsValue = null,
                 pyValue = 'None';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
 
-        it('Pythonify an integer value', function() {
-            var jsValue = 1,
+        it('Pythonify an integer value', () => {
+            const jsValue = 1,
                 pyValue = '1';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify a float value', function() {
-            var jsValue = 1.1,
+        it('Pythonify a float value', () => {
+            const jsValue = 1.1,
                 pyValue = '1.1';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify an string value', function() {
-            var jsValue = 'one',
+        it('Pythonify an string value', () => {
+            const jsValue = 'one',
                 pyValue = '"one"';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify a quoted string', function () {
-            var jsValue = 'a "quoted" string',
+        it('Pythonify a quoted string', () => {
+            const jsValue = 'a "quoted" string',
                 pyValue = '"a \\"quoted\\" string"';
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify an array of ints value', function() {
-            var jsValue = [1,2,3],
+        it('Pythonify an array of ints value', () => {
+            const jsValue = [1, 2, 3],
                 pyValue = '[1, 2, 3]';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify an array of floats value', function() {
-            var jsValue = [1.2, 2.3, 3.4],
+        it('Pythonify an array of floats value', () => {
+            const jsValue = [1.2, 2.3, 3.4],
                 pyValue = '[1.2, 2.3, 3.4]';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify an array of ints value', function() {
-            var jsValue = ['one', 'two', 'three'],
+        it('Pythonify an array of ints value', () => {
+            const jsValue = ['one', 'two', 'three'],
                 pyValue = '["one", "two", "three"]';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify a map of ints', function() {
-            var jsValue = {one: 1, two: 2, three: 3},
+        it('Pythonify a map of ints', () => {
+            const jsValue = { one: 1, two: 2, three: 3 },
                 pyValue = '{\n    "one": 1,\n    "two": 2,\n    "three": 3\n}',
                 actual = PythonInterop.pythonifyValue(jsValue);
 
             expect(actual).toEqual(pyValue);
         });
-        it('Pythonify a map of floats', function() {
-            var jsValue = {one: 1.2, two: 2.3, three: 3.4},
+        it('Pythonify a map of floats', () => {
+            const jsValue = { one: 1.2, two: 2.3, three: 3.4 },
                 pyValue = '{\n    "one": 1.2,\n    "two": 2.3,\n    "three": 3.4\n}';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify a map of strings', function() {
-            var jsValue = {one: 'one', two: 'two', three: 'three'},
+        it('Pythonify a map of strings', () => {
+            const jsValue = { one: 'one', two: 'two', three: 'three' },
                 pyValue = '{\n    "one": "one",\n    "two": "two",\n    "three": "three"\n}';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify an array of arrays', function() {
-            var jsValue = [[1,2,3],['a', 'b', 'c'], [5.4, 4.3, 3.2]],
+        it('Pythonify an array of arrays', () => {
+            const jsValue = [
+                    [1, 2, 3],
+                    ['a', 'b', 'c'],
+                    [5.4, 4.3, 3.2],
+                ],
                 pyValue = '[[1, 2, 3], ["a", "b", "c"], [5.4, 4.3, 3.2]]';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Pythonify an array of maps', function() {
-            var jsValue = [{one: 1, two: 2, three: 3},{one: 1.2, two: 2.3, three: 3.4}, {one: 'one', two: 'two', three: 'three'}],
-                pyValue = '[{\n    "one": 1,\n    "two": 2,\n    "three": 3\n}, {\n    "one": 1.2,\n    "two": 2.3,\n    "three": 3.4\n}, {\n    "one": "one",\n    "two": "two",\n    "three": "three"\n}]';
+        it('Pythonify an array of maps', () => {
+            const jsValue = [
+                    { one: 1, two: 2, three: 3 },
+                    { one: 1.2, two: 2.3, three: 3.4 },
+                    { one: 'one', two: 'two', three: 'three' },
+                ],
+                pyValue =
+                    '[{\n    "one": 1,\n    "two": 2,\n    "three": 3\n}, {\n    "one": 1.2,\n    "two": 2.3,\n    "three": 3.4\n}, {\n    "one": "one",\n    "two": "two",\n    "three": "three"\n}]';
 
             expect(PythonInterop.pythonifyValue(jsValue)).toEqual(pyValue);
         });
-        it('Build output works', function () {
-            var inputs = {
+        it('Build output works', () => {
+            const inputs = {
                     arg1: 1,
                     arg2: 2,
-                    arg3: 3
+                    arg3: 3,
                 },
-                code = 'from biokbase.narrative.widgetmanager import WidgetManager\n' +
-                       'WidgetManager().show_output_widget(\n' +
-                       '    "widget",\n' +
-                       '    {\n' +
-                       '        "arg1": 1,\n' +
-                       '        "arg2": 2,\n' +
-                       '        "arg3": 3\n' +
-                       '    },\n' +
-                       '    tag="tag",\n' +
-                       '    cell_id="my_cell_id"\n' +
-                       ')';
-            expect(PythonInterop.buildOutputRunner('widget', 'tag', 'my_cell_id', inputs)).toEqual(code);
+                code =
+                    'from biokbase.narrative.widgetmanager import WidgetManager\n' +
+                    'WidgetManager().show_output_widget(\n' +
+                    '    "widget",\n' +
+                    '    {\n' +
+                    '        "arg1": 1,\n' +
+                    '        "arg2": 2,\n' +
+                    '        "arg3": 3\n' +
+                    '    },\n' +
+                    '    tag="tag",\n' +
+                    '    cell_id="my_cell_id"\n' +
+                    ')';
+            expect(PythonInterop.buildOutputRunner('widget', 'tag', 'my_cell_id', inputs)).toEqual(
+                code
+            );
         });
-        it('Build app runner works', function () {
-            var cellId = 'my_cell_id',
+        it('Build app runner works', () => {
+            const cellId = 'my_cell_id',
                 runId = 'my_run_id',
                 app = {
                     id: 'MyModule/my_app',
                     version: 'app_version',
-                    tag: 'tag'
+                    tag: 'tag',
                 },
                 params = {
                     arg1: 1,
                     arg2: 'two',
                     arg3: ['t', 'h', 'r', 'e', 'e'],
                     arg4: {
-                        four: 4
-                    }
+                        four: 4,
+                    },
                 },
-                code = 'from biokbase.narrative.jobs.appmanager import AppManager\n' +
-                       'AppManager().run_app(\n' +
-                       '    "MyModule/my_app",\n' +
-                       '    {\n' +
-                       '        "arg1": 1,\n' +
-                       '        "arg2": "two",\n' +
-                       '        "arg3": ["t", "h", "r", "e", "e"],\n' +
-                       '        "arg4": {\n' + 
-                       '            "four": 4\n' +
-                       '        }\n'+
-                       '    },\n' +
-                       '    tag="tag",\n' +
-                       '    version="app_version",\n' +
-                       '    cell_id="my_cell_id",\n' +
-                       '    run_id="my_run_id"\n' +
-                       ')';
+                code =
+                    'from biokbase.narrative.jobs.appmanager import AppManager\n' +
+                    'AppManager().run_app(\n' +
+                    '    "MyModule/my_app",\n' +
+                    '    {\n' +
+                    '        "arg1": 1,\n' +
+                    '        "arg2": "two",\n' +
+                    '        "arg3": ["t", "h", "r", "e", "e"],\n' +
+                    '        "arg4": {\n' +
+                    '            "four": 4\n' +
+                    '        }\n' +
+                    '    },\n' +
+                    '    tag="tag",\n' +
+                    '    version="app_version",\n' +
+                    '    cell_id="my_cell_id",\n' +
+                    '    run_id="my_run_id"\n' +
+                    ')';
             expect(PythonInterop.buildAppRunner(cellId, runId, app, params)).toEqual(code);
         });
-        it('Build app runner works for a batch', function () {
-            var cellId = 'my_cell_id',
+        it('Build app runner works for a batch', () => {
+            const cellId = 'my_cell_id',
                 runId = 'my_run_id',
                 app = {
                     id: 'MyModule/my_app',
                     version: 'app_version',
-                    tag: 'tag'
+                    tag: 'tag',
                 },
-                params = [{
-                    arg1: 1,
-                    arg2: 'two'
-                },{
-                    arg3: ['t', 'h', 'r', 'e', 'e'],
-                    arg4: {
-                        four: 4
-                    }
-                }],
-                code = 'from biokbase.narrative.jobs.appmanager import AppManager\n' +
-                       'AppManager().run_app_batch(\n' +
-                       '    "MyModule/my_app",\n' +
-                       '    [{\n' +
-                       '        "arg1": 1,\n' +
-                       '        "arg2": "two"\n' +
-                       '    }, {\n' +
-                       '        "arg3": ["t", "h", "r", "e", "e"],\n' +
-                       '        "arg4": {\n' + 
-                       '            "four": 4\n' +
-                       '        }\n'+
-                       '    }],\n' +
-                       '    tag="tag",\n' +
-                       '    version="app_version",\n' +
-                       '    cell_id="my_cell_id",\n' +
-                       '    run_id="my_run_id"\n' +
-                       ')';
+                params = [
+                    {
+                        arg1: 1,
+                        arg2: 'two',
+                    },
+                    {
+                        arg3: ['t', 'h', 'r', 'e', 'e'],
+                        arg4: {
+                            four: 4,
+                        },
+                    },
+                ],
+                code =
+                    'from biokbase.narrative.jobs.appmanager import AppManager\n' +
+                    'AppManager().run_app_batch(\n' +
+                    '    "MyModule/my_app",\n' +
+                    '    [{\n' +
+                    '        "arg1": 1,\n' +
+                    '        "arg2": "two"\n' +
+                    '    }, {\n' +
+                    '        "arg3": ["t", "h", "r", "e", "e"],\n' +
+                    '        "arg4": {\n' +
+                    '            "four": 4\n' +
+                    '        }\n' +
+                    '    }],\n' +
+                    '    tag="tag",\n' +
+                    '    version="app_version",\n' +
+                    '    cell_id="my_cell_id",\n' +
+                    '    run_id="my_run_id"\n' +
+                    ')';
             expect(PythonInterop.buildAppRunner(cellId, runId, app, params)).toEqual(code);
         });
     });
-
 });

--- a/test/unit/spec/common/sdk-Spec.js
+++ b/test/unit/spec/common/sdk-Spec.js
@@ -4,27 +4,23 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
+define([
     'common/sdk',
     'json!/test/data/NarrativeTest.test_simple_inputs.spec.json',
-    'json!/test/data/NarrativeTest.test_input_params.spec.json'
-], function(
-    SDK,
-    SimpleAppSpec,
-    ComplexAppSpec
-) {
+    'json!/test/data/NarrativeTest.test_input_params.spec.json',
+], (SDK, SimpleAppSpec, ComplexAppSpec) => {
     'use strict';
-    var validateConvertedSpec = function(spec) {
+    const validateConvertedSpec = function (spec) {
         if (!spec || !('parameters' in spec)) {
             return false;
         }
         if (!('layout' in spec.parameters) || !('specs' in spec.parameters)) {
             return false;
         }
-        var paramKeys = ['id', 'multipleItems', 'ui', 'data', '_position'];
-        var passedInternal = true;
-        spec.parameters.layout.forEach(function(param) {
-            paramKeys.forEach(function(key) {
+        const paramKeys = ['id', 'multipleItems', 'ui', 'data', '_position'];
+        let passedInternal = true;
+        spec.parameters.layout.forEach((param) => {
+            paramKeys.forEach((key) => {
                 if (!(key in spec.parameters.specs[param])) {
                     passedInternal = false;
                     console.error('TEST ERROR: param ' + param + ' missing key ' + key);
@@ -34,23 +30,22 @@ define ([
         return passedInternal;
     };
 
-    describe('Test SDK convertor tool', function() {
-        it('Is alive!', function() {
+    describe('Test SDK convertor tool', () => {
+        it('Is alive!', () => {
             expect(SDK).toBeTruthy();
         });
 
-        it('Can convert a simple app spec', function() {
-            var spec = SDK.convertAppSpec(SimpleAppSpec);
+        it('Can convert a simple app spec', () => {
+            const spec = SDK.convertAppSpec(SimpleAppSpec);
             expect(validateConvertedSpec(spec)).toBe(true);
         });
 
-        it('Can convert a rather complex app spec', function() {
-            var spec = SDK.convertAppSpec(ComplexAppSpec);
+        it('Can convert a rather complex app spec', () => {
+            const spec = SDK.convertAppSpec(ComplexAppSpec);
             expect(validateConvertedSpec(spec)).toBe(true);
-
         });
 
-        it('Throws an error with an app spec with missing stuff', function() {
+        it('Throws an error with an app spec with missing stuff', () => {
             try {
                 SDK.convertAppSpec(null);
             } catch (error) {
@@ -58,5 +53,4 @@ define ([
             }
         });
     });
-
 });

--- a/test/unit/spec/common/sdk-Spec.js
+++ b/test/unit/spec/common/sdk-Spec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define([
     'common/sdk',
     'json!/test/data/NarrativeTest.test_simple_inputs.spec.json',

--- a/test/unit/spec/common/validate-Spec.js
+++ b/test/unit/spec/common/validate-Spec.js
@@ -1,12 +1,9 @@
 /*global define,describe,it,expect*/
 /*jslint white:true,browser:true*/
-define([
-    'bluebird',
-    'common/validation'
-], function (Promise, Validation) {
+define(['bluebird', 'common/validation'], (Promise, Validation) => {
     'use strict';
 
-    describe('Validator functions', function () {
+    describe('Validator functions', () => {
         /* map from wsid to objects that match the name
          * used for mocking out the responses needed for validateWorkspaceObjectName,
          * in the case where we want to ensure that the object
@@ -19,43 +16,64 @@ define([
         const wsObjName = 'SomeObject',
             wsObjType = 'SomeModule.SomeType',
             wsObjMapping = {
-                '1': [null],
-                '2': [[1, wsObjName, wsObjType, '2019-07-23T22:42:44+0000', 1, 'someuser', 2, 'someworkspace', 'somehash', 123, null]],
-                '3': [[1, wsObjName, 'SomeOtherModule.SomeOtherType', '2019-07-23T22:42:44+0000', 1, 'someotheruser', 3, 'someotherworkspace', 'somehash', 123, null]]
+                1: [null],
+                2: [
+                    [
+                        1,
+                        wsObjName,
+                        wsObjType,
+                        '2019-07-23T22:42:44+0000',
+                        1,
+                        'someuser',
+                        2,
+                        'someworkspace',
+                        'somehash',
+                        123,
+                        null,
+                    ],
+                ],
+                3: [
+                    [
+                        1,
+                        wsObjName,
+                        'SomeOtherModule.SomeOtherType',
+                        '2019-07-23T22:42:44+0000',
+                        1,
+                        'someotheruser',
+                        3,
+                        'someotherworkspace',
+                        'somehash',
+                        123,
+                        null,
+                    ],
+                ],
             },
             fakeWsUrl = 'https://test.kbase.us/services/ws';
 
         beforeEach(() => {
             jasmine.Ajax.install();
 
-            jasmine.Ajax.stubRequest(
-                fakeWsUrl,
-                /wsid.\s*\:\s*1\s*,/
-            ).andReturn((function() {
-                return {
-                    status: 200,
-                    statusText: 'HTTP/1.1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({'result': [wsObjMapping['1']]})
-                }
-            })());
-            jasmine.Ajax.stubRequest(
-                fakeWsUrl,
-                /wsid.\s*:\s*2\s*,/
-            ).andReturn({
+            jasmine.Ajax.stubRequest(fakeWsUrl, /wsid.\s*\:\s*1\s*,/).andReturn(
+                (function () {
+                    return {
+                        status: 200,
+                        statusText: 'HTTP/1.1 200 OK',
+                        contentType: 'application/json',
+                        responseText: JSON.stringify({ result: [wsObjMapping['1']] }),
+                    };
+                })()
+            );
+            jasmine.Ajax.stubRequest(fakeWsUrl, /wsid.\s*:\s*2\s*,/).andReturn({
                 status: 200,
                 statusText: 'HTTP/1.1 200 OK',
                 contentType: 'application/json',
-                responseText: JSON.stringify({'result': [wsObjMapping['2']]})
+                responseText: JSON.stringify({ result: [wsObjMapping['2']] }),
             });
-            jasmine.Ajax.stubRequest(
-                fakeWsUrl,
-                /wsid.\s*:\s*3\s*,/
-            ).andReturn({
+            jasmine.Ajax.stubRequest(fakeWsUrl, /wsid.\s*:\s*3\s*,/).andReturn({
                 status: 200,
                 statusText: 'HTTP/1.1 200 OK',
                 contentType: 'application/json',
-                responseText: JSON.stringify({'result': [wsObjMapping['3']]})
+                responseText: JSON.stringify({ result: [wsObjMapping['3']] }),
             });
         });
 
@@ -68,20 +86,19 @@ define([
                 shouldNotExist: true,
                 workspaceId: 1,
                 workspaceServiceUrl: fakeWsUrl,
-                types:[wsObjType]
-            })
-                .then((result) => {
-                    expect(result).toEqual({
-                        isValid: true,
-                        messageId: undefined,
-                        errorMessage: undefined,
-                        shortMessage: undefined,
-                        diagnosis: 'valid',
-                        value: wsObjName,
-                        parsedValue: wsObjName
-                    });
-                    done();
+                types: [wsObjType],
+            }).then((result) => {
+                expect(result).toEqual({
+                    isValid: true,
+                    messageId: undefined,
+                    errorMessage: undefined,
+                    shortMessage: undefined,
+                    diagnosis: 'valid',
+                    value: wsObjName,
+                    parsedValue: wsObjName,
                 });
+                done();
+            });
         });
 
         it('validateWorkspaceObjectName - returns valid-ish when type exists of same type', (done) => {
@@ -89,20 +106,19 @@ define([
                 shouldNotExist: true,
                 workspaceId: 2,
                 workspaceServiceUrl: fakeWsUrl,
-                types: [wsObjType]
-            })
-                .then(result => {
-                    expect(result).toEqual({
-                        isValid: true,
-                        messageId: 'obj-overwrite-warning',
-                        shortMessage: 'an object already exists with this name',
-                        diagnosis: 'suspect',
-                        errorMessage: undefined,
-                        value: wsObjName,
-                        parsedValue: wsObjName
-                    });
-                    done();
-                })
+                types: [wsObjType],
+            }).then((result) => {
+                expect(result).toEqual({
+                    isValid: true,
+                    messageId: 'obj-overwrite-warning',
+                    shortMessage: 'an object already exists with this name',
+                    diagnosis: 'suspect',
+                    errorMessage: undefined,
+                    value: wsObjName,
+                    parsedValue: wsObjName,
+                });
+                done();
+            });
         });
 
         it('validateWorkspaceObjectName - returns invalid when type exists of different type', (done) => {
@@ -110,20 +126,20 @@ define([
                 shouldNotExist: true,
                 workspaceId: 3,
                 workspaceServiceUrl: fakeWsUrl,
-                types: [wsObjType]
-            })
-                .then(result => {
-                    expect(result).toEqual({
-                        isValid: false,
-                        messageId: 'obj-overwrite-diff-type',
-                        errorMessage: 'an object already exists with this name and is not of the same type',
-                        diagnosis: 'invalid',
-                        shortMessage: undefined,
-                        value: wsObjName,
-                        parsedValue: wsObjName
-                    });
-                    done();
-                })
+                types: [wsObjType],
+            }).then((result) => {
+                expect(result).toEqual({
+                    isValid: false,
+                    messageId: 'obj-overwrite-diff-type',
+                    errorMessage:
+                        'an object already exists with this name and is not of the same type',
+                    diagnosis: 'invalid',
+                    shortMessage: undefined,
+                    value: wsObjName,
+                    parsedValue: wsObjName,
+                });
+                done();
+            });
         });
 
         it('Can look up workspace names', (done) => {
@@ -131,17 +147,15 @@ define([
                 shouldNotExist: true,
                 workspaceId: 1,
                 workspaceServiceUrl: 'https://test.kbase.us/services/ws',
-                types:[wsObjType]
-            })
-                .then((result) => {
-                    console.log(result);
-                    done();
-                });
+                types: [wsObjType],
+            }).then((result) => {
+                console.log(result);
+                done();
+            });
         });
 
-
-        it('Is alive', function () {
-            var alive;
+        it('Is alive', () => {
+            let alive;
             if (Validation) {
                 alive = true;
             } else {
@@ -153,7 +167,7 @@ define([
         // STRING
 
         function wrap(val) {
-            return Promise.try(function () {
+            return Promise.try(() => {
                 return val;
             });
         }
@@ -164,75 +178,80 @@ define([
                 errorMessage: null,
                 diagnosis: 'valid',
                 value: value,
-                parsedValue: value
+                parsedValue: value,
             });
         });
 
-        it('validateTextString - Validate a simple string without constraints', function () {
+        it('validateTextString - Validate a simple string without constraints', () => {
             expect(Validation.validateTextString('test', {}).isValid).toEqual(true);
         });
 
-        it('validateTextString - Validate a simple string required and supplied', function () {
+        it('validateTextString - Validate a simple string required and supplied', () => {
             const result = Validation.validateTextString('test', {
-                required: true
+                required: true,
             });
             expect(result.isValid).toEqual(true);
         });
-        it('validateTextString - Validate a simple string, required, empty string', function (done) {
-            wrap(Validation.validateTextString('', {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateTextString - Validate a simple string, required, empty string', (done) => {
+            wrap(
+                Validation.validateTextString('', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateTextString - Validate a simple string, required, null', function (done) {
-            wrap(Validation.validateTextString(null, {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateTextString - Validate a simple string, required, null', (done) => {
+            wrap(
+                Validation.validateTextString(null, {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateTextString - Validate a simple string, min and max length, within range', function (done) {
-            wrap(Validation.validateTextString('hello', {
-                required: true,
-                min_length: 5,
-                max_length: 10
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('validateTextString - Validate a simple string, min and max length, within range', (done) => {
+            wrap(
+                Validation.validateTextString('hello', {
+                    required: true,
+                    min_length: 5,
+                    max_length: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('validateTextString - Validate a simple string, min and max length, below', function (done) {
-            wrap(Validation.validateTextString('hi', {
-                required: true,
-                min_length: 5,
-                max_length: 10
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateTextString - Validate a simple string, min and max length, below', (done) => {
+            wrap(
+                Validation.validateTextString('hi', {
+                    required: true,
+                    min_length: 5,
+                    max_length: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateTextString - Validate a simple string, min and max length, above range', function (done) {
-            wrap(Validation.validateTextString('hello earthling', {
-                required: true,
-                min_length: 5,
-                max_length: 10
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateTextString - Validate a simple string, min and max length, above range', (done) => {
+            wrap(
+                Validation.validateTextString('hello earthling', {
+                    required: true,
+                    min_length: 5,
+                    max_length: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
         it('validateTextString - Validate a regexp with matching string', () => {
             const value = 'foobar';
             const options = {
-                regexp_constraint: /^foo/
+                regexp_constraint: /^foo/,
             };
             const result = Validation.validateTextString(value, options);
             expect(result).toEqual({
@@ -240,203 +259,210 @@ define([
                 diagnosis: 'valid',
                 value: value,
                 parsedValue: value,
-                errorMessage: undefined
+                errorMessage: undefined,
             });
         });
         it('validateTextString - Validate a regexp with non-matching string', () => {
             const value = 'barfoo';
             const options = {
-                regexp_constraint: /^\d+$/
+                regexp_constraint: /^\d+$/,
             };
             expect(Validation.validateTextString(value, options)).toEqual({
                 isValid: false,
                 diagnosis: 'invalid',
                 value: value,
                 parsedValue: value,
-                errorMessage: 'The text value did not match the regular expression constraint ' + options.regexp_constraint
+                errorMessage:
+                    'The text value did not match the regular expression constraint ' +
+                    options.regexp_constraint,
             });
-        })
+        });
 
         // INTEGER
-        it('validateIntString - Validate an integer without constraints', function (done) {
-            wrap(Validation.validateIntString('42', {}))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('validateIntString - Validate an integer without constraints', (done) => {
+            wrap(Validation.validateIntString('42', {})).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('validateIntString - Validate an integer, required', function (done) {
-            wrap(Validation.validateIntString('42', {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('validateIntString - Validate an integer, required', (done) => {
+            wrap(
+                Validation.validateIntString('42', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('validateIntString - Validate an integer, required', function (done) {
-            wrap(Validation.validateIntString('', {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateIntString - Validate an integer, required', (done) => {
+            wrap(
+                Validation.validateIntString('', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateIntString - Validate an integer, required', function (done) {
-            wrap(Validation.validateIntString(null, {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateIntString - Validate an integer, required', (done) => {
+            wrap(
+                Validation.validateIntString(null, {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateIntString - Validate an integer, required', function (done) {
-            wrap(Validation.validateIntString('7', {
-                required: true,
-                min_int: 5,
-                max_int: 10
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('validateIntString - Validate an integer, required', (done) => {
+            wrap(
+                Validation.validateIntString('7', {
+                    required: true,
+                    min_int: 5,
+                    max_int: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('validateIntString - Validate an integer, required', function (done) {
-            wrap(Validation.validateIntString('3', {
-                required: true,
-                min_int: 5,
-                max_int: 10
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateIntString - Validate an integer, required', (done) => {
+            wrap(
+                Validation.validateIntString('3', {
+                    required: true,
+                    min_int: 5,
+                    max_int: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateIntString - Validate an integer, required', function (done) {
-            wrap(Validation.validateIntString('42', {
-                required: true,
-                min_int: 5,
-                max_int: 10
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateIntString - Validate an integer, required', (done) => {
+            wrap(
+                Validation.validateIntString('42', {
+                    required: true,
+                    min_int: 5,
+                    max_int: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateIntString - Validate an integer, wront type (int)', function (done) {
-            wrap(Validation.validateIntString(42, {
-                required: true,
-                min_int: 5,
-                max_int: 10
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateIntString - Validate an integer, wront type (int)', (done) => {
+            wrap(
+                Validation.validateIntString(42, {
+                    required: true,
+                    min_int: 5,
+                    max_int: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-
 
         // FLOAT
-        it('validateFloatString - Validate a float without constraints', function (done) {
-            wrap(Validation.validateFloatString('42.12', {}))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('validateFloatString - Validate a float without constraints', (done) => {
+            wrap(Validation.validateFloatString('42.12', {})).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('validateFloatString - Validate a bad without constraints', function (done) {
-            wrap(Validation.validateFloatString('x', {}))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateFloatString - Validate a bad without constraints', (done) => {
+            wrap(Validation.validateFloatString('x', {})).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateFloatString - Validate an empty without constraints', function (done) {
-            wrap(Validation.validateFloatString('', {}))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('validateFloatString - Validate an empty without constraints', (done) => {
+            wrap(Validation.validateFloatString('', {})).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('validateFloatString - Validate a float string, required', function (done) {
-            wrap(Validation.validateFloatString('42.12', {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('validateFloatString - Validate a float string, required', (done) => {
+            wrap(
+                Validation.validateFloatString('42.12', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('validateFloatString - Validate an empty string, required', function (done) {
-            wrap(Validation.validateFloatString('', {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateFloatString - Validate an empty string, required', (done) => {
+            wrap(
+                Validation.validateFloatString('', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateFloatString - Validate an empty string, required', function (done) {
-            wrap(Validation.validateFloatString(null, {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateFloatString - Validate an empty string, required', (done) => {
+            wrap(
+                Validation.validateFloatString(null, {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
         // bad types
-        it('validateFloatString - Validate an undefined, required', function (done) {
-            wrap(Validation.validateFloatString(undefined, {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateFloatString - Validate an undefined, required', (done) => {
+            wrap(
+                Validation.validateFloatString(undefined, {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('validateFloatString - Validate an array, required', function (done) {
-            wrap(Validation.validateFloatString([], {
-                required: true
-            }))
-                .then(function (result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('validateFloatString - Validate an array, required', (done) => {
+            wrap(
+                Validation.validateFloatString([], {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
 
         function runTests(method, tests) {
-            tests.forEach(function (testSet) {
-                testSet.forEach(function (test) {
+            tests.forEach((testSet) => {
+                testSet.forEach((test) => {
                     if (test.options.required === undefined) {
-                        [true, false].forEach(function (required) {
-                            it(method + ' - ' + test.title + ' - required: ' + required, function (done) {
-                                Promise.try(function () {
-                                    let options = test.options;
+                        [true, false].forEach((required) => {
+                            it(method + ' - ' + test.title + ' - required: ' + required, (done) => {
+                                Promise.try(() => {
+                                    const options = test.options;
                                     options.required = required;
                                     return Validation[method](test.value, options);
-                                })
-                                    .then(function (result) {
-                                        Object.keys(test.result).forEach(function (key) {
-                                            expect(result[key]).toEqual(test.result[key]);
-                                        });
-                                        done();
-                                    });
-                            });
-                        });
-                    } else {
-                        it(method + ' - ' + test.title, function (done) {
-                            Promise.try(function () {
-                                return Validation[method](test.value, test.options);
-                            })
-                                .then(function (result) {
-                                    Object.keys(test.result).forEach(function (key) {
+                                }).then((result) => {
+                                    Object.keys(test.result).forEach((key) => {
                                         expect(result[key]).toEqual(test.result[key]);
                                     });
                                     done();
                                 });
+                            });
+                        });
+                    } else {
+                        it(method + ' - ' + test.title, (done) => {
+                            Promise.try(() => {
+                                return Validation[method](test.value, test.options);
+                            }).then((result) => {
+                                Object.keys(test.result).forEach((key) => {
+                                    expect(result[key]).toEqual(test.result[key]);
+                                });
+                                done();
+                            });
                         });
                     }
                 });
@@ -445,81 +471,80 @@ define([
 
         // FLOATS
         (function () {
-            var emptyValues = [
-                {
-                    title: 'empty string',
-                    value: '',
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+            const emptyValues = [
+                    {
+                        title: 'empty string',
                         value: '',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'string of just spaces same as empty',
-                    value: '   ',
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: '',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'string of just spaces same as empty',
                         value: '   ',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'null',
-                    value: null,
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: '   ',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'null',
                         value: null,
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'empty string, required',
-                    value: '',
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: null,
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'empty string, required',
                         value: '',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'string of empty spaces, required',
-                    value: '   ',
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: '',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'string of empty spaces, required',
                         value: '   ',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'null, required',
-                    value: null,
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: '   ',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'null, required',
                         value: null,
-                        parsedValue: undefined
-                    }
-                }
-
-            ],
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: null,
+                            parsedValue: undefined,
+                        },
+                    },
+                ],
                 acceptableFormatTests = [
                     {
                         title: 'integer format',
@@ -530,8 +555,8 @@ define([
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: '42',
-                            parsedValue: 42
-                        }
+                            parsedValue: 42,
+                        },
                     },
                     {
                         title: 'decmial format',
@@ -542,8 +567,8 @@ define([
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: '42.12',
-                            parsedValue: 42.12
-                        }
+                            parsedValue: 42.12,
+                        },
                     },
                     {
                         title: 'float exp format',
@@ -554,9 +579,9 @@ define([
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: '42e2',
-                            parsedValue: 42e2
-                        }
-                    }
+                            parsedValue: 42e2,
+                        },
+                    },
                 ],
                 badValueTests = [
                     {
@@ -568,9 +593,9 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be numeric',
                             value: 'abc',
-                            parsedValue: undefined
-                        }
-                    }
+                            parsedValue: undefined,
+                        },
+                    },
                 ],
                 typeTests = [
                     {
@@ -582,8 +607,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "undefined")',
                             value: undefined,
-                            pasedValue: undefined
-                        }
+                            pasedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate array',
@@ -594,8 +619,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: [],
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate object',
@@ -606,8 +631,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: {},
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate date',
@@ -618,9 +643,9 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: new Date(0),
-                            parsedValue: undefined
-                        }
-                    }
+                            parsedValue: undefined,
+                        },
+                    },
                     // could go on..
                 ],
                 validateRangeTests = [
@@ -628,44 +653,44 @@ define([
                         title: 'value over max',
                         value: '123.45',
                         options: {
-                            max_float: 100
+                            max_float: 100,
                         },
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
                             errorMessage: 'the maximum value for this parameter is 100',
                             value: '123.45',
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'value under min',
                         value: '5',
                         options: {
-                            min_float: 10
+                            min_float: 10,
                         },
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
                             errorMessage: 'the minimum value for this parameter is 10',
                             value: '5',
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'within range',
                         value: '5.5',
                         options: {
                             min_float: 0,
-                            max_float: 10
+                            max_float: 10,
                         },
                         result: {
                             isValid: true,
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: '5.5',
-                            parsedValue: 5.5
-                        }
+                            parsedValue: 5.5,
+                        },
                     },
                     {
                         title: 'infinite',
@@ -676,98 +701,97 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a finite float',
                             value: 'Infinity',
-                            parsedValue: undefined
-                        }
-                    }
+                            parsedValue: undefined,
+                        },
+                    },
                 ],
                 tests = [
                     emptyValues,
                     acceptableFormatTests,
                     badValueTests,
                     typeTests,
-                    validateRangeTests
+                    validateRangeTests,
                 ];
 
             runTests('validateFloatString', tests);
-        }());
+        })();
 
         // INTS
         (function () {
-            var emptyValues = [
-                {
-                    title: 'empty string',
-                    value: '',
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+            const emptyValues = [
+                    {
+                        title: 'empty string',
                         value: '',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'string of just spaces same as empty',
-                    value: '   ',
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: '',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'string of just spaces same as empty',
                         value: '   ',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'null',
-                    value: null,
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: '   ',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'null',
                         value: null,
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'empty string, required',
-                    value: '',
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: null,
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'empty string, required',
                         value: '',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'string of empty spaces, required',
-                    value: '   ',
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: '',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'string of empty spaces, required',
                         value: '   ',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'null, required',
-                    value: null,
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: '   ',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'null, required',
                         value: null,
-                        parsedValue: undefined
-                    }
-                }
-
-            ],
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: null,
+                            parsedValue: undefined,
+                        },
+                    },
+                ],
                 acceptableFormatTests = [
                     {
                         title: 'integer format',
@@ -778,9 +802,9 @@ define([
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: '42',
-                            parsedValue: 42
-                        }
-                    }
+                            parsedValue: 42,
+                        },
+                    },
                 ],
                 badValueTests = [
                     {
@@ -792,8 +816,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'Invalid integer format',
                             value: 'abc',
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'decmial format',
@@ -804,9 +828,9 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'Invalid integer format',
                             value: '42.12',
-                            parsedValue: undefined
-                        }
-                    }
+                            parsedValue: undefined,
+                        },
+                    },
                 ],
                 typeTests = [
                     {
@@ -818,8 +842,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "undefined")',
                             value: undefined,
-                            pasedValue: undefined
-                        }
+                            pasedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate array',
@@ -830,8 +854,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: [],
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate object',
@@ -842,8 +866,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: {},
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate date',
@@ -854,98 +878,92 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: new Date(0),
-                            parsedValue: undefined
-                        }
-                    }
+                            parsedValue: undefined,
+                        },
+                    },
                     // could go on..
                 ],
-                tests = [
-                    emptyValues,
-                    acceptableFormatTests,
-                    badValueTests,
-                    typeTests
-                ];
+                tests = [emptyValues, acceptableFormatTests, badValueTests, typeTests];
 
             runTests('validateIntString', tests);
-        }());
+        })();
 
         // STRINGS
         (function () {
-            var emptyValues = [
-                {
-                    title: 'empty string',
-                    value: '',
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+            const emptyValues = [
+                    {
+                        title: 'empty string',
                         value: '',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'string of just spaces same as empty',
-                    value: '   ',
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: '',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'string of just spaces same as empty',
                         value: '   ',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'null',
-                    value: null,
-                    options: {required: false},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'optional-empty',
-                        errorMessage: undefined,
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: '   ',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'null',
                         value: null,
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'empty string, required',
-                    value: '',
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: false },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'optional-empty',
+                            errorMessage: undefined,
+                            value: null,
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'empty string, required',
                         value: '',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'string of empty spaces, required',
-                    value: '   ',
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: '',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'string of empty spaces, required',
                         value: '   ',
-                        parsedValue: undefined
-                    }
-                },
-                {
-                    title: 'null, required',
-                    value: null,
-                    options: {required: true},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'required-missing',
-                        errorMessage: 'value is required',
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: '   ',
+                            parsedValue: undefined,
+                        },
+                    },
+                    {
+                        title: 'null, required',
                         value: null,
-                        parsedValue: undefined
-                    }
-                }
-
-            ],
+                        options: { required: true },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'required-missing',
+                            errorMessage: 'value is required',
+                            value: null,
+                            parsedValue: undefined,
+                        },
+                    },
+                ],
                 acceptableFormatTests = [
                     {
                         title: 'string format',
@@ -956,8 +974,8 @@ define([
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: '42',
-                            parsedValue: '42'
-                        }
+                            parsedValue: '42',
+                        },
                     },
                     {
                         title: 'string format',
@@ -968,8 +986,8 @@ define([
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: 'abc',
-                            parsedValue: 'abc'
-                        }
+                            parsedValue: 'abc',
+                        },
                     },
                     {
                         title: 'string format',
@@ -980,12 +998,11 @@ define([
                             diagnosis: 'valid',
                             errorMessage: undefined,
                             value: 'uniîcodé',
-                            parsedValue: 'uniîcodé'
-                        }
-                    }
+                            parsedValue: 'uniîcodé',
+                        },
+                    },
                 ],
-                badValueTests = [
-                ],
+                badValueTests = [],
                 typeTests = [
                     {
                         title: 'validate undefined',
@@ -996,8 +1013,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "undefined")',
                             value: undefined,
-                            pasedValue: undefined
-                        }
+                            pasedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate array',
@@ -1008,8 +1025,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: [],
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate object',
@@ -1020,8 +1037,8 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: {},
-                            parsedValue: undefined
-                        }
+                            parsedValue: undefined,
+                        },
                     },
                     {
                         title: 'validate date',
@@ -1032,20 +1049,15 @@ define([
                             diagnosis: 'invalid',
                             errorMessage: 'value must be a string (it is of type "object")',
                             value: new Date(0),
-                            parsedValue: undefined
-                        }
-                    }
+                            parsedValue: undefined,
+                        },
+                    },
                     // could go on..
                 ],
-                tests = [
-                    emptyValues,
-                    acceptableFormatTests,
-                    badValueTests,
-                    typeTests
-                ];
+                tests = [emptyValues, acceptableFormatTests, badValueTests, typeTests];
 
             runTests('validateTextString', tests);
-        }());
+        })();
 
         // ObjectReferenceName
 
@@ -1058,82 +1070,81 @@ define([
                     options: {},
                     result: {
                         isValid: true,
-                        diagnosis: 'optional-empty'
-                    }
+                        diagnosis: 'optional-empty',
+                    },
                 },
                 {
                     title: 'undefined, not required',
                     value: undefined,
-                    options: {required: false},
+                    options: { required: false },
                     result: {
                         isValid: true,
                         diagnosis: 'optional-empty',
                         parsedValue: undefined,
                         errorMessage: undefined,
-                        value: undefined
+                        value: undefined,
                     },
                 },
                 {
                     title: 'undefined, required',
                     value: undefined,
-                    options: {required: true},
+                    options: { required: true },
                     result: {
                         isValid: false,
                         diagnosis: 'required-missing',
                         parsedValue: undefined,
                         errorMessage: 'value is required',
-                        value: undefined
-                    }
+                        value: undefined,
+                    },
                 },
                 {
                     title: 'boolean, required, ok',
                     value: true,
-                    options: {required: true, values: [true, false]},
+                    options: { required: true, values: [true, false] },
                     result: {
                         isValid: true,
                         parsedValue: true,
-                        value: true
-                    }
+                        value: true,
+                    },
                 },
                 {
                     title: 'boolean, not required, ok',
                     value: true,
-                    options: {required: false, values: [true, false]},
+                    options: { required: false, values: [true, false] },
                     result: {
                         isValid: true,
                         parsedValue: true,
-                        value: true
-                    }
+                        value: true,
+                    },
                 },
                 {
                     title: 'value not present',
                     value: 'a',
-                    options: {required: false, values: ['b', 'c']},
+                    options: { required: false, values: ['b', 'c'] },
                     result: {
                         isValid: false,
                         errorMessage: 'Value not in the set',
                         parsedValue: 'a',
                         value: 'a',
-                        diagnosis: 'invalid'
-                    }
-                }
-
+                        diagnosis: 'invalid',
+                    },
+                },
             ];
 
-            testCases.forEach(function (testCase) {
+            testCases.forEach((testCase) => {
                 it('validateSet - ' + testCase.title, () => {
                     const result = Validation.validateSet(testCase.value, testCase.options);
-                    Object.keys(testCase.result).forEach(key => {
+                    Object.keys(testCase.result).forEach((key) => {
                         expect(testCase.result[key]).toEqual(result[key]);
                     });
                 });
             });
-        }());
+        })();
 
         // validate data palette object reference path
         (function () {
             const nonStringValues = [1, 0, -1, undefined, null, [], {}],
-                nonStringCases = nonStringValues.map(value => {
+                nonStringCases = nonStringValues.map((value) => {
                     return {
                         title: 'non string - ' + value,
                         value: value,
@@ -1141,35 +1152,39 @@ define([
                         result: {
                             isValid: false,
                             errorMessage: 'value must be a string in data reference format',
-                            diagnosis: 'invalid'
-                        }
+                            diagnosis: 'invalid',
+                        },
                     };
                 }),
                 emptyStringValues = ['', ' ', '\t'],
-                emptyStringCases = emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - required',
-                        value: value,
-                        options: {required: true},
-                        result: {
-                            isValid: false,
-                            errorMessage: 'value is required',
-                            diagnosis: 'required-missing'
-                        }
-                    }
-                }).concat(emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - not required',
-                        value: value,
-                        options: {required: false},
-                        result: {
-                            isValid: true,
-                            diagnosis: 'optional-empty'
-                        }
-                    }
-                })),
+                emptyStringCases = emptyStringValues
+                    .map((value, idx) => {
+                        return {
+                            title: 'empty string type ' + (idx + 1) + ' - required',
+                            value: value,
+                            options: { required: true },
+                            result: {
+                                isValid: false,
+                                errorMessage: 'value is required',
+                                diagnosis: 'required-missing',
+                            },
+                        };
+                    })
+                    .concat(
+                        emptyStringValues.map((value, idx) => {
+                            return {
+                                title: 'empty string type ' + (idx + 1) + ' - not required',
+                                value: value,
+                                options: { required: false },
+                                result: {
+                                    isValid: true,
+                                    diagnosis: 'optional-empty',
+                                },
+                            };
+                        })
+                    ),
                 badStringValues = ['wat', '123/45/6/7', '123/456/789;123', '123/456/7;123/45/6/7'],
-                badStringCases = badStringValues.map(value => {
+                badStringCases = badStringValues.map((value) => {
                     return {
                         title: 'bad string - ' + value,
                         value: value,
@@ -1177,75 +1192,87 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
-                            errorMessage: 'Invalid object reference path -  ( should be #/#/#;#/#/#;...)'
-                        }
+                            errorMessage:
+                                'Invalid object reference path -  ( should be #/#/#;#/#/#;...)',
+                        },
                     };
                 }),
                 goodStringValues = [
-                    '1/2/3', '123/45/678', '1234567890123/4576894876498756/192387129837198237198273',
-                    '1/2/3;4/5/6', '1/2;4/5/6', '1/2;3/4;5/6', '1/2/3;4/5/6;7/8/9'
+                    '1/2/3',
+                    '123/45/678',
+                    '1234567890123/4576894876498756/192387129837198237198273',
+                    '1/2/3;4/5/6',
+                    '1/2;4/5/6',
+                    '1/2;3/4;5/6',
+                    '1/2/3;4/5/6;7/8/9',
                 ],
-                goodStringCases = goodStringValues.map(value => {
+                goodStringCases = goodStringValues.map((value) => {
                     return {
                         title: 'good string - ' + value,
                         value: value,
                         options: {},
                         result: {
                             isValid: true,
-                            diagnosis: 'valid'
-                        }
+                            diagnosis: 'valid',
+                        },
                     };
                 });
 
-            const testCases = [
-                nonStringCases,
-                emptyStringCases,
-                badStringCases,
-                goodStringCases
-            ];
+            const testCases = [nonStringCases, emptyStringCases, badStringCases, goodStringCases];
             runTests('validateWorkspaceDataPaletteRef', testCases);
-        }());
+        })();
 
         // Validate workspace object ref
         (function () {
             const nonStringValues = [1, 0, -1, undefined, null, [], {}],
-                nonStringCases = nonStringValues.map(value => {
+                nonStringCases = nonStringValues.map((value) => {
                     return {
                         title: 'non string - ' + value,
                         value: value,
                         options: {},
                         result: {
                             isValid: false,
-                            errorMessage: 'value must be a string in workspace object reference format',
-                            diagnosis: 'invalid'
-                        }
+                            errorMessage:
+                                'value must be a string in workspace object reference format',
+                            diagnosis: 'invalid',
+                        },
                     };
                 }),
                 emptyStringValues = ['', ' ', '\t'],
-                emptyStringCases = emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - required',
-                        value: value,
-                        options: {required: true},
-                        result: {
-                            isValid: false,
-                            errorMessage: 'value is required',
-                            diagnosis: 'required-missing'
-                        }
-                    }
-                }).concat(emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - not required',
-                        value: value,
-                        options: {required: false},
-                        result: {
-                            isValid: true,
-                            diagnosis: 'optional-empty'
-                        }
-                    }
-                })),
-                badStringValues = ['wat', '123/45/6/7', '123/456/789;123', '123/456/7;123/45/6/7', 'foo/bar/baz'],
-                badStringCases = badStringValues.map(value => {
+                emptyStringCases = emptyStringValues
+                    .map((value, idx) => {
+                        return {
+                            title: 'empty string type ' + (idx + 1) + ' - required',
+                            value: value,
+                            options: { required: true },
+                            result: {
+                                isValid: false,
+                                errorMessage: 'value is required',
+                                diagnosis: 'required-missing',
+                            },
+                        };
+                    })
+                    .concat(
+                        emptyStringValues.map((value, idx) => {
+                            return {
+                                title: 'empty string type ' + (idx + 1) + ' - not required',
+                                value: value,
+                                options: { required: false },
+                                result: {
+                                    isValid: true,
+                                    diagnosis: 'optional-empty',
+                                },
+                            };
+                        })
+                    ),
+                badStringValues = [
+                    'wat',
+                    '123/45/6/7',
+                    '123/456/789;123',
+                    '123/456/7;123/45/6/7',
+                    'foo/bar/baz',
+                ],
+                badStringCases = badStringValues.map((value) => {
                     return {
                         title: 'bad string - ' + value,
                         value: value,
@@ -1253,211 +1280,241 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
-                            errorMessage: 'Invalid object reference format, should be #/#/#'
-                        }
+                            errorMessage: 'Invalid object reference format, should be #/#/#',
+                        },
                     };
                 }),
                 goodStringValues = [
-                    '1/2/3', '123/45/678', '1234567890123/4576894876498756/192387129837198237198273'
+                    '1/2/3',
+                    '123/45/678',
+                    '1234567890123/4576894876498756/192387129837198237198273',
                 ],
-                goodStringCases = goodStringValues.map(value => {
+                goodStringCases = goodStringValues.map((value) => {
                     return {
                         title: 'good string - ' + value,
                         value: value,
                         options: {},
                         result: {
                             isValid: true,
-                            diagnosis: 'valid'
-                        }
+                            diagnosis: 'valid',
+                        },
                     };
                 });
 
-            const testCases = [
-                nonStringCases,
-                emptyStringCases,
-                badStringCases,
-                goodStringCases
-            ];
+            const testCases = [nonStringCases, emptyStringCases, badStringCases, goodStringCases];
             runTests('validateWorkspaceObjectRef', testCases);
-        }());
+        })();
 
-        (function() {
+        (function () {
             const nonStringValues = [1, 0, -1, undefined, [], {}],
-                nonStringCases = nonStringValues.map(value => {
+                nonStringCases = nonStringValues.map((value) => {
                     return {
                         title: 'non string - ' + value,
                         value: value,
                         options: {},
                         result: {
                             isValid: false,
-                            errorMessage: 'value must be a string (it is of type "' + (typeof value) + '")',
-                            diagnosis: 'invalid'
-                        }
+                            errorMessage:
+                                'value must be a string (it is of type "' + typeof value + '")',
+                            diagnosis: 'invalid',
+                        },
                     };
                 }),
                 emptyStringValues = ['', ' ', '\t'],
-                emptyStringCases = emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - required',
-                        value: value,
-                        options: {required: true},
-                        result: {
-                            isValid: false,
-                            errorMessage: 'value is required',
-                            diagnosis: 'required-missing'
-                        }
-                    }
-                }).concat(emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - not required',
-                        value: value,
-                        options: {required: false},
-                        result: {
-                            isValid: true,
-                            diagnosis: 'optional-empty'
-                        }
-                    }
-                })),
-                badStringValues = ['wat', '123/45/6/7', '123/456/789;123', '123/456/7;123/45/6/7', 'foo/bar/baz'],
-                badStringCases = badStringValues.map(value => {
+                emptyStringCases = emptyStringValues
+                    .map((value, idx) => {
+                        return {
+                            title: 'empty string type ' + (idx + 1) + ' - required',
+                            value: value,
+                            options: { required: true },
+                            result: {
+                                isValid: false,
+                                errorMessage: 'value is required',
+                                diagnosis: 'required-missing',
+                            },
+                        };
+                    })
+                    .concat(
+                        emptyStringValues.map((value, idx) => {
+                            return {
+                                title: 'empty string type ' + (idx + 1) + ' - not required',
+                                value: value,
+                                options: { required: false },
+                                result: {
+                                    isValid: true,
+                                    diagnosis: 'optional-empty',
+                                },
+                            };
+                        })
+                    ),
+                badStringValues = [
+                    'wat',
+                    '123/45/6/7',
+                    '123/456/789;123',
+                    '123/456/7;123/45/6/7',
+                    'foo/bar/baz',
+                ],
+                badStringCases = badStringValues.map((value) => {
                     return {
                         title: 'bad string - ' + value,
                         value: value,
                         options: {},
                         result: {
                             isValid: false,
-                            diagnosis: 'invalid'
-                        }
+                            diagnosis: 'invalid',
+                        },
                     };
                 }),
                 goodStringValues = [
-                    'true', 'false', 'TRUE', 'FALSE', 'True', 'False', 't', 'f', 'T', 'F', 'yes', 'no', 'y', 'n'
+                    'true',
+                    'false',
+                    'TRUE',
+                    'FALSE',
+                    'True',
+                    'False',
+                    't',
+                    'f',
+                    'T',
+                    'F',
+                    'yes',
+                    'no',
+                    'y',
+                    'n',
                 ],
-                goodStringCases = goodStringValues.map(value => {
+                goodStringCases = goodStringValues.map((value) => {
                     return {
                         title: 'good string - ' + value,
                         value: value,
                         options: {},
                         result: {
                             isValid: true,
-                            diagnosis: 'valid'
-                        }
+                            diagnosis: 'valid',
+                        },
                     };
                 });
 
-            const testCases = [
-                nonStringCases,
-                emptyStringCases,
-                badStringCases,
-                goodStringCases
-            ];
+            const testCases = [nonStringCases, emptyStringCases, badStringCases, goodStringCases];
             runTests('validateBoolean', testCases);
-        }());
+        })();
 
         // validate workspace object name string -- a case of validateText/validateTextString
-        (function() {
+        (function () {
             const nonStringValues = [1, 0, -1, undefined, [], {}],
-                nonStringCases = nonStringValues.map(value => {
+                nonStringCases = nonStringValues.map((value) => {
                     return {
                         title: 'non string - ' + value,
                         value: value,
-                        options: {type: 'WorkspaceObjectName'},
+                        options: { type: 'WorkspaceObjectName' },
                         result: {
                             isValid: false,
                             errorMessage: 'value must be a string in workspace object name format',
-                            diagnosis: 'invalid'
-                        }
+                            diagnosis: 'invalid',
+                        },
                     };
                 }),
                 emptyStringValues = ['', ' ', '\t'],
-                emptyStringCases = emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - required',
-                        value: value,
-                        options: {required: true, type: 'WorkspaceObjectName'},
-                        result: {
-                            isValid: false,
-                            errorMessage: 'value is required',
-                            diagnosis: 'required-missing'
-                        }
-                    }
-                }).concat(emptyStringValues.map((value, idx) => {
-                    return {
-                        title: 'empty string type ' + (idx+1) + ' - not required',
-                        value: value,
-                        options: {required: false, type: 'WorkspaceObjectName'},
-                        result: {
-                            isValid: true,
-                            diagnosis: 'optional-empty'
-                        }
-                    }
-                })),
+                emptyStringCases = emptyStringValues
+                    .map((value, idx) => {
+                        return {
+                            title: 'empty string type ' + (idx + 1) + ' - required',
+                            value: value,
+                            options: { required: true, type: 'WorkspaceObjectName' },
+                            result: {
+                                isValid: false,
+                                errorMessage: 'value is required',
+                                diagnosis: 'required-missing',
+                            },
+                        };
+                    })
+                    .concat(
+                        emptyStringValues.map((value, idx) => {
+                            return {
+                                title: 'empty string type ' + (idx + 1) + ' - not required',
+                                value: value,
+                                options: { required: false, type: 'WorkspaceObjectName' },
+                                result: {
+                                    isValid: true,
+                                    diagnosis: 'optional-empty',
+                                },
+                            };
+                        })
+                    ),
                 spacedStringValues = ['foo bar', 'foo bar baz'],
-                spacedStringCases = spacedStringValues.map(value => {
+                spacedStringCases = spacedStringValues.map((value) => {
                     return {
                         title: 'spaced string - ' + value,
                         value: value,
-                        options: {type: 'WorkspaceObjectName'},
+                        options: { type: 'WorkspaceObjectName' },
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
                             messageId: 'obj-name-no-spaces',
-                            errorMessage: 'an object name may not contain a space'
-                        }
-                    }
+                            errorMessage: 'an object name may not contain a space',
+                        },
+                    };
                 }),
                 intStringValues = ['1', '23', '-5', '123456789012345678901234567890'],
-                intStringCases = intStringValues.map(value => {
+                intStringCases = intStringValues.map((value) => {
                     return {
                         title: 'int string - ' + value,
                         value: value,
-                        options: {type: 'WorkspaceObjectName'},
+                        options: { type: 'WorkspaceObjectName' },
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
                             messageId: 'obj-name-not-integer',
-                            errorMessage: 'an object name may not be in the form of an integer'
-                        }
-                    }
+                            errorMessage: 'an object name may not be in the form of an integer',
+                        },
+                    };
                 }),
                 invalidCharValues = ['foo!', 'bar@baz', 'a#a', '1$1', '%', '!@#$%^&*('],
-                invalidCharCases = invalidCharValues.map(value => {
+                invalidCharCases = invalidCharValues.map((value) => {
                     return {
                         title: 'invalid char string - ' + value,
                         value: value,
-                        options: {type: 'WorkspaceObjectName'},
+                        options: { type: 'WorkspaceObjectName' },
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
                             messageId: 'obj-name-invalid-characters',
-                            errorMessage: 'one or more invalid characters detected; an object name may only include alphabetic characters, numbers, and the symbols "_",  "-",  ".",  and "|"'
-                        }
-                    }
+                            errorMessage:
+                                'one or more invalid characters detected; an object name may only include alphabetic characters, numbers, and the symbols "_",  "-",  ".",  and "|"',
+                        },
+                    };
                 }),
-                tooLongCase = [{
-                    title: 'string too long',
-                    value: Array(256).fill('a').join(''),
-                    options: {type: 'WorkspaceObjectName'},
-                    result: {
-                        isValid: false,
-                        diagnosis: 'invalid',
-                        messageId: 'obj-name-too-long',
-                        errorMessage: 'an object name may not exceed 255 characters in length'
-                    }
-                }],
-                goodStringValues = [
-                    'AGenome', 'Some_Object', 'another.object', '-foo', 'bar-', 'da5id', '3dog', '  foobar  '
+                tooLongCase = [
+                    {
+                        title: 'string too long',
+                        value: Array(256).fill('a').join(''),
+                        options: { type: 'WorkspaceObjectName' },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'invalid',
+                            messageId: 'obj-name-too-long',
+                            errorMessage: 'an object name may not exceed 255 characters in length',
+                        },
+                    },
                 ],
-                goodStringCases = goodStringValues.map(value => {
+                goodStringValues = [
+                    'AGenome',
+                    'Some_Object',
+                    'another.object',
+                    '-foo',
+                    'bar-',
+                    'da5id',
+                    '3dog',
+                    '  foobar  ',
+                ],
+                goodStringCases = goodStringValues.map((value) => {
                     return {
                         title: 'good string - ' + value,
                         value: value,
-                        options: {type: 'WorkspaceObjectName'},
+                        options: { type: 'WorkspaceObjectName' },
                         result: {
                             isValid: true,
                             diagnosis: 'valid',
-                            parsedValue: value.trim()
-                        }
+                            parsedValue: value.trim(),
+                        },
                     };
                 });
 
@@ -1468,71 +1525,77 @@ define([
                 intStringCases,
                 invalidCharCases,
                 tooLongCase,
-                goodStringCases
+                goodStringCases,
             ];
             runTests('validateText', testCases);
-            runTests('validateWorkspaceObjectName', testCases);  // covers all but the case where we have to see if the object exists
-        }());
+            runTests('validateWorkspaceObjectName', testCases); // covers all but the case where we have to see if the object exists
+        })();
 
-        (function() {
+        (function () {
             const emptySets = [null, [], [''], [' '], ['\t', '', '  ']],
-                emptySetCases = emptySets.map(set => {
-                    return {
-                        title: 'empty set - ' + JSON.stringify(set) + ' - not required',
-                        value: set,
-                        options: {required: false},
-                        result: {
-                            isValid: true,
-                            diagnosis: 'optional-empty'
-                        }
-                    };
-                }).concat(emptySets.map(set => {
-                    return {
-                        title: 'empty set' + JSON.stringify(set) + ' - required',
-                        value: set,
-                        options: {required: true},
-                        result: {
-                            isValid: false,
-                            diagnosis: 'required-missing',
-                            errorMessage: 'value is required'
-                        }
-                    }
-                })),
+                emptySetCases = emptySets
+                    .map((set) => {
+                        return {
+                            title: 'empty set - ' + JSON.stringify(set) + ' - not required',
+                            value: set,
+                            options: { required: false },
+                            result: {
+                                isValid: true,
+                                diagnosis: 'optional-empty',
+                            },
+                        };
+                    })
+                    .concat(
+                        emptySets.map((set) => {
+                            return {
+                                title: 'empty set' + JSON.stringify(set) + ' - required',
+                                value: set,
+                                options: { required: true },
+                                result: {
+                                    isValid: false,
+                                    diagnosis: 'required-missing',
+                                    errorMessage: 'value is required',
+                                },
+                            };
+                        })
+                    ),
                 populatedSets = [['a', 'b'], ['a'], [1, 2]],
-                populatedOkCases = populatedSets.map(set => {
+                populatedOkCases = populatedSets.map((set) => {
                     return {
                         title: 'set ok - ' + JSON.stringify(set),
                         value: set,
-                        options: {values: ['a', 'b', 'c', 1, 2, 3]},
+                        options: { values: ['a', 'b', 'c', 1, 2, 3] },
                         result: {
                             isValid: true,
-                            diagnosis: 'valid'
-                        }
-                    }
+                            diagnosis: 'valid',
+                        },
+                    };
                 }),
-                populatedFailCases = populatedSets.map(set => {
+                populatedFailCases = populatedSets.map((set) => {
                     return {
                         title: 'set not ok - ' + JSON.stringify(set),
                         value: set,
-                        options: {values: ['b', 'd', 1, 4]},
+                        options: { values: ['b', 'd', 1, 4] },
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
-                            errorMessage: 'Value not in the set'
-                        }
-                    }
+                            errorMessage: 'Value not in the set',
+                        },
+                    };
                 }),
-                populatedNoopCase = [{
-                    title: 'set with no test',
-                    value: ['a', 'b', 'c'],
-                    options: {},
-                    result: {
-                        isValid: true,
-                        diagnosis: 'valid'
-                    }
-                }],
+                populatedNoopCase = [
+                    {
+                        title: 'set with no test',
+                        value: ['a', 'b', 'c'],
+                        options: {},
+                        result: {
+                            isValid: true,
+                            diagnosis: 'valid',
+                        },
+                    },
+                ],
                 notArraySets = [undefined, 'foo', 1, {}],
-                notArrayCases = notArraySets.map(set => {
+                notArrayCases = notArraySets.map((set) => {
                     return {
                         title: 'not an array - ' + set,
                         value: set,
@@ -1540,9 +1603,9 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: 'invalid',
-                            errorMessage: 'value must be an array'
-                        }
-                    }
+                            errorMessage: 'value must be an array',
+                        },
+                    };
                 });
 
             const testCases = [
@@ -1550,11 +1613,10 @@ define([
                 populatedOkCases,
                 populatedFailCases,
                 populatedNoopCase,
-                notArrayCases
+                notArrayCases,
             ];
             runTests('validateTextSet', testCases);
             runTests('validateStringSet', testCases);
-        }());
-
+        })();
     });
 });

--- a/test/unit/spec/common/validate-Spec.js
+++ b/test/unit/spec/common/validate-Spec.js
@@ -1,5 +1,3 @@
-/*global define,describe,it,expect*/
-/*jslint white:true,browser:true*/
 define(['bluebird', 'common/validation'], (Promise, Validation) => {
     'use strict';
 
@@ -53,7 +51,7 @@ define(['bluebird', 'common/validation'], (Promise, Validation) => {
         beforeEach(() => {
             jasmine.Ajax.install();
 
-            jasmine.Ajax.stubRequest(fakeWsUrl, /wsid.\s*\:\s*1\s*,/).andReturn(
+            jasmine.Ajax.stubRequest(fakeWsUrl, /wsid.\s*:\s*1\s*,/).andReturn(
                 (function () {
                     return {
                         status: 200,

--- a/test/unit/spec/common/validate2-Spec.js
+++ b/test/unit/spec/common/validate2-Spec.js
@@ -4,13 +4,13 @@ define([
     'bluebird',
     'common/validation',
     'widgets/appWidgets2/validators/int',
-    'widgets/appWidgets2/validators/resolver'
-], function(Promise, Validation, IntValidation, ValidationResolver) {
+    'widgets/appWidgets2/validators/resolver',
+], (Promise, Validation, IntValidation, ValidationResolver) => {
     'use strict';
 
-    describe('Props core functions', function() {
-        it('Is alive', function() {
-            var alive;
+    describe('Props core functions', () => {
+        it('Is alive', () => {
+            let alive;
             if (Validation) {
                 alive = true;
             } else {
@@ -22,310 +22,303 @@ define([
         // STRING
 
         function wrap(val) {
-            return Promise.try(function() {
+            return Promise.try(() => {
                 return val;
             });
         }
 
-        it('Validate a simple string without constraints', function(done) {
-            wrap(Validation.validateTextString('test', {}))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('Validate a simple string without constraints', (done) => {
+            wrap(Validation.validateTextString('test', {})).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate a simple string required and supplied', function(done) {
-            wrap(Validation.validateTextString('test', {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('Validate a simple string required and supplied', (done) => {
+            wrap(
+                Validation.validateTextString('test', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate a simple string, required, empty string', function(done) {
-            wrap(Validation.validateTextString('', {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('Validate a simple string, required, empty string', (done) => {
+            wrap(
+                Validation.validateTextString('', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate a simple string, required, null', function(done) {
-            wrap(Validation.validateTextString(null, {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('Validate a simple string, required, null', (done) => {
+            wrap(
+                Validation.validateTextString(null, {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate a simple string, min and max length, within range', function(done) {
-            wrap(Validation.validateTextString('hello', {
+        it('Validate a simple string, min and max length, within range', (done) => {
+            wrap(
+                Validation.validateTextString('hello', {
                     required: true,
                     min_length: 5,
-                    max_length: 10
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+                    max_length: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate a simple string, min and max length, below', function(done) {
-            wrap(Validation.validateTextString('hi', {
+        it('Validate a simple string, min and max length, below', (done) => {
+            wrap(
+                Validation.validateTextString('hi', {
                     required: true,
                     min_length: 5,
-                    max_length: 10
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+                    max_length: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate a simple string, min and max length, above range', function(done) {
-            wrap(Validation.validateTextString('hello earthling', {
+        it('Validate a simple string, min and max length, above range', (done) => {
+            wrap(
+                Validation.validateTextString('hello earthling', {
                     required: true,
                     min_length: 5,
-                    max_length: 10
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+                    max_length: 10,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
 
-        // INTEGER 
-        it('Validate an integer without constraints', function(done) {
-            var spec = {
+        // INTEGER
+        it('Validate an integer without constraints', (done) => {
+            const spec = {
                 data: {
-                    constraints: {}
-                }
+                    constraints: {},
+                },
             };
-            wrap(IntValidation.validate(42, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+            wrap(IntValidation.validate(42, spec)).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate an integer, required, valid value', function(done) {
-            var spec = {
-                data: {
-                    constraints: {
-                        required: true
-                    }
-                }
-            };
-            wrap(IntValidation.validate(42, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
-        });
-        it('Validate an integer, required, empty string value', function(done) {
-            var spec = {
+        it('Validate an integer, required, valid value', (done) => {
+            const spec = {
                 data: {
                     constraints: {
-                        required: true
-                    }
-                }
+                        required: true,
+                    },
+                },
             };
-            wrap(IntValidation.validate('', spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+            wrap(IntValidation.validate(42, spec)).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate an integer, required, null value', function(done) {
-            var spec = {
+        it('Validate an integer, required, empty string value', (done) => {
+            const spec = {
                 data: {
                     constraints: {
-                        required: true
-                    }
-                }
+                        required: true,
+                    },
+                },
             };
-            wrap(IntValidation.validate(null, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+            wrap(IntValidation.validate('', spec)).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate an integer, required, NaN value', function(done) {
-            var spec = {
+        it('Validate an integer, required, null value', (done) => {
+            const spec = {
                 data: {
                     constraints: {
-                        required: true
-                    }
-                }
+                        required: true,
+                    },
+                },
             };
-            wrap(IntValidation.validate(0 / 0, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+            wrap(IntValidation.validate(null, spec)).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate an integer, required, float value', function(done) {
-            var spec = {
+        it('Validate an integer, required, NaN value', (done) => {
+            const spec = {
                 data: {
                     constraints: {
-                        required: true
-                    }
-                }
+                        required: true,
+                    },
+                },
             };
-            wrap(IntValidation.validate(1.23, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+            wrap(IntValidation.validate(0 / 0, spec)).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate an integer, required, range given, within range', function(done) {
-            var spec = {
+        it('Validate an integer, required, float value', (done) => {
+            const spec = {
+                data: {
+                    constraints: {
+                        required: true,
+                    },
+                },
+            };
+            wrap(IntValidation.validate(1.23, spec)).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
+        });
+        it('Validate an integer, required, range given, within range', (done) => {
+            const spec = {
                 data: {
                     constraints: {
                         required: true,
                         min_int: 5,
-                        max_int: 10
-                    }
-                }
+                        max_int: 10,
+                    },
+                },
             };
-            wrap(IntValidation.validate(7, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+            wrap(IntValidation.validate(7, spec)).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate an integer, required, range given, below range', function(done) {
-            var spec = {
+        it('Validate an integer, required, range given, below range', (done) => {
+            const spec = {
                 data: {
                     constraints: {
                         required: true,
                         min_int: 5,
-                        max_int: 10
-                    }
-                }
+                        max_int: 10,
+                    },
+                },
             };
-            wrap(IntValidation.validate(3, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+            wrap(IntValidation.validate(3, spec)).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate an integer, required, range given, above range', function(done) {
-            var spec = {
+        it('Validate an integer, required, range given, above range', (done) => {
+            const spec = {
                 data: {
                     constraints: {
                         required: true,
                         min_int: 5,
-                        max_int: 10
-                    }
-                }
+                        max_int: 10,
+                    },
+                },
             };
-            wrap(IntValidation.validate(24, spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+            wrap(IntValidation.validate(24, spec)).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate an integer, required, range given, wrong type (date)', function(done) {
-            var spec = {
+        it('Validate an integer, required, range given, wrong type (date)', (done) => {
+            const spec = {
                 data: {
                     constraints: {
                         required: true,
                         min_int: 5,
-                        max_int: 10
-                    }
-                }
+                        max_int: 10,
+                    },
+                },
             };
-            wrap(IntValidation.validate(new Date(), spec))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+            wrap(IntValidation.validate(new Date(), spec)).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-
 
         // FLOAT
-        it('Validate a float without constraints', function(done) {
-            wrap(Validation.validateFloatString('42.12', {}))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('Validate a float without constraints', (done) => {
+            wrap(Validation.validateFloatString('42.12', {})).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate a bad without constraints', function(done) {
-            wrap(Validation.validateFloatString('x', {}))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('Validate a bad without constraints', (done) => {
+            wrap(Validation.validateFloatString('x', {})).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate an empty without constraints', function(done) {
-            wrap(Validation.validateFloatString('', {}))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('Validate an empty without constraints', (done) => {
+            wrap(Validation.validateFloatString('', {})).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate a float string, required', function(done) {
-            wrap(Validation.validateFloatString('42.12', {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(true);
-                    done();
-                });
+        it('Validate a float string, required', (done) => {
+            wrap(
+                Validation.validateFloatString('42.12', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(true);
+                done();
+            });
         });
-        it('Validate an empty string, required', function(done) {
-            wrap(Validation.validateFloatString('', {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('Validate an empty string, required', (done) => {
+            wrap(
+                Validation.validateFloatString('', {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate an empty string, required', function(done) {
-            wrap(Validation.validateFloatString(null, {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('Validate an empty string, required', (done) => {
+            wrap(
+                Validation.validateFloatString(null, {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
         // bad types
-        it('Validate an undefined, required', function(done) {
-            wrap(Validation.validateFloatString(undefined, {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('Validate an undefined, required', (done) => {
+            wrap(
+                Validation.validateFloatString(undefined, {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
-        it('Validate an array, required', function(done) {
-            wrap(Validation.validateFloatString([], {
-                    required: true
-                }))
-                .then(function(result) {
-                    expect(result.isValid).toEqual(false);
-                    done();
-                });
+        it('Validate an array, required', (done) => {
+            wrap(
+                Validation.validateFloatString([], {
+                    required: true,
+                })
+            ).then((result) => {
+                expect(result.isValid).toEqual(false);
+                done();
+            });
         });
 
         function runTests(method, tests) {
-            tests.forEach(function(testSet) {
-                testSet.forEach(function(test) {
-
-                    it(test.title, function(done) {
-
-                        ValidationResolver.validate(test.value, test.spec)
-                            .then(function(result) {
-                                Object.keys(test.result).forEach(function(key) {
-                                    expect(result[key]).toEqual(test.result[key]);
-                                });
-                                done();
+            tests.forEach((testSet) => {
+                testSet.forEach((test) => {
+                    it(test.title, (done) => {
+                        ValidationResolver.validate(test.value, test.spec).then((result) => {
+                            Object.keys(test.result).forEach((key) => {
+                                expect(result[key]).toEqual(test.result[key]);
                             });
+                            done();
+                        });
                     });
                 });
             });
@@ -334,9 +327,6 @@ define([
         // function runTestsx(method, tests) {
         //     tests.forEach(function(testSet) {
         //         testSet.forEach(function(test) {
-
-
-
 
         //             if (test.options.required === undefined) {
         //                 [true, false].forEach(function(required) {
@@ -369,7 +359,7 @@ define([
         //     });
         // }
 
-        // FLOATS        
+        // FLOATS
         // (function() {
         //     var emptyValues = [{
         //                 title: 'empty string',
@@ -556,24 +546,25 @@ define([
         // }());
 
         // INTS
-        (function() {
-            var emptyValues = [{
+        (function () {
+            const emptyValues = [
+                    {
                         title: 'empty string',
                         value: null,
                         spec: {
                             data: {
                                 type: 'int',
                                 constraints: {
-                                    required: false
-                                }
-                            }
+                                    required: false,
+                                },
+                            },
                         },
                         result: {
                             isValid: true,
                             diagnosis: 'optional-empty',
-                            errorMessage: undefined
-                        }
-                    }
+                            errorMessage: undefined,
+                        },
+                    },
                     // {
                     //     title: 'string of just spaces same as empty',
                     //     value: '   ',
@@ -634,42 +625,45 @@ define([
                     //         parsedValue: undefined
                     //     }
                     // }
-
                 ],
-                acceptableFormatTests = [{
-                    title: 'integer format',
-                    value: 42,
-                    spec: {
-                        data: {
-                            type: 'int',
-                            constraints: {
-                                required: false
-                            }
-                        }
+                acceptableFormatTests = [
+                    {
+                        title: 'integer format',
+                        value: 42,
+                        spec: {
+                            data: {
+                                type: 'int',
+                                constraints: {
+                                    required: false,
+                                },
+                            },
+                        },
+                        result: {
+                            isValid: true,
+                            diagnosis: 'valid',
+                            errorMessage: undefined,
+                        },
                     },
-                    result: {
-                        isValid: true,
-                        diagnosis: 'valid',
-                        errorMessage: undefined
-                    }
-                }],
-                badValueTests = [{
-                    title: 'string of chars',
-                    value: 'abc',
-                    spec: {
-                        data: {
-                            type: 'int',
-                            constraints: {
-                                required: false
-                            }
-                        }
+                ],
+                badValueTests = [
+                    {
+                        title: 'string of chars',
+                        value: 'abc',
+                        spec: {
+                            data: {
+                                type: 'int',
+                                constraints: {
+                                    required: false,
+                                },
+                            },
+                        },
+                        result: {
+                            isValid: false,
+                            diagnosis: 'invalid',
+                            errorMessage: 'value must be numeric',
+                        },
                     },
-                    result: {
-                        isValid: false,
-                        diagnosis: 'invalid',
-                        errorMessage: 'value must be numeric'
-                    }
-                }],
+                ],
                 // typeTests = [{
                 //         title: 'validate undefined',
                 //         value: undefined,
@@ -723,12 +717,12 @@ define([
                 tests = [
                     emptyValues,
                     acceptableFormatTests,
-                    badValueTests
+                    badValueTests,
                     // typeTests
                 ];
 
             runTests('validateIntString', tests);
-        }());
+        })();
 
         // // STRINGS
         // (function() {
@@ -911,8 +905,5 @@ define([
         // Set of Ints
 
         // Set of Floats
-
     });
-
-
 });

--- a/test/unit/spec/common/validate2-Spec.js
+++ b/test/unit/spec/common/validate2-Spec.js
@@ -1,5 +1,3 @@
-/*global define,describe,it,expect*/
-/*jslint white:true,browser:true*/
 define([
     'bluebird',
     'common/validation',

--- a/test/unit/spec/dynamicTableSpec.js
+++ b/test/unit/spec/dynamicTableSpec.js
@@ -1,26 +1,26 @@
-define([
-    'jquery',
-    'bluebird',
-    'widgets/dynamicTable'
-], function($, Promise, DynamicTable) {
+define(['jquery', 'bluebird', 'widgets/dynamicTable'], ($, Promise, DynamicTable) => {
     'use strict';
-    var dummyRows = [
-            [ 1, 2, 3 ],
-            [ 4, 5, 6 ]
+    let dummyRows = [
+            [1, 2, 3],
+            [4, 5, 6],
         ],
-        dummyHeaders = [{
-            id: 'col1',
-            text: 'Column 1',
-            isSortable: true
-        }, {
-            id: 'col2',
-            text: 'Column 2',
-            isSortable: true
-        }, {
-            id: 'col3',
-            text: 'Column 3',
-            isSortable: false
-        }],
+        dummyHeaders = [
+            {
+                id: 'col1',
+                text: 'Column 1',
+                isSortable: true,
+            },
+            {
+                id: 'col2',
+                text: 'Column 2',
+                isSortable: true,
+            },
+            {
+                id: 'col3',
+                text: 'Column 3',
+                isSortable: false,
+            },
+        ],
         $dummyDiv = $('<div>'),
         dummyTable;
 
@@ -28,60 +28,46 @@ define([
         beforeEach(() => {
             dummyTable = new DynamicTable($dummyDiv, {
                 headers: dummyHeaders,
-                updateFunction: function(pageNum, query, sortColId, sortColDir) {
+                updateFunction: function (pageNum, query, sortColId, sortColDir) {
                     return Promise.resolve({
                         start: 0,
                         total: dummyRows.length,
-                        rows: dummyRows
+                        rows: dummyRows,
                     });
-                }
+                },
             });
         });
 
         it('Should instantiate with essentially empty data', () => {
-            let $container = $('<div>');
-            let dt = new DynamicTable($container, {
+            const $container = $('<div>');
+            const dt = new DynamicTable($container, {
                 updateFunction: () => {
                     return Promise.resolve({
                         start: 0,
                         total: 0,
-                        rows: []
+                        rows: [],
                     });
-                }
+                },
             });
             expect(dt).toEqual(jasmine.any(Object));
         });
 
-        it('Should display data', function() {
+        it('Should display data', () => {
             expect(dummyTable).toEqual(jasmine.any(Object));
         });
 
-        it('Should paginate and show which page', function() {
+        it('Should paginate and show which page', () => {});
 
-        });
+        it('Should show an error when pagination fails', () => {});
 
-        it('Should show an error when pagination fails', function() {
+        it('Should sort properly', () => {});
 
-        });
+        it('Should decorate rows properly', () => {});
 
-        it('Should sort properly', function() {
+        it('Should add outer widget classes properly', () => {});
 
-        });
+        it('Should add table styles properly', () => {});
 
-        it('Should decorate rows properly', function() {
-
-        });
-
-        it('Should add outer widget classes properly', function() {
-
-        });
-
-        it('Should add table styles properly', function() {
-
-        });
-
-        it('Should have optional download buttons', function() {
-
-        });
+        it('Should have optional download buttons', () => {});
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataBoxplot-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataBoxplot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'AbundanceDataBoxplot'
-], function(Widget) {
-    describe('Test the AbundanceDataBoxplot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['AbundanceDataBoxplot'], (Widget) => {
+    describe('Test the AbundanceDataBoxplot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataBoxplot-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataBoxplot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['AbundanceDataBoxplot'], (Widget) => {
     describe('Test the AbundanceDataBoxplot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/AbundanceDataBoxplot-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataBoxplot-spec.js
@@ -1,5 +1,8 @@
 define(['AbundanceDataBoxplot'], (Widget) => {
-    describe('Test the AbundanceDataBoxplot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The AbundanceDataBoxplot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataHeatmap-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataHeatmap-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'AbundanceDataHeatmap'
-], function(Widget) {
-    describe('Test the AbundanceDataHeatmap widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['AbundanceDataHeatmap'], (Widget) => {
+    describe('Test the AbundanceDataHeatmap widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataHeatmap-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataHeatmap-spec.js
@@ -1,5 +1,8 @@
 define(['AbundanceDataHeatmap'], (Widget) => {
-    describe('Test the AbundanceDataHeatmap widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The AbundanceDataHeatmap widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataHeatmap-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataHeatmap-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['AbundanceDataHeatmap'], (Widget) => {
     describe('Test the AbundanceDataHeatmap widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/AbundanceDataPcoa-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataPcoa-spec.js
@@ -1,5 +1,8 @@
 define(['AbundanceDataPcoa'], (Widget) => {
-    describe('Test the AbundanceDataPcoa widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The AbundanceDataPcoa widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataPcoa-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataPcoa-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['AbundanceDataPcoa'], (Widget) => {
     describe('Test the AbundanceDataPcoa widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/AbundanceDataPcoa-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataPcoa-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'AbundanceDataPcoa'
-], function(Widget) {
-    describe('Test the AbundanceDataPcoa widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['AbundanceDataPcoa'], (Widget) => {
+    describe('Test the AbundanceDataPcoa widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataTable-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataTable-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'AbundanceDataTable'
-], function(Widget) {
-    describe('Test the AbundanceDataTable widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['AbundanceDataTable'], (Widget) => {
+    describe('Test the AbundanceDataTable widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataTable-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataTable-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['AbundanceDataTable'], (Widget) => {
     describe('Test the AbundanceDataTable widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/AbundanceDataTable-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataTable-spec.js
@@ -1,5 +1,8 @@
 define(['AbundanceDataTable'], (Widget) => {
-    describe('Test the AbundanceDataTable widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The AbundanceDataTable widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataView-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['AbundanceDataView'], (Widget) => {
     describe('Test the AbundanceDataView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/AbundanceDataView-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'AbundanceDataView'
-], function(Widget) {
-    describe('Test the AbundanceDataView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['AbundanceDataView'], (Widget) => {
+    describe('Test the AbundanceDataView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/AbundanceDataView-spec.js
+++ b/test/unit/spec/function_output/AbundanceDataView-spec.js
@@ -1,5 +1,8 @@
 define(['AbundanceDataView'], (Widget) => {
-    describe('Test the AbundanceDataView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The AbundanceDataView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/AnnotationSetTable-spec.js
+++ b/test/unit/spec/function_output/AnnotationSetTable-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'AnnotationSetTable'
-], function(Widget) {
-    describe('Test the AnnotationSetTable widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['AnnotationSetTable'], (Widget) => {
+    describe('Test the AnnotationSetTable widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/AnnotationSetTable-spec.js
+++ b/test/unit/spec/function_output/AnnotationSetTable-spec.js
@@ -1,5 +1,8 @@
 define(['AnnotationSetTable'], (Widget) => {
-    describe('Test the AnnotationSetTable widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The AnnotationSetTable widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/AnnotationSetTable-spec.js
+++ b/test/unit/spec/function_output/AnnotationSetTable-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['AnnotationSetTable'], (Widget) => {
     describe('Test the AnnotationSetTable widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/AssemblyWidget-spec.js
+++ b/test/unit/spec/function_output/AssemblyWidget-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['AssemblyWidget'], (Widget) => {
     describe('Test the AssemblyWidget widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/AssemblyWidget-spec.js
+++ b/test/unit/spec/function_output/AssemblyWidget-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'AssemblyWidget'
-], function(Widget) {
-    describe('Test the AssemblyWidget widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['AssemblyWidget'], (Widget) => {
+    describe('Test the AssemblyWidget widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/AssemblyWidget-spec.js
+++ b/test/unit/spec/function_output/AssemblyWidget-spec.js
@@ -1,5 +1,8 @@
 define(['AssemblyWidget'], (Widget) => {
-    describe('Test the AssemblyWidget widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The AssemblyWidget widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/CollectionView-spec.js
+++ b/test/unit/spec/function_output/CollectionView-spec.js
@@ -1,5 +1,8 @@
 define(['CollectionView'], (Widget) => {
-    describe('Test the CollectionView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The CollectionView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/CollectionView-spec.js
+++ b/test/unit/spec/function_output/CollectionView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['CollectionView'], (Widget) => {
     describe('Test the CollectionView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/CollectionView-spec.js
+++ b/test/unit/spec/function_output/CollectionView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'CollectionView'
-], function(Widget) {
-    describe('Test the CollectionView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['CollectionView'], (Widget) => {
+    describe('Test the CollectionView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/ContigBrowserPanel-spec.js
+++ b/test/unit/spec/function_output/ContigBrowserPanel-spec.js
@@ -1,5 +1,8 @@
 define(['ContigBrowserPanel'], (Widget) => {
-    describe('Test the ContigBrowserPanel widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The ContigBrowserPanel widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/ContigBrowserPanel-spec.js
+++ b/test/unit/spec/function_output/ContigBrowserPanel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['ContigBrowserPanel'], (Widget) => {
     describe('Test the ContigBrowserPanel widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/ContigBrowserPanel-spec.js
+++ b/test/unit/spec/function_output/ContigBrowserPanel-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'ContigBrowserPanel'
-], function(Widget) {
-    describe('Test the ContigBrowserPanel widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['ContigBrowserPanel'], (Widget) => {
+    describe('Test the ContigBrowserPanel widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/FbaModelComparisonWidget-spec.js
+++ b/test/unit/spec/function_output/FbaModelComparisonWidget-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'FbaModelComparisonWidget'
-], function(Widget) {
-    describe('Test the FbaModelComparisonWidget widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['FbaModelComparisonWidget'], (Widget) => {
+    describe('Test the FbaModelComparisonWidget widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/FbaModelComparisonWidget-spec.js
+++ b/test/unit/spec/function_output/FbaModelComparisonWidget-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['FbaModelComparisonWidget'], (Widget) => {
     describe('Test the FbaModelComparisonWidget widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/FbaModelComparisonWidget-spec.js
+++ b/test/unit/spec/function_output/FbaModelComparisonWidget-spec.js
@@ -1,5 +1,8 @@
 define(['FbaModelComparisonWidget'], (Widget) => {
-    describe('Test the FbaModelComparisonWidget widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The FbaModelComparisonWidget widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/GenomeCategorizer-spec.js
+++ b/test/unit/spec/function_output/GenomeCategorizer-spec.js
@@ -1,9 +1,4 @@
-define([
-    'jquery',
-    'GenomeCategorizer',
-    'narrativeConfig',
-    'base/js/namespace'
-], (
+define(['jquery', 'GenomeCategorizer', 'narrativeConfig', 'base/js/namespace'], (
     $,
     GenomeCategorizer,
     Config,
@@ -16,7 +11,7 @@ define([
             jasmine.Ajax.install();
             $div = $('<div>');
             Jupyter.narrative = {
-                getAuthToken: () => 'NotARealToken!'
+                getAuthToken: () => 'NotARealToken!',
             };
         });
 
@@ -26,50 +21,57 @@ define([
         });
 
         it('Should properly render data', () => {
-            let genomecatgorizerdata = {
-                'attribute_data':['EamA family transporter RarD','hydrogenase nickel incorporation protein HypA'],
-                'attribute_type':'functional_roles',
-                'class_list_mapping':{'N':1,'P':0},
-                'classifier_description':'this is my description',
-                'classifier_handle_ref':'c061a832-1d64-4119-a2fb-75a360fa1f53',
-                'classifier_id':'',
-                'classifier_name':'DTCFL_DecisionTreeClassifier_entropy',
-                'classifier_type':'DecisionTreeClassifier',
-                'lib_name':'sklearn',
-                'number_of_attributes':3320,
-                'number_of_genomes':2,
-                'training_set_ref':'35279/17/1'
-            };
-            let trainingsetdata = {
-                'classes':['P','N'],
-                'classification_data':[
-                    {
-                        'evidence_types':['another','some','list'],
-                        'genome_classification':'N','genome_id': 'my_genome_id',
-                        'genome_name':'Acetivibrio_ethanolgignens',
-                        'genome_ref':'35279/3/1',
-                        'references':['some','list']
-                    },{
-                        'evidence_types':['another','some','list'],
-                        'genome_classification':'P',
-                        'genome_id':'my_genome_id',
-                        'genome_name':'Aggregatibacter_actinomycetemcomitans_serotype_b_str._SCC4092',
-                        'genome_ref':'35279/4/1',
-                        'references':['some','list']
-                    },{
-                        'evidence_types':['another','some','list'],
-                        'genome_classification':'N',
-                        'genome_id':'my_genome_id',
-                        'genome_name':'Afipia_felis_ATCC_53690',
-                        'genome_ref':'35279/5/1',
-                        'references':['some','list']
-                    }
+            const genomecatgorizerdata = {
+                attribute_data: [
+                    'EamA family transporter RarD',
+                    'hydrogenase nickel incorporation protein HypA',
                 ],
-                'classification_type':'my_classification_type',
-                'description':'my_description',
-                'name':'my_name',
-                'number_of_classes':2,
-                'number_of_genomes':3
+                attribute_type: 'functional_roles',
+                class_list_mapping: { N: 1, P: 0 },
+                classifier_description: 'this is my description',
+                classifier_handle_ref: 'c061a832-1d64-4119-a2fb-75a360fa1f53',
+                classifier_id: '',
+                classifier_name: 'DTCFL_DecisionTreeClassifier_entropy',
+                classifier_type: 'DecisionTreeClassifier',
+                lib_name: 'sklearn',
+                number_of_attributes: 3320,
+                number_of_genomes: 2,
+                training_set_ref: '35279/17/1',
+            };
+            const trainingsetdata = {
+                classes: ['P', 'N'],
+                classification_data: [
+                    {
+                        evidence_types: ['another', 'some', 'list'],
+                        genome_classification: 'N',
+                        genome_id: 'my_genome_id',
+                        genome_name: 'Acetivibrio_ethanolgignens',
+                        genome_ref: '35279/3/1',
+                        references: ['some', 'list'],
+                    },
+                    {
+                        evidence_types: ['another', 'some', 'list'],
+                        genome_classification: 'P',
+                        genome_id: 'my_genome_id',
+                        genome_name:
+                            'Aggregatibacter_actinomycetemcomitans_serotype_b_str._SCC4092',
+                        genome_ref: '35279/4/1',
+                        references: ['some', 'list'],
+                    },
+                    {
+                        evidence_types: ['another', 'some', 'list'],
+                        genome_classification: 'N',
+                        genome_id: 'my_genome_id',
+                        genome_name: 'Afipia_felis_ATCC_53690',
+                        genome_ref: '35279/5/1',
+                        references: ['some', 'list'],
+                    },
+                ],
+                classification_type: 'my_classification_type',
+                description: 'my_description',
+                name: 'my_name',
+                number_of_classes: 2,
+                number_of_genomes: 3,
             };
             // this code is more of less ignored, because two WS calls are made both can't be stubbed
             jasmine.Ajax.stubRequest(Config.url('workspace')).andReturn({
@@ -79,25 +81,24 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        data: [{data: trainingsetdata}]
-                    }]
-                })
+                    result: [
+                        {
+                            data: [{ data: trainingsetdata }],
+                        },
+                    ],
+                }),
             });
-            let w = new GenomeCategorizer($div, {upas: {upas: ['fake']}});
+            const w = new GenomeCategorizer($div, { upas: { upas: ['fake'] } });
             w.objData = genomecatgorizerdata;
             w.trainingSetData = trainingsetdata;
             w.render();
-            [
-                'Overview',
-                'Training Set'
-            ].forEach((str) => {
+            ['Overview', 'Training Set'].forEach((str) => {
                 expect($div.html()).toContain(str);
             });
             // more complex structure matching
-            let tabs = $div.find('.tabbable');
+            const tabs = $div.find('.tabbable');
             expect(tabs).not.toBeNull();
-            let tabsContent = $div.find('.tab-pane');
+            const tabsContent = $div.find('.tab-pane');
             expect(tabsContent.length).toEqual(2);
             [
                 'Classifier Name',

--- a/test/unit/spec/function_output/GenomeCategorizer-spec.js
+++ b/test/unit/spec/function_output/GenomeCategorizer-spec.js
@@ -5,7 +5,7 @@ define(['jquery', 'GenomeCategorizer', 'narrativeConfig', 'base/js/namespace'], 
     Jupyter
 ) => {
     'use strict';
-    describe('Test the GenomeCategorizer widget', () => {
+    describe('The GenomeCategorizer widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/function_output/GenomeClassifierTrainingSet-spec.js
+++ b/test/unit/spec/function_output/GenomeClassifierTrainingSet-spec.js
@@ -1,10 +1,5 @@
 /*jslint white: true*/
-define([
-    'jquery',
-    'GenomeClassifierTrainingSet',
-    'base/js/namespace',
-    'kbaseNarrative'
-], (
+define(['jquery', 'GenomeClassifierTrainingSet', 'base/js/namespace', 'kbaseNarrative'], (
     $,
     GenomeClassifierTrainingSet,
     Jupyter,
@@ -17,7 +12,9 @@ define([
             jasmine.Ajax.install();
             $div = $('<div>');
             Jupyter.narrative = new Narrative();
-            Jupyter.narrative.getAuthToken = () => { return 'NotARealToken!' };
+            Jupyter.narrative.getAuthToken = () => {
+                return 'NotARealToken!';
+            };
         });
 
         afterEach(() => {
@@ -26,35 +23,40 @@ define([
         });
 
         it('Should properly render data', (done) => {
-            let trainingsetdata = {
-                "classes":["P","N"],
-                "classification_data":[
+            const trainingsetdata = {
+                classes: ['P', 'N'],
+                classification_data: [
                     {
-                        "evidence_types":["another","some","list"],
-                        "genome_classification":"N","genome_id": "my_genome_id",
-                        "genome_name":"Acetivibrio_ethanolgignens",
-                        "genome_ref":"35279/3/1",
-                        "references":["some","list"]
-                    },{
-                        "evidence_types":["another","some","list"],
-                        "genome_classification":"P",
-                        "genome_id":"my_genome_id",
-                        "genome_name":"Aggregatibacter_actinomycetemcomitans_serotype_b_str._SCC4092",
-                        "genome_ref":"35279/4/1",
-                        "references":["some","list"]
-                    },{
-                        "evidence_types":["another","some","list"],
-                        "genome_classification":"N",
-                        "genome_id":"my_genome_id",
-                        "genome_name":"Afipia_felis_ATCC_53690",
-                        "genome_ref":"35279/5/1",
-                        "references":["some","list"]
-                }],
-                "classification_type":"my_classification_type",
-                "description":"my_description",
-                "name":"my_name",
-                "number_of_classes":2,
-                "number_of_genomes":3
+                        evidence_types: ['another', 'some', 'list'],
+                        genome_classification: 'N',
+                        genome_id: 'my_genome_id',
+                        genome_name: 'Acetivibrio_ethanolgignens',
+                        genome_ref: '35279/3/1',
+                        references: ['some', 'list'],
+                    },
+                    {
+                        evidence_types: ['another', 'some', 'list'],
+                        genome_classification: 'P',
+                        genome_id: 'my_genome_id',
+                        genome_name:
+                            'Aggregatibacter_actinomycetemcomitans_serotype_b_str._SCC4092',
+                        genome_ref: '35279/4/1',
+                        references: ['some', 'list'],
+                    },
+                    {
+                        evidence_types: ['another', 'some', 'list'],
+                        genome_classification: 'N',
+                        genome_id: 'my_genome_id',
+                        genome_name: 'Afipia_felis_ATCC_53690',
+                        genome_ref: '35279/5/1',
+                        references: ['some', 'list'],
+                    },
+                ],
+                classification_type: 'my_classification_type',
+                description: 'my_description',
+                name: 'my_name',
+                number_of_classes: 2,
+                number_of_genomes: 3,
             };
             jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
                 status: 200,
@@ -63,36 +65,30 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        data: [{data: trainingsetdata}]
-                    }]
-                })
+                    result: [
+                        {
+                            data: [{ data: trainingsetdata }],
+                        },
+                    ],
+                }),
             });
-            let w = new GenomeClassifierTrainingSet($div, {upas: {upas: ['fake']}});
+            const w = new GenomeClassifierTrainingSet($div, { upas: { upas: ['fake'] } });
             w.trainingSetData = trainingsetdata;
             w.render();
-            [
-                'Overview',
-                'Training Set'
-            ].forEach((str) => {
+            ['Overview', 'Training Set'].forEach((str) => {
                 expect($div.html()).toContain(str);
             });
             // more complex structure matching
-            let tabs = $div.find('.tabbable');
+            const tabs = $div.find('.tabbable');
             expect(tabs).not.toBeNull();
-            let tabsContent = $div.find('.tab-pane');
+            const tabsContent = $div.find('.tab-pane');
             expect(tabsContent.length).toEqual(2);
-            [
-                'Training Set Name',
-                'my_name',
-                'Number of genomes',
-                '3',
-            ].forEach((str) => {
+            ['Training Set Name', 'my_name', 'Number of genomes', '3'].forEach((str) => {
                 expect($(tabsContent[0]).html()).toContain(str);
             });
             expect($(tabsContent[1]).html()).toContain('Acetivibrio_ethanolgignens');
             expect($(tabsContent[1]).html()).not.toContain('<table>');
             done();
         });
-    })
-})
+    });
+});

--- a/test/unit/spec/function_output/GenomeClassifierTrainingSet-spec.js
+++ b/test/unit/spec/function_output/GenomeClassifierTrainingSet-spec.js
@@ -1,4 +1,3 @@
-/*jslint white: true*/
 define(['jquery', 'GenomeClassifierTrainingSet', 'base/js/namespace', 'kbaseNarrative'], (
     $,
     GenomeClassifierTrainingSet,

--- a/test/unit/spec/function_output/GenomeClassifierTrainingSet-spec.js
+++ b/test/unit/spec/function_output/GenomeClassifierTrainingSet-spec.js
@@ -5,7 +5,7 @@ define(['jquery', 'GenomeClassifierTrainingSet', 'base/js/namespace', 'kbaseNarr
     Narrative
 ) => {
     'use strict';
-    describe('Test the GenomeClassifierTrainingSet widget', () => {
+    describe('The GenomeClassifierTrainingSet widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/function_output/GenomeComparisonWidget-spec.js
+++ b/test/unit/spec/function_output/GenomeComparisonWidget-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['GenomeComparisonWidget'], (Widget) => {
     describe('Test the GenomeComparisonWidget widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/GenomeComparisonWidget-spec.js
+++ b/test/unit/spec/function_output/GenomeComparisonWidget-spec.js
@@ -1,5 +1,8 @@
 define(['GenomeComparisonWidget'], (Widget) => {
-    describe('Test the GenomeComparisonWidget widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The GenomeComparisonWidget widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/GenomeComparisonWidget-spec.js
+++ b/test/unit/spec/function_output/GenomeComparisonWidget-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'GenomeComparisonWidget'
-], function(Widget) {
-    describe('Test the GenomeComparisonWidget widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['GenomeComparisonWidget'], (Widget) => {
+    describe('Test the GenomeComparisonWidget widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/KBaseFBA.ModelComparison-spec.js
+++ b/test/unit/spec/function_output/KBaseFBA.ModelComparison-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseFBA.ModelComparison'
-], function(Widget) {
-    describe('Test the KBaseFBA.ModelComparison widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['KBaseFBA.ModelComparison'], (Widget) => {
+    describe('Test the KBaseFBA.ModelComparison widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/KBaseFBA.ModelComparison-spec.js
+++ b/test/unit/spec/function_output/KBaseFBA.ModelComparison-spec.js
@@ -1,5 +1,8 @@
 define(['KBaseFBA.ModelComparison'], (Widget) => {
-    describe('Test the KBaseFBA.ModelComparison widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The KBaseFBA.ModelComparison widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/KBaseFBA.ModelComparison-spec.js
+++ b/test/unit/spec/function_output/KBaseFBA.ModelComparison-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseFBA.ModelComparison'], (Widget) => {
     describe('Test the KBaseFBA.ModelComparison widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/MetagenomeView-spec.js
+++ b/test/unit/spec/function_output/MetagenomeView-spec.js
@@ -1,5 +1,8 @@
 define(['MetagenomeView'], (Widget) => {
-    describe('Test the MetagenomeView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The MetagenomeView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/MetagenomeView-spec.js
+++ b/test/unit/spec/function_output/MetagenomeView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'MetagenomeView'
-], function(Widget) {
-    describe('Test the MetagenomeView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['MetagenomeView'], (Widget) => {
+    describe('Test the MetagenomeView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/MetagenomeView-spec.js
+++ b/test/unit/spec/function_output/MetagenomeView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['MetagenomeView'], (Widget) => {
     describe('Test the MetagenomeView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/RankAbundancePlot-spec.js
+++ b/test/unit/spec/function_output/RankAbundancePlot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'RankAbundancePlot'
-], function(Widget) {
-    describe('Test the RankAbundancePlot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['RankAbundancePlot'], (Widget) => {
+    describe('Test the RankAbundancePlot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/RankAbundancePlot-spec.js
+++ b/test/unit/spec/function_output/RankAbundancePlot-spec.js
@@ -1,5 +1,8 @@
 define(['RankAbundancePlot'], (Widget) => {
-    describe('Test the RankAbundancePlot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The RankAbundancePlot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/RankAbundancePlot-spec.js
+++ b/test/unit/spec/function_output/RankAbundancePlot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['RankAbundancePlot'], (Widget) => {
     describe('Test the RankAbundancePlot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseAlignment-spec.js
+++ b/test/unit/spec/function_output/kbaseAlignment-spec.js
@@ -1,10 +1,5 @@
 /*jslint white: true*/
-define([
-    'jquery',
-    'kbaseAlignment',
-    'base/js/namespace',
-    'kbaseNarrative'
-], (
+define(['jquery', 'kbaseAlignment', 'base/js/namespace', 'kbaseNarrative'], (
     $,
     kbaseAlignment,
     Jupyter,
@@ -17,7 +12,9 @@ define([
             jasmine.Ajax.install();
             $div = $('<div>');
             Jupyter.narrative = new Narrative();
-            Jupyter.narrative.getAuthToken = () => { return 'NotARealToken!' };
+            Jupyter.narrative.getAuthToken = () => {
+                return 'NotARealToken!';
+            };
         });
 
         afterEach(() => {
@@ -26,31 +23,31 @@ define([
         });
 
         it('Should properly render data', (done) => {
-            let alignmentData = {
-              "aligned_using": "tophat2",
-              "aligner_version": "2.1.1",
-              "alignment_stats": {
-                "alignment_rate": 89.24360336685788,
-                "mapped_reads": 1012018,
-                "multiple_alignments": 0,
-                "properly_paired": 0,
-                "singletons": 0,
-                "total_reads": 1133995,
-                "unmapped_reads": 121977
-              },
-              "condition": "Ecoli_WT",
-              "file": {
-                "file_name": "merged_hits.bam",
-                "hid": "KBH_2674228",
-                "id": "8ed0e9da-bfb8-4e50-9d54-e146c14cf30c",
-                "remote_md5": "1079e6d16a6d81c63162b093ef9f25d5",
-                "type": "shock",
-                "url": "https://kbase.us/services/shock-api/"
-              },
-              "genome_id": "29494/8/1",
-              "library_type": "KBaseFile.SingleEndLibrary-2.1",
-              "read_sample_id": "29494/10/1;29433/6/1",
-              "size": 37291951
+            const alignmentData = {
+                aligned_using: 'tophat2',
+                aligner_version: '2.1.1',
+                alignment_stats: {
+                    alignment_rate: 89.24360336685788,
+                    mapped_reads: 1012018,
+                    multiple_alignments: 0,
+                    properly_paired: 0,
+                    singletons: 0,
+                    total_reads: 1133995,
+                    unmapped_reads: 121977,
+                },
+                condition: 'Ecoli_WT',
+                file: {
+                    file_name: 'merged_hits.bam',
+                    hid: 'KBH_2674228',
+                    id: '8ed0e9da-bfb8-4e50-9d54-e146c14cf30c',
+                    remote_md5: '1079e6d16a6d81c63162b093ef9f25d5',
+                    type: 'shock',
+                    url: 'https://kbase.us/services/shock-api/',
+                },
+                genome_id: '29494/8/1',
+                library_type: 'KBaseFile.SingleEndLibrary-2.1',
+                read_sample_id: '29494/10/1;29433/6/1',
+                size: 37291951,
             };
             // this code is more of less ignored, because two WS calls are made both can't be stubbed
             jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
@@ -60,23 +57,23 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        data: [{data: alignmentData}]
-                    }]
-                })
+                    result: [
+                        {
+                            data: [{ data: alignmentData }],
+                        },
+                    ],
+                }),
             });
-            let w = new kbaseAlignment($div, {upas: {upas: ['fake']}});
+            const w = new kbaseAlignment($div, { upas: { upas: ['fake'] } });
             w.objData = alignmentData;
             w.render();
-            [
-                'Overview',
-            ].forEach((str) => {
+            ['Overview'].forEach((str) => {
                 expect($div.html()).toContain(str);
             });
             // more complex structure matching
-            let tabs = $div.find('.tabbable');
+            const tabs = $div.find('.tabbable');
             expect(tabs).not.toBeNull();
-            let tabsContent = $div.find('.tab-pane');
+            const tabsContent = $div.find('.tab-pane');
             expect(tabsContent.length).toEqual(1);
             [
                 'Aligned Using',
@@ -84,11 +81,11 @@ define([
                 'Total Reads',
                 '1,133,995',
                 'Mapped Reads',
-                '1,012,018 (89.24%)'
+                '1,012,018 (89.24%)',
             ].forEach((str) => {
                 expect($(tabsContent[0]).html()).toContain(str);
             });
             done();
         });
-    })
-})
+    });
+});

--- a/test/unit/spec/function_output/kbaseAlignment-spec.js
+++ b/test/unit/spec/function_output/kbaseAlignment-spec.js
@@ -1,4 +1,3 @@
-/*jslint white: true*/
 define(['jquery', 'kbaseAlignment', 'base/js/namespace', 'kbaseNarrative'], (
     $,
     kbaseAlignment,

--- a/test/unit/spec/function_output/kbaseAlignment-spec.js
+++ b/test/unit/spec/function_output/kbaseAlignment-spec.js
@@ -5,7 +5,7 @@ define(['jquery', 'kbaseAlignment', 'base/js/namespace', 'kbaseNarrative'], (
     Narrative
 ) => {
     'use strict';
-    describe('Test the kbaseAlignment widget', () => {
+    describe('The kbaseAlignment widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/function_output/kbaseAnnotatedMetagenomeAssembly-spec.js
+++ b/test/unit/spec/function_output/kbaseAnnotatedMetagenomeAssembly-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseAnnotatedMetagenomeAssemblyView'], (Widget) => {
     describe('Test the kbaseAnnotatedMetagenomeAssembly viewer widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseAnnotatedMetagenomeAssembly-spec.js
+++ b/test/unit/spec/function_output/kbaseAnnotatedMetagenomeAssembly-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseAnnotatedMetagenomeAssemblyView'
-], function(Widget) {
-    describe('Test the kbaseAnnotatedMetagenomeAssembly viewer widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseAnnotatedMetagenomeAssemblyView'], (Widget) => {
+    describe('Test the kbaseAnnotatedMetagenomeAssembly viewer widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseAnnotatedMetagenomeAssembly-spec.js
+++ b/test/unit/spec/function_output/kbaseAnnotatedMetagenomeAssembly-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseAnnotatedMetagenomeAssemblyView'], (Widget) => {
-    describe('Test the kbaseAnnotatedMetagenomeAssembly viewer widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseAnnotatedMetagenomeAssembly viewer widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseAssemblyView-spec.js
+++ b/test/unit/spec/function_output/kbaseAssemblyView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseAssemblyView'
-], function(Widget) {
-    describe('Test the kbaseAssemblyView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseAssemblyView'], (Widget) => {
+    describe('Test the kbaseAssemblyView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseAssemblyView-spec.js
+++ b/test/unit/spec/function_output/kbaseAssemblyView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseAssemblyView'], (Widget) => {
     describe('Test the kbaseAssemblyView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseAssemblyView-spec.js
+++ b/test/unit/spec/function_output/kbaseAssemblyView-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseAssemblyView'], (Widget) => {
-    describe('Test the kbaseAssemblyView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseAssemblyView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseAttributeMapping-spec.js
+++ b/test/unit/spec/function_output/kbaseAttributeMapping-spec.js
@@ -1,10 +1,5 @@
 /*jslint white: true*/
-define([
-    'jquery',
-    'kbaseAttributeMapping',
-    'base/js/namespace',
-    'kbaseNarrative'
-], (
+define(['jquery', 'kbaseAttributeMapping', 'base/js/namespace', 'kbaseNarrative'], (
     $,
     kbaseAttributeMapping,
     Jupyter,
@@ -17,7 +12,9 @@ define([
             jasmine.Ajax.install();
             $div = $('<div>');
             Jupyter.narrative = new Narrative();
-            Jupyter.narrative.getAuthToken = () => { return 'NotARealToken!' };
+            Jupyter.narrative.getAuthToken = () => {
+                return 'NotARealToken!';
+            };
         });
 
         afterEach(() => {
@@ -26,64 +23,37 @@ define([
         });
 
         it('Should properly render AttributeMapping data', (done) => {
-            let attributeMappingData = {
-              "ontology_mapping_method": "User Curation",
-              "instances": {
-                "S9": [
-                  "0",
-                  "200"
-                ],
-                "S8": [
-                  "0",
-                  "200"
-                ],
-                "S3": [
-                  "0",
-                  "0"
-                ],
-                "S2": [
-                  "0",
-                  "0"
-                ],
-                "S1": [
-                  "0",
-                  "0"
-                ],
-                "S7": [
-                  "0",
-                  "200"
-                ],
-                "S6": [
-                  "2",
-                  "0"
-                ],
-                "S5": [
-                  "2",
-                  "0"
-                ],
-                "S4": [
-                  "2",
-                  "0"
-                ]
-              },
-              "attributes": [
-                {
-                  "attribute_ont_id": "Custom:Term",
-                  "unit_ont_id": "Custom:Unit",
-                  "unit_ont_ref": "KbaseOntologies/Custom",
-                  "attribute_ont_ref": "KbaseOntologies/Custom",
-                  "unit": "Hour",
-                  "attribute": "Time series design"
+            const attributeMappingData = {
+                ontology_mapping_method: 'User Curation',
+                instances: {
+                    S9: ['0', '200'],
+                    S8: ['0', '200'],
+                    S3: ['0', '0'],
+                    S2: ['0', '0'],
+                    S1: ['0', '0'],
+                    S7: ['0', '200'],
+                    S6: ['2', '0'],
+                    S5: ['2', '0'],
+                    S4: ['2', '0'],
                 },
-                {
-                  "attribute_ont_id": "Custom:Term",
-                  "unit_ont_id": "Custom:Unit",
-                  "unit_ont_ref": "KbaseOntologies/Custom",
-                  "attribute_ont_ref": "KbaseOntologies/Custom",
-                  "unit": "nanogram per milliliter",
-                  "attribute": "Treatment with Sirolimus"
-                }
-              ]
+                attributes: [
+                    {
+                        attribute_ont_id: 'Custom:Term',
+                        unit_ont_id: 'Custom:Unit',
+                        unit_ont_ref: 'KbaseOntologies/Custom',
+                        attribute_ont_ref: 'KbaseOntologies/Custom',
+                        unit: 'Hour',
+                        attribute: 'Time series design',
+                    },
+                    {
+                        attribute_ont_id: 'Custom:Term',
+                        unit_ont_id: 'Custom:Unit',
+                        unit_ont_ref: 'KbaseOntologies/Custom',
+                        attribute_ont_ref: 'KbaseOntologies/Custom',
+                        unit: 'nanogram per milliliter',
+                        attribute: 'Treatment with Sirolimus',
+                    },
+                ],
             };
             // this code is more of less ignored, because two WS calls are made both can't be stubbed
             jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
@@ -93,82 +63,52 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        data: [{data: attributeMappingData}]
-                    }]
-                })
+                    result: [
+                        {
+                            data: [{ data: attributeMappingData }],
+                        },
+                    ],
+                }),
             });
-            let w = new kbaseAttributeMapping($div, {upas: {obj_ref: 'fake'}});
-            [
-                'Time series design',
-                'Treatment with Sirolimus',
-                'S1',
-                'S9'
-            ].forEach((str) => {
+            const w = new kbaseAttributeMapping($div, { upas: { obj_ref: 'fake' } });
+            ['Time series design', 'Treatment with Sirolimus', 'S1', 'S9'].forEach((str) => {
                 expect($div.html()).toContain(str);
             });
             done();
         });
 
         it('Should properly render ConditionSet data', (done) => {
-            let conditionSetData = {
-              "ontology_mapping_method": "User Curation",
-              "conditions": {
-                "S9": [
-                  "0",
-                  "200"
-                ],
-                "S8": [
-                  "0",
-                  "200"
-                ],
-                "S3": [
-                  "0",
-                  "0"
-                ],
-                "S2": [
-                  "0",
-                  "0"
-                ],
-                "S1": [
-                  "0",
-                  "0"
-                ],
-                "S7": [
-                  "0",
-                  "200"
-                ],
-                "S6": [
-                  "2",
-                  "0"
-                ],
-                "S5": [
-                  "2",
-                  "0"
-                ],
-                "S4": [
-                  "2",
-                  "0"
-                ]
-              },
-              "factors": [
-                {
-                  "factor_ont_id": "Custom:Term",
-                  "unit_ont_id": "Custom:Unit",
-                  "unit_ont_ref": "KbaseOntologies/Custom",
-                  "factor_ont_ref": "KbaseOntologies/Custom",
-                  "unit": "Hour",
-                  "factor": "Time series design"
+            const conditionSetData = {
+                ontology_mapping_method: 'User Curation',
+                conditions: {
+                    S9: ['0', '200'],
+                    S8: ['0', '200'],
+                    S3: ['0', '0'],
+                    S2: ['0', '0'],
+                    S1: ['0', '0'],
+                    S7: ['0', '200'],
+                    S6: ['2', '0'],
+                    S5: ['2', '0'],
+                    S4: ['2', '0'],
                 },
-                {
-                  "factor_ont_id": "Custom:Term",
-                  "unit_ont_id": "Custom:Unit",
-                  "unit_ont_ref": "KbaseOntologies/Custom",
-                  "factor_ont_ref": "KbaseOntologies/Custom",
-                  "unit": "nanogram per milliliter",
-                  "factor": "Treatment with Sirolimus"
-                }
-              ]
+                factors: [
+                    {
+                        factor_ont_id: 'Custom:Term',
+                        unit_ont_id: 'Custom:Unit',
+                        unit_ont_ref: 'KbaseOntologies/Custom',
+                        factor_ont_ref: 'KbaseOntologies/Custom',
+                        unit: 'Hour',
+                        factor: 'Time series design',
+                    },
+                    {
+                        factor_ont_id: 'Custom:Term',
+                        unit_ont_id: 'Custom:Unit',
+                        unit_ont_ref: 'KbaseOntologies/Custom',
+                        factor_ont_ref: 'KbaseOntologies/Custom',
+                        unit: 'nanogram per milliliter',
+                        factor: 'Treatment with Sirolimus',
+                    },
+                ],
             };
             // this code is more of less ignored, because two WS calls are made both can't be stubbed
             jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
@@ -178,21 +118,18 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        data: [{data: conditionSetData}]
-                    }]
-                })
+                    result: [
+                        {
+                            data: [{ data: conditionSetData }],
+                        },
+                    ],
+                }),
             });
-            let w = new kbaseAttributeMapping($div, {upas: {obj_ref: 'fake'}});
-            [
-                'Time series design',
-                'Treatment with Sirolimus',
-                'S1',
-                'S9'
-            ].forEach((str) => {
+            const w = new kbaseAttributeMapping($div, { upas: { obj_ref: 'fake' } });
+            ['Time series design', 'Treatment with Sirolimus', 'S1', 'S9'].forEach((str) => {
                 expect($div.html()).toContain(str);
             });
             done();
         });
-    })
-})
+    });
+});

--- a/test/unit/spec/function_output/kbaseAttributeMapping-spec.js
+++ b/test/unit/spec/function_output/kbaseAttributeMapping-spec.js
@@ -1,4 +1,3 @@
-/*jslint white: true*/
 define(['jquery', 'kbaseAttributeMapping', 'base/js/namespace', 'kbaseNarrative'], (
     $,
     kbaseAttributeMapping,

--- a/test/unit/spec/function_output/kbaseAttributeMapping-spec.js
+++ b/test/unit/spec/function_output/kbaseAttributeMapping-spec.js
@@ -5,7 +5,7 @@ define(['jquery', 'kbaseAttributeMapping', 'base/js/namespace', 'kbaseNarrative'
     Narrative
 ) => {
     'use strict';
-    describe('Test the kbaseAttributeMapping widget', () => {
+    describe('The kbaseAttributeMapping widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/function_output/kbaseBinnedContigs-spec.js
+++ b/test/unit/spec/function_output/kbaseBinnedContigs-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseBinnedContigs'
-], function(Widget) {
-    describe('Test the KBaseBinnedContigs widget', function() {
-        it('Should instantiate', function() {
-
-        });
+define(['kbaseBinnedContigs'], (Widget) => {
+    describe('Test the KBaseBinnedContigs widget', () => {
+        it('Should instantiate', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseBinnedContigs-spec.js
+++ b/test/unit/spec/function_output/kbaseBinnedContigs-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseBinnedContigs'], (Widget) => {
-    describe('Test the KBaseBinnedContigs widget', () => {
-        it('Should instantiate', () => {});
+    'use strict';
+    describe('The KBaseBinnedContigs widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseBinnedContigs-spec.js
+++ b/test/unit/spec/function_output/kbaseBinnedContigs-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseBinnedContigs'], (Widget) => {
     describe('Test the KBaseBinnedContigs widget', () => {
         it('Should instantiate', () => {});

--- a/test/unit/spec/function_output/kbaseBlastOutput-spec.js
+++ b/test/unit/spec/function_output/kbaseBlastOutput-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseBlastOutput'], (Widget) => {
-    describe('Test the kbaseBlastOutput widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseBlastOutput widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseBlastOutput-spec.js
+++ b/test/unit/spec/function_output/kbaseBlastOutput-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseBlastOutput'], (Widget) => {
     describe('Test the kbaseBlastOutput widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseBlastOutput-spec.js
+++ b/test/unit/spec/function_output/kbaseBlastOutput-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseBlastOutput'
-], function(Widget) {
-    describe('Test the kbaseBlastOutput widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseBlastOutput'], (Widget) => {
+    describe('Test the kbaseBlastOutput widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseChromatograms-spec.js
+++ b/test/unit/spec/function_output/kbaseChromatograms-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseChromatograms'
-], function(Widget) {
-    describe('Test the kbaseChromatograms widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseChromatograms'], (Widget) => {
+    describe('Test the kbaseChromatograms widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseChromatograms-spec.js
+++ b/test/unit/spec/function_output/kbaseChromatograms-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseChromatograms'], (Widget) => {
-    describe('Test the kbaseChromatograms widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseChromatograms widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseChromatograms-spec.js
+++ b/test/unit/spec/function_output/kbaseChromatograms-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseChromatograms'], (Widget) => {
     describe('Test the kbaseChromatograms widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseChromatographyMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseChromatographyMatrix-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseChromatographyMatrix'
-], function(Widget) {
-    describe('Test the kbaseChromatographyMatrix widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseChromatographyMatrix'], (Widget) => {
+    describe('Test the kbaseChromatographyMatrix widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseChromatographyMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseChromatographyMatrix-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseChromatographyMatrix'], (Widget) => {
     describe('Test the kbaseChromatographyMatrix widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseChromatographyMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseChromatographyMatrix-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseChromatographyMatrix'], (Widget) => {
-    describe('Test the kbaseChromatographyMatrix widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseChromatographyMatrix widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseContigSetView-spec.js
+++ b/test/unit/spec/function_output/kbaseContigSetView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseContigSetView'
-], function(Widget) {
-    describe('Test the kbaseContigSetView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseContigSetView'], (Widget) => {
+    describe('Test the kbaseContigSetView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseContigSetView-spec.js
+++ b/test/unit/spec/function_output/kbaseContigSetView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseContigSetView'], (Widget) => {
     describe('Test the kbaseContigSetView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseContigSetView-spec.js
+++ b/test/unit/spec/function_output/kbaseContigSetView-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseContigSetView'], (Widget) => {
-    describe('Test the kbaseContigSetView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseContigSetView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseDefaultNarrativeOutput-spec.js
+++ b/test/unit/spec/function_output/kbaseDefaultNarrativeOutput-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseDefaultNarrativeOutput'], (Widget) => {
     describe('Test the kbaseDefaultNarrativeOutput widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseDefaultNarrativeOutput-spec.js
+++ b/test/unit/spec/function_output/kbaseDefaultNarrativeOutput-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseDefaultNarrativeOutput'], (Widget) => {
-    describe('Test the kbaseDefaultNarrativeOutput widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseDefaultNarrativeOutput widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseDefaultNarrativeOutput-spec.js
+++ b/test/unit/spec/function_output/kbaseDefaultNarrativeOutput-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseDefaultNarrativeOutput'
-], function(Widget) {
-    describe('Test the kbaseDefaultNarrativeOutput widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseDefaultNarrativeOutput'], (Widget) => {
+    describe('Test the kbaseDefaultNarrativeOutput widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseDefaultObjectView-spec.js
+++ b/test/unit/spec/function_output/kbaseDefaultObjectView-spec.js
@@ -6,7 +6,7 @@ define([
     'kbaseNarrative',
 ], ($, KBaseDefaultObjectView, Runtime, Jupyter, Narrative) => {
     'use strict';
-    describe('Test the kbaseDefaultObjectView widget', () => {
+    describe('The kbaseDefaultObjectView widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/function_output/kbaseDefaultObjectView-spec.js
+++ b/test/unit/spec/function_output/kbaseDefaultObjectView-spec.js
@@ -4,14 +4,8 @@ define([
     'widgets/function_output/kbaseDefaultObjectView',
     'common/runtime',
     'base/js/namespace',
-    'kbaseNarrative'
-], (
-    $,
-    KBaseDefaultObjectView,
-    Runtime,
-    Jupyter,
-    Narrative
-) => {
+    'kbaseNarrative',
+], ($, KBaseDefaultObjectView, Runtime, Jupyter, Narrative) => {
     'use strict';
     describe('Test the kbaseDefaultObjectView widget', () => {
         let $div = null;
@@ -19,7 +13,9 @@ define([
             jasmine.Ajax.install();
             $div = $('<div>');
             Jupyter.narrative = new Narrative();
-            Jupyter.narrative.getAuthToken = () => { return 'NotARealToken!' };
+            Jupyter.narrative.getAuthToken = () => {
+                return 'NotARealToken!';
+            };
         });
 
         afterEach(() => {
@@ -28,26 +24,26 @@ define([
         });
 
         it('Should load properly when no upas given', (done) => {
-            let w = new KBaseDefaultObjectView($div);
-            w.render()
-                .then(() => {
-                    expect($div.html()).toContain('No objects to display!');
-                    done();
-                });
+            const w = new KBaseDefaultObjectView($div);
+            w.render().then(() => {
+                expect($div.html()).toContain('No objects to display!');
+                done();
+            });
         });
 
         it('Should load properly when not logged in', (done) => {
-            Jupyter.narrative.getAuthToken = () => { return null; }
-            let w = new KBaseDefaultObjectView($div);
-            w.render()
-                .then(() => {
-                    expect($div.html()).toContain('Not logged in.');
-                    done();
-                });
+            Jupyter.narrative.getAuthToken = () => {
+                return null;
+            };
+            const w = new KBaseDefaultObjectView($div);
+            w.render().then(() => {
+                expect($div.html()).toContain('Not logged in.');
+                done();
+            });
         });
 
         it('Should properly load with a valid upa without metadata', (done) => {
-            let ws = 1111,
+            const ws = 1111,
                 oid = 2222,
                 ver = 3333,
                 name = 'fake_test_object',
@@ -67,63 +63,66 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        infos: [[
-                            oid,
-                            name,
-                            objType,
-                            saveDate,
-                            ver,
-                            userId,
-                            ws,
-                            wsName,
-                            checksum,
-                            size,
-                            meta
-                        ]],
-                        paths: [[upa]]
-                    }]
-                })
+                    result: [
+                        {
+                            infos: [
+                                [
+                                    oid,
+                                    name,
+                                    objType,
+                                    saveDate,
+                                    ver,
+                                    userId,
+                                    ws,
+                                    wsName,
+                                    checksum,
+                                    size,
+                                    meta,
+                                ],
+                            ],
+                            paths: [[upa]],
+                        },
+                    ],
+                }),
             });
 
-            let w = new KBaseDefaultObjectView($div, {upas: {upas: [upa]}});
-            w.render([upa])
-                .then(() => {
-                    // simple string matching
-                    [
-                        'Overview',
-                        'Metadata',
-                        'Objects of this type don\'t have a viewer associated with them. Showing default information.',
-                        'No metadata found for this object'
-                    ].forEach((str) => {
-                        expect($div.html()).toContain(str);
-                    });
-                    // more complex structure matching
-                    let tabs = $div.find('.tabbable');
-                    expect(tabs).not.toBeNull();
-                    let tabsContent = $div.find('.tab-pane');
-                    expect(tabsContent.length).toEqual(2);
-                    [
-                        upa,
-                        name,
-                        userId,
-                        size.toLocaleString(),
-                        'Explore data landing page',
-                        'View data provenance and relationships',
-                        objType,
-                        'module info',
-                        'type spec'
-                    ].forEach((str) => {
-                        expect($(tabsContent[0]).html()).toContain(str);
-                    });
-                    expect($(tabsContent[1]).html()).toContain('No metadata found for this object.');
-                    expect($(tabsContent[1]).html()).not.toContain('<table>');
-                    done();
+            const w = new KBaseDefaultObjectView($div, { upas: { upas: [upa] } });
+            w.render([upa]).then(() => {
+                // simple string matching
+                [
+                    'Overview',
+                    'Metadata',
+                    "Objects of this type don't have a viewer associated with them. Showing default information.",
+                    'No metadata found for this object',
+                ].forEach((str) => {
+                    expect($div.html()).toContain(str);
                 });
+                // more complex structure matching
+                const tabs = $div.find('.tabbable');
+                expect(tabs).not.toBeNull();
+                const tabsContent = $div.find('.tab-pane');
+                expect(tabsContent.length).toEqual(2);
+                [
+                    upa,
+                    name,
+                    userId,
+                    size.toLocaleString(),
+                    'Explore data landing page',
+                    'View data provenance and relationships',
+                    objType,
+                    'module info',
+                    'type spec',
+                ].forEach((str) => {
+                    expect($(tabsContent[0]).html()).toContain(str);
+                });
+                expect($(tabsContent[1]).html()).toContain('No metadata found for this object.');
+                expect($(tabsContent[1]).html()).not.toContain('<table>');
+                done();
+            });
         });
 
         it('Should properly load with a valid upa with metadata', (done) => {
-            let ws = 1111,
+            const ws = 1111,
                 oid = 2222,
                 ver = 3333,
                 name = 'fake_test_object',
@@ -133,8 +132,8 @@ define([
                 wsName = 'fakeWs',
                 checksum = '12345',
                 meta = {
-                    'key1': 'value1',
-                    'key2': 'value2'
+                    key1: 'value1',
+                    key2: 'value2',
                 },
                 size = 1234567,
                 upa = String(ws) + '/' + String(oid) + '/' + String(ver);
@@ -146,82 +145,86 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        infos: [[
-                            oid,
-                            name,
-                            objType,
-                            saveDate,
-                            ver,
-                            userId,
-                            ws,
-                            wsName,
-                            checksum,
-                            size,
-                            meta
-                        ]],
-                        paths: [[upa]]
-                    }]
-                })
+                    result: [
+                        {
+                            infos: [
+                                [
+                                    oid,
+                                    name,
+                                    objType,
+                                    saveDate,
+                                    ver,
+                                    userId,
+                                    ws,
+                                    wsName,
+                                    checksum,
+                                    size,
+                                    meta,
+                                ],
+                            ],
+                            paths: [[upa]],
+                        },
+                    ],
+                }),
             });
 
-            let w = new KBaseDefaultObjectView($div, {upas: {upas: [upa]}});
-            w.render([upa])
-                .then(() => {
-                    // simple string matching
-                    [
-                        'Overview',
-                        'Metadata',
-                        'Objects of this type don\'t have a viewer associated with them. Showing default information.'
-                    ].forEach((str) => {
-                        expect($div.html()).toContain(str);
-                    });
-                    // more complex structure matching
-                    let tabs = $div.find('.tabbable');
-                    expect(tabs).not.toBeNull();
-                    let tabsContent = $div.find('.tab-pane');
-                    expect(tabsContent.length).toEqual(2);
-                    [
-                        upa,
-                        name,
-                        userId,
-                        size.toLocaleString(),
-                        'Explore data landing page',
-                        'View data provenance and relationships',
-                        objType,
-                        'module info',
-                        'type spec'
-                    ].forEach((str) => {
-                        expect($(tabsContent[0]).html()).toContain(str);
-                    });
-                    expect($(tabsContent[1]).html()).not.toContain('No metadata found for this object.');
-                    expect($(tabsContent[1]).html()).toContain('table');
-                    Object.keys(meta).forEach((key) => {
-                        expect($(tabsContent[1]).html()).toContain(key);
-                        expect($(tabsContent[1]).html()).toContain(meta[key]);
-                    });
-                    done();
+            const w = new KBaseDefaultObjectView($div, { upas: { upas: [upa] } });
+            w.render([upa]).then(() => {
+                // simple string matching
+                [
+                    'Overview',
+                    'Metadata',
+                    "Objects of this type don't have a viewer associated with them. Showing default information.",
+                ].forEach((str) => {
+                    expect($div.html()).toContain(str);
                 });
+                // more complex structure matching
+                const tabs = $div.find('.tabbable');
+                expect(tabs).not.toBeNull();
+                const tabsContent = $div.find('.tab-pane');
+                expect(tabsContent.length).toEqual(2);
+                [
+                    upa,
+                    name,
+                    userId,
+                    size.toLocaleString(),
+                    'Explore data landing page',
+                    'View data provenance and relationships',
+                    objType,
+                    'module info',
+                    'type spec',
+                ].forEach((str) => {
+                    expect($(tabsContent[0]).html()).toContain(str);
+                });
+                expect($(tabsContent[1]).html()).not.toContain(
+                    'No metadata found for this object.'
+                );
+                expect($(tabsContent[1]).html()).toContain('table');
+                Object.keys(meta).forEach((key) => {
+                    expect($(tabsContent[1]).html()).toContain(key);
+                    expect($(tabsContent[1]).html()).toContain(meta[key]);
+                });
+                done();
+            });
         });
 
-        it('Should fail to load with an error message if there\'s a problem', (done) => {
+        it("Should fail to load with an error message if there's a problem", (done) => {
             jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
                 status: 500,
                 statusText: 'success',
                 contentType: 'application/json',
                 responseHeaders: '',
                 responseText: JSON.stringify({
-                    error: 'ERROR! OMG!'
-                })
+                    error: 'ERROR! OMG!',
+                }),
             });
 
-            let w = new KBaseDefaultObjectView($div, {upas: {upas: ['nope']}});
-            w.render(['nope'])
-                .then(() => {
-                    expect($div.html()).toContain('Unable to retrieve object information');
-                    expect($div.find('.alert.alert-danger').length).toEqual(1);
-                    done();
-                });
+            const w = new KBaseDefaultObjectView($div, { upas: { upas: ['nope'] } });
+            w.render(['nope']).then(() => {
+                expect($div.html()).toContain('Unable to retrieve object information');
+                expect($div.find('.alert.alert-danger').length).toEqual(1);
+                done();
+            });
         });
     });
 });

--- a/test/unit/spec/function_output/kbaseDefaultObjectView-spec.js
+++ b/test/unit/spec/function_output/kbaseDefaultObjectView-spec.js
@@ -1,4 +1,3 @@
-/*jslint white: true*/
 define([
     'jquery',
     'widgets/function_output/kbaseDefaultObjectView',

--- a/test/unit/spec/function_output/kbaseDomainAnnotation-spec.js
+++ b/test/unit/spec/function_output/kbaseDomainAnnotation-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseDomainAnnotation'
-], function(Widget) {
-    describe('Test the kbaseDomainAnnotation widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseDomainAnnotation'], (Widget) => {
+    describe('Test the kbaseDomainAnnotation widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseDomainAnnotation-spec.js
+++ b/test/unit/spec/function_output/kbaseDomainAnnotation-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseDomainAnnotation'], (Widget) => {
     describe('Test the kbaseDomainAnnotation widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseDomainAnnotation-spec.js
+++ b/test/unit/spec/function_output/kbaseDomainAnnotation-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseDomainAnnotation'], (Widget) => {
-    describe('Test the kbaseDomainAnnotation widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseDomainAnnotation widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionAnalysis-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionAnalysis-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionAnalysis'], (Widget) => {
     describe('Test the kbaseExpressionAnalysis widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionAnalysis-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionAnalysis-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionAnalysis'], (Widget) => {
-    describe('Test the kbaseExpressionAnalysis widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionAnalysis widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionAnalysis-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionAnalysis-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionAnalysis'
-], function(Widget) {
-    describe('Test the kbaseExpressionAnalysis widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionAnalysis'], (Widget) => {
+    describe('Test the kbaseExpressionAnalysis widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionEstimateK-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionEstimateK-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionEstimateK'], (Widget) => {
     describe('Test the kbaseExpressionEstimateK widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionEstimateK-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionEstimateK-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionEstimateK'
-], function(Widget) {
-    describe('Test the kbaseExpressionEstimateK widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionEstimateK'], (Widget) => {
+    describe('Test the kbaseExpressionEstimateK widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionEstimateK-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionEstimateK-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionEstimateK'], (Widget) => {
-    describe('Test the kbaseExpressionEstimateK widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionEstimateK widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionFeatureClusters-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionFeatureClusters-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionFeatureClusters'], (Widget) => {
     describe('Test the kbaseExpressionFeatureClusters widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionFeatureClusters-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionFeatureClusters-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionFeatureClusters'], (Widget) => {
-    describe('Test the kbaseExpressionFeatureClusters widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionFeatureClusters widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionFeatureClusters-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionFeatureClusters-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionFeatureClusters'
-], function(Widget) {
-    describe('Test the kbaseExpressionFeatureClusters widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionFeatureClusters'], (Widget) => {
+    describe('Test the kbaseExpressionFeatureClusters widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionGenesetBaseWidget-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionGenesetBaseWidget-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionGenesetBaseWidget'
-], function(Widget) {
-    describe('Test the kbaseExpressionGenesetBaseWidget widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionGenesetBaseWidget'], (Widget) => {
+    describe('Test the kbaseExpressionGenesetBaseWidget widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionGenesetBaseWidget-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionGenesetBaseWidget-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionGenesetBaseWidget'], (Widget) => {
-    describe('Test the kbaseExpressionGenesetBaseWidget widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionGenesetBaseWidget widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionGenesetBaseWidget-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionGenesetBaseWidget-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionGenesetBaseWidget'], (Widget) => {
     describe('Test the kbaseExpressionGenesetBaseWidget widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionHeatmap-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionHeatmap-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionHeatmap'], (Widget) => {
-    describe('Test the kbaseExpressionHeatmap widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionHeatmap widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionHeatmap-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionHeatmap-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionHeatmap'], (Widget) => {
     describe('Test the kbaseExpressionHeatmap widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionHeatmap-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionHeatmap-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionHeatmap'
-], function(Widget) {
-    describe('Test the kbaseExpressionHeatmap widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionHeatmap'], (Widget) => {
+    describe('Test the kbaseExpressionHeatmap widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionMatrix-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionMatrix'], (Widget) => {
-    describe('Test the kbaseExpressionMatrix widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionMatrix widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionMatrix-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionMatrix'
-], function(Widget) {
-    describe('Test the kbaseExpressionMatrix widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionMatrix'], (Widget) => {
+    describe('Test the kbaseExpressionMatrix widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionMatrix-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionMatrix'], (Widget) => {
     describe('Test the kbaseExpressionMatrix widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionPairwiseCorrelation-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionPairwiseCorrelation-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionPairwiseCorrelation'
-], function(Widget) {
-    describe('Test the kbaseExpressionPairwiseCorrelation widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionPairwiseCorrelation'], (Widget) => {
+    describe('Test the kbaseExpressionPairwiseCorrelation widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionPairwiseCorrelation-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionPairwiseCorrelation-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionPairwiseCorrelation'], (Widget) => {
     describe('Test the kbaseExpressionPairwiseCorrelation widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionPairwiseCorrelation-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionPairwiseCorrelation-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionPairwiseCorrelation'], (Widget) => {
-    describe('Test the kbaseExpressionPairwiseCorrelation widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionPairwiseCorrelation widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionSparkline-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionSparkline-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionSparkline'
-], function(Widget) {
-    describe('Test the kbaseExpressionSparkline widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionSparkline'], (Widget) => {
+    describe('Test the kbaseExpressionSparkline widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionSparkline-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionSparkline-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionSparkline'], (Widget) => {
-    describe('Test the kbaseExpressionSparkline widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionSparkline widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionSparkline-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionSparkline-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionSparkline'], (Widget) => {
     describe('Test the kbaseExpressionSparkline widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionVolcanoPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionVolcanoPlot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionVolcanoPlot'], (Widget) => {
     describe('Test the kbaseExpressionVolcanoPlot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseExpressionVolcanoPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionVolcanoPlot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionVolcanoPlot'
-], function(Widget) {
-    describe('Test the kbaseExpressionVolcanoPlot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionVolcanoPlot'], (Widget) => {
+    describe('Test the kbaseExpressionVolcanoPlot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseExpressionVolcanoPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseExpressionVolcanoPlot-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionVolcanoPlot'], (Widget) => {
-    describe('Test the kbaseExpressionVolcanoPlot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionVolcanoPlot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseFbaModelComparisonNew-spec.js
+++ b/test/unit/spec/function_output/kbaseFbaModelComparisonNew-spec.js
@@ -1,7 +1,7 @@
-
 // define([
 //     'kbaseFbaModelComparisonNew'
 // ], function(Widget) {
+//     'use strict';
 //     describe('Test the kbaseFbaModelComparisonNew widget', function() {
 //         it('Should do things', function() {
 //

--- a/test/unit/spec/function_output/kbaseFbaModelComparisonNew-spec.js
+++ b/test/unit/spec/function_output/kbaseFbaModelComparisonNew-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 
 // define([
 //     'kbaseFbaModelComparisonNew'

--- a/test/unit/spec/function_output/kbaseFeatureSet-spec.js
+++ b/test/unit/spec/function_output/kbaseFeatureSet-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseFeatureSet'
-], function(Widget) {
-    describe('Test the kbaseFeatureSet widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseFeatureSet'], (Widget) => {
+    describe('Test the kbaseFeatureSet widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseFeatureSet-spec.js
+++ b/test/unit/spec/function_output/kbaseFeatureSet-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseFeatureSet'], (Widget) => {
     describe('Test the kbaseFeatureSet widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseFeatureSet-spec.js
+++ b/test/unit/spec/function_output/kbaseFeatureSet-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseFeatureSet'], (Widget) => {
-    describe('Test the kbaseFeatureSet widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseFeatureSet widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGenericMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseGenericMatrix-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGenericMatrix'], (Widget) => {
     describe('Test the kbaseGenericMatrix widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGenericMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseGenericMatrix-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGenericMatrix'], (Widget) => {
-    describe('Test the kbaseGenericMatrix widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGenericMatrix widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGenericMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseGenericMatrix-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGenericMatrix'
-], function(Widget) {
-    describe('Test the kbaseGenericMatrix widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGenericMatrix'], (Widget) => {
+    describe('Test the kbaseGenericMatrix widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeAnnotationAssembly-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeAnnotationAssembly-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGenomeAnnotationAssembly'
-], function(Widget) {
-    describe('Test the kbaseGenomeAnnotationAssembly widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGenomeAnnotationAssembly'], (Widget) => {
+    describe('Test the kbaseGenomeAnnotationAssembly widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeAnnotationAssembly-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeAnnotationAssembly-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGenomeAnnotationAssembly'], (Widget) => {
-    describe('Test the kbaseGenomeAnnotationAssembly widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGenomeAnnotationAssembly widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeAnnotationAssembly-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeAnnotationAssembly-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGenomeAnnotationAssembly'], (Widget) => {
     describe('Test the kbaseGenomeAnnotationAssembly widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGenomeAnnotationViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeAnnotationViewer-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGenomeAnnotationViewer'], (Widget) => {
-    describe('Test the kbaseGenomeAnnotationViewer widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGenomeAnnotationViewer widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeAnnotationViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeAnnotationViewer-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGenomeAnnotationViewer'
-], function(Widget) {
-    describe('Test the kbaseGenomeAnnotationViewer widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGenomeAnnotationViewer'], (Widget) => {
+    describe('Test the kbaseGenomeAnnotationViewer widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeAnnotationViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeAnnotationViewer-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGenomeAnnotationViewer'], (Widget) => {
     describe('Test the kbaseGenomeAnnotationViewer widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGenomeComparisonViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeComparisonViewer-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGenomeComparisonViewer'], (Widget) => {
     describe('Test the kbaseGenomeComparisonViewer widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGenomeComparisonViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeComparisonViewer-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGenomeComparisonViewer'
-], function(Widget) {
-    describe('Test the kbaseGenomeComparisonViewer widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGenomeComparisonViewer'], (Widget) => {
+    describe('Test the kbaseGenomeComparisonViewer widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeComparisonViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeComparisonViewer-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGenomeComparisonViewer'], (Widget) => {
-    describe('Test the kbaseGenomeComparisonViewer widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGenomeComparisonViewer widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeSetBuilder-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeSetBuilder-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGenomeSetBuilder'], (Widget) => {
-    describe('Test the kbaseGenomeSetBuilder widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGenomeSetBuilder widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeSetBuilder-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeSetBuilder-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGenomeSetBuilder'
-], function(Widget) {
-    describe('Test the kbaseGenomeSetBuilder widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGenomeSetBuilder'], (Widget) => {
+    describe('Test the kbaseGenomeSetBuilder widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeSetBuilder-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeSetBuilder-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGenomeSetBuilder'], (Widget) => {
     describe('Test the kbaseGenomeSetBuilder widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGenomeView-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGenomeView'
-], function(Widget) {
-    describe('Test the kbaseGenomeView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGenomeView'], (Widget) => {
+    describe('Test the kbaseGenomeView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeView-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeView-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGenomeView'], (Widget) => {
-    describe('Test the kbaseGenomeView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGenomeView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGenomeView-spec.js
+++ b/test/unit/spec/function_output/kbaseGenomeView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGenomeView'], (Widget) => {
     describe('Test the kbaseGenomeView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGrowthCurves-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthCurves-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGrowthCurves'], (Widget) => {
-    describe('Test the kbaseGrowthCurves widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGrowthCurves widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthCurves-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthCurves-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGrowthCurves'], (Widget) => {
     describe('Test the kbaseGrowthCurves widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGrowthCurves-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthCurves-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGrowthCurves'
-], function(Widget) {
-    describe('Test the kbaseGrowthCurves widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGrowthCurves'], (Widget) => {
+    describe('Test the kbaseGrowthCurves widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthMatrix-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGrowthMatrix'], (Widget) => {
-    describe('Test the kbaseGrowthMatrix widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGrowthMatrix widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthMatrix-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGrowthMatrix'
-], function(Widget) {
-    describe('Test the kbaseGrowthMatrix widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGrowthMatrix'], (Widget) => {
+    describe('Test the kbaseGrowthMatrix widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthMatrix-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGrowthMatrix'], (Widget) => {
     describe('Test the kbaseGrowthMatrix widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGrowthMatrixAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthMatrixAbstract-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGrowthMatrixAbstract'], (Widget) => {
-    describe('Test the kbaseGrowthMatrixAbstract widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGrowthMatrixAbstract widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthMatrixAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthMatrixAbstract-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGrowthMatrixAbstract'], (Widget) => {
     describe('Test the kbaseGrowthMatrixAbstract widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGrowthMatrixAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthMatrixAbstract-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGrowthMatrixAbstract'
-], function(Widget) {
-    describe('Test the kbaseGrowthMatrixAbstract widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGrowthMatrixAbstract'], (Widget) => {
+    describe('Test the kbaseGrowthMatrixAbstract widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParameters-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParameters-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGrowthParameters'
-], function(Widget) {
-    describe('Test the kbaseGrowthParameters widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGrowthParameters'], (Widget) => {
+    describe('Test the kbaseGrowthParameters widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParameters-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParameters-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGrowthParameters'], (Widget) => {
-    describe('Test the kbaseGrowthParameters widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGrowthParameters widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParameters-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParameters-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGrowthParameters'], (Widget) => {
     describe('Test the kbaseGrowthParameters widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGrowthParametersAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParametersAbstract-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGrowthParametersAbstract'], (Widget) => {
-    describe('Test the kbaseGrowthParametersAbstract widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGrowthParametersAbstract widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParametersAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParametersAbstract-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGrowthParametersAbstract'
-], function(Widget) {
-    describe('Test the kbaseGrowthParametersAbstract widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGrowthParametersAbstract'], (Widget) => {
+    describe('Test the kbaseGrowthParametersAbstract widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParametersAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParametersAbstract-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGrowthParametersAbstract'], (Widget) => {
     describe('Test the kbaseGrowthParametersAbstract widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGrowthParams2DPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParams2DPlot-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGrowthParams2DPlot'], (Widget) => {
-    describe('Test the kbaseGrowthParams2DPlot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGrowthParams2DPlot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParams2DPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParams2DPlot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGrowthParams2DPlot'
-], function(Widget) {
-    describe('Test the kbaseGrowthParams2DPlot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGrowthParams2DPlot'], (Widget) => {
+    describe('Test the kbaseGrowthParams2DPlot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParams2DPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParams2DPlot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGrowthParams2DPlot'], (Widget) => {
     describe('Test the kbaseGrowthParams2DPlot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseGrowthParamsPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParamsPlot-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseGrowthParamsPlot'], (Widget) => {
-    describe('Test the kbaseGrowthParamsPlot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseGrowthParamsPlot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParamsPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParamsPlot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseGrowthParamsPlot'
-], function(Widget) {
-    describe('Test the kbaseGrowthParamsPlot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseGrowthParamsPlot'], (Widget) => {
+    describe('Test the kbaseGrowthParamsPlot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseGrowthParamsPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseGrowthParamsPlot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseGrowthParamsPlot'], (Widget) => {
     describe('Test the kbaseGrowthParamsPlot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseMSA-spec.js
+++ b/test/unit/spec/function_output/kbaseMSA-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseMSA'], (Widget) => {
-    describe('Test the kbaseMSA widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseMSA widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseMSA-spec.js
+++ b/test/unit/spec/function_output/kbaseMSA-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseMSA'
-], function(Widget) {
-    describe('Test the kbaseMSA widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseMSA'], (Widget) => {
+    describe('Test the kbaseMSA widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseMSA-spec.js
+++ b/test/unit/spec/function_output/kbaseMSA-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseMSA'], (Widget) => {
     describe('Test the kbaseMSA widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseMatrix2DAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseMatrix2DAbstract-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseMatrix2DAbstract'], (Widget) => {
     describe('Test the kbaseMatrix2DAbstract widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseMatrix2DAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseMatrix2DAbstract-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseMatrix2DAbstract'
-], function(Widget) {
-    describe('Test the kbaseMatrix2DAbstract widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseMatrix2DAbstract'], (Widget) => {
+    describe('Test the kbaseMatrix2DAbstract widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseMatrix2DAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseMatrix2DAbstract-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseMatrix2DAbstract'], (Widget) => {
-    describe('Test the kbaseMatrix2DAbstract widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseMatrix2DAbstract widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbasePanGenome-spec.js
+++ b/test/unit/spec/function_output/kbasePanGenome-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbasePanGenome'], (Widget) => {
     describe('Test the kbasePanGenome widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbasePanGenome-spec.js
+++ b/test/unit/spec/function_output/kbasePanGenome-spec.js
@@ -1,5 +1,8 @@
 define(['kbasePanGenome'], (Widget) => {
-    describe('Test the kbasePanGenome widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbasePanGenome widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbasePanGenome-spec.js
+++ b/test/unit/spec/function_output/kbasePanGenome-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbasePanGenome'
-], function(Widget) {
-    describe('Test the kbasePanGenome widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbasePanGenome'], (Widget) => {
+    describe('Test the kbasePanGenome widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseReadsSetView-spec.js
+++ b/test/unit/spec/function_output/kbaseReadsSetView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseReadsSetView'
-], function(Widget) {
-    describe('Test the kbaseReadsSetView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseReadsSetView'], (Widget) => {
+    describe('Test the kbaseReadsSetView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseReadsSetView-spec.js
+++ b/test/unit/spec/function_output/kbaseReadsSetView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseReadsSetView'], (Widget) => {
     describe('Test the kbaseReadsSetView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseReadsSetView-spec.js
+++ b/test/unit/spec/function_output/kbaseReadsSetView-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseReadsSetView'], (Widget) => {
-    describe('Test the kbaseReadsSetView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseReadsSetView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseReadsViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseReadsViewer-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseReadsViewer'], (Widget) => {
-    describe('Test the kbaseReadsViewer widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseReadsViewer widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseReadsViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseReadsViewer-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseReadsViewer'], (Widget) => {
     describe('Test the kbaseReadsViewer widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseReadsViewer-spec.js
+++ b/test/unit/spec/function_output/kbaseReadsViewer-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseReadsViewer'
-], function(Widget) {
-    describe('Test the kbaseReadsViewer widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseReadsViewer'], (Widget) => {
+    describe('Test the kbaseReadsViewer widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseRegisterRepoState-spec.js
+++ b/test/unit/spec/function_output/kbaseRegisterRepoState-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseRegisterRepoState'], (Widget) => {
     describe('Test the kbaseRegisterRepoState widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseRegisterRepoState-spec.js
+++ b/test/unit/spec/function_output/kbaseRegisterRepoState-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseRegisterRepoState'], (Widget) => {
-    describe('Test the kbaseRegisterRepoState widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseRegisterRepoState widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseRegisterRepoState-spec.js
+++ b/test/unit/spec/function_output/kbaseRegisterRepoState-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseRegisterRepoState'
-], function(Widget) {
-    describe('Test the kbaseRegisterRepoState widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseRegisterRepoState'], (Widget) => {
+    describe('Test the kbaseRegisterRepoState widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseReportView-spec.js
+++ b/test/unit/spec/function_output/kbaseReportView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseReportView'], (Widget) => {
     describe('Test the kbaseReportView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseReportView-spec.js
+++ b/test/unit/spec/function_output/kbaseReportView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseReportView'
-], function(Widget) {
-    describe('Test the kbaseReportView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseReportView'], (Widget) => {
+    describe('Test the kbaseReportView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseReportView-spec.js
+++ b/test/unit/spec/function_output/kbaseReportView-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseReportView'], (Widget) => {
-    describe('Test the kbaseReportView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseReportView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseSampleProperty2DPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleProperty2DPlot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseSampleProperty2DPlot'], (Widget) => {
     describe('Test the kbaseSampleProperty2DPlot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseSampleProperty2DPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleProperty2DPlot-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseSampleProperty2DPlot'], (Widget) => {
-    describe('Test the kbaseSampleProperty2DPlot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseSampleProperty2DPlot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseSampleProperty2DPlot-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleProperty2DPlot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseSampleProperty2DPlot'
-], function(Widget) {
-    describe('Test the kbaseSampleProperty2DPlot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseSampleProperty2DPlot'], (Widget) => {
+    describe('Test the kbaseSampleProperty2DPlot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseSamplePropertyHistogram-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyHistogram-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseSamplePropertyHistogram'
-], function(Widget) {
-    describe('Test the kbaseSamplePropertyHistogram widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseSamplePropertyHistogram'], (Widget) => {
+    describe('Test the kbaseSamplePropertyHistogram widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseSamplePropertyHistogram-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyHistogram-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseSamplePropertyHistogram'], (Widget) => {
     describe('Test the kbaseSamplePropertyHistogram widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseSamplePropertyHistogram-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyHistogram-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseSamplePropertyHistogram'], (Widget) => {
-    describe('Test the kbaseSamplePropertyHistogram widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseSamplePropertyHistogram widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseSamplePropertyMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyMatrix-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseSamplePropertyMatrix'], (Widget) => {
-    describe('Test the kbaseSamplePropertyMatrix widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseSamplePropertyMatrix widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseSamplePropertyMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyMatrix-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseSamplePropertyMatrix'], (Widget) => {
     describe('Test the kbaseSamplePropertyMatrix widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseSamplePropertyMatrix-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyMatrix-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseSamplePropertyMatrix'
-], function(Widget) {
-    describe('Test the kbaseSamplePropertyMatrix widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseSamplePropertyMatrix'], (Widget) => {
+    describe('Test the kbaseSamplePropertyMatrix widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseSamplePropertyMatrixAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyMatrixAbstract-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseSamplePropertyMatrixAbstract'
-], function(Widget) {
-    describe('Test the kbaseSamplePropertyMatrixAbstract widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseSamplePropertyMatrixAbstract'], (Widget) => {
+    describe('Test the kbaseSamplePropertyMatrixAbstract widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseSamplePropertyMatrixAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyMatrixAbstract-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseSamplePropertyMatrixAbstract'], (Widget) => {
     describe('Test the kbaseSamplePropertyMatrixAbstract widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseSamplePropertyMatrixAbstract-spec.js
+++ b/test/unit/spec/function_output/kbaseSamplePropertyMatrixAbstract-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseSamplePropertyMatrixAbstract'], (Widget) => {
-    describe('Test the kbaseSamplePropertyMatrixAbstract widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseSamplePropertyMatrixAbstract widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseSampleSet-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleSet-spec.js
@@ -1,10 +1,5 @@
 /*jslint white: true*/
-define([
-    'jquery',
-    'kbaseSampleSetView',
-    'base/js/namespace',
-    'narrativeConfig'
-], (
+define(['jquery', 'kbaseSampleSetView', 'base/js/namespace', 'narrativeConfig'], (
     $,
     Widget,
     Jupyter,
@@ -17,7 +12,7 @@ define([
             jasmine.Ajax.install();
             $div = $('<div>');
             Jupyter.narrative = {
-                getAuthToken: () => 'NotARealToken!'
+                getAuthToken: () => 'NotARealToken!',
             };
         });
 
@@ -28,14 +23,14 @@ define([
         });
 
         it('Should properly render SampleSet', (done) => {
-            let SampleSet = {
-                'samples': [
-                    {'id': 'madeup', 'name': 'sample1'},
-                    {'id': 'idtwo', 'name': 'sample2'}
+            const SampleSet = {
+                samples: [
+                    { id: 'madeup', name: 'sample1' },
+                    { id: 'idtwo', name: 'sample2' },
                 ],
-                'description': 'This is a test sample set.'
+                description: 'This is a test sample set.',
             };
-            let obj_info = [35,'name',',',1,'',45700];
+            const obj_info = [35, 'name', ',', 1, '', 45700];
             jasmine.Ajax.stubRequest(Config.url('workspace')).andReturn({
                 status: 200,
                 statusText: 'success',
@@ -43,27 +38,31 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        data: [
-                            {
-                                data: SampleSet,
-                                info: obj_info
-                            }
-                        ]
-                    }]
-                })
+                    result: [
+                        {
+                            data: [
+                                {
+                                    data: SampleSet,
+                                    info: obj_info,
+                                },
+                            ],
+                        },
+                    ],
+                }),
             });
-            const fakeServiceUrl = "https://ci.kbase.us/services/fake_url";
-            var sampleServiceInfo = {
+            const fakeServiceUrl = 'https://ci.kbase.us/services/fake_url';
+            const sampleServiceInfo = {
                 version: '1.1',
                 id: '12345',
-                result: [{
-                    git_commit_hash: 'foo',
-                    hash: 'bar',
-                    health: 'healthy',
-                    module_name: 'SampleService',
-                    url: fakeServiceUrl
-                }]
+                result: [
+                    {
+                        git_commit_hash: 'foo',
+                        hash: 'bar',
+                        health: 'healthy',
+                        module_name: 'SampleService',
+                        url: fakeServiceUrl,
+                    },
+                ],
             };
             jasmine.Ajax.stubRequest(Config.url('service_wizard')).andReturn({
                 status: 200,
@@ -79,54 +78,49 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        sample_id: 'id',
-                        user: 'user',
-                        node_tree: [{
-                            id: 'identificazione',
-                            parent: null,
-                            type: 'sample',
-                            meta_controlled: {
-                                'controlled1': {'value': 1, 'units': 'bars'},
-                                'controlled2': {'value': 'two', 'units': 'units'},
-                                'controlled3': {'value': '3'}
-                            },
-                            meta_user: {
-                                'user1': {'value': 6, 'units': 'units'},
-                                'user2': {'value': 'foo'},
-                                'user3': {'value': 'bar'}
-                            }
-                        }],
-                        name: 'sample_name',
-                        save_date: 'a time',
-                        version: 1
-                    }]
-                })
+                    result: [
+                        {
+                            sample_id: 'id',
+                            user: 'user',
+                            node_tree: [
+                                {
+                                    id: 'identificazione',
+                                    parent: null,
+                                    type: 'sample',
+                                    meta_controlled: {
+                                        controlled1: { value: 1, units: 'bars' },
+                                        controlled2: { value: 'two', units: 'units' },
+                                        controlled3: { value: '3' },
+                                    },
+                                    meta_user: {
+                                        user1: { value: 6, units: 'units' },
+                                        user2: { value: 'foo' },
+                                        user3: { value: 'bar' },
+                                    },
+                                },
+                            ],
+                            name: 'sample_name',
+                            save_date: 'a time',
+                            version: 1,
+                        },
+                    ],
+                }),
             });
-            let w = new Widget($div, {upas: {id: 'fake'}});
+            const w = new Widget($div, { upas: { id: 'fake' } });
             setTimeout(() => {
-                [
-                    'Description',
-                    'KBase Object Name',
-                    'This is a test sample set.'
-                ].forEach((str) => {
-                    expect($div.html()).toContain(str);
-                });
+                ['Description', 'KBase Object Name', 'This is a test sample set.'].forEach(
+                    (str) => {
+                        expect($div.html()).toContain(str);
+                    }
+                );
                 $div.find('a[data-tab="Samples"]').click();
                 setTimeout(() => {
-                    [
-                        'Sample ID',
-                        'Sample Name',
-                        'madeup',
-                        'idtwo',
-                        'two units'
-                    ].forEach((str) => {
+                    ['Sample ID', 'Sample Name', 'madeup', 'idtwo', 'two units'].forEach((str) => {
                         expect($div.html()).toContain(str);
                     });
                     done();
                 }, 1000);
             }, 1000);
-
         });
     });
 });

--- a/test/unit/spec/function_output/kbaseSampleSet-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleSet-spec.js
@@ -5,7 +5,7 @@ define(['jquery', 'kbaseSampleSetView', 'base/js/namespace', 'narrativeConfig'],
     Config
 ) => {
     'use strict';
-    describe('Test the kbaseSampleSet viewer widget', () => {
+    describe('The kbaseSampleSet viewer widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/function_output/kbaseSampleSet-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleSet-spec.js
@@ -1,4 +1,3 @@
-/*jslint white: true*/
 define(['jquery', 'kbaseSampleSetView', 'base/js/namespace', 'narrativeConfig'], (
     $,
     Widget,

--- a/test/unit/spec/function_output/kbaseSeqCompView-spec.js
+++ b/test/unit/spec/function_output/kbaseSeqCompView-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseSeqCompView'
-], function(Widget) {
-    describe('Test the kbaseSeqCompView widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseSeqCompView'], (Widget) => {
+    describe('Test the kbaseSeqCompView widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/kbaseSeqCompView-spec.js
+++ b/test/unit/spec/function_output/kbaseSeqCompView-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseSeqCompView'], (Widget) => {
-    describe('Test the kbaseSeqCompView widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseSeqCompView widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseSeqCompView-spec.js
+++ b/test/unit/spec/function_output/kbaseSeqCompView-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseSeqCompView'], (Widget) => {
     describe('Test the kbaseSeqCompView widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseTree-spec.js
+++ b/test/unit/spec/function_output/kbaseTree-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseTree'], (Widget) => {
     describe('Test the kbaseTree widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/kbaseTree-spec.js
+++ b/test/unit/spec/function_output/kbaseTree-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseTree'], (Widget) => {
-    describe('Test the kbaseTree widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseTree widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/kbaseTree-spec.js
+++ b/test/unit/spec/function_output/kbaseTree-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseTree'
-], function(Widget) {
-    describe('Test the kbaseTree widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseTree'], (Widget) => {
+    describe('Test the kbaseTree widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/modeling/KBModeling-spec.js
+++ b/test/unit/spec/function_output/modeling/KBModeling-spec.js
@@ -3,27 +3,24 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'jquery',
-    'KBModeling'
-], function($, kbm) {
-    describe('test the KBModeling module', function() {
-        it('should load a function', function() {
+define(['jquery', 'KBModeling'], ($, kbm) => {
+    describe('test the KBModeling module', () => {
+        it('should load a function', () => {
             expect(KBModeling).toEqual(jasmine.any(Function));
         });
 
-        it('KBModeling should return an api object', function() {
-            var fakeToken = 'mytoken';
-            var api = new KBModeling(fakeToken);
+        it('KBModeling should return an api object', () => {
+            const fakeToken = 'mytoken';
+            const api = new KBModeling(fakeToken);
             expect(api.token).toEqual(fakeToken);
             expect(api.kbapi).toEqual(jasmine.any(Function));
         });
 
-        it('should create a loading plugin', function() {
+        it('should create a loading plugin', () => {
             expect($.fn.loading).toBeDefined();
         });
 
-        it('should create a rmloading plugin', function() {
+        it('should create a rmloading plugin', () => {
             expect($.fn.rmLoading).toBeDefined();
         });
     });

--- a/test/unit/spec/function_output/modeling/KBModeling-spec.js
+++ b/test/unit/spec/function_output/modeling/KBModeling-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['jquery', 'KBModeling'], ($, kbm) => {
     describe('test the KBModeling module', () => {
         it('should load a function', () => {

--- a/test/unit/spec/function_output/modeling/KBModeling-spec.js
+++ b/test/unit/spec/function_output/modeling/KBModeling-spec.js
@@ -1,4 +1,5 @@
 define(['jquery', 'KBModeling'], ($, kbm) => {
+    'use strict';
     describe('test the KBModeling module', () => {
         it('should load a function', () => {
             expect(KBModeling).toEqual(jasmine.any(Function));

--- a/test/unit/spec/function_output/modeling/KBaseBiochem.CompoundSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseBiochem.CompoundSet-spec.js
@@ -1,4 +1,5 @@
 define(['KBaseBiochem.CompoundSet', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBaseBiochem.CompoundSet widget', () => {
         it('Should inject KBaseBiochem.CompoundSet function', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBaseBiochem.CompoundSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseBiochem.CompoundSet-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseBiochem.CompoundSet', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBaseBiochem.CompoundSet widget', () => {
         it('Should inject KBaseBiochem.CompoundSet function', () => {

--- a/test/unit/spec/function_output/modeling/KBaseBiochem.CompoundSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseBiochem.CompoundSet-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseBiochem.CompoundSet',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBaseBiochem.CompoundSet widget', function() {
-        it('Should inject KBaseBiochem.CompoundSet function', function() {
-            var api = new KBModeling('token');
+define(['KBaseBiochem.CompoundSet', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBaseBiochem.CompoundSet widget', () => {
+        it('Should inject KBaseBiochem.CompoundSet function', () => {
+            const api = new KBModeling('token');
             expect(api.KBaseBiochem_Media).toBeDefined();
         });
     });

--- a/test/unit/spec/function_output/modeling/KBaseBiochem.Media-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseBiochem.Media-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseBiochem.Media',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBaseBiochem.Media widget', function() {
-        it('Should inject KBaseBiochem.Media function', function() {
-            var api = new KBModeling('token');
+define(['KBaseBiochem.Media', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBaseBiochem.Media widget', () => {
+        it('Should inject KBaseBiochem.Media function', () => {
+            const api = new KBModeling('token');
             expect(api.KBaseBiochem_Media).toBeDefined();
         });
     });

--- a/test/unit/spec/function_output/modeling/KBaseBiochem.Media-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseBiochem.Media-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseBiochem.Media', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBaseBiochem.Media widget', () => {
         it('Should inject KBaseBiochem.Media function', () => {

--- a/test/unit/spec/function_output/modeling/KBaseBiochem.Media-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseBiochem.Media-spec.js
@@ -1,4 +1,5 @@
 define(['KBaseBiochem.Media', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBaseBiochem.Media widget', () => {
         it('Should inject KBaseBiochem.Media function', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBA-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBA-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseFBA.FBA',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBaseFBA.FBA widget', function() {
-        it('Should load the module', function() {
-            var api = new KBModeling('token');
+define(['KBaseFBA.FBA', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBaseFBA.FBA widget', () => {
+        it('Should load the module', () => {
+            const api = new KBModeling('token');
             expect(api.KBaseFBA_FBA).toBeDefined();
         });
     });

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBA-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBA-spec.js
@@ -1,4 +1,5 @@
 define(['KBaseFBA.FBA', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBaseFBA.FBA widget', () => {
         it('Should load the module', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBA-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBA-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseFBA.FBA', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBaseFBA.FBA widget', () => {
         it('Should load the module', () => {

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAComparison-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAComparison-spec.js
@@ -1,4 +1,5 @@
 define(['KBaseFBA.FBAComparison', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBaseFBA.FBAComparison widget', () => {
         it('Should load the module', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAComparison-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAComparison-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseFBA.FBAComparison', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBaseFBA.FBAComparison widget', () => {
         it('Should load the module', () => {

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAComparison-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAComparison-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseFBA.FBAComparison',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBaseFBA.FBAComparison widget', function() {
-        it('Should load the module', function() {
-            var api = new KBModeling('token');
+define(['KBaseFBA.FBAComparison', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBaseFBA.FBAComparison widget', () => {
+        it('Should load the module', () => {
+            const api = new KBModeling('token');
             expect(api.KBaseFBA_FBAComparison).toEqual(jasmine.any(Function));
         });
     });

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAModel-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAModel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseFBA.FBAModel', 'KBModeling'], (Widget) => {
     describe('Test the KBaseFBA.FBAModel widget', () => {
         it('Should load the module', () => {

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAModel-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAModel-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseFBA.FBAModel',
-    'KBModeling'
-], function(Widget) {
-    describe('Test the KBaseFBA.FBAModel widget', function() {
-        it('Should load the module', function() {
-            var api = new KBModeling('token');
+define(['KBaseFBA.FBAModel', 'KBModeling'], (Widget) => {
+    describe('Test the KBaseFBA.FBAModel widget', () => {
+        it('Should load the module', () => {
+            const api = new KBModeling('token');
             expect(api.KBaseFBA_FBAModel).toEqual(jasmine.any(Function));
         });
     });

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAModel-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAModel-spec.js
@@ -1,4 +1,5 @@
 define(['KBaseFBA.FBAModel', 'KBModeling'], (Widget) => {
+    'use strict';
     describe('Test the KBaseFBA.FBAModel widget', () => {
         it('Should load the module', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAModelSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAModelSet-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseFBA.FBAModelSet',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBaseFBA.FBAModelSet widget', function() {
-        it('Should do things', function() {
-            var api = new KBModeling('token');
+define(['KBaseFBA.FBAModelSet', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBaseFBA.FBAModelSet widget', () => {
+        it('Should do things', () => {
+            const api = new KBModeling('token');
             expect(api.KBaseFBA_FBAModelSet).toEqual(jasmine.any(Function));
         });
     });

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAModelSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAModelSet-spec.js
@@ -1,4 +1,5 @@
 define(['KBaseFBA.FBAModelSet', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBaseFBA.FBAModelSet widget', () => {
         it('Should do things', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBaseFBA.FBAModelSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseFBA.FBAModelSet-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseFBA.FBAModelSet', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBaseFBA.FBAModelSet widget', () => {
         it('Should do things', () => {

--- a/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSet-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBasePhenotypes.PhenotypeSet',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBasePhenotypes.PhenotypeSet widget', function() {
-        it('Should load the module', function() {
-            var api = new KBModeling('token');
+define(['KBasePhenotypes.PhenotypeSet', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBasePhenotypes.PhenotypeSet widget', () => {
+        it('Should load the module', () => {
+            const api = new KBModeling('token');
             expect(api.KBasePhenotypes_PhenotypeSet).toEqual(jasmine.any(Function));
         });
     });

--- a/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSet-spec.js
@@ -1,4 +1,5 @@
 define(['KBasePhenotypes.PhenotypeSet', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBasePhenotypes.PhenotypeSet widget', () => {
         it('Should load the module', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSet-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBasePhenotypes.PhenotypeSet', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBasePhenotypes.PhenotypeSet widget', () => {
         it('Should load the module', () => {

--- a/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSimulationSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSimulationSet-spec.js
@@ -1,4 +1,5 @@
 define(['KBasePhenotypes.PhenotypeSimulationSet', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBasePhenotypes.PhenotypeSimulationSet widget', () => {
         it('Should load the module', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSimulationSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSimulationSet-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBasePhenotypes.PhenotypeSimulationSet',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBasePhenotypes.PhenotypeSimulationSet widget', function() {
-        it('Should load the module', function() {
-            var api = new KBModeling('token');
+define(['KBasePhenotypes.PhenotypeSimulationSet', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBasePhenotypes.PhenotypeSimulationSet widget', () => {
+        it('Should load the module', () => {
+            const api = new KBModeling('token');
             expect(api.KBasePhenotypes_PhenotypeSimulationSet).toEqual(jasmine.any(Function));
         });
     });

--- a/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSimulationSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBasePhenotypes.PhenotypeSimulationSet-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBasePhenotypes.PhenotypeSimulationSet', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBasePhenotypes.PhenotypeSimulationSet widget', () => {
         it('Should load the module', () => {

--- a/test/unit/spec/function_output/modeling/KBaseSearch.GenomeSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseSearch.GenomeSet-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['KBaseSearch.GenomeSet', 'KBModeling'], (Widget, kbm) => {
     describe('Test the KBaseSearch.GenomeSet widget', () => {
         it('Should load the module', () => {

--- a/test/unit/spec/function_output/modeling/KBaseSearch.GenomeSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseSearch.GenomeSet-spec.js
@@ -3,13 +3,10 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'KBaseSearch.GenomeSet',
-    'KBModeling'
-], function(Widget, kbm) {
-    describe('Test the KBaseSearch.GenomeSet widget', function() {
-        it('Should load the module', function() {
-            var api = new KBModeling('token');
+define(['KBaseSearch.GenomeSet', 'KBModeling'], (Widget, kbm) => {
+    describe('Test the KBaseSearch.GenomeSet widget', () => {
+        it('Should load the module', () => {
+            const api = new KBModeling('token');
             expect(api.KBaseSearch_GenomeSet).toEqual(jasmine.any(Function));
         });
     });

--- a/test/unit/spec/function_output/modeling/KBaseSearch.GenomeSet-spec.js
+++ b/test/unit/spec/function_output/modeling/KBaseSearch.GenomeSet-spec.js
@@ -1,4 +1,5 @@
 define(['KBaseSearch.GenomeSet', 'KBModeling'], (Widget, kbm) => {
+    'use strict';
     describe('Test the KBaseSearch.GenomeSet widget', () => {
         it('Should load the module', () => {
             const api = new KBModeling('token');

--- a/test/unit/spec/function_output/modeling/kbasePathways-spec.js
+++ b/test/unit/spec/function_output/modeling/kbasePathways-spec.js
@@ -3,11 +3,9 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbasePathways',
-], function(Widget) {
-    describe('Test the kbasePathways widget', function() {
-        it('Should load the widget', function() {
+define(['kbasePathways'], (Widget) => {
+    describe('Test the kbasePathways widget', () => {
+        it('Should load the widget', () => {
             expect(Widget).toBeDefined();
         });
     });

--- a/test/unit/spec/function_output/modeling/kbasePathways-spec.js
+++ b/test/unit/spec/function_output/modeling/kbasePathways-spec.js
@@ -1,4 +1,5 @@
 define(['kbasePathways'], (Widget) => {
+    'use strict';
     describe('Test the kbasePathways widget', () => {
         it('Should load the widget', () => {
             expect(Widget).toBeDefined();

--- a/test/unit/spec/function_output/modeling/kbasePathways-spec.js
+++ b/test/unit/spec/function_output/modeling/kbasePathways-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbasePathways'], (Widget) => {
     describe('Test the kbasePathways widget', () => {
         it('Should load the widget', () => {

--- a/test/unit/spec/function_output/modeling/kbaseTabTable-spec.js
+++ b/test/unit/spec/function_output/modeling/kbaseTabTable-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseTabTable'], (Widget) => {
     describe('Test the kbaseTabTable widget', () => {
         it('Should do things', () => {

--- a/test/unit/spec/function_output/modeling/kbaseTabTable-spec.js
+++ b/test/unit/spec/function_output/modeling/kbaseTabTable-spec.js
@@ -1,4 +1,5 @@
 define(['kbaseTabTable'], (Widget) => {
+    'use strict';
     describe('Test the kbaseTabTable widget', () => {
         it('Should do things', () => {
             expect(Widget).toBeDefined();

--- a/test/unit/spec/function_output/modeling/kbaseTabTable-spec.js
+++ b/test/unit/spec/function_output/modeling/kbaseTabTable-spec.js
@@ -3,11 +3,9 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseTabTable'
-], function(Widget) {
-    describe('Test the kbaseTabTable widget', function() {
-        it('Should do things', function() {
+define(['kbaseTabTable'], (Widget) => {
+    describe('Test the kbaseTabTable widget', () => {
+        it('Should do things', () => {
             expect(Widget).toBeDefined();
         });
     });

--- a/test/unit/spec/function_output/modeling/kbaseTabTableTabs-spec.js
+++ b/test/unit/spec/function_output/modeling/kbaseTabTableTabs-spec.js
@@ -1,4 +1,5 @@
 define(['kbaseTabTableTabs'], (Widget) => {
+    'use strict';
     describe('Test the kbaseTabTableTabs widget', () => {
         it('Should load the widget', () => {
             expect(Widget).toBeDefined();

--- a/test/unit/spec/function_output/modeling/kbaseTabTableTabs-spec.js
+++ b/test/unit/spec/function_output/modeling/kbaseTabTableTabs-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseTabTableTabs'], (Widget) => {
     describe('Test the kbaseTabTableTabs widget', () => {
         it('Should load the widget', () => {

--- a/test/unit/spec/function_output/modeling/kbaseTabTableTabs-spec.js
+++ b/test/unit/spec/function_output/modeling/kbaseTabTableTabs-spec.js
@@ -3,11 +3,9 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseTabTableTabs'
-], function(Widget) {
-    describe('Test the kbaseTabTableTabs widget', function() {
-        it('Should load the widget', function() {
+define(['kbaseTabTableTabs'], (Widget) => {
+    describe('Test the kbaseTabTableTabs widget', () => {
+        it('Should load the widget', () => {
             expect(Widget).toBeDefined();
         });
     });

--- a/test/unit/spec/function_output/modeling/modelSeedVizConfig-spec.js
+++ b/test/unit/spec/function_output/modeling/modelSeedVizConfig-spec.js
@@ -1,4 +1,5 @@
 define(['modelSeedVizConfig'], (Widget) => {
+    'use strict';
     describe('Test the modelSeedVizConfig widget', () => {
         let cfg;
 

--- a/test/unit/spec/function_output/modeling/modelSeedVizConfig-spec.js
+++ b/test/unit/spec/function_output/modeling/modelSeedVizConfig-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['modelSeedVizConfig'], (Widget) => {
     describe('Test the modelSeedVizConfig widget', () => {
         let cfg;

--- a/test/unit/spec/function_output/modeling/modelSeedVizConfig-spec.js
+++ b/test/unit/spec/function_output/modeling/modelSeedVizConfig-spec.js
@@ -3,26 +3,24 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'modelSeedVizConfig'
-], function(Widget) {
-    describe('Test the modelSeedVizConfig widget', function() {
-        var cfg;
+define(['modelSeedVizConfig'], (Widget) => {
+    describe('Test the modelSeedVizConfig widget', () => {
+        let cfg;
 
-        beforeEach(function() {
+        beforeEach(() => {
             cfg = new ModelSeedVizConfig();
         });
 
-        it('Should load the functions', function() {
+        it('Should load the functions', () => {
             expect(ModelSeedVizConfig).toBeDefined();
         });
 
-        it('Has a known gene color', function() {
+        it('Has a known gene color', () => {
             expect(cfg.geneColor).toBe('#87CEEB');
         });
 
-        it('Implements a getColor function', function() {
-            var col = cfg.getColor(100, 100);
+        it('Implements a getColor function', () => {
+            const col = cfg.getColor(100, 100);
             expect(col).toBe('#8b0000');
         });
     });

--- a/test/unit/spec/function_output/modeling/msPathway-spec.js
+++ b/test/unit/spec/function_output/modeling/msPathway-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['msPathway', 'jquery'], (Widget, $) => {
     describe('Test the msPathway widget', () => {
         it('Should load the module', () => {

--- a/test/unit/spec/function_output/modeling/msPathway-spec.js
+++ b/test/unit/spec/function_output/modeling/msPathway-spec.js
@@ -1,4 +1,5 @@
 define(['msPathway', 'jquery'], (Widget, $) => {
+    'use strict';
     describe('Test the msPathway widget', () => {
         it('Should load the module', () => {
             expect(ModelSeedPathway).toEqual(jasmine.any(Function));

--- a/test/unit/spec/function_output/modeling/msPathway-spec.js
+++ b/test/unit/spec/function_output/modeling/msPathway-spec.js
@@ -3,30 +3,25 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'msPathway',
-    'jquery'
-], function(Widget, $) {
-    describe('Test the msPathway widget', function() {
-        it('Should load the module', function() {
+define(['msPathway', 'jquery'], (Widget, $) => {
+    describe('Test the msPathway widget', () => {
+        it('Should load the module', () => {
             expect(ModelSeedPathway).toEqual(jasmine.any(Function));
         });
 
-        it('Should do something or other', function() {
-            var nodeName = 'path-node';
+        it('Should do something or other', () => {
+            const nodeName = 'path-node';
             $('body').append('<div id="' + nodeName + '">');
-            var pathwayWidget = new ModelSeedPathway(
-                {
-                    elem: nodeName,
-                    mapName: '',
-                    mapData: {
-                        groups: [],
-                        reactions: [],
-                        compounds: [],
-                        linkedmaps: []
-                    }
-                }
-            );
+            const pathwayWidget = new ModelSeedPathway({
+                elem: nodeName,
+                mapName: '',
+                mapData: {
+                    groups: [],
+                    reactions: [],
+                    compounds: [],
+                    linkedmaps: [],
+                },
+            });
         });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseCummerbundPlot-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseCummerbundPlot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseCummerbundPlot'
-], function(Widget) {
-    describe('Test the kbaseCummerbundPlot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseCummerbundPlot'], (Widget) => {
+    describe('Test the kbaseCummerbundPlot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseCummerbundPlot-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseCummerbundPlot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseCummerbundPlot'], (Widget) => {
     describe('Test the kbaseCummerbundPlot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseCummerbundPlot-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseCummerbundPlot-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseCummerbundPlot'], (Widget) => {
-    describe('Test the kbaseCummerbundPlot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseCummerbundPlot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionMatrixHeatmap-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionMatrixHeatmap-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionMatrixHeatmap'], (Widget) => {
-    describe('Test the kbaseExpressionMatrixHeatmap widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionMatrixHeatmap widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionMatrixHeatmap-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionMatrixHeatmap-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionMatrixHeatmap'
-], function(Widget) {
-    describe('Test the kbaseExpressionMatrixHeatmap widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionMatrixHeatmap'], (Widget) => {
+    describe('Test the kbaseExpressionMatrixHeatmap widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionMatrixHeatmap-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionMatrixHeatmap-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionMatrixHeatmap'], (Widget) => {
     describe('Test the kbaseExpressionMatrixHeatmap widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTable-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTable-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionSampleTable'
-], function(Widget) {
-    describe('Test the kbaseExpressionSampleTable widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionSampleTable'], (Widget) => {
+    describe('Test the kbaseExpressionSampleTable widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTable-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTable-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionSampleTable'], (Widget) => {
-    describe('Test the kbaseExpressionSampleTable widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionSampleTable widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTable-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTable-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionSampleTable'], (Widget) => {
     describe('Test the kbaseExpressionSampleTable widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTableNew-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTableNew-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseExpressionSampleTableNew'], (Widget) => {
-    describe('Test the kbaseExpressionSampleTableNew widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseExpressionSampleTableNew widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTableNew-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTableNew-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseExpressionSampleTableNew'
-], function(Widget) {
-    describe('Test the kbaseExpressionSampleTableNew widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseExpressionSampleTableNew'], (Widget) => {
+    describe('Test the kbaseExpressionSampleTableNew widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTableNew-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseExpressionSampleTableNew-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseExpressionSampleTableNew'], (Widget) => {
     describe('Test the kbaseExpressionSampleTableNew widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseFigureObjectHeatmap-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseFigureObjectHeatmap-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseFigureObjectHeatmap'], (Widget) => {
     describe('Test the kbaseFigureObjectHeatmap widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseFigureObjectHeatmap-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseFigureObjectHeatmap-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseFigureObjectHeatmap'
-], function(Widget) {
-    describe('Test the kbaseFigureObjectHeatmap widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseFigureObjectHeatmap'], (Widget) => {
+    describe('Test the kbaseFigureObjectHeatmap widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseFigureObjectHeatmap-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseFigureObjectHeatmap-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseFigureObjectHeatmap'], (Widget) => {
-    describe('Test the kbaseFigureObjectHeatmap widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseFigureObjectHeatmap widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbasePValueHistogram-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbasePValueHistogram-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbasePValueHistogram'
-], function(Widget) {
-    describe('Test the kbasePValueHistogram widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbasePValueHistogram'], (Widget) => {
+    describe('Test the kbasePValueHistogram widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbasePValueHistogram-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbasePValueHistogram-spec.js
@@ -1,5 +1,8 @@
 define(['kbasePValueHistogram'], (Widget) => {
-    describe('Test the kbasePValueHistogram widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbasePValueHistogram widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbasePValueHistogram-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbasePValueHistogram-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbasePValueHistogram'], (Widget) => {
     describe('Test the kbasePValueHistogram widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysis-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysis-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseRNASeqAnalysis'], (Widget) => {
-    describe('Test the kbaseRNASeqAnalysis widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseRNASeqAnalysis widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysis-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysis-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseRNASeqAnalysis'
-], function(Widget) {
-    describe('Test the kbaseRNASeqAnalysis widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseRNASeqAnalysis'], (Widget) => {
+    describe('Test the kbaseRNASeqAnalysis widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysis-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysis-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseRNASeqAnalysis'], (Widget) => {
     describe('Test the kbaseRNASeqAnalysis widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysisNew-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysisNew-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseRNASeqAnalysisNew'], (Widget) => {
-    describe('Test the kbaseRNASeqAnalysisNew widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseRNASeqAnalysisNew widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysisNew-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysisNew-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseRNASeqAnalysisNew'], (Widget) => {
     describe('Test the kbaseRNASeqAnalysisNew widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysisNew-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqAnalysisNew-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseRNASeqAnalysisNew'
-], function(Widget) {
-    describe('Test the kbaseRNASeqAnalysisNew widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseRNASeqAnalysisNew'], (Widget) => {
+    describe('Test the kbaseRNASeqAnalysisNew widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqHistogram-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqHistogram-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseRNASeqHistogram'], (Widget) => {
-    describe('Test the kbaseRNASeqHistogram widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseRNASeqHistogram widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqHistogram-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqHistogram-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseRNASeqHistogram'
-], function(Widget) {
-    describe('Test the kbaseRNASeqHistogram widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseRNASeqHistogram'], (Widget) => {
+    describe('Test the kbaseRNASeqHistogram widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqHistogram-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqHistogram-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseRNASeqHistogram'], (Widget) => {
     describe('Test the kbaseRNASeqHistogram widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqSample-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqSample-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseRNASeqSample'], (Widget) => {
     describe('Test the kbaseRNASeqSample widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqSample-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqSample-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseRNASeqSample'
-], function(Widget) {
-    describe('Test the kbaseRNASeqSample widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseRNASeqSample'], (Widget) => {
+    describe('Test the kbaseRNASeqSample widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/function_output/rna-seq/kbaseRNASeqSample-spec.js
+++ b/test/unit/spec/function_output/rna-seq/kbaseRNASeqSample-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseRNASeqSample'], (Widget) => {
-    describe('Test the kbaseRNASeqSample widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseRNASeqSample widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -1,5 +1,3 @@
-/*global describe, it, expect, jasmine, beforeEach, afterEach */
-
 define([
     'jquery',
     'narrativeConfig',

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -1,20 +1,13 @@
 /*global describe, it, expect, jasmine, beforeEach, afterEach */
 
-define ([
+define([
     'jquery',
     'narrativeConfig',
     'kbaseNarrative',
     'base/js/namespace',
     'narrativeLogin',
-    'narrativeMocks'
-], (
-    $,
-    Config,
-    Narrative,
-    Jupyter,
-    NarrativeLogin,
-    Mocks
-) => {
+    'narrativeMocks',
+], ($, Config, Narrative, Jupyter, NarrativeLogin, Mocks) => {
     'use strict';
 
     const DEFAULT_FULLY_LOADED = false,
@@ -24,30 +17,38 @@ define ([
         TEST_USER = 'some_user';
 
     describe('Test the kbaseNarrative module', () => {
-        let loginDiv = $('<div>');
+        const loginDiv = $('<div>');
 
         beforeEach(async () => {
             // we need to be "logged in" for various tests to work, especially initing the Narrative object.
             // this means mocking up some auth responses, and the NarrativeLogin object.
             Mocks.setAuthToken(TEST_TOKEN);
             jasmine.Ajax.install();
-            Mocks.mockAuthRequest('token', {
-                expires: Date.now() + 10 * 60 * 60 * 24 * 1000,
-                created: Date.now(),
-                name: 'some_token',
-                id: 'some_uuid',
-                type: 'Login',
-                user: TEST_USER,
-                cachefor: 500000
-            }, 200);
-            Mocks.mockAuthRequest('me', {
-                display: 'Some User',
-                user: TEST_USER,
-                email: `${TEST_USER}@kbase.us`,
-            }, 200);
+            Mocks.mockAuthRequest(
+                'token',
+                {
+                    expires: Date.now() + 10 * 60 * 60 * 24 * 1000,
+                    created: Date.now(),
+                    name: 'some_token',
+                    id: 'some_uuid',
+                    type: 'Login',
+                    user: TEST_USER,
+                    cachefor: 500000,
+                },
+                200
+            );
+            Mocks.mockAuthRequest(
+                'me',
+                {
+                    display: 'Some User',
+                    user: TEST_USER,
+                    email: `${TEST_USER}@kbase.us`,
+                },
+                200
+            );
             Mocks.mockJsonRpc1Call({
                 url: Config.url('user_profile'),
-                response: [{}]
+                response: [{}],
             });
 
             // mock a jupyter notebook.
@@ -57,33 +58,35 @@ define ([
                 writable: DEFAULT_WRITABLE,
                 keyboard_manager: {
                     edit_shortcuts: {
-                        remove_shortcut: () => {}
+                        remove_shortcut: () => {},
                     },
                     command_shortcuts: {
-                        remove_shortcut: () => {}
-                    }
+                        remove_shortcut: () => {},
+                    },
                 },
                 kernel: {
                     is_connected: () => false,
                     comm_info: (comm_name, callback) => {
-                        callback({content: {
-                            comms: {
-                                'some_comm_id': {
-                                    target_name: 'KBaseJobs'
-                                }
-                            }
-                        }});
+                        callback({
+                            content: {
+                                comms: {
+                                    some_comm_id: {
+                                        target_name: 'KBaseJobs',
+                                    },
+                                },
+                            },
+                        });
                     },
                     comm_manager: {
-                        register_comm: () => {}
+                        register_comm: () => {},
                     },
                     execute: (code, callbacks) => {
                         callbacks.shell.reply({
-                            content: {}
+                            content: {},
                         });
-                    }
+                    },
                 },
-                notebook_name: DEFAULT_NOTEBOOK_NAME
+                notebook_name: DEFAULT_NOTEBOOK_NAME,
             };
             Jupyter.keyboard_manager = Jupyter.notebook.keyboard_manager;
 
@@ -110,8 +113,7 @@ define ([
                 const jobsReadyCallback = (err) => {
                     if (err) {
                         reject('This should not have failed', err);
-                    }
-                    else {
+                    } else {
                         resolve();
                     }
                 };
@@ -129,8 +131,7 @@ define ([
                 const jobsReadyCallback = (err) => {
                     if (err) {
                         resolve();
-                    }
-                    else {
+                    } else {
                         reject('expected an error');
                     }
                 };
@@ -159,6 +160,5 @@ define ([
             const narr = new Narrative();
             expect(narr.getAuthToken()).toBe(TEST_TOKEN);
         });
-
     });
 });

--- a/test/unit/spec/kbaseVisWidget-spec.js
+++ b/test/unit/spec/kbaseVisWidget-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseVisWidget'
-], function(Widget) {
-    describe('Test the kbaseVisWidget widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseVisWidget'], (Widget) => {
+    describe('Test the kbaseVisWidget widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/kbaseVisWidget-spec.js
+++ b/test/unit/spec/kbaseVisWidget-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseVisWidget'], (Widget) => {
     describe('Test the kbaseVisWidget widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/kbaseVisWidget-spec.js
+++ b/test/unit/spec/kbaseVisWidget-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseVisWidget'], (Widget) => {
-    describe('Test the kbaseVisWidget widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseVisWidget widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/loadingWidgetSpec.js
+++ b/test/unit/spec/loadingWidgetSpec.js
@@ -4,56 +4,52 @@
 /*global beforeEach, afterEach, spyOn*/
 /*jslint white: true*/
 
-define ([
-    'jquery',
-    'widgets/loadingWidget'
-], function(
-    $,
-    LoadingWidget
-) {
+define(['jquery', 'widgets/loadingWidget'], ($, LoadingWidget) => {
     'use strict';
 
-    describe('Test the LoadingWidget module', function() {
-        var dummyNode, dummyNode2, widget;
+    describe('Test the LoadingWidget module', () => {
+        let dummyNode, dummyNode2, widget;
 
-        beforeEach(function () {
+        beforeEach(() => {
             dummyNode = document.createElement('div');
             dummyNode2 = document.createElement('div');
             dummyNode.querySelector = jasmine.createSpy('HTML Element').and.returnValue(dummyNode2);
-            dummyNode2.querySelector = jasmine.createSpy('HTML Element').and.returnValue(dummyNode2);
-            widget = new LoadingWidget({node: dummyNode});
+            dummyNode2.querySelector = jasmine
+                .createSpy('HTML Element')
+                .and.returnValue(dummyNode2);
+            widget = new LoadingWidget({ node: dummyNode });
         });
 
-        afterEach(function () {
+        afterEach(() => {
             widget.remove();
         });
 
-        it('Should instantiate with a null node', function() {
-            var widget = new LoadingWidget({node: null});
+        it('Should instantiate with a null node', () => {
+            const widget = new LoadingWidget({ node: null });
             expect(widget).not.toBeNull();
         });
 
-        it('Should be able to update its progress', function () {
+        it('Should be able to update its progress', () => {
             widget.updateProgress('data', true);
         });
 
-        it('Should be able to remove its container node', function () {
+        it('Should be able to remove its container node', () => {
             spyOn(LoadingWidget.prototype, 'remove');
             widget = new LoadingWidget({ node: dummyNode });
-            ['data', 'narrative', 'jobs', 'apps', 'kernel'].forEach(function(name) {
+            ['data', 'narrative', 'jobs', 'apps', 'kernel'].forEach((name) => {
                 widget.updateProgress(name, true);
             });
             expect(widget.remove).toHaveBeenCalled();
         });
 
-        it('Should not show the loading warning when first starting', function () {
+        it('Should not show the loading warning when first starting', () => {
             expect($($(dummyNode).find('.loading-warning')[0]).is(':visible')).toBeFalsy();
         });
 
-        it('Should show the loading warning after a timeout', function (done) {
+        it('Should show the loading warning after a timeout', (done) => {
             spyOn(LoadingWidget.prototype, 'showTimeoutWarning');
-            widget = new LoadingWidget({node: dummyNode, timeout: 1});
-            setTimeout(function () {
+            widget = new LoadingWidget({ node: dummyNode, timeout: 1 });
+            setTimeout(() => {
                 expect(widget.showTimeoutWarning).toHaveBeenCalled();
                 done();
             }, 100);

--- a/test/unit/spec/loadingWidgetSpec.js
+++ b/test/unit/spec/loadingWidgetSpec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach, spyOn*/
-/*jslint white: true*/
-
 define(['jquery', 'widgets/loadingWidget'], ($, LoadingWidget) => {
     'use strict';
 

--- a/test/unit/spec/narrativeConfigSpec.js
+++ b/test/unit/spec/narrativeConfigSpec.js
@@ -1,51 +1,45 @@
 /*eslint-env jasmine*/
-define ([
-    'narrativeConfig'
-], function(
-    Config
-) {
+define(['narrativeConfig'], (Config) => {
     'use strict';
-    describe('Tests for narrativeConfig', function() {
-        it('loaded the config module', function() {
+    describe('Tests for narrativeConfig', () => {
+        it('loaded the config module', () => {
             expect(Config).not.toBe.null;
         });
 
-        it('has a config object', function() {
+        it('has a config object', () => {
             expect(Config.config).not.toBe.null;
         });
 
-        it('has a valid workspace url', function() {
+        it('has a valid workspace url', () => {
             expect(Config.config.urls.workspace).toMatch(/https:\/\/.*kbase\.us\/services\/ws/);
         });
 
-        it('tries to update paths from ui-common and gets data source config', function() {
-            return Config.updateConfig()
-                .then(function(config) {
-                    expect(config).toBeDefined();
-                });
+        it('tries to update paths from ui-common and gets data source config', () => {
+            return Config.updateConfig().then((config) => {
+                expect(config).toBeDefined();
+            });
         });
 
-        it('updates paths and sees data sources for example data', function() {
-            return Config.updateConfig()
-                .then(function(config) {
-                    expect(config.exampleData).toBeDefined();
-                });
+        it('updates paths and sees data sources for example data', () => {
+            return Config.updateConfig().then((config) => {
+                expect(config.exampleData).toBeDefined();
+            });
         });
 
-        it('can use the url method to fetch a url', function() {
+        it('can use the url method to fetch a url', () => {
             expect(Config.url('workspace')).toMatch(/https:\/\/.*kbase\.us\/services\/ws/);
         });
 
-        it('can use the get method to fetch tooltip info', function() {
+        it('can use the get method to fetch tooltip info', () => {
             expect(Config.get('tooltip').showDelay).toEqual(jasmine.any(Number));
         });
 
-        it('should return undefined for an unknown configuration key', function() {
+        it('should return undefined for an unknown configuration key', () => {
             expect(Config.get('gleeblegorf')).toBeUndefined();
         });
 
-        it('can use the get method to see what features should be enabled or not', function() {
-            var features = Config.get('features');
+        it('can use the get method to see what features should be enabled or not', () => {
+            const features = Config.get('features');
             expect(features).toEqual(jasmine.any(Object));
             expect(features.stagingDataViewer).toBeDefined();
         });

--- a/test/unit/spec/narrativeConfigSpec.js
+++ b/test/unit/spec/narrativeConfigSpec.js
@@ -1,13 +1,12 @@
-/*eslint-env jasmine*/
 define(['narrativeConfig'], (Config) => {
     'use strict';
     describe('Tests for narrativeConfig', () => {
         it('loaded the config module', () => {
-            expect(Config).not.toBe.null;
+            expect(Config).not.toBeNull();
         });
 
         it('has a config object', () => {
-            expect(Config.config).not.toBe.null;
+            expect(Config.config).not.toBeNull();
         });
 
         it('has a valid workspace url', () => {

--- a/test/unit/spec/narrativeLoginSpec.js
+++ b/test/unit/spec/narrativeLoginSpec.js
@@ -1,10 +1,5 @@
 /* global describe, it, expect, jasmine, beforeEach, afterEach */
-define ([
-    'jquery',
-    'narrativeLogin',
-    'narrativeConfig',
-    'narrativeMocks'
-], (
+define(['jquery', 'narrativeLogin', 'narrativeConfig', 'narrativeMocks'], (
     $,
     Login,
     Config,
@@ -27,7 +22,7 @@ define ([
 
         it('Should instantiate and have expected functions', () => {
             expect(Login).toBeDefined();
-            ['init', 'sessionInfo', 'getAuthToken', 'clearTokenCheckTimers'].forEach(item => {
+            ['init', 'sessionInfo', 'getAuthToken', 'clearTokenCheckTimers'].forEach((item) => {
                 expect(Login[item]).toBeDefined();
             });
         });
@@ -43,7 +38,7 @@ define ([
                     id: 'some_uuid',
                     type: 'Login',
                     user: 'some_user',
-                    cachefor: 500000
+                    cachefor: 500000,
                 },
                 profileInfo = {
                     created: Date.now() - 10000,
@@ -54,8 +49,7 @@ define ([
                     user: fakeUser,
                     local: false,
                     email: `${fakeName}@kbase.us`,
-                    idents: []
-
+                    idents: [],
                 };
             // these should capture the happy path calls that Login.init should make
             // copying some boilerplate from specs/api/authSpec
@@ -66,9 +60,9 @@ define ([
             // required here.
             Mocks.mockJsonRpc1Call({
                 url: Config.url('user_profile'),
-                response: [{}]
+                response: [{}],
             });
-            return Login.init($node, true)  // true here means there's no kernel
+            return Login.init($node, true) // true here means there's no kernel
                 .finally(() => {
                     const request = jasmine.Ajax.requests.mostRecent();
                     expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
@@ -83,9 +77,9 @@ define ([
 
         it('Should throw an error when instantiating with a bad token', () => {
             const $node = $('<div>');
-            Mocks.mockAuthRequest('token', {error: {}}, 401);
-            Mocks.mockAuthRequest('me', {error: {}}, 401);
-            return Login.init($node, true)  // true here means there's no kernel
+            Mocks.mockAuthRequest('token', { error: {} }, 401);
+            Mocks.mockAuthRequest('me', { error: {} }, 401);
+            return Login.init($node, true) // true here means there's no kernel
                 .then(() => {
                     const request = jasmine.Ajax.requests.mostRecent();
                     expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);

--- a/test/unit/spec/narrativeLoginSpec.js
+++ b/test/unit/spec/narrativeLoginSpec.js
@@ -1,4 +1,3 @@
-/* global describe, it, expect, jasmine, beforeEach, afterEach */
 define(['jquery', 'narrativeLogin', 'narrativeConfig', 'narrativeMocks'], (
     $,
     Login,

--- a/test/unit/spec/narrative_core/ipythonCellMenu-spec.js
+++ b/test/unit/spec/narrative_core/ipythonCellMenu-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'ipythonCellMenu'
-], function(Widget) {
-    describe('Test the ipythonCellMenu widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['ipythonCellMenu'], (Widget) => {
+    describe('Test the ipythonCellMenu widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/ipythonCellMenu-spec.js
+++ b/test/unit/spec/narrative_core/ipythonCellMenu-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['ipythonCellMenu'], (Widget) => {
     describe('Test the ipythonCellMenu widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/ipythonCellMenu-spec.js
+++ b/test/unit/spec/narrative_core/ipythonCellMenu-spec.js
@@ -1,5 +1,8 @@
 define(['ipythonCellMenu'], (Widget) => {
-    describe('Test the ipythonCellMenu widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The ipythonCellMenu widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/jobCommChannel-spec.js
+++ b/test/unit/spec/narrative_core/jobCommChannel-spec.js
@@ -3,11 +3,7 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'jobCommChannel',
-    'base/js/namespace',
-    'common/runtime'
-], (
+define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
     JobCommChannel,
     Jupyter,
     Runtime
@@ -17,13 +13,13 @@ define([
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     const DEFAULT_COMM_INFO = {
         content: {
-            comms: []
-        }
+            comms: [],
+        },
     };
     const DEFAULT_COMM = {
-        on_msg: () => { },
-        send: () => { },
-        send_shell_message: () => { }
+        on_msg: () => {},
+        send: () => {},
+        send_shell_message: () => {},
     };
 
     /**
@@ -45,21 +41,23 @@ define([
      * @param {function} cb
      */
     function channelChecker(channelName, channelId, channelKey, cb, msgCmp) {
-        let channel = {};
+        const channel = {};
         channel[channelName] = channelId;
 
-        Runtime.make().bus().listen({
-            channel,
-            key: {
-                type: channelKey
-            },
-            handle: (msg) => {
-                if (msgCmp) {
-                    expect(msg).toEqual(msgCmp);
-                }
-                cb(msg);
-            }
-        });
+        Runtime.make()
+            .bus()
+            .listen({
+                channel,
+                key: {
+                    type: channelKey,
+                },
+                handle: (msg) => {
+                    if (msgCmp) {
+                        expect(msg).toEqual(msgCmp);
+                    }
+                    cb(msg);
+                },
+            });
     }
 
     function makeMockNotebook(commInfoReturn, registerTargetReturn, executeReply) {
@@ -67,15 +65,17 @@ define([
         registerTargetReturn = registerTargetReturn || DEFAULT_COMM;
         executeReply = executeReply || {};
         return {
-            save_checkpoint: () => { /* no op */ },
+            save_checkpoint: () => {
+                /* no op */
+            },
             kernel: {
                 comm_info: (name, cb) => cb(commInfoReturn),
-                execute: (code, cb) => cb.shell.reply({content: executeReply}),
+                execute: (code, cb) => cb.shell.reply({ content: executeReply }),
                 comm_manager: {
                     register_comm: () => {},
-                    register_target: (name, cb) => cb(registerTargetReturn, {})
-                }
-            }
+                    register_target: (name, cb) => cb(registerTargetReturn, {}),
+                },
+            },
         };
     }
 
@@ -84,9 +84,9 @@ define([
             content: {
                 data: {
                     msg_type: msgType,
-                    content: content
-                }
-            }
+                    content: content,
+                },
+            },
         };
     }
 
@@ -107,13 +107,13 @@ define([
         });
 
         it('Should be instantiable and contain the right components', () => {
-            let comm = new JobCommChannel();
+            const comm = new JobCommChannel();
             expect(comm.initCommChannel).toBeDefined();
             expect(comm.jobStates).toEqual({});
         });
 
         it('Should initialize correctly in the base case', (done, fail) => {
-            let comm = new JobCommChannel();
+            const comm = new JobCommChannel();
             comm.initCommChannel()
                 .then(done)
                 .catch((err) => {
@@ -123,15 +123,15 @@ define([
         });
 
         it('Should re-initialize with an existing channel', (done, fail) => {
-            let comm = new JobCommChannel();
+            const comm = new JobCommChannel();
             Jupyter.notebook = makeMockNotebook({
                 content: {
                     comms: {
-                        '12345': {
-                            target_name: 'KBaseJobs'
-                        }
-                    }
-                }
+                        12345: {
+                            target_name: 'KBaseJobs',
+                        },
+                    },
+                },
             });
             comm.initCommChannel()
                 .then(() => {
@@ -145,11 +145,11 @@ define([
         });
 
         it('Should fail to initialize with a failed reply from the JobManager startup', (done, fail) => {
-            let comm = new JobCommChannel();
+            const comm = new JobCommChannel();
             Jupyter.notebook = makeMockNotebook(null, null, {
                 name: 'Failed to start',
                 evalue: 'Some error',
-                error: 'Yes. Very yes.'
+                error: 'Yes. Very yes.',
             });
             comm.initCommChannel()
                 .then(() => {
@@ -162,25 +162,25 @@ define([
                 });
         });
 
-        let busMsgCases = [
-            ['ping-comm-channel', {pingId: 'ping!'}],
-            ['request-job-cancellation', {jobId: 'someJob'}],
-            ['request-job-status', {jobId: 'someJob', parentJobId: 'someParent'}],
-            ['request-job-update', {jobId: 'someJob', parentJobId: 'someParent'}],
-            ['request-job-completion', {jobId: 'someJob'}],
-            ['request-job-log', {jobId: 'someJob', options: {}}],
-            ['request-latest-job-log', {jobId: 'someJob', options: {}}],
-            ['request-job-info', {jobId: 'someJob', parentJobId: 'someParent'}]
+        const busMsgCases = [
+            ['ping-comm-channel', { pingId: 'ping!' }],
+            ['request-job-cancellation', { jobId: 'someJob' }],
+            ['request-job-status', { jobId: 'someJob', parentJobId: 'someParent' }],
+            ['request-job-update', { jobId: 'someJob', parentJobId: 'someParent' }],
+            ['request-job-completion', { jobId: 'someJob' }],
+            ['request-job-log', { jobId: 'someJob', options: {} }],
+            ['request-latest-job-log', { jobId: 'someJob', options: {} }],
+            ['request-job-info', { jobId: 'someJob', parentJobId: 'someParent' }],
         ];
-        busMsgCases.forEach(function (testCase) {
+        busMsgCases.forEach((testCase) => {
             it('Should handle ' + testCase[0] + ' bus message', (done) => {
-                let comm = new JobCommChannel();
+                const comm = new JobCommChannel();
                 comm.initCommChannel()
                     .then(() => {
                         expect(comm.comm).not.toBeNull();
                         spyOn(comm.comm, 'send');
                         runtime.bus().emit(testCase[0], testCase[1]);
-                        return new Promise(resolve => setTimeout(resolve, 100));
+                        return new Promise((resolve) => setTimeout(resolve, 100));
                     })
                     .then(() => {
                         expect(comm.comm.send).toHaveBeenCalled();
@@ -190,8 +190,8 @@ define([
         });
 
         it('Should error properly when trying to send a comm with an uninited channel', (done) => {
-            let comm = new JobCommChannel();
-            let prom = comm.sendCommMessage('some_msg', 'foo', {});
+            const comm = new JobCommChannel();
+            const prom = comm.sendCommMessage('some_msg', 'foo', {});
             prom.then(() => {
                 fail('This should have failed');
             }).catch((err) => {
@@ -204,242 +204,234 @@ define([
          * calling the handleCommMessage function directly.
          */
         it('Should handle a start message', (done) => {
-            let comm = new JobCommChannel();
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(makeCommMsg('start', {}));
-                    done();
-                });
+            const comm = new JobCommChannel();
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(makeCommMsg('start', {}));
+                done();
+            });
         });
 
         it('Should respond to new_job by saving the Narrative', (done) => {
-            let comm = new JobCommChannel();
+            const comm = new JobCommChannel();
             spyOn(Jupyter.notebook, 'save_checkpoint');
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(makeCommMsg('new_job', {}));
-                    expect(Jupyter.notebook.save_checkpoint).toHaveBeenCalled();
-                    done();
-                });
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(makeCommMsg('new_job', {}));
+                expect(Jupyter.notebook.save_checkpoint).toHaveBeenCalled();
+                done();
+            });
         });
 
         it('Should send job_status messages to the bus', (done) => {
             const jobId = 'someJob',
-            msg = makeCommMsg('job_status', {
-                state: {
-                    job_id: jobId
-                },
-                spec: {},
-                widget_info: {}
-            }),
-            busMsg = {
-                jobId: jobId,
-                jobState: {
-                    job_id: jobId
-                },
-                outputWidgetInfo: {}
-            };
+                msg = makeCommMsg('job_status', {
+                    state: {
+                        job_id: jobId,
+                    },
+                    spec: {},
+                    widget_info: {},
+                }),
+                busMsg = {
+                    jobId: jobId,
+                    jobState: {
+                        job_id: jobId,
+                    },
+                    outputWidgetInfo: {},
+                };
 
-            let comm = new JobCommChannel();
+            const comm = new JobCommChannel();
 
             channelChecker('jobId', jobId, 'job-status', done, busMsg);
 
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should send a set of job statuses to the bus, and delete extras', (done) => {
             let caughtMsgs = 0,
                 msg = makeCommMsg('job_status_all', {
-                'id1': {
-                    state: {
-                        job_id: 'id1'
-                    }
-                },
-                'id2': {
-                    state: {
-                        job_id: 'id2'
-                    }
-                }
-            });
-            let comm = new JobCommChannel();
-            comm.jobStates['deletedJob'] = {state: {job_id: 'deletedJob'}};
+                    id1: {
+                        state: {
+                            job_id: 'id1',
+                        },
+                    },
+                    id2: {
+                        state: {
+                            job_id: 'id2',
+                        },
+                    },
+                });
+            const comm = new JobCommChannel();
+            comm.jobStates['deletedJob'] = { state: { job_id: 'deletedJob' } };
             const msgCounter = () => {
                 caughtMsgs++;
                 if (caughtMsgs === 3) {
                     done();
                 }
-            }
+            };
 
             ['id1', 'id2'].forEach((jobId) => {
                 channelChecker('jobId', jobId, 'job-status', msgCounter, {
                     jobId: jobId,
                     jobState: {
-                        job_id: jobId
-                    }
+                        job_id: jobId,
+                    },
                 });
-
             });
             channelChecker('jobId', 'deletedJob', 'job-deleted', msgCounter, {
                 jobId: 'deletedJob',
-                via: 'no_longer_exists'
+                via: 'no_longer_exists',
             });
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should send a job-info message to the bus', (done) => {
-            let jobId = 'foo',
+            const jobId = 'foo',
                 msg = makeCommMsg('job_info', {
                     job_id: jobId,
                     state: {
-                        job_id: jobId
-                    }
+                        job_id: jobId,
+                    },
                 });
 
             channelChecker('jobId', jobId, 'job-info', done, {
                 jobId: jobId,
-                jobInfo: msg.content.data.content
+                jobInfo: msg.content.data.content,
             });
-            let comm = new JobCommChannel();
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            const comm = new JobCommChannel();
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should send a run_status message to the bus', (done) => {
-            let jobId = 'foo',
+            const jobId = 'foo',
                 cellId = 'bar',
                 msg = makeCommMsg('run_status', {
                     cell_id: cellId,
                     job_id: jobId,
                 });
             channelChecker('cell', cellId, 'run-status', done, msg.content.data.content);
-            let comm = new JobCommChannel();
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            const comm = new JobCommChannel();
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should send job_canceled message to the bus', (done) => {
-            let jobId = 'foo-canceled',
+            const jobId = 'foo-canceled',
                 msg = makeCommMsg('job_canceled', {
                     job_id: jobId,
                 });
-                channelChecker('jobId', jobId, 'job-canceled', done, {
-                    jobId: jobId, via: 'job_canceled'
-                });
-            let comm = new JobCommChannel();
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            channelChecker('jobId', jobId, 'job-canceled', done, {
+                jobId: jobId,
+                via: 'job_canceled',
+            });
+            const comm = new JobCommChannel();
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should send job_does_not_exist messages to the bus', (done) => {
-            let jobId = 'foo-dne',
+            const jobId = 'foo-dne',
                 msg = makeCommMsg('job_does_not_exist', {
                     job_id: jobId,
-                    source: 'someSource'
+                    source: 'someSource',
                 }),
                 comm = new JobCommChannel();
             channelChecker('jobId', jobId, 'job-does-not-exist', done, {
-                jobId: jobId, source: 'someSource'
+                jobId: jobId,
+                source: 'someSource',
             });
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should send job_logs to the bus', (done) => {
-            let jobId = 'foo-logs',
+            const jobId = 'foo-logs',
                 msg = makeCommMsg('job_logs', {
                     job_id: jobId,
                     latest: true,
-                    logs: [{}]
+                    logs: [{}],
                 }),
                 comm = new JobCommChannel();
             channelChecker('jobId', jobId, 'job-logs', done, {
                 jobId: jobId,
                 logs: msg.content.data.content,
-                latest: msg.content.data.content.latest
+                latest: msg.content.data.content.latest,
             });
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         const errCases = {
-            'cancel_job': 'job-cancel-error',
-            'job_logs': 'job-log-deleted',
-            'job_logs_latest': 'job-log-deleted',
-            'job_status': 'job-status-error',
+            cancel_job: 'job-cancel-error',
+            job_logs: 'job-log-deleted',
+            job_logs_latest: 'job-log-deleted',
+            job_status: 'job-status-error',
         };
 
         Object.keys(errCases).forEach((errCase) => {
             it('Should handle job_comm_error of type ' + errCase, (done) => {
-                let jobId = 'job-' + errCase,
+                const jobId = 'job-' + errCase,
                     errMsg = errCase + ' error happened!',
                     msg = makeCommMsg('job_comm_error', {
                         source: errCase,
                         job_id: jobId,
-                        message: errMsg
+                        message: errMsg,
                     }),
                     comm = new JobCommChannel();
                 channelChecker('jobId', jobId, errCases[errCase], done, {
                     jobId: jobId,
-                    message: errMsg
+                    message: errMsg,
                 });
-                comm.initCommChannel()
-                    .then(() => {
-                        comm.handleCommMessages(msg)
-                    });
+                comm.initCommChannel().then(() => {
+                    comm.handleCommMessages(msg);
+                });
             });
         });
 
         it('Handle unknown job errors generically', (done) => {
-            let jobId = 'jobWithErrors',
+            const jobId = 'jobWithErrors',
                 errMsg = 'some random error',
                 requestType = 'some-error',
                 msg = makeCommMsg('job_comm_error', {
                     source: requestType,
                     job_id: jobId,
-                    message: errMsg
+                    message: errMsg,
                 }),
                 comm = new JobCommChannel();
             channelChecker('jobId', jobId, 'job-error', done, {
                 jobId: jobId,
                 message: errMsg,
-                request: requestType
+                request: requestType,
             });
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should handle job_init_err and job_init_lookup_err', (done) => {
             let count = 0;
             ['job_init_err', 'job_init_lookup_err'].forEach((errType) => {
-                let msg = makeCommMsg(errType, {
-                    service: 'job service',
-                    error: 'An error happened!',
-                    name: 'Error',
-                    source: 'jobmanager'
-                }),
+                const msg = makeCommMsg(errType, {
+                        service: 'job service',
+                        error: 'An error happened!',
+                        name: 'Error',
+                        source: 'jobmanager',
+                    }),
                     comm = new JobCommChannel();
                 comm.initCommChannel()
                     .then(() => {
                         comm.handleCommMessages(msg);
-                        return new Promise((resolve) => { setInterval(resolve, 1000) });
+                        return new Promise((resolve) => {
+                            setInterval(resolve, 1000);
+                        });
                     })
                     .then(() => {
                         expect(document.querySelector('#kb-job-err-report')).not.toBeNull();
@@ -452,31 +444,29 @@ define([
         });
 
         it('Should send a result message to the bus', (done) => {
-            let cellId = 'someCellId',
+            const cellId = 'someCellId',
                 msg = makeCommMsg('result', {
                     address: {
-                        cell_id: cellId
+                        cell_id: cellId,
                     },
-                    result: [1]
+                    result: [1],
                 }),
                 comm = new JobCommChannel();
             channelChecker('cell', cellId, 'result', done, msg.content.data.content);
-            comm.initCommChannel()
-                .then(() => {
-                    comm.handleCommMessages(msg);
-                });
+            comm.initCommChannel().then(() => {
+                comm.handleCommMessages(msg);
+            });
         });
 
         it('Should handle unknown messages with console warnings', (done) => {
-            let comm = new JobCommChannel(),
-                msg = makeCommMsg('unknown_weird_msg', {})
-            comm.initCommChannel()
-                .then(() => {
-                    spyOn(console, 'warn');
-                    comm.handleCommMessages(msg);
-                    expect(console.warn).toHaveBeenCalled();
-                    done();
-                });
+            const comm = new JobCommChannel(),
+                msg = makeCommMsg('unknown_weird_msg', {});
+            comm.initCommChannel().then(() => {
+                spyOn(console, 'warn');
+                comm.handleCommMessages(msg);
+                expect(console.warn).toHaveBeenCalled();
+                done();
+            });
         });
     });
 });

--- a/test/unit/spec/narrative_core/jobCommChannel-spec.js
+++ b/test/unit/spec/narrative_core/jobCommChannel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
     JobCommChannel,
     Jupyter,
@@ -41,8 +36,9 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
      * @param {function} cb
      */
     function channelChecker(channelName, channelId, channelKey, cb, msgCmp) {
-        const channel = {};
-        channel[channelName] = channelId;
+        const channel = {
+            channelName: channelId,
+        };
 
         Runtime.make()
             .bus()
@@ -90,7 +86,7 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
         };
     }
 
-    describe('Test the jobCommChannel widget', () => {
+    describe('The jobCommChannel widget', () => {
         let runtime;
 
         beforeEach(() => {
@@ -112,17 +108,16 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
             expect(comm.jobStates).toEqual({});
         });
 
-        it('Should initialize correctly in the base case', (done, fail) => {
+        it('Should initialize correctly in the base case', (done) => {
             const comm = new JobCommChannel();
             comm.initCommChannel()
                 .then(done)
                 .catch((err) => {
-                    console.error(err);
-                    fail();
+                    fail(err);
                 });
         });
 
-        it('Should re-initialize with an existing channel', (done, fail) => {
+        it('Should re-initialize with an existing channel', (done) => {
             const comm = new JobCommChannel();
             Jupyter.notebook = makeMockNotebook({
                 content: {
@@ -139,12 +134,11 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                     done();
                 })
                 .catch((err) => {
-                    console.error(err);
-                    fail();
+                    fail(err);
                 });
         });
 
-        it('Should fail to initialize with a failed reply from the JobManager startup', (done, fail) => {
+        it('Should fail to initialize with a failed reply from the JobManager startup', (done) => {
             const comm = new JobCommChannel();
             Jupyter.notebook = makeMockNotebook(null, null, {
                 name: 'Failed to start',
@@ -248,8 +242,8 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
         });
 
         it('Should send a set of job statuses to the bus, and delete extras', (done) => {
-            let caughtMsgs = 0,
-                msg = makeCommMsg('job_status_all', {
+            let caughtMsgs = 0;
+            const msg = makeCommMsg('job_status_all', {
                     id1: {
                         state: {
                             job_id: 'id1',

--- a/test/unit/spec/narrative_core/kbaseAppCard-spec.js
+++ b/test/unit/spec/narrative_core/kbaseAppCard-spec.js
@@ -3,8 +3,9 @@ define(['jquery', 'base/js/namespace', 'kbase/js/widgets/narrative_core/kbaseApp
     Jupyter,
     AppCard
 ) => {
+    'use strict';
     let app, $card;
-    describe('Test the kbaseAppCard widget', () => {
+    describe('The kbaseAppCard widget', () => {
         beforeEach(() => {
             app = {
                 info: {

--- a/test/unit/spec/narrative_core/kbaseAppCard-spec.js
+++ b/test/unit/spec/narrative_core/kbaseAppCard-spec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['jquery', 'base/js/namespace', 'kbase/js/widgets/narrative_core/kbaseAppCard'], (
     $,
     Jupyter,

--- a/test/unit/spec/narrative_core/kbaseAppCard-spec.js
+++ b/test/unit/spec/narrative_core/kbaseAppCard-spec.js
@@ -4,60 +4,60 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-
-define([
-    'jquery',
-    'base/js/namespace',
-    'kbase/js/widgets/narrative_core/kbaseAppCard'
-], function ($, Jupyter, AppCard) {
-    var app, $card;
-    describe('Test the kbaseAppCard widget', function() {
-        beforeEach(function () {
+define(['jquery', 'base/js/namespace', 'kbase/js/widgets/narrative_core/kbaseAppCard'], (
+    $,
+    Jupyter,
+    AppCard
+) => {
+    let app, $card;
+    describe('Test the kbaseAppCard widget', () => {
+        beforeEach(() => {
             app = {
                 info: {
                     id: 'modle/descript',
                     git_commit_hash: '',
-                    icon:{ url: "img?method_id=ProkkaAnnotation/annotate_contigs&image_name=prokka.png&tag=release" },
-                    authors:["rsutormin"],
+                    icon: {
+                        url:
+                            'img?method_id=ProkkaAnnotation/annotate_contigs&image_name=prokka.png&tag=release',
+                    },
+                    authors: ['rsutormin'],
                     app_type: 'app',
                     categories: ['annotation'],
                     name: 'Title',
                     namespace: 'type',
-                    ver: '134.34'
+                    ver: '134.34',
                 },
-                favorite: 124
+                favorite: 124,
             };
             $card = AppCard({
                 app: app,
-                favorite: '123'
+                favorite: '123',
             });
         });
-        it('Should initalize properly', function(done) {
+        it('Should initalize properly', (done) => {
             expect($card instanceof $).toEqual(true);
             done();
         });
-        it('Should use name as Title', function(done) {
-            var $title = $card.find('.kb-data-list-name');
+        it('Should use name as Title', (done) => {
+            const $title = $card.find('.kb-data-list-name');
             expect($title.html()).toEqual(app.info.name);
             done();
         });
 
-        it('Should parse Type', function() {
-            var $type = $card.find('.kb-data-list-type');
+        it('Should parse Type', () => {
+            const $type = $card.find('.kb-data-list-type');
             expect($type.html()).toContain(app.info.ver);
         });
-        it('Should not mutate moreContent passed in', function() {
-            var $moreContent = $('<div>').text('More Content').addClass('test-more-content');
+        it('Should not mutate moreContent passed in', () => {
+            const $moreContent = $('<div>').text('More Content').addClass('test-more-content');
 
-            var $card2 = AppCard({
+            const $card2 = AppCard({
                 app: app,
                 favorite: '123',
                 moreContent: $moreContent,
             });
-            var content = $card2.find('.narrative-card-row-more').children()[0];
+            const content = $card2.find('.narrative-card-row-more').children()[0];
             expect($moreContent.is($(content))).toEqual(true);
         });
-        
-
     });
 });

--- a/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
@@ -1,19 +1,11 @@
 /*global describe, it, expect, beforeAll */
 /*jslint white: true*/
-define([
-    'jquery',
-    'kbaseCellToolbarMenu',
-    'base/js/namespace'
-], function (
-    $,
-    Widget,
-    Jupyter
-) {
+define(['jquery', 'kbaseCellToolbarMenu', 'base/js/namespace'], ($, Widget, Jupyter) => {
     'use strict';
-    describe('Test the kbaseCellToolbarMenu widget', function () {
+    describe('Test the kbaseCellToolbarMenu widget', () => {
         beforeAll(() => {
             Jupyter.narrative = {
-                readonly: false
+                readonly: false,
             };
         });
 
@@ -21,7 +13,7 @@ define([
             const messageContainer = document.createElement('div');
             const currentState = {
                 mode: mode,
-                stage: stage
+                stage: stage,
             };
             const fsm = {
                 currentState: currentState,
@@ -32,14 +24,14 @@ define([
                 metadata: {
                     kbase: {
                         appCell: {
-                            fsm: fsm
+                            fsm: fsm,
                         },
                         cellState: {
-                            toggleMinMax: collapsedState
+                            toggleMinMax: collapsedState,
                         },
-                        type: 'app'
-                    }
-                }
+                        type: 'app',
+                    },
+                },
             };
         };
 
@@ -48,30 +40,30 @@ define([
             const parentCell = mockParentCell(mode, stage, collapsedState);
             const toolbarDiv = document.createElement('div');
             instance.register_callback([toolbarDiv], parentCell);
-            return toolbarDiv.querySelectorAll(
-                'div.title div:nth-child(3)'
-            )[0].innerText;
+            return toolbarDiv.querySelectorAll('div.title div:nth-child(3)')[0].innerText;
         };
-
 
         const mockToolbarDataTestNodes = (mode, stage, collapsedState) => {
             const instance = Widget.make();
             const parentCell = mockParentCell(mode, stage, collapsedState);
             const toolbarDiv = document.createElement('div');
             instance.register_callback([toolbarDiv], parentCell);
-            return toolbarDiv.querySelectorAll(
-                '[data-test]'
-            );
+            return toolbarDiv.querySelectorAll('[data-test]');
         };
 
         // This test might better be served through Snapshot Testing
         // This test might want to check to see if each buttton has the correct fa-* class
-        it('Should render the correct app cell buttons in the correct order', function () {
-            var testToolBar = mockToolbarDataTestNodes('success', '', 'maximized');
-            var expectedButtonOrder = ['cell-dropdown', 'cell-move-up', 'cell-move-down', 'cell-toggle-expansion'];
-            var extractedButtons = [];
-            testToolBar.forEach(function (element) {
-                var attribute = element.getAttribute('data-test');
+        it('Should render the correct app cell buttons in the correct order', () => {
+            const testToolBar = mockToolbarDataTestNodes('success', '', 'maximized');
+            const expectedButtonOrder = [
+                'cell-dropdown',
+                'cell-move-up',
+                'cell-move-down',
+                'cell-toggle-expansion',
+            ];
+            const extractedButtons = [];
+            testToolBar.forEach((element) => {
+                const attribute = element.getAttribute('data-test');
                 if (expectedButtonOrder.includes(attribute)) {
                     extractedButtons.push(attribute);
                 }
@@ -80,53 +72,36 @@ define([
             expect(extractedButtons).toEqual(expectedButtonOrder);
         });
 
-
-        it('Should say Error when minimized and mode is error', function () {
-            expect(
-                mockToolbar('error', '', 'minimized')
-            ).toBe('Error');
+        it('Should say Error when minimized and mode is error', () => {
+            expect(mockToolbar('error', '', 'minimized')).toBe('Error');
         });
 
-        it('Should say Error when minimized and mode is internal-error', function () {
-            expect(
-                mockToolbar('internal-error', '', 'minimized')
-            ).toBe('Error');
+        it('Should say Error when minimized and mode is internal-error', () => {
+            expect(mockToolbar('internal-error', '', 'minimized')).toBe('Error');
         });
 
-        it('Should say Canceled when minimized and canceling', function () {
-            expect(
-                mockToolbar('canceling', '', 'minimized')
-            ).toBe('Canceled');
+        it('Should say Canceled when minimized and canceling', () => {
+            expect(mockToolbar('canceling', '', 'minimized')).toBe('Canceled');
         });
 
-        it('Should say Canceled when minimized and canceled', function () {
-            expect(
-                mockToolbar('canceled', '', 'minimized')
-            ).toBe('Canceled');
+        it('Should say Canceled when minimized and canceled', () => {
+            expect(mockToolbar('canceled', '', 'minimized')).toBe('Canceled');
         });
 
-        it('Should say Running when minimized and running', function () {
-            expect(
-                mockToolbar('processing', 'running', 'minimized')
-            ).toBe('Running');
+        it('Should say Running when minimized and running', () => {
+            expect(mockToolbar('processing', 'running', 'minimized')).toBe('Running');
         });
 
-        it('Should say Running when minimized and queued', function () {
-            expect(
-                mockToolbar('processing', 'queued', 'minimized')
-            ).toBe('Queued');
+        it('Should say Running when minimized and queued', () => {
+            expect(mockToolbar('processing', 'queued', 'minimized')).toBe('Queued');
         });
 
-        it('Should say Success when minimized and mode is success', function () {
-            expect(
-                mockToolbar('success', '', 'minimized')
-            ).toBe('Success');
+        it('Should say Success when minimized and mode is success', () => {
+            expect(mockToolbar('success', '', 'minimized')).toBe('Success');
         });
 
-        it('Should suppress the status message if maximized', function () {
-            expect(
-                mockToolbar('processing', 'running', 'maximized')
-            ).toBe('');
+        it('Should suppress the status message if maximized', () => {
+            expect(mockToolbar('processing', 'running', 'maximized')).toBe('');
         });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
@@ -1,6 +1,6 @@
 define(['jquery', 'kbaseCellToolbarMenu', 'base/js/namespace'], ($, Widget, Jupyter) => {
     'use strict';
-    describe('Test the kbaseCellToolbarMenu widget', () => {
+    describe('The kbaseCellToolbarMenu widget', () => {
         beforeAll(() => {
             Jupyter.narrative = {
                 readonly: false,

--- a/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
@@ -1,5 +1,3 @@
-/*global describe, it, expect, beforeAll */
-/*jslint white: true*/
 define(['jquery', 'kbaseCellToolbarMenu', 'base/js/namespace'], ($, Widget, Jupyter) => {
     'use strict';
     describe('Test the kbaseCellToolbarMenu widget', () => {

--- a/test/unit/spec/narrative_core/kbaseDataCard-spec.js
+++ b/test/unit/spec/narrative_core/kbaseDataCard-spec.js
@@ -1,11 +1,11 @@
-
 define(['jquery', 'base/js/namespace', 'kbase/js/widgets/narrative_core/kbaseDataCard'], (
     $,
     Jupyter,
     DataCard
 ) => {
+    'use strict';
     let object_info, $card;
-    describe('Test the kbaseDataCard widget', () => {
+    describe('The kbaseDataCard widget', () => {
         beforeEach(() => {
             object_info = [
                 1,

--- a/test/unit/spec/narrative_core/kbaseDataCard-spec.js
+++ b/test/unit/spec/narrative_core/kbaseDataCard-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 
 define(['jquery', 'base/js/namespace', 'kbase/js/widgets/narrative_core/kbaseDataCard'], (
     $,

--- a/test/unit/spec/narrative_core/kbaseDataCard-spec.js
+++ b/test/unit/spec/narrative_core/kbaseDataCard-spec.js
@@ -4,56 +4,62 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-
-define([
-    'jquery',
-    'base/js/namespace',
-    'kbase/js/widgets/narrative_core/kbaseDataCard'
-], function ($, Jupyter, DataCard) {
-    var object_info, $card;
-    describe('Test the kbaseDataCard widget', function() {
-        beforeEach(function () {
+define(['jquery', 'base/js/namespace', 'kbase/js/widgets/narrative_core/kbaseDataCard'], (
+    $,
+    Jupyter,
+    DataCard
+) => {
+    let object_info, $card;
+    describe('Test the kbaseDataCard widget', () => {
+        beforeEach(() => {
             object_info = [
-                1, 'Object Name', 'objecttype.Type-1.0', '2017-10-16T20:19:00+0000', 1, 
-                'user', 2, 'user:narrative_2', 'chsum', 3, {}
+                1,
+                'Object Name',
+                'objecttype.Type-1.0',
+                '2017-10-16T20:19:00+0000',
+                1,
+                'user',
+                2,
+                'user:narrative_2',
+                'chsum',
+                3,
+                {},
             ];
             $card = DataCard({
-                object_info: object_info
+                object_info: object_info,
             });
         });
-        it('Should initalize properly', function(done) {
+        it('Should initalize properly', (done) => {
             expect($card instanceof $).toEqual(true);
             done();
         });
-        it('Should use name as Title', function(done) {
-            var $title = $card.find('.kb-data-list-name');
+        it('Should use name as Title', (done) => {
+            const $title = $card.find('.kb-data-list-name');
             expect($title.html()).toEqual(object_info[1]);
             done();
         });
-        it('Should shorten Title', function(done) {
-            var $card2 = DataCard({
+        it('Should shorten Title', (done) => {
+            const $card2 = DataCard({
                 object_info: object_info,
                 max_name_length: 5,
             });
-            var $title = $card2.find('.kb-data-list-name');
+            const $title = $card2.find('.kb-data-list-name');
             expect($title.html().length).toEqual(5);
             done();
         });
-        it('Should parse Type', function() {
-            var $type = $card.find('.kb-data-list-type');
+        it('Should parse Type', () => {
+            const $type = $card.find('.kb-data-list-type');
             expect($type.html()).toEqual('Type');
         });
-        it('Should not mutate moreContent passed in', function() {
-            var $moreContent = $('<div>').text('More Content').addClass('test-more-content');
+        it('Should not mutate moreContent passed in', () => {
+            const $moreContent = $('<div>').text('More Content').addClass('test-more-content');
 
-            var $card2 = DataCard({
+            const $card2 = DataCard({
                 object_info: object_info,
                 moreContent: $moreContent,
             });
-            var content = $card2.find('.narrative-card-row-more').children()[0];
+            const content = $card2.find('.narrative-card-row-more').children()[0];
             expect($moreContent.is($(content))).toEqual(true);
         });
-        
-
     });
 });

--- a/test/unit/spec/narrative_core/kbaseModal-spec.js
+++ b/test/unit/spec/narrative_core/kbaseModal-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseModal'], (Widget) => {
-    describe('Test the kbaseModal widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseModal widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseModal-spec.js
+++ b/test/unit/spec/narrative_core/kbaseModal-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseModal'], (Widget) => {
     describe('Test the kbaseModal widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseModal-spec.js
+++ b/test/unit/spec/narrative_core/kbaseModal-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseModal'
-], function(Widget) {
-    describe('Test the kbaseModal widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseModal'], (Widget) => {
+    describe('Test the kbaseModal widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -1,4 +1,3 @@
-/* global describe, it, expect, jasmine, beforeEach, afterEach , spyOn */
 define([
     'jquery',
     'kbaseNarrativeAppPanel',

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -7,23 +7,21 @@ define([
     'narrativeMocks',
 ], ($, AppPanel, Jupyter, Config, Mocks) => {
     'use strict';
-    let $panel,
-        appPanel;
+    let $panel, appPanel;
     const FAKE_USER = 'some_user',
         FAKE_TOKEN = 'some_fake_token',
         NS_URL = 'https://kbase.us/service/fakeNSUrl',
         CATEGORY_A = 'categorya',
         CATEGORY_B = 'categoryb',
-
         // a map of ignored categories returned from NarrativeService.get_ignored_categories
         // maps from category name -> 1 (if ignored)
         IGNORED_CATEGORIES = {
-            inactive: 1
+            inactive: 1,
         },
         APP_INFO = {
             module_versions: {
                 a_module: '0.1',
-                another_module: '0.2'
+                another_module: '0.2',
             },
             app_infos: {
                 'a_module/an_app': {
@@ -35,19 +33,18 @@ define([
                         ver: '1.0.0',
                         subtitle: 'Run an app',
                         tooltip: 'Run an app',
-                        icon: { url: 'img?method_id=a_module/an_app&image_name=an_app.png&tag=release' },
+                        icon: {
+                            url: 'img?method_id=a_module/an_app&image_name=an_app.png&tag=release',
+                        },
                         categories: ['active', CATEGORY_A],
                         authors: [FAKE_USER],
-                        input_types: [
-                            'Module1.Type1',
-                            'Module2.Type2'
-                        ],
+                        input_types: ['Module1.Type1', 'Module2.Type2'],
                         output_types: ['ModuleOut.TypeOut'],
                         app_type: 'app',
                         namespace: 'a_module',
                         short_input_types: ['Type1', 'Type2'],
-                        short_output_types: ['TypeOut']
-                    }
+                        short_output_types: ['TypeOut'],
+                    },
                 },
                 'another_module/another_app': {
                     info: {
@@ -58,21 +55,22 @@ define([
                         ver: '1.0.0',
                         subtitle: 'Run an app',
                         tooltip: 'Run an app',
-                        icon: { url: 'img?method_id=another_module/another_app&image_name=an_app.png&tag=release' },
+                        icon: {
+                            url:
+                                'img?method_id=another_module/another_app&image_name=an_app.png&tag=release',
+                        },
                         categories: ['active', CATEGORY_B],
                         authors: [FAKE_USER],
-                        input_types: [
-                            'Module1.Type1',
-                        ],
+                        input_types: ['Module1.Type1'],
                         output_types: ['ModuleOut.TypeOut'],
                         app_type: 'app',
                         namespace: 'another_module',
                         short_input_types: ['Type1'],
-                        short_output_types: ['TypeOut']
+                        short_output_types: ['TypeOut'],
                     },
-                    favorite: 1612814706712
-                }
-            }
+                    favorite: 1612814706712,
+                },
+            },
         };
 
     describe('Test the kbaseNarrativeAppPanel widget', () => {
@@ -81,31 +79,31 @@ define([
                 getAuthToken: () => FAKE_TOKEN,
                 userId: FAKE_USER,
                 narrController: {
-                    uiModeIs: () => false
-                }
+                    uiModeIs: () => false,
+                },
             };
 
             // just a dummy mock so we don't see error messages. Don't actually need a kernel.
             Jupyter.notebook = {
                 kernel: {
-                    execute: () => { }
-                }
+                    execute: () => {},
+                },
             };
 
             jasmine.Ajax.install();
             Mocks.mockServiceWizardLookup({
                 module: 'NarrativeService',
-                url: NS_URL
+                url: NS_URL,
             });
             Mocks.mockJsonRpc1Call({
                 url: NS_URL,
                 body: /get_all_app_info/,
-                response: APP_INFO
+                response: APP_INFO,
             });
             Mocks.mockJsonRpc1Call({
                 url: NS_URL,
                 body: /get_ignore_categories/,
-                response: IGNORED_CATEGORIES
+                response: IGNORED_CATEGORIES,
             });
 
             $panel = $('<div>');
@@ -177,38 +175,57 @@ define([
             expect($panel.find(dropdownSelector).length).not.toBe(0);
             // should have category, input types, output types, name a-z, name z-a
             const filterList = ['category', 'input types', 'output types', 'name a-z', 'name z-a'];
-            $panel.find(dropdownSelector).parent().find('.dropdown-menu li').each((idx, item) => {
-                expect($(item).text().toLowerCase()).toEqual(filterList[idx]);
-            });
+            $panel
+                .find(dropdownSelector)
+                .parent()
+                .find('.dropdown-menu li')
+                .each((idx, item) => {
+                    expect($(item).text().toLowerCase()).toEqual(filterList[idx]);
+                });
             // should default to category
-            expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('category');
+            expect(
+                $panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()
+            ).toEqual('category');
             const appListSel = '.kb-function-body > div:last-child > div > div';
             // spot check category list.
-            let categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
-                const str = elem.innerText.toLowerCase();
-                return str.substring(0, str.lastIndexOf(' '));
-            });
+            let categoryList = $panel
+                .find(appListSel + '> div.row')
+                .toArray()
+                .map((elem) => {
+                    const str = elem.innerText.toLowerCase();
+                    return str.substring(0, str.lastIndexOf(' '));
+                });
             // no "my favorites" because we're not logged in
             expect(categoryList.indexOf(CATEGORY_A)).not.toBe(-1);
             expect(categoryList.indexOf(CATEGORY_B)).not.toBe(-1);
 
             // click input types
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(2) a').click();
-            expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('input');
-            categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
-                const str = elem.innerText.toLowerCase();
-                return str.substring(0, str.lastIndexOf(' '));
-            });
+            expect(
+                $panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()
+            ).toEqual('input');
+            categoryList = $panel
+                .find(appListSel + '> div.row')
+                .toArray()
+                .map((elem) => {
+                    const str = elem.innerText.toLowerCase();
+                    return str.substring(0, str.lastIndexOf(' '));
+                });
             expect(categoryList.indexOf('type1')).not.toBe(-1);
             expect(categoryList.indexOf('type2')).not.toBe(-1);
 
             // click output types
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(3) a').click();
-            expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('output');
-            categoryList = $panel.find(appListSel + '> div.row').toArray().map((elem) => {
-                const str = elem.innerText.toLowerCase();
-                return str.substring(0, str.lastIndexOf(' '));
-            });
+            expect(
+                $panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()
+            ).toEqual('output');
+            categoryList = $panel
+                .find(appListSel + '> div.row')
+                .toArray()
+                .map((elem) => {
+                    const str = elem.innerText.toLowerCase();
+                    return str.substring(0, str.lastIndexOf(' '));
+                });
             expect(categoryList.indexOf('typeout')).not.toBe(-1);
             expect(categoryList.indexOf('type1')).toBe(-1);
             expect(categoryList.indexOf('type2')).toBe(-1);
@@ -216,26 +233,35 @@ define([
             // click name a-z
             // show alphabetical names of apps
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(4) a').click();
-            expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('a-z');
-            let appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map((item) => {
-                return item.innerText.toLowerCase();
-            });
+            expect(
+                $panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()
+            ).toEqual('a-z');
+            let appList = $panel
+                .find(appListSel + ' div.kb-data-list-name')
+                .toArray()
+                .map((item) => {
+                    return item.innerText.toLowerCase();
+                });
             // sort it, then compare to see if in same order. remember, we don't have favorites that pop to the top.
             expect(appList.sort().join('')).toEqual(appList.join(''));
 
             // click name z-a
             $panel.find(dropdownSelector).parent().find('.dropdown-menu li:nth-child(5) a').click();
-            expect($panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()).toEqual('z-a');
-            appList = $panel.find(appListSel + ' div.kb-data-list-name').toArray().map((item) => {
-                return item.innerText.toLowerCase();
-            });
+            expect(
+                $panel.find(dropdownSelector).find('span:first-child').text().toLowerCase()
+            ).toEqual('z-a');
+            appList = $panel
+                .find(appListSel + ' div.kb-data-list-name')
+                .toArray()
+                .map((item) => {
+                    return item.innerText.toLowerCase();
+                });
             // sort it, then compare to see if in same order. remember, we don't have favorites that pop to the top.
             expect(appList.sort().reverse().join('')).toEqual(appList.join(''));
-
         });
 
         it('Should have a working version toggle button', () => {
-            appPanel.$toggleVersionBtn.tooltip = () => { };  // to stop any jquery/bootstrap nonsense that happens in testing.
+            appPanel.$toggleVersionBtn.tooltip = () => {}; // to stop any jquery/bootstrap nonsense that happens in testing.
             const toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
             expect(toggleBtn.length).toBe(1);
             spyOn(appPanel, 'refreshFromService');
@@ -258,7 +284,7 @@ define([
             expect(appPanel.refreshFromService).toHaveBeenCalled();
             expect(appPanel.refreshFromService).toHaveBeenCalledWith('release');
             const toggleBtn = $panel.find('.btn-toolbar button:nth-child(4)');
-            appPanel.$toggleVersionBtn.tooltip = () => { };  // to stop any jquery/bootstrap nonsense that happens in testing.
+            appPanel.$toggleVersionBtn.tooltip = () => {}; // to stop any jquery/bootstrap nonsense that happens in testing.
             toggleBtn.click();
             refreshBtn.click();
             expect(appPanel.refreshFromService).toHaveBeenCalledWith('beta');
@@ -271,12 +297,12 @@ define([
             const lookupId = 'a_module/an_app',
                 dummySpec = {
                     info: {
-                        id: lookupId
-                    }
+                        id: lookupId,
+                    },
                 };
             Mocks.mockJsonRpc1Call({
                 url: Config.url('narrative_method_store'),
-                response: [dummySpec]
+                response: [dummySpec],
             });
 
             const cb = (specs) => {
@@ -285,7 +311,7 @@ define([
                 done();
             };
             const appRequest = {
-                methods: [lookupId]
+                methods: [lookupId],
             };
             $(document).trigger('getFunctionSpecs.Narrative', [appRequest, cb]);
         });
@@ -297,12 +323,12 @@ define([
                 done();
             };
             const appRequest = {
-                methods: ['notAModule/notAnApp']
+                methods: ['notAModule/notAnApp'],
             };
             Mocks.mockJsonRpc1Call({
                 url: Config.url('narrative_method_store'),
-                response: { error: 'repository notAModule wasn\'t registered' },
-                statusCode: 500
+                response: { error: "repository notAModule wasn't registered" },
+                statusCode: 500,
             });
             $(document).trigger('getFunctionSpecs.Narrative', [appRequest, cb]);
         });
@@ -323,7 +349,7 @@ define([
                     cb({
                         token: FAKE_TOKEN,
                         user_id: FAKE_USER,
-                        kbase_sessionid: 'fake_session'
+                        kbase_sessionid: 'fake_session',
                     });
                 }
             });
@@ -356,13 +382,13 @@ define([
             const appId = 'a_module/an_app',
                 dummySpec = {
                     info: {
-                        id: appId
-                    }
+                        id: appId,
+                    },
                 },
                 appTag = 'release';
             Mocks.mockJsonRpc1Call({
                 url: Config.url('narrative_method_store'),
-                response: [dummySpec]
+                response: [dummySpec],
             });
             // in actual usage, this event gets bound to either $(document) or some other
             // widget that it percolates up to. Jasmine doesn't like that, so we bind it here

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -72,7 +72,7 @@ define([
             },
         };
 
-    describe('Test the kbaseNarrativeAppPanel widget', () => {
+    describe('The kbaseNarrativeAppPanel widget', () => {
         beforeEach(() => {
             Jupyter.narrative = {
                 getAuthToken: () => FAKE_TOKEN,

--- a/test/unit/spec/narrative_core/kbaseNarrativeCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeCell-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeCell'], (Widget) => {
     describe('Test the kbaseNarrativeCell widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeCell-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeCell'
-], function(Widget) {
-    describe('Test the kbaseNarrativeCell widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeCell'], (Widget) => {
+    describe('Test the kbaseNarrativeCell widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeCell-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeCell'], (Widget) => {
-    describe('Test the kbaseNarrativeCell widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeCell widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeCellMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeCellMenu-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeCellMenu'], (Widget) => {
     describe('Test the kbaseNarrativeCellMenu widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeCellMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeCellMenu-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeCellMenu'
-], function(Widget) {
-    describe('Test the kbaseNarrativeCellMenu widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeCellMenu'], (Widget) => {
+    describe('Test the kbaseNarrativeCellMenu widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeCellMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeCellMenu-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeCellMenu'], (Widget) => {
-    describe('Test the kbaseNarrativeCellMenu widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeCellMenu widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeControlPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeControlPanel-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeControlPanel'], (Widget) => {
-    describe('Test the kbaseNarrativeControlPanel widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeControlPanel widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeControlPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeControlPanel-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeControlPanel'
-], function(Widget) {
-    describe('Test the kbaseNarrativeControlPanel widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeControlPanel'], (Widget) => {
+    describe('Test the kbaseNarrativeControlPanel widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeControlPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeControlPanel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeControlPanel'], (Widget) => {
     describe('Test the kbaseNarrativeControlPanel widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataCell-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeDataCell'], (Widget) => {
     describe('Test the kbaseNarrativeDataCell widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataCell-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeDataCell'
-], function(Widget) {
-    describe('Test the kbaseNarrativeDataCell widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeDataCell'], (Widget) => {
+    describe('Test the kbaseNarrativeDataCell widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataCell-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeDataCell'], (Widget) => {
-    describe('Test the kbaseNarrativeDataCell widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeDataCell widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
@@ -8,23 +8,25 @@ define([
     'jquery',
     'narrativeConfig',
     'kb_service/client/workspace',
-    'base/js/namespace'
-], function (DataList, $, Config, Workspace, Jupyter) {
+    'base/js/namespace',
+], (DataList, $, Config, Workspace, Jupyter) => {
     'use strict';
-    var $dataList = $('<div>');
-    var dataListObj = null;
+    let $dataList = $('<div>');
+    let dataListObj = null;
 
     const fakeNSUrl = 'https://ci.kbase.us/services/fake_url';
     const narrativeServiceInfo = {
         version: '1.1',
         id: '12345',
-        result: [{
-            git_commit_hash: 'foo',
-            hash: 'bar',
-            health: 'healthy',
-            module_name: 'SampleService',
-            url: fakeNSUrl
-        }]
+        result: [
+            {
+                git_commit_hash: 'foo',
+                hash: 'bar',
+                health: 'healthy',
+                module_name: 'SampleService',
+                url: fakeNSUrl,
+            },
+        ],
     };
 
     function mockServiceWizard() {
@@ -32,7 +34,7 @@ define([
             status: 200,
             statusText: 'HTTP/1/1 200 OK',
             contentType: 'application/json',
-            responseText: JSON.stringify(narrativeServiceInfo)
+            responseText: JSON.stringify(narrativeServiceInfo),
         });
     }
 
@@ -44,14 +46,16 @@ define([
             responseText: JSON.stringify({
                 version: '1.1',
                 id: '12345',
-                result: [{
-                    // The data object is where objects will be return
-                    data: objData,
-                    data_palette_refs: {}
-                }]
-            })
+                result: [
+                    {
+                        // The data object is where objects will be return
+                        data: objData,
+                        data_palette_refs: {},
+                    },
+                ],
+            }),
         });
-    };
+    }
 
     function mockWorkSpaceService() {
         jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
@@ -61,33 +65,34 @@ define([
             responseHeaders: '',
             responseText: JSON.stringify({
                 version: '1.1',
-                result: [[
-                    35855,
-                    'testUser:narrative_1534979778065',
-                    'testUser',
-                    '2020-09-30T23:22:25+0000',
-                    2,
-                    'a',
-                    'n',
-                    'unlocked',
-                    {
-                        'narrative_nice_name': 'CI Scratch',
-                        'searchtags': 'narrative',
-                        'is_temporary': 'false',
-                        'narrative': '1'
-                    }
-                ]]
-            })
+                result: [
+                    [
+                        35855,
+                        'testUser:narrative_1534979778065',
+                        'testUser',
+                        '2020-09-30T23:22:25+0000',
+                        2,
+                        'a',
+                        'n',
+                        'unlocked',
+                        {
+                            narrative_nice_name: 'CI Scratch',
+                            searchtags: 'narrative',
+                            is_temporary: 'false',
+                            narrative: '1',
+                        },
+                    ],
+                ],
+            }),
         });
-    };
+    }
 
     describe('Test the kbaseNarrativeDataList', () => {
-
         beforeEach(() => {
             jasmine.Ajax.install();
             Jupyter.narrative = {
                 getAuthToken: () => 'someToken',
-                getWorkspaceName: () => 'someWorkspace'
+                getWorkspaceName: () => 'someWorkspace',
             };
         });
 
@@ -98,8 +103,8 @@ define([
         });
 
         describe('Without data', () => {
-            beforeEach( async () => {
-                var objData = [];
+            beforeEach(async () => {
+                const objData = [];
 
                 // mock service calls
                 mockServiceWizard();
@@ -121,26 +126,24 @@ define([
                 expect($dataList.html()).toContain('This Narrative has no data yet.');
             });
 
-
             it('Should render the add data text button and hide the other add data button', () => {
-                var $addDataTxtButton = $dataList.find('.kb-data-list-add-data-text-button');
+                const $addDataTxtButton = $dataList.find('.kb-data-list-add-data-text-button');
                 expect($addDataTxtButton).toBeDefined();
                 expect($addDataTxtButton.length).toEqual(1);
                 expect($addDataTxtButton.is('button')).toBeTruthy();
                 expect($addDataTxtButton.html()).toContain('Add Data');
 
-                var $addDataButton = $dataList.find('.kb-data-list-add-data-button');
+                const $addDataButton = $dataList.find('.kb-data-list-add-data-button');
                 // When .hide() is called on a jquery element, the display attribute is set to none.
                 expect($addDataButton.css('display')).toEqual('none');
             });
-
         });
 
         describe('With data', () => {
-            beforeEach( async () => {
-                var objData = [
+            beforeEach(async () => {
+                const objData = [
                     {
-                        'object_info': [
+                        object_info: [
                             5,
                             'Rhodobacter_CACIA_14H1',
                             'KBaseGenomes.Genome-7.0',
@@ -151,9 +154,9 @@ define([
                             'testuser:narrative_1601675739009',
                             '53af8071b814a1db43f81eb490a35491',
                             3110399,
-                            {}
-                        ]
-                    }
+                            {},
+                        ],
+                    },
                 ];
 
                 // mock service calls
@@ -179,7 +182,7 @@ define([
             });
 
             it('Should generate the add data button ', () => {
-                var $addDataButton = $dataList.find('.kb-data-list-add-data-button');
+                const $addDataButton = $dataList.find('.kb-data-list-add-data-button');
                 expect($addDataButton).toBeDefined();
                 expect($addDataButton.length).toEqual(1);
                 expect($addDataButton.is('button')).toBeTruthy();

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define([
     'kbaseNarrativeDataList',
     'jquery',

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataPanel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeDataPanel'], (Widget) => {
     describe('Test the kbaseNarrativeDataPanel widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataPanel-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeDataPanel'
-], function(Widget) {
-    describe('Test the kbaseNarrativeDataPanel widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeDataPanel'], (Widget) => {
+    describe('Test the kbaseNarrativeDataPanel widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataPanel-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeDataPanel'], (Widget) => {
-    describe('Test the kbaseNarrativeDataPanel widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeDataPanel widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
@@ -8,21 +8,17 @@ define([
     'kbaseNarrativeDownloadPanel',
     'common/runtime',
     'base/js/namespace',
-    'kbaseNarrative'
-], (
-    $,
-    kbaseNarrativeDownloadPanel,
-    Runtime,
-    Jupyter,
-    Narrative
-) => {
+    'kbaseNarrative',
+], ($, kbaseNarrativeDownloadPanel, Runtime, Jupyter, Narrative) => {
     describe('Test the kbaseNarrativeDownloadPanel widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();
             $div = $('<div>');
             Jupyter.narrative = new Narrative();
-            Jupyter.narrative.getAuthToken = () => { return 'NotARealToken!' };
+            Jupyter.narrative.getAuthToken = () => {
+                return 'NotARealToken!';
+            };
         });
 
         afterEach(() => {
@@ -31,7 +27,7 @@ define([
         });
 
         it('Should properly load with a valid upa', () => {
-            let ws = 1111,
+            const ws = 1111,
                 oid = 2222,
                 ver = 3333,
                 name = 'fake_test_object',
@@ -51,41 +47,48 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     version: '1.1',
-                    result: [{
-                        infos: [[
-                            oid,
-                            name,
-                            objType,
-                            saveDate,
-                            ver,
-                            userId,
-                            ws,
-                            wsName,
-                            checksum,
-                            size,
-                            meta
-                        ]],
-                        paths: [[upa]]
-                    }]
-                })
+                    result: [
+                        {
+                            infos: [
+                                [
+                                    oid,
+                                    name,
+                                    objType,
+                                    saveDate,
+                                    ver,
+                                    userId,
+                                    ws,
+                                    wsName,
+                                    checksum,
+                                    size,
+                                    meta,
+                                ],
+                            ],
+                            paths: [[upa]],
+                        },
+                    ],
+                }),
             });
 
-            let w = new kbaseNarrativeDownloadPanel($div, {
-                    token: null,
-                    type: objType,
-                    objId: oid,
-                    ref: upa,
-                    objName: name,
-                    downloadSpecCache: {'lastUpdateTime': 100, 'types': {
-                        [objType]: {'export_functions': {"FAKE": "fake_method"}}}
-                    }
+            const w = new kbaseNarrativeDownloadPanel($div, {
+                token: null,
+                type: objType,
+                objId: oid,
+                ref: upa,
+                objName: name,
+                downloadSpecCache: {
+                    lastUpdateTime: 100,
+                    types: {
+                        [objType]: { export_functions: { FAKE: 'fake_method' } },
+                    },
+                },
             });
-            expect($div.html()).toContain("JSON");
-            expect($div.html()).toContain("FAKE");
+            expect($div.html()).toContain('JSON');
+            expect($div.html()).toContain('FAKE');
         });
 
         it('Should load and register a Staging app button', () => {
-            let ws = 1111,
+            const ws = 1111,
                 oid = 2222,
                 ver = 3333,
                 name = 'fake_test_object',
@@ -98,23 +101,23 @@ define([
                 size = 1234567,
                 upa = String(ws) + '/' + String(oid) + '/' + String(ver);
 
-            let w = new kbaseNarrativeDownloadPanel($div, {
+            const w = new kbaseNarrativeDownloadPanel($div, {
                 token: null,
                 type: objType,
                 objName: name,
                 objId: oid,
                 ref: upa,
                 downloadSpecCache: {
-                    'lastUpdateTime': 100,
-                    'types': {
+                    lastUpdateTime: 100,
+                    types: {
                         [objType]: {
-                            'export_functions': {
-                                "FAKE": "fake_method",
-                                "STAGING": "staging_method"
-                            }
-                        }
-                    }
-                }
+                            export_functions: {
+                                FAKE: 'fake_method',
+                                STAGING: 'staging_method',
+                            },
+                        },
+                    },
+                },
             });
 
             expect($div.html()).toContain('STAGING');

--- a/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define([
     'jquery',
     'kbaseNarrativeDownloadPanel',

--- a/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
@@ -5,7 +5,8 @@ define([
     'base/js/namespace',
     'kbaseNarrative',
 ], ($, kbaseNarrativeDownloadPanel, Runtime, Jupyter, Narrative) => {
-    describe('Test the kbaseNarrativeDownloadPanel widget', () => {
+    'use strict';
+    describe('The kbaseNarrativeDownloadPanel widget', () => {
         let $div = null;
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/narrative_core/kbaseNarrativeExampleDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeExampleDataTab-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeExampleDataTab'
-], function(Widget) {
-    describe('Test the kbaseNarrativeExampleDataTab widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeExampleDataTab'], (Widget) => {
+    describe('Test the kbaseNarrativeExampleDataTab widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeExampleDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeExampleDataTab-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeExampleDataTab'], (Widget) => {
     describe('Test the kbaseNarrativeExampleDataTab widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeExampleDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeExampleDataTab-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeExampleDataTab'], (Widget) => {
-    describe('Test the kbaseNarrativeExampleDataTab widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeExampleDataTab widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeJobStatus-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeJobStatus-spec.js
@@ -3,17 +3,14 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'jquery',
-    'kbaseNarrativeJobStatus'
-], function($, JobStatusWidget) {
-    describe('Test the kbaseNarrativeJobStatus widget', function() {
-        var dummyNode;
-        beforeEach(function() {
+define(['jquery', 'kbaseNarrativeJobStatus'], ($, JobStatusWidget) => {
+    describe('Test the kbaseNarrativeJobStatus widget', () => {
+        let dummyNode;
+        beforeEach(() => {
             dummyNode = document.createElement('div');
         });
 
-        it('Should load successfully', function() {
+        it('Should load successfully', () => {
             // var w = new JobStatusWidget($(dummyNode));
             // expect(w).not.toBeNull();
         });

--- a/test/unit/spec/narrative_core/kbaseNarrativeJobStatus-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeJobStatus-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['jquery', 'kbaseNarrativeJobStatus'], ($, JobStatusWidget) => {
     describe('Test the kbaseNarrativeJobStatus widget', () => {
         let dummyNode;

--- a/test/unit/spec/narrative_core/kbaseNarrativeJobStatus-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeJobStatus-spec.js
@@ -1,5 +1,6 @@
 define(['jquery', 'kbaseNarrativeJobStatus'], ($, JobStatusWidget) => {
-    describe('Test the kbaseNarrativeJobStatus widget', () => {
+    'use strict';
+    describe('The kbaseNarrativeJobStatus widget', () => {
         let dummyNode;
         beforeEach(() => {
             dummyNode = document.createElement('div');

--- a/test/unit/spec/narrative_core/kbaseNarrativeManagePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeManagePanel-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeManagePanel'], (Widget) => {
-    describe('Test the kbaseNarrativeManagePanel widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeManagePanel widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeManagePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeManagePanel-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeManagePanel'
-], function(Widget) {
-    describe('Test the kbaseNarrativeManagePanel widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeManagePanel'], (Widget) => {
+    describe('Test the kbaseNarrativeManagePanel widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeManagePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeManagePanel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeManagePanel'], (Widget) => {
     describe('Test the kbaseNarrativeManagePanel widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeMethodCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeMethodCell-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeMethodCell'], (Widget) => {
-    describe('Test the kbaseNarrativeMethodCell widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeMethodCell widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeMethodCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeMethodCell-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeMethodCell'], (Widget) => {
     describe('Test the kbaseNarrativeMethodCell widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeMethodCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeMethodCell-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeMethodCell'
-], function(Widget) {
-    describe('Test the kbaseNarrativeMethodCell widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeMethodCell'], (Widget) => {
+    describe('Test the kbaseNarrativeMethodCell widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define([
     'jquery',
     'kbaseNarrativeOutputCell',

--- a/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
@@ -7,7 +7,7 @@ define([
     'narrativeConfig',
 ], ($, Widget, Jupyter, Narrative, Runtime, Config) => {
     'use strict';
-    describe('Test the kbaseNarrativeOutputCell widget', () => {
+    describe('The kbaseNarrativeOutputCell widget', () => {
         let currentWsId = 10,
             testWidget = 'kbaseDefaultNarrativeOutput',
             testUpas = {

--- a/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
@@ -9,50 +9,43 @@ define([
     'base/js/namespace',
     'kbaseNarrative',
     'common/runtime',
-    'narrativeConfig'
-], function(
-    $,
-    Widget,
-    Jupyter,
-    Narrative,
-    Runtime,
-    Config
-) {
+    'narrativeConfig',
+], ($, Widget, Jupyter, Narrative, Runtime, Config) => {
     'use strict';
-    describe('Test the kbaseNarrativeOutputCell widget', function() {
-        var currentWsId = 10,
+    describe('Test the kbaseNarrativeOutputCell widget', () => {
+        let currentWsId = 10,
             testWidget = 'kbaseDefaultNarrativeOutput',
             testUpas = {
-                'test': '3/4/5',
-                'testList': ['1/2/3', '6/7/8']
+                test: '3/4/5',
+                testList: ['1/2/3', '6/7/8'],
             },
             serialUpas = {
-                'test': '[3]/4/5',
-                'testList': ['[1]/2/3', '[6]/7/8']
+                test: '[3]/4/5',
+                testList: ['[1]/2/3', '[6]/7/8'],
             },
             deserialUpas = {
-                'test': '10/4/5',
-                'testList': ['10/2/3', '10/7/8']
+                test: '10/4/5',
+                testList: ['10/2/3', '10/7/8'],
             },
-            testData = { 'foo': 'bar', 'baz': [1, 2, 3] },
+            testData = { foo: 'bar', baz: [1, 2, 3] },
             $target = $('<div>'),
             cellId = 'a-cell-id',
             myWidget = null;
 
-        var validateUpas = function(source, comparison) {
-            Object.keys(comparison).forEach(function(upaKey) {
+        const validateUpas = function (source, comparison) {
+            Object.keys(comparison).forEach((upaKey) => {
                 if (typeof comparison[upaKey] === 'string') {
                     expect(source[upaKey]).toEqual(comparison[upaKey]);
-                }
-                else { // it better be a list
-                    comparison[upaKey].forEach(function(upa) {
+                } else {
+                    // it better be a list
+                    comparison[upaKey].forEach((upa) => {
                         expect(source[upaKey].indexOf(upa)).toBeGreaterThan(-1);
                     });
                 }
             });
         };
 
-        beforeEach(function() {
+        beforeEach(() => {
             history.pushState(null, null, '/narrative/ws.10.obj.1');
             Config.config.workspaceId = 10;
             Jupyter.narrative = new Narrative();
@@ -61,106 +54,104 @@ define([
                 widget: testWidget,
                 data: testData,
                 type: 'viewer',
-                upas: testUpas
+                upas: testUpas,
             });
             myWidget.cell = {};
             myWidget.metadata = myWidget.initMetadata();
         });
 
-        afterEach(function() {
+        afterEach(() => {
             $('body').empty();
             $target = $('<div>');
         });
 
-        it('Should load properly with a dummy UPA', function() {
+        it('Should load properly with a dummy UPA', () => {
             expect(myWidget).not.toBeNull();
         });
 
-        it('Should serialize UPA info properly', function() {
+        it('Should serialize UPA info properly', () => {
             myWidget.handleUpas();
-            var serialized = myWidget.cell.metadata.kbase.dataCell.upas;
+            const serialized = myWidget.cell.metadata.kbase.dataCell.upas;
             validateUpas(serialUpas, serialized);
         });
 
         // skip until we get better notebook support.
-        xit('Should attach a widget using a pre-existing cell id', function() {
-            var $newDiv = $('<div id="' + cellId  + '">');
+        xit('Should attach a widget using a pre-existing cell id', () => {
+            const $newDiv = $('<div id="' + cellId + '">');
             $('#notebook-container').append($newDiv);
-            var newWidget = new Widget($newDiv, {
+            const newWidget = new Widget($newDiv, {
                 widget: testWidget,
                 data: testData,
                 type: 'viewer',
                 upas: testUpas,
-                cellId: cellId
+                cellId: cellId,
             });
             expect(newWidget.cell).toBeTruthy();
         });
 
-        it('Should deserialize a pre-existing UPA properly', function() {
+        it('Should deserialize a pre-existing UPA properly', () => {
             myWidget.cell.metadata = {
                 kbase: {
                     dataCell: {
-                        upas: serialUpas
-                    }
-                }
+                        upas: serialUpas,
+                    },
+                },
             };
             myWidget.metadata = myWidget.initMetadata();
             myWidget.handleUpas();
             validateUpas(deserialUpas, myWidget.options.upas);
         });
 
-        it('Should do lazy rendering if the option is enabled', function() {
+        it('Should do lazy rendering if the option is enabled', () => {});
 
-        });
-
-        it('inViewport should return true by default, if it\'s missing parameters', function() {
+        it("inViewport should return true by default, if it's missing parameters", () => {
             expect(myWidget.inViewport()).toBe(true);
         });
 
-        it('Should render properly', function(done) {
-            myWidget.render()
-                .then(function() {
-                    // exercise the header button a bit
-                    expect($target.find('.btn.kb-data-obj')).not.toBeNull();
-                    $target.find('.btn.kb-data-obj').click();
-                    expect(myWidget.headerShown).toBeTruthy();
-                    $target.find('.btn.kb-data-obj').click();
-                    expect(myWidget.headerShown).toBeFalsy();
-                    done();
-                });
+        it('Should render properly', (done) => {
+            myWidget.render().then(() => {
+                // exercise the header button a bit
+                expect($target.find('.btn.kb-data-obj')).not.toBeNull();
+                $target.find('.btn.kb-data-obj').click();
+                expect(myWidget.headerShown).toBeTruthy();
+                $target.find('.btn.kb-data-obj').click();
+                expect(myWidget.headerShown).toBeFalsy();
+                done();
+            });
         });
 
-        it('Should render an error properly when its viewer doesn\'t exist', function() {
-            var $nuTarget = $('<div>');
+        it("Should render an error properly when its viewer doesn't exist", () => {
+            const $nuTarget = $('<div>');
             $('#notebook-container').append($nuTarget);
-            var w = new Widget($nuTarget, {
+            const w = new Widget($nuTarget, {
                 widget: 'NotAWidget',
                 data: testData,
                 type: 'viewer',
-                upas: testUpas
+                upas: testUpas,
             });
-            w.render()
-                .then(function() {
-                    expect(w.options.title).toEqual('App Error');
-                });
+            w.render().then(() => {
+                expect(w.options.title).toEqual('App Error');
+            });
         });
 
-        it('Should update its UPAs properly with a version change request', function(done) {
-            myWidget.render()
-                .then(function() {
-                    myWidget.displayVersionChange('test', 4);
-                    expect(myWidget.cell.metadata.kbase.dataCell.upas.test).toEqual('[3]/4/4');
-                    done();
-                });
+        it('Should update its UPAs properly with a version change request', (done) => {
+            myWidget.render().then(() => {
+                myWidget.displayVersionChange('test', 4);
+                expect(myWidget.cell.metadata.kbase.dataCell.upas.test).toEqual('[3]/4/4');
+                done();
+            });
         });
 
-        it('Should handle UPAs correctly when forcing to overwrite existing metadata', function() {
+        it('Should handle UPAs correctly when forcing to overwrite existing metadata', () => {
             myWidget.metadata = myWidget.initMetadata();
             myWidget.handleUpas();
             myWidget.options.upas = deserialUpas;
             myWidget.handleUpas(true);
             expect(myWidget.cell.metadata.kbase.dataCell.upas.test).toEqual('[10]/4/5');
-            expect(myWidget.cell.metadata.kbase.dataCell.upas.testList).toEqual(['[10]/2/3', '[10]/7/8']);
+            expect(myWidget.cell.metadata.kbase.dataCell.upas.testList).toEqual([
+                '[10]/2/3',
+                '[10]/7/8',
+            ]);
         });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativePrestartSpec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativePrestartSpec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativePrestart'], (Prestart) => {
+    'use strict';
     describe('Test the kbaseNarrativePrestart module', () => {
-        it('Should do things', () => {});
+        it('should be defined', () => {
+            expect(Prestart).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativePrestartSpec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativePrestartSpec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativePrestart'], (Prestart) => {
     describe('Test the kbaseNarrativePrestart module', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativePrestartSpec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativePrestartSpec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativePrestart'
-], function(Prestart) {
-    describe('Test the kbaseNarrativePrestart module', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativePrestart'], (Prestart) => {
+    describe('Test the kbaseNarrativePrestart module', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSharePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSharePanel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['jquery', 'kbaseNarrativeSharePanel'], ($, Widget) => {
     describe('Test the kbaseNarrativeSharePanel widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeSharePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSharePanel-spec.js
@@ -1,5 +1,8 @@
 define(['jquery', 'kbaseNarrativeSharePanel'], ($, Widget) => {
-    describe('Test the kbaseNarrativeSharePanel widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeSharePanel widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSharePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSharePanel-spec.js
@@ -3,13 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'jquery',
-    'kbaseNarrativeSharePanel'
-], function($, Widget) {
-    describe('Test the kbaseNarrativeSharePanel widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['jquery', 'kbaseNarrativeSharePanel'], ($, Widget) => {
+    describe('Test the kbaseNarrativeSharePanel widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSideImportTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSideImportTab-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeSideImportTab'], (Widget) => {
     describe('Test the kbaseNarrativeSideImportTab widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeSideImportTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSideImportTab-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeSideImportTab'], (Widget) => {
-    describe('Test the kbaseNarrativeSideImportTab widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeSideImportTab widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSideImportTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSideImportTab-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeSideImportTab'
-], function(Widget) {
-    describe('Test the kbaseNarrativeSideImportTab widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeSideImportTab'], (Widget) => {
+    describe('Test the kbaseNarrativeSideImportTab widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSidePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSidePanel-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeSidePanel'], (Widget) => {
     describe('Test the kbaseNarrativeSidePanel widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/kbaseNarrativeSidePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSidePanel-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeSidePanel'], (Widget) => {
-    describe('Test the kbaseNarrativeSidePanel widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseNarrativeSidePanel widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSidePanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSidePanel-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeSidePanel'
-], function(Widget) {
-    describe('Test the kbaseNarrativeSidePanel widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeSidePanel'], (Widget) => {
+    describe('Test the kbaseNarrativeSidePanel widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSidePublicTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSidePublicTab-spec.js
@@ -1,11 +1,7 @@
 /*eslint-env node, jasmine*/
-define([
-    'kbaseNarrativeSidePublicTab'
-], function(Widget) {
+define(['kbaseNarrativeSidePublicTab'], (Widget) => {
     'use strict';
-    describe('Test the kbaseNarrativeSidePublicTab widget', function() {
-        it('Should do things', function() {
-            
-        });
+    describe('Test the kbaseNarrativeSidePublicTab widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeSidePublicTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSidePublicTab-spec.js
@@ -1,4 +1,3 @@
-/*eslint-env node, jasmine*/
 define(['kbaseNarrativeSidePublicTab'], (Widget) => {
     'use strict';
     describe('Test the kbaseNarrativeSidePublicTab widget', () => {

--- a/test/unit/spec/narrative_core/kbaseNarrativeSidePublicTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeSidePublicTab-spec.js
@@ -1,6 +1,8 @@
 define(['kbaseNarrativeSidePublicTab'], (Widget) => {
     'use strict';
-    describe('Test the kbaseNarrativeSidePublicTab widget', () => {
-        it('Should do things', () => {});
+    describe('The kbaseNarrativeSidePublicTab widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
@@ -1,15 +1,11 @@
 /*global define*/
 /*global jasmine, describe, it, expect, beforeEach, afterEach, spyOn*/
 /*jslint white: true*/
-define([
-    'jquery',
-    'kbaseNarrativeStagingDataTab',
-    'base/js/namespace'
-], function(
+define(['jquery', 'kbaseNarrativeStagingDataTab', 'base/js/namespace'], (
     $,
     StagingDataTab,
     Jupyter
-) {
+) => {
     'use strict';
     describe('Test the kbaseNarrativeStagingDataTab widget', () => {
         const fakeUser = 'notAUser';
@@ -22,14 +18,17 @@ define([
                 responseHeaders: '',
                 responseText: JSON.stringify({
                     user: fakeUser,
-                    idents: [{
-                        provider: 'Google',
-                        provusername: 'notAUser@google.com'
-                    }, {
-                        provider: 'Globus',
-                        provusername: 'notauser@globusid.org'
-                    }]
-                })
+                    idents: [
+                        {
+                            provider: 'Google',
+                            provusername: 'notAUser@google.com',
+                        },
+                        {
+                            provider: 'Globus',
+                            provusername: 'notauser@globusid.org',
+                        },
+                    ],
+                }),
             });
             jasmine.Ajax.stubRequest(/.*\/staging_service\/list\/.*/).andReturn({
                 status: 200,
@@ -42,19 +41,22 @@ define([
                         path: fakeUser + '/test_folder',
                         mtime: 1532738637499,
                         size: 34,
-                        isFolder: true
-                    }, {
+                        isFolder: true,
+                    },
+                    {
                         name: 'file_list.txt',
                         path: fakeUser + '/test_folder/file_list.txt',
                         mtime: 1532738637555,
                         size: 49233,
-                        source: 'KBase upload'
-                    }
-                ])
+                        source: 'KBase upload',
+                    },
+                ]),
             });
             Jupyter.narrative = {
                 userId: fakeUser,
-                getAuthToken: () => { return 'fakeToken'; }
+                getAuthToken: () => {
+                    return 'fakeToken';
+                },
             };
         });
 
@@ -75,19 +77,19 @@ define([
                 statusText: 'error',
                 contentType: 'text/html',
                 responseHeaders: '',
-                responseText: 'error! no profile for you!'
+                responseText: 'error! no profile for you!',
             });
             const $dummyNode = $('<div>'),
                 stagingWidget = new StagingDataTab($dummyNode);
             const userInfo = await stagingWidget.getUserInfo();
-            expect(userInfo).toEqual({user: fakeUser, globusLinked: false});
+            expect(userInfo).toEqual({ user: fakeUser, globusLinked: false });
         });
 
         it('gets user info and parsed into whether or not the user is linked to globus', async () => {
             const $dummyNode = $('<div>'),
                 stagingWidget = new StagingDataTab($dummyNode);
             const userInfo = await stagingWidget.getUserInfo();
-            expect(userInfo).toEqual({user: fakeUser, globusLinked: true});
+            expect(userInfo).toEqual({ user: fakeUser, globusLinked: true });
         });
 
         it('can update its path properly', async () => {
@@ -140,7 +142,7 @@ define([
             await stagingWidget.render();
             spyOn(stagingWidget, 'updateView');
             // a little more cheating with implementation, this triggers the "upload complete" event
-            stagingWidget.uploadWidget.dropzone.emit('complete', {name: 'foo', size: 12345});
+            stagingWidget.uploadWidget.dropzone.emit('complete', { name: 'foo', size: 12345 });
             expect(stagingWidget.updateView).toHaveBeenCalled();
         });
 
@@ -153,7 +155,7 @@ define([
             // run a bunch of triggers, should only call render on the staging area once
             spyOn(stagingWidget.stagingAreaViewer, 'render');
             for (let i = 0; i < 100; i++) {
-                stagingWidget.uploadWidget.dropzone.emit('complete', {name: 'foo', size: 12345});
+                stagingWidget.uploadWidget.dropzone.emit('complete', { name: 'foo', size: 12345 });
             }
             jasmine.clock().tick(stagingWidget.minRefreshTime + 100);
             expect(stagingWidget.stagingAreaViewer.render.calls.count()).toEqual(1);

--- a/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
@@ -1,6 +1,3 @@
-/*global define*/
-/*global jasmine, describe, it, expect, beforeEach, afterEach, spyOn*/
-/*jslint white: true*/
 define(['jquery', 'kbaseNarrativeStagingDataTab', 'base/js/namespace'], (
     $,
     StagingDataTab,

--- a/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
@@ -4,7 +4,7 @@ define(['jquery', 'kbaseNarrativeStagingDataTab', 'base/js/namespace'], (
     Jupyter
 ) => {
     'use strict';
-    describe('Test the kbaseNarrativeStagingDataTab widget', () => {
+    describe('The kbaseNarrativeStagingDataTab widget', () => {
         const fakeUser = 'notAUser';
         beforeEach(() => {
             jasmine.Ajax.install();

--- a/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseNarrativeWorkspace'], (Widget) => {
+    'use strict';
     describe('Test the kbaseNarrativeWorkspace widget', () => {
-        it('Should do things', () => {});
+        it('Should do things', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseNarrativeWorkspace'
-], function(Widget) {
-    describe('Test the kbaseNarrativeWorkspace widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseNarrativeWorkspace'], (Widget) => {
+    describe('Test the kbaseNarrativeWorkspace widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseNarrativeWorkspace'], (Widget) => {
     describe('Test the kbaseNarrativeWorkspace widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/narrative_core/narrativeViewersSpec.js
+++ b/test/unit/spec/narrative_core/narrativeViewersSpec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 define(['narrativeViewers', 'narrativeConfig'], (Viewers, Config) => {
     'use strict';
 

--- a/test/unit/spec/narrative_core/narrativeViewersSpec.js
+++ b/test/unit/spec/narrative_core/narrativeViewersSpec.js
@@ -1,11 +1,5 @@
 /* eslint-env jasmine */
-define ([
-    'narrativeViewers',
-    'narrativeConfig'
-], (
-    Viewers,
-    Config
-) => {
+define(['narrativeViewers', 'narrativeConfig'], (Viewers, Config) => {
     'use strict';
 
     /** data format taken from
@@ -22,8 +16,8 @@ define ([
         {
             'Viewers/a_viewer_app': {},
             'Viewers/error_viewer_app': {
-                loading_error: 'Not a real app'
-            }
+                loading_error: 'Not a real app',
+            },
         },
         // list of "apps" (in the NMS lingo), all obsolete and no longer used or needed
         {},
@@ -32,71 +26,77 @@ define ([
             'Module.Type1': {
                 view_method_ids: ['Viewers/a_viewer_app'],
                 landing_page_url_prefix: 'type1',
-                name: 'Type 1'
+                name: 'Type 1',
             },
             'Module.Type2': {
                 view_method_ids: ['Viewers/missing_viewer_app'],
                 landing_page_url_prefix: 'type2',
-                name: 'Type 2'
+                name: 'Type 2',
             },
             'Module.Type3': {
                 view_method_ids: ['Viewers/error_viewer_app'],
                 landing_page_url_prefix: 'type3',
-                name: 'Type 3'
-            }
-        }
+                name: 'Type 3',
+            },
+        },
     ];
 
     /** "method" data is the NMS lingo for app specs. This just mocks what's needed for
      * NarrativeViewers to function for a single mock app.
      * - returned by NarrativeMethodStore.get_method_spec
      */
-    const methodData = [{
-        'Viewers/a_viewer_app': {
-            behavior: {},
-            fixed_parameters: [],
-            info: {
-                id: 'Viewers/a_viewer_app',
-                module_name: 'Viewers',
-                app_type: 'viewer',
-                input_types: ['Module.Type1'],
-                name: 'View Module Type 1',
+    const methodData = [
+        {
+            'Viewers/a_viewer_app': {
+                behavior: {},
+                fixed_parameters: [],
+                info: {
+                    id: 'Viewers/a_viewer_app',
+                    module_name: 'Viewers',
+                    app_type: 'viewer',
+                    input_types: ['Module.Type1'],
+                    name: 'View Module Type 1',
+                },
+                parameters: [],
+                widgets: {
+                    input: 'null',
+                    output: 'SomeViewerWidget',
+                },
             },
-            parameters: [],
-            widgets: {
-                input: 'null',
-                output: 'SomeViewerWidget'
-            }
-        }
-    }];
+        },
+    ];
 
     describe('Test the NarrativeViewers module', () => {
         beforeEach(() => {
             jasmine.Ajax.install();
 
-            jasmine.Ajax.stubRequest(Config.url('narrative_method_store'), /list_categories/)
-                .andReturn({
-                    status: 200,
-                    statusText: 'HTTP/1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({
-                        version: '1.1',
-                        id: '12345',
-                        result: categoryData
-                    })
-                });
+            jasmine.Ajax.stubRequest(
+                Config.url('narrative_method_store'),
+                /list_categories/
+            ).andReturn({
+                status: 200,
+                statusText: 'HTTP/1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify({
+                    version: '1.1',
+                    id: '12345',
+                    result: categoryData,
+                }),
+            });
 
-            jasmine.Ajax.stubRequest(Config.url('narrative_method_store'), /get_method_spec/)
-                .andReturn({
-                    status: 200,
-                    statusText: 'HTTP/1 200 OK',
-                    contentType: 'application/json',
-                    responseText: JSON.stringify({
-                        version: '1.1',
-                        id: '12345',
-                        result: methodData
-                    })
-                });
+            jasmine.Ajax.stubRequest(
+                Config.url('narrative_method_store'),
+                /get_method_spec/
+            ).andReturn({
+                status: 200,
+                statusText: 'HTTP/1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify({
+                    version: '1.1',
+                    id: '12345',
+                    result: methodData,
+                }),
+            });
         });
 
         afterEach(() => {
@@ -106,17 +106,15 @@ define ([
         it('should load and have expected functions', () => {
             expect(Viewers).toBeDefined();
 
-            ['getViewerInfo', 'createViewer', 'defaultViewer'].forEach(fn => {
+            ['getViewerInfo', 'createViewer', 'defaultViewer'].forEach((fn) => {
                 expect(Viewers[fn]).toBeDefined();
             });
         });
 
         it('should load viewer info as a promise', () => {
-            const expectedItems = [
-                'viewers', 'typeNames', 'specs', 'methodIds', 'landingPageUrls'
-            ];
+            const expectedItems = ['viewers', 'typeNames', 'specs', 'methodIds', 'landingPageUrls'];
             return Viewers.getViewerInfo().then((info) => {
-                expectedItems.forEach(item => {
+                expectedItems.forEach((item) => {
                     expect(info[item]).toBeDefined();
                 });
             });
@@ -126,8 +124,8 @@ define ([
             const dataCell = {
                 obj_info: {
                     type: 'Module.Type1-1.0',
-                    bare_type: 'Module.Type1'
-                }
+                    bare_type: 'Module.Type1',
+                },
             };
             return Viewers.createViewer(dataCell).then((view) => {
                 expect(view.widget).toBeDefined();
@@ -136,12 +134,12 @@ define ([
             });
         });
 
-        it('should still make a default widget when the type doesn\'t exist', () => {
+        it("should still make a default widget when the type doesn't exist", () => {
             const dataCell = {
                 obj_info: {
                     type: 'NotARealType',
-                    bare_type: 'NotARealType'
-                }
+                    bare_type: 'NotARealType',
+                },
             };
             return Viewers.createViewer(dataCell).then((view) => {
                 expect(view.widget).toBeDefined();

--- a/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
+++ b/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
@@ -6,14 +6,8 @@ define([
     'base/js/namespace',
     'kbaseNarrative',
     'narrativeConfig',
-    'widgets/narrative_core/staticNarrativesManager'
-], (
-    $,
-    Jupyter,
-    Narrative,
-    Config,
-    StaticNarrativesManager
-) => {
+    'widgets/narrative_core/staticNarrativesManager',
+], ($, Jupyter, Narrative, Config, StaticNarrativesManager) => {
     'use strict';
     const staticNarrativeServiceUrl = 'https://ci.kbase.us/dynserv/blah.StaticNarrative';
 
@@ -31,28 +25,28 @@ define([
             wsId,
             'wjriehl:narrative_1564523505497',
             'cdf315ef72b24adf26c1229e98909f3d',
-            421216
+            421216,
         ],
-        staticInfo = [{
-            ws_id: wsId,
-            version: staticVer,
-            narrative_id: objId,
-            url: '/' + wsId + '/' + staticVer,
-            static_saved: 1574877642060,
-            narr_saved: 1572997477000
-        }],
-
+        staticInfo = [
+            {
+                ws_id: wsId,
+                version: staticVer,
+                narrative_id: objId,
+                url: '/' + wsId + '/' + staticVer,
+                static_saved: 1574877642060,
+                narr_saved: 1572997477000,
+            },
+        ],
         userId = 'narrativetest';
 
     function jsonRPCResponse(result, isError) {
-        let res = {
+        const res = {
             id: '12345',
-            version: '1.1'
+            version: '1.1',
         };
         if (isError) {
             res.error = result;
-        }
-        else {
+        } else {
             res.result = result;
         }
         return JSON.stringify(res);
@@ -63,7 +57,7 @@ define([
             status: 200,
             statusText: 'HTTP/1.1 200 OK',
             contentType: 'application/json',
-            responseText: jsonRPCResponse(result)
+            responseText: jsonRPCResponse(result),
         };
     }
 
@@ -72,7 +66,7 @@ define([
             status: 500,
             statusText: 'HTTP/1.1 500 Internal service error',
             contentType: 'application/json',
-            responseText: jsonRPCResponse(result, true)
+            responseText: jsonRPCResponse(result, true),
         };
     }
 
@@ -81,43 +75,48 @@ define([
      *
      */
     function mockGoodServiceWizard() {
-        const goodServWizResponse = [{
-            git_commit_hash: 'b5ccb7fbfa37a422a92158d108b8ad5245a79093',
-            hash: 'b5ccb7fbfa37a422a92158d108b8ad5245a79093',
-            status: 'active',
-            version: '0.0.2',
-            release_tags: ['dev'],
-            module_name: 'StaticNarrative',
-            health: 'healthy',
-            up: '1',
-            url: staticNarrativeServiceUrl
-        }];
-        jasmine.Ajax.stubRequest(Config.url('service_wizard'))
-            .andReturn(mockOkResponse(goodServWizResponse));
+        const goodServWizResponse = [
+            {
+                git_commit_hash: 'b5ccb7fbfa37a422a92158d108b8ad5245a79093',
+                hash: 'b5ccb7fbfa37a422a92158d108b8ad5245a79093',
+                status: 'active',
+                version: '0.0.2',
+                release_tags: ['dev'],
+                module_name: 'StaticNarrative',
+                health: 'healthy',
+                up: '1',
+                url: staticNarrativeServiceUrl,
+            },
+        ];
+        jasmine.Ajax.stubRequest(Config.url('service_wizard')).andReturn(
+            mockOkResponse(goodServWizResponse)
+        );
     }
 
     function mockPermissions(isAdmin, isPublic) {
-        let permsResponse = { '*': isPublic ? 'r' : 'n' };
+        const permsResponse = { '*': isPublic ? 'r' : 'n' };
         permsResponse[userId] = isAdmin ? 'a' : 'r';
-        jasmine.Ajax.stubRequest(Config.url('workspace'), /get_permissions_mass/)
-            .andReturn(mockOkResponse([{perms: [permsResponse]}]));
+        jasmine.Ajax.stubRequest(Config.url('workspace'), /get_permissions_mass/).andReturn(
+            mockOkResponse([{ perms: [permsResponse] }])
+        );
     }
 
     function mockGetStaticNarrativeInfo(withInfo, withError) {
         if (!withError) {
             const response = withInfo ? staticInfo : [{}];
-            jasmine.Ajax.stubRequest(staticNarrativeServiceUrl,
+            jasmine.Ajax.stubRequest(
+                staticNarrativeServiceUrl,
                 /get_static_narrative_info/
             ).andReturn(mockOkResponse(response));
-        }
-        else {
+        } else {
             const err = {
                 code: -32000,
                 name: 'Server error',
                 message: 'Cannot get static narrative info',
-                error: 'Traceback ...---...'
+                error: 'Traceback ...---...',
             };
-            jasmine.Ajax.stubRequest(staticNarrativeServiceUrl,
+            jasmine.Ajax.stubRequest(
+                staticNarrativeServiceUrl,
                 /get_static_narrative_info/
             ).andReturn(mockErrorResponse(err));
         }
@@ -136,19 +135,22 @@ define([
 
     function mockCreateStaticNarrative(withError) {
         if (!withError) {
-            jasmine.Ajax.stubRequest(staticNarrativeServiceUrl,
+            jasmine.Ajax.stubRequest(
+                staticNarrativeServiceUrl,
                 /create_static_narrative/
             ).andReturn(mockOkResponse([{}]));
-        }
-        else {
-            jasmine.Ajax.stubRequest(staticNarrativeServiceUrl,
+        } else {
+            jasmine.Ajax.stubRequest(
+                staticNarrativeServiceUrl,
                 /create_static_narrative/
-            ).andReturn(mockErrorResponse({
-                code: -123,
-                message: 'Cannot create new static narrative',
-                name: 'JSONRPCError',
-                error: 'Some traceback here'
-            }));
+            ).andReturn(
+                mockErrorResponse({
+                    code: -123,
+                    message: 'Cannot create new static narrative',
+                    name: 'JSONRPCError',
+                    error: 'Some traceback here',
+                })
+            );
         }
     }
 
@@ -184,7 +186,7 @@ define([
         });
 
         it('Should be instantiable', () => {
-            let widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(node);
             expect(widget).toBeDefined();
             expect(widget.refresh).toBeDefined();
         });
@@ -193,33 +195,30 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
-                .then(() => {
-                    validateHtmlNoStatic(node);
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.render().then(() => {
+                validateHtmlNoStatic(node);
+            });
         });
 
         it('Should render when static info exists', () => {
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
-                .then(() => {
-                    validateHtmlStatic(node);
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.render().then(() => {
+                validateHtmlStatic(node);
+            });
         });
 
         it('Should refresh before a render', () => {
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.refresh()
-                .then(() => {
-                    validateHtmlNoStatic(node);
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.refresh().then(() => {
+                validateHtmlNoStatic(node);
+            });
         });
 
         it('Should detach after rendering', () => {
@@ -227,8 +226,9 @@ define([
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
             expect(node.html()).toBe('');
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
+            const widget = new StaticNarrativesManager(node);
+            return widget
+                .render()
                 .then(() => {
                     return widget.detach();
                 })
@@ -242,8 +242,9 @@ define([
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
             expect(node.html()).toBe('');
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
+            const widget = new StaticNarrativesManager(node);
+            return widget
+                .render()
                 .then(() => widget.detach())
                 .then(() => widget.render())
                 .then(() => widget.detach())
@@ -259,13 +260,12 @@ define([
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
             mockCreateStaticNarrative();
-            let widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(node);
             spyOn(widget, 'saveStaticNarrative');
-            return widget.render()
-                .then(() => {
-                    node.find('button').click();
-                    expect(widget.saveStaticNarrative).toHaveBeenCalled();
-                });
+            return widget.render().then(() => {
+                node.find('button').click();
+                expect(widget.saveStaticNarrative).toHaveBeenCalled();
+            });
         });
 
         it('saveStaticNarrative should work in ok case and re-render', () => {
@@ -273,8 +273,9 @@ define([
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
             mockCreateStaticNarrative();
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
+            const widget = new StaticNarrativesManager(node);
+            return widget
+                .render()
                 .then(() => {
                     return widget.saveStaticNarrative();
                 })
@@ -288,8 +289,9 @@ define([
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
             mockCreateStaticNarrative(true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
+            const widget = new StaticNarrativesManager(node);
+            return widget
+                .render()
                 .then(() => {
                     return widget.saveStaticNarrative();
                 })
@@ -302,11 +304,10 @@ define([
             mockPermissions(true, true);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true, true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
-                .then(() => {
-                    validateHtmlError(node);
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.render().then(() => {
+                validateHtmlError(node);
+            });
         });
 
         it('render should create an error when narrative doc info is not available', () => {
@@ -314,50 +315,46 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
             Jupyter.narrative.documentVersionInfo = null;
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
-                .then(() => {
-                    validateHtmlError(node);
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.render().then(() => {
+                validateHtmlError(node);
+            });
         });
 
         it('should render a warning if user is not an admin', () => {
             mockPermissions(false, true);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
-                .then(() => {
-                    expect(node.html()).toContain('Not an admin');
-                    expect(node.html()).not.toContain('Not public');
-                    expect(node.html()).not.toContain('Create static narrative');
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.render().then(() => {
+                expect(node.html()).toContain('Not an admin');
+                expect(node.html()).not.toContain('Not public');
+                expect(node.html()).not.toContain('Create static narrative');
+            });
         });
 
         it('should render a warning if narrative is not public', () => {
             mockPermissions(true, false);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
-                .then(() => {
-                    expect(node.html()).not.toContain('Not an admin');
-                    expect(node.html()).toContain('Not public');
-                    expect(node.html()).not.toContain('Create static narrative');
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.render().then(() => {
+                expect(node.html()).not.toContain('Not an admin');
+                expect(node.html()).toContain('Not public');
+                expect(node.html()).not.toContain('Create static narrative');
+            });
         });
 
         it('should render two warnings if user is not an admin and narrative is not public', () => {
             mockPermissions(false, false);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
-            let widget = new StaticNarrativesManager(node);
-            return widget.render()
-                .then(() => {
-                    expect(node.html()).toContain('Not an admin');
-                    expect(node.html()).toContain('Not public');
-                    expect(node.html()).not.toContain('Create static narrative');
-                });
+            const widget = new StaticNarrativesManager(node);
+            return widget.render().then(() => {
+                expect(node.html()).toContain('Not an admin');
+                expect(node.html()).toContain('Not public');
+                expect(node.html()).not.toContain('Create static narrative');
+            });
         });
     });
 });

--- a/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
+++ b/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
@@ -164,7 +164,7 @@ define([
         expect(node.html()).toContain('Static Narrative Error');
     }
 
-    describe('Test the Static Narrative manager widget', () => {
+    describe('The Static Narrative manager widget', () => {
         beforeEach(() => {
             Jupyter.narrative = new Narrative();
             Jupyter.narrative.userId = userId;

--- a/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
+++ b/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
@@ -1,6 +1,3 @@
-/*global define*/
-/*global jasmine, describe, it, expect, spyOn, beforeEach, afterEach */
-/*jslint white: true*/
 define([
     'jquery',
     'base/js/namespace',

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -1,7 +1,3 @@
-/*global define, jasmine*/
-/*global describe, it, expect*/
-/*global beforeEach, afterEach, spyOn*/
-/*jslint white: true*/
 define([
     'jquery',
     'kbase/js/widgets/narrative_core/upload/fileUploadWidget',
@@ -10,9 +6,8 @@ define([
 ], ($, FileUploadWidget, Jupyter, Config) => {
     'use strict';
 
-    let fuWidget,
-        $targetNode,
-        fakeUser = 'notAUser';
+    let fuWidget, $targetNode;
+    const fakeUser = 'notAUser';
 
     const mockUploadEndpoint = (filename, username, isFolder) => {
         jasmine.Ajax.stubRequest(Config.url('staging_api_url') + '/upload').andReturn({

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -6,13 +6,8 @@ define([
     'jquery',
     'kbase/js/widgets/narrative_core/upload/fileUploadWidget',
     'base/js/namespace',
-    'narrativeConfig'
-], (
-    $,
-    FileUploadWidget,
-    Jupyter,
-    Config
-) => {
+    'narrativeConfig',
+], ($, FileUploadWidget, Jupyter, Config) => {
     'use strict';
 
     let fuWidget,
@@ -20,17 +15,24 @@ define([
         fakeUser = 'notAUser';
 
     const mockUploadEndpoint = (filename, username, isFolder) => {
-        jasmine.Ajax.stubRequest(Config.url('staging_api_url') + '/upload')
-            .andReturn({
-                status: 200,
-                statusText: 'HTTP/1.1 200 OK',
-                contentType: 'application/json',
-                responseText: JSON.stringify([{name: filename, path: `${username}/${filename}`, mtime: 1596747139855, size: 1376, isFolder: isFolder}])
-            });
+        jasmine.Ajax.stubRequest(Config.url('staging_api_url') + '/upload').andReturn({
+            status: 200,
+            statusText: 'HTTP/1.1 200 OK',
+            contentType: 'application/json',
+            responseText: JSON.stringify([
+                {
+                    name: filename,
+                    path: `${username}/${filename}`,
+                    mtime: 1596747139855,
+                    size: 1376,
+                    isFolder: isFolder,
+                },
+            ]),
+        });
     };
 
     const createMockFile = (filename) => {
-        let file = new File(['file contents'], filename, { type: 'text/html' });
+        const file = new File(['file contents'], filename, { type: 'text/html' });
         return file;
     };
 
@@ -39,21 +41,23 @@ define([
             jasmine.Ajax.install();
             Jupyter.narrative = {
                 userId: fakeUser,
-                getAuthToken: () => { return 'fakeToken'; },
-                sidePanel: {
-                    '$dataWidget': {
-                        '$overlayPanel': {}
-                    }
+                getAuthToken: () => {
+                    return 'fakeToken';
                 },
-                showDataOverlay: () => {}
+                sidePanel: {
+                    $dataWidget: {
+                        $overlayPanel: {},
+                    },
+                },
+                showDataOverlay: () => {},
             };
             $targetNode = $('<div>');
             fuWidget = new FileUploadWidget($targetNode, {
                 path: '/',
                 userInfo: {
                     user: fakeUser,
-                    globusLinked: false
-                }
+                    globusLinked: false,
+                },
             });
         });
 
@@ -68,8 +72,8 @@ define([
                     path: '/',
                     userInfo: {
                         user: fakeUser,
-                        globusLinked: true
-                    }
+                        globusLinked: true,
+                    },
                 });
             const newPath = 'newPath';
             fuw.setPath(newPath);
@@ -77,7 +81,7 @@ define([
         });
 
         it('Should start and succeed on an upload when a file is given', (done) => {
-            const filename='foo.txt';
+            const filename = 'foo.txt';
             mockUploadEndpoint(filename, fakeUser, false);
             const mockFile = createMockFile(filename);
             const adderMock = jasmine.createSpy('adderMock');
@@ -102,7 +106,7 @@ define([
             // Let's set it shorter than disabled.
             fuWidget.dropzone.options.timeout = 100; // ms
             expect(fuWidget.dropzone.options.timeout).toBe(100);
-            const filename='foo.txt';
+            const filename = 'foo.txt';
             mockUploadEndpoint(filename, fakeUser, false);
             const mockFile = createMockFile(filename);
             fuWidget.dropzone.on('error', (file, errorMessage) => {
@@ -123,10 +127,10 @@ define([
             fuWidget.dropzone.options.maxFilesize = 1;
 
             // Create file
-            const filename='foo.txt';
+            const filename = 'foo.txt';
             mockUploadEndpoint(filename, fakeUser, false);
-            var mockFile = createMockFile(filename);
-            Object.defineProperty(mockFile, 'size', {value: Math.pow(1024, 4), writable: false});
+            const mockFile = createMockFile(filename);
+            Object.defineProperty(mockFile, 'size', { value: Math.pow(1024, 4), writable: false });
 
             // Create mock calls
             const adderMock = jasmine.createSpy('adderMock');
@@ -150,10 +154,10 @@ define([
             fuWidget.dropzone.options.maxFilesize = 1;
 
             // Create file
-            const filename='foo.txt';
+            const filename = 'foo.txt';
             mockUploadEndpoint(filename, fakeUser, false);
-            var mockFile = createMockFile(filename);
-            Object.defineProperty(mockFile, 'size', {value: Math.pow(1024, 4), writable: false});
+            const mockFile = createMockFile(filename);
+            Object.defineProperty(mockFile, 'size', { value: Math.pow(1024, 4), writable: false });
 
             // Create mock calls
             const adderMock = jasmine.createSpy('adderMock');
@@ -163,33 +167,37 @@ define([
 
             fuWidget.dropzone.addFile(mockFile);
             setTimeout(() => {
-                let $fileTemplate = fuWidget.$elem;
+                const $fileTemplate = fuWidget.$elem;
                 expect(document.getElementById('clear_all_button')).toBeDefined();
-                expect($fileTemplate.find('#upload_progress_and_cancel').css('display')).toEqual('none');
+                expect($fileTemplate.find('#upload_progress_and_cancel').css('display')).toEqual(
+                    'none'
+                );
                 expect($fileTemplate.find('#error_icon').css('display')).toEqual('flex');
-                expect($fileTemplate.find('#globus_error_link').attr('href')).toEqual('https://docs.kbase.us/data/globus');
+                expect($fileTemplate.find('#globus_error_link').attr('href')).toEqual(
+                    'https://docs.kbase.us/data/globus'
+                );
                 done();
             });
         });
 
         it('Should provide a link to a globus accout when file upload maxfile size error occurs', (done) => {
             $targetNode = $('<div>');
-            var uploadWidget = new FileUploadWidget($targetNode, {
+            const uploadWidget = new FileUploadWidget($targetNode, {
                 path: '/',
                 userInfo: {
                     user: fakeUser,
-                    globusLinked: true
-                }
+                    globusLinked: true,
+                },
             });
 
             // Set the file max size to 0
             uploadWidget.dropzone.options.maxFilesize = 1;
 
             // Create file
-            const filename='foo.txt';
+            const filename = 'foo.txt';
             mockUploadEndpoint(filename, fakeUser, false);
-            var mockFile = createMockFile(filename);
-            Object.defineProperty(mockFile, 'size', {value: Math.pow(1024, 4), writable: false});
+            const mockFile = createMockFile(filename);
+            Object.defineProperty(mockFile, 'size', { value: Math.pow(1024, 4), writable: false });
 
             // Create mock calls
             const adderMock = jasmine.createSpy('adderMock');
@@ -199,11 +207,13 @@ define([
 
             uploadWidget.dropzone.addFile(mockFile);
             setTimeout(() => {
-                let $fileTemplate = uploadWidget.$elem;
-                expect($fileTemplate.find('#globus_error_link').attr('href')).toEqual('https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&destination_path=' + fakeUser);
+                const $fileTemplate = uploadWidget.$elem;
+                expect($fileTemplate.find('#globus_error_link').attr('href')).toEqual(
+                    'https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&destination_path=' +
+                        fakeUser
+                );
                 done();
             });
         });
-
     });
 });

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -1,5 +1,3 @@
-/*jslint white: true*/
-
 define([
     'jquery',
     'kbase/js/widgets/narrative_core/upload/stagingAreaViewer',
@@ -8,10 +6,9 @@ define([
 ], ($, StagingAreaViewer, Jupyter) => {
     'use strict';
 
-    describe('Test the staging area viewer widget', () => {
-        let stagingViewer,
-            $targetNode,
-            startingPath = '/',
+    describe('The staging area viewer widget', () => {
+        let stagingViewer, $targetNode;
+        const startingPath = '/',
             updatePathFn = () => {},
             fakeUser = 'notAUser';
 

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -1,15 +1,11 @@
 /*jslint white: true*/
 
-define ([
+define([
     'jquery',
     'kbase/js/widgets/narrative_core/upload/stagingAreaViewer',
     'base/js/namespace',
-    'kbaseNarrative'
-], (
-    $,
-    StagingAreaViewer,
-    Jupyter
-) => {
+    'kbaseNarrative',
+], ($, StagingAreaViewer, Jupyter) => {
     'use strict';
 
     describe('Test the staging area viewer widget', () => {
@@ -32,26 +28,27 @@ define ([
                         path: fakeUser + '/test_folder',
                         mtime: 1532738637499,
                         size: 34,
-                        isFolder: true
-                    }, {
+                        isFolder: true,
+                    },
+                    {
                         name: 'file_list.txt',
                         path: fakeUser + '/test_folder/file_list.txt',
                         mtime: 1532738637555,
                         size: 49233,
-                        source: 'KBase upload'
-                    }
-                ])
+                        source: 'KBase upload',
+                    },
+                ]),
             });
             Jupyter.narrative = {
                 userId: fakeUser,
                 getAuthToken: () => 'fakeToken',
                 sidePanel: {
-                    '$dataWidget': {
-                        '$overlayPanel': {}
+                    $dataWidget: {
+                        $overlayPanel: {},
                     },
-                    '$methodsWidget': {
-                        currentTag: 'release'
-                    }
+                    $methodsWidget: {
+                        currentTag: 'release',
+                    },
                 },
                 showDataOverlay: () => {},
                 addAndPopulateApp: () => {},
@@ -63,8 +60,8 @@ define ([
                 updatePathFn: updatePathFn,
                 userInfo: {
                     user: fakeUser,
-                    globusLinked: false
-                }
+                    globusLinked: false,
+                },
             });
         });
 
@@ -84,28 +81,30 @@ define ([
         });
 
         it('Should render properly with a Globus linked account', async (done) => {
-            let $node = $('<div>'),
+            const $node = $('<div>'),
                 linkedStagingViewer = new StagingAreaViewer($node, {
                     path: startingPath,
                     updatePathFn: updatePathFn,
                     userInfo: {
                         user: fakeUser,
-                        globusLinked: true
-                    }
+                        globusLinked: true,
+                    },
                 });
-            await linkedStagingViewer.render()
-                .then(() => {
-                    var $globusButton = $node.find('#globusLinked');
-                    expect($globusButton).toBeDefined();
-                    expect($globusButton.html()).toContain('Upload with Globus');
-                    expect($globusButton.attr('href')).toEqual('https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&destination_path=' + fakeUser);
-                    done();
-                });
+            await linkedStagingViewer.render().then(() => {
+                const $globusButton = $node.find('#globusLinked');
+                expect($globusButton).toBeDefined();
+                expect($globusButton.html()).toContain('Upload with Globus');
+                expect($globusButton.attr('href')).toEqual(
+                    'https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a&destination_path=' +
+                        fakeUser
+                );
+                done();
+            });
         });
 
         it('Should render properly without a Globus linked account', async () => {
             await stagingViewer.render();
-            var $globusButton = $targetNode.find('#globusNotLinked');
+            const $globusButton = $targetNode.find('#globusNotLinked');
             expect($globusButton).toBeDefined();
             expect($globusButton.html()).toContain('Upload with Globus');
             expect($globusButton.attr('href')).toEqual('https://docs.kbase.us/data/globus');
@@ -113,13 +112,12 @@ define ([
 
         it('Should render a url button', async () => {
             await stagingViewer.render();
-            var $urlButton = $targetNode.find('.web_upload_div');
+            const $urlButton = $targetNode.find('.web_upload_div');
             expect($urlButton).toBeDefined();
             expect($urlButton.html()).toContain('Upload with URL');
         });
 
-
-        it('Should start a help tour', function() {
+        it('Should start a help tour', () => {
             stagingViewer.render();
             stagingViewer.startTour();
             expect(stagingViewer.tour).not.toBeNull();
@@ -136,7 +134,7 @@ define ([
                 statusText: 'success',
                 contentType: 'text/plain',
                 responseHeaders: '',
-                responseText: errorText
+                responseText: errorText,
             });
 
             await stagingViewer.setPath('//foo');
@@ -149,7 +147,7 @@ define ([
                 statusText: 'success',
                 contentType: 'text/plain',
                 responseHeaders: '',
-                responseText: JSON.stringify([])
+                responseText: JSON.stringify([]),
             });
 
             await stagingViewer.setPath('//empty');
@@ -200,11 +198,11 @@ define ([
                 inputs = {
                     fastq_fwd_staging_file_name: fileName,
                     name: fileName + '_reads',
-                    import_type: 'FASTQ/FASTA'
+                    import_type: 'FASTQ/FASTA',
                 };
             spyOn(Jupyter.narrative, 'addAndPopulateApp');
             spyOn(Jupyter.narrative, 'hideOverlay');
-            stagingViewer.initImportApp(fileType, {name: fileName});
+            stagingViewer.initImportApp(fileType, { name: fileName });
             expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledWith(appId, tag, inputs);
             expect(Jupyter.narrative.hideOverlay).toHaveBeenCalled();
         });
@@ -219,10 +217,9 @@ define ([
 
         it('Creates a downloader iframe when requested', () => {
             stagingViewer.downloadFile('some_url');
-            let dlNode = document.getElementById('hiddenDownloader');
+            const dlNode = document.getElementById('hiddenDownloader');
             expect(dlNode).toBeDefined();
             expect(dlNode.getAttribute('src')).toEqual('some_url');
         });
-
     });
 });

--- a/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-spec.js
+++ b/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-spec.js
@@ -4,12 +4,8 @@
 define([
     '../../../../../../../narrative/nbextensions/appCell2/widgets/appCellWidget',
     'common/runtime',
-    'base/js/namespace'
-], function(
-    AppCell,
-    Runtime,
-    Jupyter
-) {
+    'base/js/namespace',
+], (AppCell, Runtime, Jupyter) => {
     'use strict';
     let mockAppCell;
 
@@ -22,13 +18,13 @@ define([
             narrative_nice_name: 'Test Narrative',
             searchtags: 'narrative',
             is_temporary: 'false',
-            narrative: '1'
+            narrative: '1',
         },
         moddate: '2020-10-06T03:30:52+0000',
         name: 'testUser:narrative_1601948894239',
         object_count: 1,
         owner: 'testUser',
-        user_permission: 'a'
+        user_permission: 'a',
     };
 
     const cell = {
@@ -36,54 +32,56 @@ define([
         metadata: {
             kbase: {
                 type: 'app',
-                attributes:{
+                attributes: {
                     created: 'Fri, 27 Mar 2020 17:39:10 GMT',
                     id: '71e12dca-3a12-4dd7-862b-125f4337e723',
                     info: {
                         label: 'more...',
-                        url: '/#appcatalog/app/simpleapp/example_method/beta'
+                        url: '/#appcatalog/app/simpleapp/example_method/beta',
                     },
                     lastLoaded: 'Tue, 06 Oct 2020 23:28:26 GMT',
                     status: 'new',
                     subtitle: 'Perform some kind of method',
-                    title: 'SimpleApp Simple Add'
+                    title: 'SimpleApp Simple Add',
                 },
                 appCell: {
                     app: {
                         spec: {
-                            parameters: [{
-                                advanced: 0,
-                                allow_multiple: 0,
-                                default_values: ['0'],
-                                description: 'The first parameter that needs to be entered to drive the method. This might be the first of many.',
-                                disabled: 0,
-                                field_type: 'text',
-                                id: 'base_number',
-                                optional: 1,
-                                short_hint: 'The first parameter',
-                                text_options:{
-                                    is_output_name: 0,
-                                    placeholder: '',
-                                    regex_constraint: [],
-                                    valid_ws_types: [],
-                                    validate_as: 'int',
-                                    ui_class: 'parameter',
-                                    ui_name: 'base_number',
-                                }
-                            }]
-                        }
-                    }
+                            parameters: [
+                                {
+                                    advanced: 0,
+                                    allow_multiple: 0,
+                                    default_values: ['0'],
+                                    description:
+                                        'The first parameter that needs to be entered to drive the method. This might be the first of many.',
+                                    disabled: 0,
+                                    field_type: 'text',
+                                    id: 'base_number',
+                                    optional: 1,
+                                    short_hint: 'The first parameter',
+                                    text_options: {
+                                        is_output_name: 0,
+                                        placeholder: '',
+                                        regex_constraint: [],
+                                        valid_ws_types: [],
+                                        validate_as: 'int',
+                                        ui_class: 'parameter',
+                                        ui_name: 'base_number',
+                                    },
+                                },
+                            ],
+                        },
+                    },
                 },
-            }
-        }
+            },
+        },
     };
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     // Can only test the public functions...
     describe('The appCell widget', () => {
-
         beforeEach(() => {
-            let bus = Runtime.make().bus();
+            const bus = Runtime.make().bus();
             mockAppCell = AppCell.make({
                 workspaceInfo: workspaceInfo,
                 bus: bus,
@@ -91,10 +89,10 @@ define([
             });
 
             Jupyter.notebook = {
-                writable: true
+                writable: true,
             };
             Jupyter.narrative = {
-                readonly: false
+                readonly: false,
             };
         });
 
@@ -118,20 +116,20 @@ define([
         });
 
         it('Has expected functions when instantiated', () => {
-            ['init', 'attach', 'start', 'stop', 'detach'].forEach(fn => {
+            ['init', 'attach', 'start', 'stop', 'detach'].forEach((fn) => {
                 expect(mockAppCell[fn]).toBeDefined();
             });
         });
 
         it('has a method "init" which returns a promise then null', () => {
-            return mockAppCell.init()
-                .then(() => {
-                    // something to see if it worked
-                });
+            return mockAppCell.init().then(() => {
+                // something to see if it worked
+            });
         });
 
         it('has a method stop which returns a Promise', () => {
-            return mockAppCell.init()
+            return mockAppCell
+                .init()
                 .then(() => {
                     return mockAppCell.stop();
                 })
@@ -141,7 +139,8 @@ define([
         });
 
         it('has a method detach which returns a Promise', () => {
-            return mockAppCell.init()
+            return mockAppCell
+                .init()
                 .then(() => {
                     return mockAppCell.stop();
                 })
@@ -152,7 +151,5 @@ define([
                     //see if it worked.
                 });
         });
-
     });
-
 });

--- a/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-spec.js
+++ b/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-spec.js
@@ -1,6 +1,3 @@
-/*global describe, it, expect*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define([
     '../../../../../../../narrative/nbextensions/appCell2/widgets/appCellWidget',
     'common/runtime',

--- a/test/unit/spec/tourSpec.js
+++ b/test/unit/spec/tourSpec.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 define(['jquery', 'narrativeTour', 'bootstraptour'], ($, Tour, BSTour) => {
     'use strict';
     describe('Test the narrativeTour module', () => {

--- a/test/unit/spec/tourSpec.js
+++ b/test/unit/spec/tourSpec.js
@@ -4,33 +4,25 @@
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
 
-define ([
-    'jquery',
-    'narrativeTour',
-    'bootstraptour'
-], function (
-    $,
-    Tour,
-    BSTour
-) {
+define(['jquery', 'narrativeTour', 'bootstraptour'], ($, Tour, BSTour) => {
     'use strict';
-    describe('Test the narrativeTour module', function() {
-        it('Loaded the Tour module', function() {
+    describe('Test the narrativeTour module', () => {
+        it('Loaded the Tour module', () => {
             expect(Tour).not.toBe(null);
             expect(BSTour).not.toBeFalsy();
         });
 
-        it('Has expected functions', function() {
+        it('Has expected functions', () => {
             expect(Tour.Tour).toBeDefined();
         });
 
-        it('Can be instantiated', function() {
-            var tourInstance = new Tour.Tour();
+        it('Can be instantiated', () => {
+            const tourInstance = new Tour.Tour();
             expect(tourInstance).not.toBe(null);
         });
 
-        it('Can be started', function() {
-            var tourInstance = new Tour.Tour();
+        it('Can be started', () => {
+            const tourInstance = new Tour.Tour();
             tourInstance.start();
             expect($.find('.kb-tour')).toBeTruthy();
             tourInstance.stop();

--- a/test/unit/spec/userMenuSpec.js
+++ b/test/unit/spec/userMenuSpec.js
@@ -1,11 +1,11 @@
 /* global describe, it, expect, jasmine, beforeEach, afterEach */
 
-define([
-    'jquery',
-    'userMenu',
-    'narrativeConfig',
-    'narrativeMocks'
-], ($, UserMenu, Config, Mocks) => {
+define(['jquery', 'userMenu', 'narrativeConfig', 'narrativeMocks'], (
+    $,
+    UserMenu,
+    Config,
+    Mocks
+) => {
     'use strict';
 
     const TEST_TOKEN = 'fake_token',
@@ -19,7 +19,7 @@ define([
             token: TEST_TOKEN,
             userName: TEST_USER,
             email: TEST_EMAIL,
-            displayName: TEST_NAME
+            displayName: TEST_NAME,
         });
     }
 
@@ -28,13 +28,15 @@ define([
             jasmine.Ajax.install();
             Mocks.mockJsonRpc1Call({
                 url: Config.url('user_profile'),
-                response: [{
-                    profile: {
-                        userdata: {
-                            gravatarDefault: 'identicon'
-                        }
-                    }
-                }]
+                response: [
+                    {
+                        profile: {
+                            userdata: {
+                                gravatarDefault: 'identicon',
+                            },
+                        },
+                    },
+                ],
             });
         });
 
@@ -47,7 +49,7 @@ define([
             expect(UserMenu.make).toBeDefined();
             const $elem = $('<div>');
             const userMenu = makeTestUserMenu($elem);
-            ['start', 'render', 'logout'].forEach(fn => {
+            ['start', 'render', 'logout'].forEach((fn) => {
                 expect(userMenu[fn]).toBeDefined();
             });
         });
@@ -55,36 +57,40 @@ define([
         it('Should start and create a menu in the target node with an empty user profile', () => {
             const $elem = $('<div>');
             const userMenu = makeTestUserMenu($elem);
-            return userMenu.start()
-                .then(() => {
-                    expect($elem.find('.login-button-avatar')).toBeDefined();
-                    const $profileItem = $elem.find('[data-menu-item="userlabel"]');
-                    expect($profileItem).toBeDefined();
-                    expect($profileItem.attr('href')).toEqual(`/#people/${TEST_USER}`);
-                    expect($profileItem.text()).toContain(TEST_NAME);
-                    expect($profileItem.text()).toContain(TEST_USER);
-                });
+            return userMenu.start().then(() => {
+                expect($elem.find('.login-button-avatar')).toBeDefined();
+                const $profileItem = $elem.find('[data-menu-item="userlabel"]');
+                expect($profileItem).toBeDefined();
+                expect($profileItem.attr('href')).toEqual(`/#people/${TEST_USER}`);
+                expect($profileItem.text()).toContain(TEST_NAME);
+                expect($profileItem.text()).toContain(TEST_USER);
+            });
         });
 
         it('Should trigger a logout popup when clicking the logout button', () => {
             const $elem = $('<div>');
             const userMenu = makeTestUserMenu($elem);
-            return userMenu.start()
-                .then(() => {
-                    expect(document.querySelector('.modal [data-element="signout-warning-body"]')).toBeNull();
-                    jasmine.clock().install();
-                    // click the signout button
-                    $elem.find('#signout-button').click();
-                    jasmine.clock().tick(2000);
-                    // expect to see the modal appear now
-                    expect(document.querySelector('.modal [data-element="signout-warning-body"]')).not.toBeNull();
-                    // click the cancel button (it has the default button style)
-                    document.querySelector('a[data-element="cancel-signout"]').click();
-                    jasmine.clock().tick(2000);
-                    // expect the modal to go away
-                    expect(document.querySelector('.modal [data-element="signout-warning-body"]')).toBeNull();
-                    jasmine.clock().uninstall();
-                });
+            return userMenu.start().then(() => {
+                expect(
+                    document.querySelector('.modal [data-element="signout-warning-body"]')
+                ).toBeNull();
+                jasmine.clock().install();
+                // click the signout button
+                $elem.find('#signout-button').click();
+                jasmine.clock().tick(2000);
+                // expect to see the modal appear now
+                expect(
+                    document.querySelector('.modal [data-element="signout-warning-body"]')
+                ).not.toBeNull();
+                // click the cancel button (it has the default button style)
+                document.querySelector('a[data-element="cancel-signout"]').click();
+                jasmine.clock().tick(2000);
+                // expect the modal to go away
+                expect(
+                    document.querySelector('.modal [data-element="signout-warning-body"]')
+                ).toBeNull();
+                jasmine.clock().uninstall();
+            });
         });
     });
 });

--- a/test/unit/spec/userMenuSpec.js
+++ b/test/unit/spec/userMenuSpec.js
@@ -1,5 +1,3 @@
-/* global describe, it, expect, jasmine, beforeEach, afterEach */
-
 define(['jquery', 'userMenu', 'narrativeConfig', 'narrativeMocks'], (
     $,
     UserMenu,

--- a/test/unit/spec/vis/kbaseBarchart-spec.js
+++ b/test/unit/spec/vis/kbaseBarchart-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseBarchart'], (Widget) => {
     describe('Test the kbaseBarchart widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseBarchart-spec.js
+++ b/test/unit/spec/vis/kbaseBarchart-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseBarchart'
-], function(Widget) {
-    describe('Test the kbaseBarchart widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseBarchart'], (Widget) => {
+    describe('Test the kbaseBarchart widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseBarchart-spec.js
+++ b/test/unit/spec/vis/kbaseBarchart-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseBarchart'], (Widget) => {
-    describe('Test the kbaseBarchart widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseBarchart widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseChordchart-spec.js
+++ b/test/unit/spec/vis/kbaseChordchart-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseChordchart'
-], function(Widget) {
-    describe('Test the kbaseChordchart widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseChordchart'], (Widget) => {
+    describe('Test the kbaseChordchart widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseChordchart-spec.js
+++ b/test/unit/spec/vis/kbaseChordchart-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseChordchart'], (Widget) => {
-    describe('Test the kbaseChordchart widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseChordchart widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseChordchart-spec.js
+++ b/test/unit/spec/vis/kbaseChordchart-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseChordchart'], (Widget) => {
     describe('Test the kbaseChordchart widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseCircularHeatmap-spec.js
+++ b/test/unit/spec/vis/kbaseCircularHeatmap-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseCircularHeatmap'], (Widget) => {
     describe('Test the kbaseCircularHeatmap widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseCircularHeatmap-spec.js
+++ b/test/unit/spec/vis/kbaseCircularHeatmap-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseCircularHeatmap'
-], function(Widget) {
-    describe('Test the kbaseCircularHeatmap widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseCircularHeatmap'], (Widget) => {
+    describe('Test the kbaseCircularHeatmap widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseCircularHeatmap-spec.js
+++ b/test/unit/spec/vis/kbaseCircularHeatmap-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseCircularHeatmap'], (Widget) => {
-    describe('Test the kbaseCircularHeatmap widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseCircularHeatmap widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseForcedNetwork-spec.js
+++ b/test/unit/spec/vis/kbaseForcedNetwork-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseForcedNetwork'
-], function(Widget) {
-    describe('Test the kbaseForcedNetwork widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseForcedNetwork'], (Widget) => {
+    describe('Test the kbaseForcedNetwork widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseForcedNetwork-spec.js
+++ b/test/unit/spec/vis/kbaseForcedNetwork-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseForcedNetwork'], (Widget) => {
     describe('Test the kbaseForcedNetwork widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseForcedNetwork-spec.js
+++ b/test/unit/spec/vis/kbaseForcedNetwork-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseForcedNetwork'], (Widget) => {
-    describe('Test the kbaseForcedNetwork widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseForcedNetwork widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseHeatmap-spec.js
+++ b/test/unit/spec/vis/kbaseHeatmap-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseHeatmap'
-], function(Widget) {
-    describe('Test the kbaseHeatmap widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseHeatmap'], (Widget) => {
+    describe('Test the kbaseHeatmap widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseHeatmap-spec.js
+++ b/test/unit/spec/vis/kbaseHeatmap-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseHeatmap'], (Widget) => {
     describe('Test the kbaseHeatmap widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseHeatmap-spec.js
+++ b/test/unit/spec/vis/kbaseHeatmap-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseHeatmap'], (Widget) => {
-    describe('Test the kbaseHeatmap widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseHeatmap widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseHistogram-spec.js
+++ b/test/unit/spec/vis/kbaseHistogram-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseHistogram'
-], function(Widget) {
-    describe('Test the kbaseHistogram widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseHistogram'], (Widget) => {
+    describe('Test the kbaseHistogram widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseHistogram-spec.js
+++ b/test/unit/spec/vis/kbaseHistogram-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseHistogram'], (Widget) => {
-    describe('Test the kbaseHistogram widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseHistogram widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseHistogram-spec.js
+++ b/test/unit/spec/vis/kbaseHistogram-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseHistogram'], (Widget) => {
     describe('Test the kbaseHistogram widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseLineSerieschart-spec.js
+++ b/test/unit/spec/vis/kbaseLineSerieschart-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseLineSerieschart'], (Widget) => {
     describe('Test the kbaseLineSerieschart widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseLineSerieschart-spec.js
+++ b/test/unit/spec/vis/kbaseLineSerieschart-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseLineSerieschart'], (Widget) => {
-    describe('Test the kbaseLineSerieschart widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseLineSerieschart widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseLineSerieschart-spec.js
+++ b/test/unit/spec/vis/kbaseLineSerieschart-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseLineSerieschart'
-], function(Widget) {
-    describe('Test the kbaseLineSerieschart widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseLineSerieschart'], (Widget) => {
+    describe('Test the kbaseLineSerieschart widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseLinechart-spec.js
+++ b/test/unit/spec/vis/kbaseLinechart-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseLinechart'], (Widget) => {
-    describe('Test the kbaseLinechart widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseLinechart widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseLinechart-spec.js
+++ b/test/unit/spec/vis/kbaseLinechart-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseLinechart'
-], function(Widget) {
-    describe('Test the kbaseLinechart widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseLinechart'], (Widget) => {
+    describe('Test the kbaseLinechart widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseLinechart-spec.js
+++ b/test/unit/spec/vis/kbaseLinechart-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseLinechart'], (Widget) => {
     describe('Test the kbaseLinechart widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbasePiechart-spec.js
+++ b/test/unit/spec/vis/kbasePiechart-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbasePiechart'
-], function(Widget) {
-    describe('Test the kbasePiechart widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbasePiechart'], (Widget) => {
+    describe('Test the kbasePiechart widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbasePiechart-spec.js
+++ b/test/unit/spec/vis/kbasePiechart-spec.js
@@ -1,5 +1,8 @@
 define(['kbasePiechart'], (Widget) => {
-    describe('Test the kbasePiechart widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbasePiechart widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbasePiechart-spec.js
+++ b/test/unit/spec/vis/kbasePiechart-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbasePiechart'], (Widget) => {
     describe('Test the kbasePiechart widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseScatterplot-spec.js
+++ b/test/unit/spec/vis/kbaseScatterplot-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseScatterplot'], (Widget) => {
     describe('Test the kbaseScatterplot widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseScatterplot-spec.js
+++ b/test/unit/spec/vis/kbaseScatterplot-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseScatterplot'
-], function(Widget) {
-    describe('Test the kbaseScatterplot widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseScatterplot'], (Widget) => {
+    describe('Test the kbaseScatterplot widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseScatterplot-spec.js
+++ b/test/unit/spec/vis/kbaseScatterplot-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseScatterplot'], (Widget) => {
-    describe('Test the kbaseScatterplot widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseScatterplot widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseTreechart-spec.js
+++ b/test/unit/spec/vis/kbaseTreechart-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseTreechart'
-], function(Widget) {
-    describe('Test the kbaseTreechart widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseTreechart'], (Widget) => {
+    describe('Test the kbaseTreechart widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseTreechart-spec.js
+++ b/test/unit/spec/vis/kbaseTreechart-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseTreechart'], (Widget) => {
     describe('Test the kbaseTreechart widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseTreechart-spec.js
+++ b/test/unit/spec/vis/kbaseTreechart-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseTreechart'], (Widget) => {
-    describe('Test the kbaseTreechart widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseTreechart widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/kbaseVenndiagram-spec.js
+++ b/test/unit/spec/vis/kbaseVenndiagram-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbaseVenndiagram'], (Widget) => {
     describe('Test the kbaseVenndiagram widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/kbaseVenndiagram-spec.js
+++ b/test/unit/spec/vis/kbaseVenndiagram-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbaseVenndiagram'
-], function(Widget) {
-    describe('Test the kbaseVenndiagram widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbaseVenndiagram'], (Widget) => {
+    describe('Test the kbaseVenndiagram widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/spec/vis/kbaseVenndiagram-spec.js
+++ b/test/unit/spec/vis/kbaseVenndiagram-spec.js
@@ -1,5 +1,8 @@
 define(['kbaseVenndiagram'], (Widget) => {
-    describe('Test the kbaseVenndiagram widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbaseVenndiagram widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/plants/kbasePMIBarchart-spec.js
+++ b/test/unit/spec/vis/plants/kbasePMIBarchart-spec.js
@@ -1,8 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
 define(['kbasePMIBarchart'], (Widget) => {
     describe('Test the kbasePMIBarchart widget', () => {
         it('Should do things', () => {});

--- a/test/unit/spec/vis/plants/kbasePMIBarchart-spec.js
+++ b/test/unit/spec/vis/plants/kbasePMIBarchart-spec.js
@@ -1,5 +1,8 @@
 define(['kbasePMIBarchart'], (Widget) => {
-    describe('Test the kbasePMIBarchart widget', () => {
-        it('Should do things', () => {});
+    'use strict';
+    describe('The kbasePMIBarchart widget', () => {
+        it('should be defined', () => {
+            expect(Widget).toBeDefined();
+        });
     });
 });

--- a/test/unit/spec/vis/plants/kbasePMIBarchart-spec.js
+++ b/test/unit/spec/vis/plants/kbasePMIBarchart-spec.js
@@ -3,12 +3,8 @@
 /*global jasmine*/
 /*global beforeEach, afterEach*/
 /*jslint white: true*/
-define([
-    'kbasePMIBarchart'
-], function(Widget) {
-    describe('Test the kbasePMIBarchart widget', function() {
-        it('Should do things', function() {
-
-        });
+define(['kbasePMIBarchart'], (Widget) => {
+    describe('Test the kbasePMIBarchart widget', () => {
+        it('Should do things', () => {});
     });
 });

--- a/test/unit/specTemplate.js
+++ b/test/unit/specTemplate.js
@@ -12,38 +12,30 @@
  * This uses the Jasmine framework for testing. You can see usage and examples here:
  * https://jasmine.github.io/2.0/introduction.html
  */
-define ([
-    'kbwidget',
-    'bootstrap',
-    'a_module'
-], function(
-    KBWidget,
-    bootstrap,
-    Module
-) {
+define(['kbwidget', 'bootstrap', 'a_module'], (KBWidget, bootstrap, Module) => {
     'use strict';
-    describe('Test the module', function() {
-        var myModule;
+    describe('Test the module', () => {
+        let myModule;
 
         // Some setup code before each individual test (not always necessary).
-        beforeEach(function () {
+        beforeEach(() => {
             myModule = Module.make();
         });
 
         // Some cleanup code after each test (not always necessary).
-        afterEach(function () {
+        afterEach(() => {
             myModule.destroy();
             myModule = null;
         });
 
         // A single test case where the result shouldn't be null.
-        it('Should do stuff', function() {
-            var result = myModule.doStuff();
+        it('Should do stuff', () => {
+            const result = myModule.doStuff();
             expect(result).not.toBeNull();
         });
 
         // A single test case where the result should be any Object.
-        it('Should have things as an object', function () {
+        it('Should have things as an object', () => {
             expect(myModule.things).toEqual(jasmine.any(Object));
         });
     });

--- a/test/unit/specTemplate.js
+++ b/test/unit/specTemplate.js
@@ -1,9 +1,3 @@
-/*global define*/
-/*global describe, it, expect*/
-/*global jasmine*/
-/*global beforeEach, afterEach*/
-/*jslint white: true*/
-
 /**
  * This is an example template for a testing spec for some widget. THIS WILL NOT ACTUALLY RUN.
  * It's just meant as an example to get you bootstrapped.

--- a/test/unit/test-main.js
+++ b/test/unit/test-main.js
@@ -2,20 +2,19 @@
 /* global requirejs */
 const tests = [
     ...['text', 'json'],
-    ...Object.keys(window.__karma__.files).filter(file => /[sS]pec\.js$/.test(file))
+    ...Object.keys(window.__karma__.files).filter((file) => /[sS]pec\.js$/.test(file)),
 ];
 
 // hack to make jed (the i18n library that Jupyter uses) happy.
 document.nbjs_translations = {
-    'domain': 'nbjs',
-    'locale_data':
-    {
-        'nbjs': {
+    domain: 'nbjs',
+    locale_data: {
+        nbjs: {
             '': {
-                'domain': 'nbjs'
-            }
-        }
-    }
+                domain: 'nbjs',
+            },
+        },
+    },
 };
 
 // hack to spoof createReactClass, needed by a Jupyter component we aren't testing.
@@ -33,7 +32,7 @@ requirejs.config({
         narrativeMocks: '../../test/unit/mocks',
         bluebird: 'ext_components/bluebird/js/browser/bluebird.min',
         jed: 'components/jed/jed',
-        custom: 'kbase/custom'
+        custom: 'kbase/custom',
     },
     map: {
         '*': {
@@ -46,19 +45,19 @@ requirejs.config({
     shim: {
         jquery: {
             deps: [],
-            exports: 'jquery'
+            exports: 'jquery',
         },
         bootstraptour: {
             deps: ['bootstrap'],
-            exports: 'Tour'
+            exports: 'Tour',
         },
         bootstrap: {
             deps: ['jquery'],
-            exports: 'Bootstrap'
+            exports: 'Bootstrap',
         },
     },
 
-    callback: function() {
+    callback: function () {
         'use strict';
 
         require(['testUtil'], (TestUtil) => {
@@ -70,5 +69,5 @@ requirejs.config({
             console.error(error);
             throw error;
         });
-    }
+    },
 });

--- a/test/unit/testUtil.js
+++ b/test/unit/testUtil.js
@@ -1,12 +1,12 @@
 /*global pending */
-define('testUtil', [
-    'bluebird',
-    'narrativeConfig',
-    'json!/test/testConfig.json'
-], function(Promise, Config, TestConfig) {
+define('testUtil', ['bluebird', 'narrativeConfig', 'json!/test/testConfig.json'], (
+    Promise,
+    Config,
+    TestConfig
+) => {
     'use strict';
 
-    var token = null,
+    let token = null,
         userId = null,
         currentNarrative = null,
         currentWorkspace = null;
@@ -27,15 +27,13 @@ define('testUtil', [
         if (currentNarrative) {
             return currentNarrative;
         }
-        var token = getAuthToken();
+        const token = getAuthToken();
         // make a new workspace
         // make a new narrative object and add it to the workspace
         // add some data to the workspace
     }
 
-    function createNarrative() {
-
-    }
+    function createNarrative() {}
 
     function loadNarrativeData() {
         /* Steps:
@@ -51,9 +49,7 @@ define('testUtil', [
          */
     }
 
-    function getCurrentWorkspace() {
-
-    }
+    function getCurrentWorkspace() {}
 
     /**
      * Runs the Jasmine pending() function if there's no Auth token available. This skips the
@@ -67,21 +63,23 @@ define('testUtil', [
 
     function initialize() {
         if (TestConfig.token === undefined) {
-            throw new Error('Missing an auth token. Please enter one (or null to skip those tests) in test/unit/testConfig.json');
+            throw new Error(
+                'Missing an auth token. Please enter one (or null to skip those tests) in test/unit/testConfig.json'
+            );
         }
         userId = TestConfig.token.user;
-        var tokenFile = TestConfig.token.file;
-        return new Promise(function(resolve) {
-            require(['text!/' + tokenFile],
-                function(loadedToken) {
-                    token = loadedToken.trim();
-                    console.warn('Loaded token file ' + tokenFile);
-                    resolve(token);
-                },
-                function() {
-                    console.warn('Unable to load token file ' + tokenFile + '. Continuing without a token');
-                    resolve(null);
-                });
+        const tokenFile = TestConfig.token.file;
+        return new Promise((resolve) => {
+            require(['text!/' + tokenFile], (loadedToken) => {
+                token = loadedToken.trim();
+                console.warn('Loaded token file ' + tokenFile);
+                resolve(token);
+            }, () => {
+                console.warn(
+                    'Unable to load token file ' + tokenFile + '. Continuing without a token'
+                );
+                resolve(null);
+            });
         });
     }
 
@@ -95,6 +93,6 @@ define('testUtil', [
         getCurrentNarrative: getCurrentNarrative,
         pendingIfNoToken: pendingIfNoToken,
         getUserId: getUserId,
-        wait: wait
+        wait: wait,
     };
 });

--- a/test/unit/testUtil.js
+++ b/test/unit/testUtil.js
@@ -1,4 +1,3 @@
-/*global pending */
 define('testUtil', ['bluebird', 'narrativeConfig', 'json!/test/testConfig.json'], (
     Promise,
     Config,
@@ -8,8 +7,7 @@ define('testUtil', ['bluebird', 'narrativeConfig', 'json!/test/testConfig.json']
 
     let token = null,
         userId = null,
-        currentNarrative = null,
-        currentWorkspace = null;
+        currentNarrative = null;
 
     function factory() {
         return initialize();


### PR DESCRIPTION
# Description of PR purpose/changes

- Ran eslint and prettier on all files under `test/unit`
- Added 'use strict' to all test files
- Removed a load of global declaration cruft, e.g. `/* global describe, it, ... */` and `/* jslint white: true */`
- Add basic widget definition tests where there were empty `it` declarations:
```js
    it('should be defined', () => {
        expect(Widget).toBeDefined();
    });
```

First commit is all automated, eslint + prettier
Second commit is removing the `/* global */` and `/* jslint */`, plus a couple of very minor eslint fixes
Third commit is adding `use strict` and very basic module existence tests

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by checking out the "Files" tab of this PR

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules - N/A
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
