### PR TITLE
DATAUP-330: Edits to the appWidgets and unit tests

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
@@ -18,17 +18,15 @@ define([
         label = t('label');
 
     function factory(config) {
-        let spec = config.parameterSpec,
+        const spec = config.parameterSpec,
             runtime = Runtime.make(),
             busConnection = runtime.bus().connect(),
             channel = busConnection.channel(config.channelName),
-            parent,
-            container,
-            ui,
             model = {
                 updates: 0,
                 value: undefined,
             };
+        let parent, container, ui;
 
         // MODEL
 
@@ -55,6 +53,7 @@ define([
             return 0;
         }
 
+        // FIXME: where is the 'input-control' element?
         function syncModelToControl() {
             const control = ui.getElement('input-control.input');
             if (model.value === 1) {
@@ -102,14 +101,7 @@ define([
                                 type: 'change',
                                 handler: function () {
                                     validate().then((result) => {
-                                        if (config.showOwnMessages) {
-                                            ui.setContent('input-container.message', '');
-                                        }
-                                        if (result.diagnosis === 'optional-empty') {
-                                            setModelValue(result.parsedValue);
-                                        } else {
-                                            setModelValue(result.parsedValue);
-                                        }
+                                        setModelValue(result.parsedValue);
                                         channel.emit('validation', {
                                             errorMessage: result.errorMessage,
                                             diagnosis: result.diagnosis,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/inputUtils.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/inputUtils.js
@@ -1,4 +1,4 @@
-define(['kb_common/html', 'common/events', 'common/ui'], (html, Events, UI) => {
+define(['common/html', 'common/events', 'common/ui'], (html, Events, UI) => {
     'use strict';
 
     const t = html.tag,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/float.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/float.js
@@ -1,9 +1,21 @@
 define(['bluebird'], (Promise) => {
     'use strict';
 
-    function importString(value) {
-        let normalizedValue;
+    function toFloat(value) {
+        const valueType = typeof value;
+        if (valueType === 'number') {
+            return value;
+        } else if (valueType === 'string') {
+            const number = Number(value);
+            if (isNaN(number)) {
+                throw new Error('Invalid float format: ' + value);
+            }
+            return number;
+        }
+        throw new Error('Type ' + valueType + ' cannot be converted to float');
+    }
 
+    function importString(value) {
         if (value === undefined || value === null) {
             return null;
         }
@@ -11,11 +23,11 @@ define(['bluebird'], (Promise) => {
         if (typeof value !== 'string') {
             throw new Error('value must be a string (it is of type "' + typeof value + '")');
         }
-        normalizedValue = value.trim();
+        const normalizedValue = value.trim();
         if (value === '') {
             return null;
         }
-        return parseFloat(normalizedValue);
+        return toFloat(normalizedValue);
     }
 
     function validateFloat(value, min, max) {
@@ -63,31 +75,6 @@ define(['bluebird'], (Promise) => {
             return applyConstraints(value, spec.data.constraints);
         });
     }
-
-    // For text values, there is
-    // function validate(value, spec) {
-    //     try {
-    //         var nativeValue = importString(value);
-    //         return {
-    //             value: {
-    //                 original: value,
-    //                 parsed: nativeValue
-    //             },
-    //             validation: applyConstraints(nativeValue, spec.data.constraints)
-    //         };
-    //     } catch (ex) {
-    //         return {
-    //             value: {
-    //                 original: value
-    //             },
-    //             validation: {
-    //                 isValid: false,
-    //                 errorMessage: ex.message,
-    //                 diagnosis: 'invalid'
-    //             }
-    //         };
-    //     }
-    // }
 
     return {
         importString: importString,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/int.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/int.js
@@ -1,4 +1,6 @@
 define(['bluebird'], (Promise) => {
+    'use strict';
+
     function toInteger(value) {
         switch (typeof value) {
             case 'number':
@@ -17,36 +19,20 @@ define(['bluebird'], (Promise) => {
     }
 
     function importString(value) {
-        let plainValue, parsedValue;
-
         if (value === undefined || value === null) {
             return null;
         }
 
         if (typeof value !== 'string') {
             throw new Error('value must be a string (it is of type "' + typeof value + '")');
-        } else {
-            plainValue = value.trim();
-            if (plainValue === '') {
-                return null;
-            }
-            parsedValue = toInteger(plainValue);
         }
 
-        return parsedValue;
+        const plainValue = value.trim();
+        if (plainValue === '') {
+            return null;
+        }
+        return toInteger(plainValue);
     }
-
-    // function validateInt(value, min, max) {
-    //     if (isNaN(value)) {
-    //         return 'value must be numeric';
-    //     }
-    //     if (max && max < value) {
-    //         return 'the maximum value for this parameter is ' + max;
-    //     }
-    //     if (min && min > value) {
-    //         return 'the minimum value for this parameter is ' + min;
-    //     }
-    // }
 
     function validateInt(value, min, max) {
         if (typeof value !== 'number') {
@@ -58,10 +44,6 @@ define(['bluebird'], (Promise) => {
                     message: 'value must be numeric',
                 };
             }
-            // return {
-            //     id: 'non-numeric',
-            //     message: 'value must be numeric'
-            // };
         }
         if (isNaN(value)) {
             return {
@@ -108,8 +90,6 @@ define(['bluebird'], (Promise) => {
                 errorMessage = error.message;
                 messageId = error.id;
                 diagnosis = 'invalid';
-            } else {
-                diagnosis = 'valid';
             }
         }
 
@@ -127,29 +107,6 @@ define(['bluebird'], (Promise) => {
         });
     }
 
-    // function validate(value, constraints) {
-    //     try {
-    //         var nativeValue = importString(value);
-    //         return {
-    //             value: {
-    //                 original: value,
-    //                 parsed: nativeValue
-    //             },
-    //             validation: applyConstraints(nativeValue, constraints)
-    //         };
-    //     } catch (ex) {
-    //         return {
-    //             value: {
-    //                 original: value
-    //             },
-    //             validation: {
-    //                 isValid: false,
-    //                 errorMessage: ex.message,
-    //                 diagnosis: 'invalid'
-    //             }
-    //         };
-    //     }
-    // }
     return {
         importString: importString,
         applyConstraints: applyConstraints,

--- a/test/unit/spec/appWidgets/input/checkboxInputSpec.js
+++ b/test/unit/spec/appWidgets/input/checkboxInputSpec.js
@@ -1,10 +1,4 @@
-define([
-    'widgets/appWidgets2/input/checkboxInput',
-    'common/runtime',
-    'base/js/namespace',
-    'kbaseNarrative',
-    'testUtil',
-], (CheckboxInput, Runtime, Jupyter, Narrative, TestUtil) => {
+define(['widgets/appWidgets2/input/checkboxInput', 'common/runtime'], (CheckboxInput, Runtime) => {
     'use strict';
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
@@ -34,12 +28,6 @@ define([
                 },
                 channelName: bus.channelName,
             };
-            Jupyter.narrative = new Narrative();
-            if (TestUtil.getAuthToken()) {
-                document.cookie = 'kbase_session=' + TestUtil.getAuthToken();
-                Jupyter.narrative.authToken = TestUtil.getAuthToken();
-                Jupyter.narrative.userId = TestUtil.getUserId();
-            }
         });
 
         afterEach(() => {
@@ -47,14 +35,16 @@ define([
             window.kbaseRuntime = null;
         });
 
-        it('should be real!', () => {
+        it('should be defined', () => {
             expect(CheckboxInput).not.toBeNull();
         });
 
         it('should instantiate with a test config', () => {
-            TestUtil.pendingIfNoToken();
             const widget = CheckboxInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('should start and stop properly without initial value', () => {
@@ -99,20 +89,6 @@ define([
             });
             const widget = CheckboxInput.make(testConfig);
             const node = document.createElement('div');
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[type="checkbox"]');
-                input.setAttribute('checked', true);
-                input.dispatchEvent(new Event('change'));
-            });
-        });
-
-        it('should show message when configured', (done) => {
-            testConfig.showOwnMessaged = true;
-            const widget = CheckboxInput.make(testConfig);
-            const node = document.createElement('div');
-            bus.on('changed', (value) => {
-                done();
-            });
             widget.start({ node: node }).then(() => {
                 const input = node.querySelector('input[type="checkbox"]');
                 input.setAttribute('checked', true);

--- a/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
+++ b/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
@@ -1,65 +1,64 @@
-define([
-    'widgets/appWidgets2/input/dynamicDropdownInput',
-    'base/js/namespace',
-    'kbaseNarrative',
-    'testUtil',
-], (DynamicDropdownInput, Jupyter, Narrative, TestUtil) => {
+define(['widgets/appWidgets2/input/dynamicDropdownInput', 'base/js/namespace', 'narrativeMocks'], (
+    DynamicDropdownInput,
+    Jupyter,
+    Mocks
+) => {
     'use strict';
 
     describe('Test dynamic dropdown input widget', () => {
         const testConfig = {
-            parameterSpec: {
-                data: {
-                    defaultValue: '',
-                    nullValue: '',
-                    constraints: {
-                        required: false,
+                parameterSpec: {
+                    data: {
+                        defaultValue: '',
+                        nullValue: '',
+                        constraints: {
+                            required: false,
+                        },
+                    },
+                    original: {
+                        dynamic_dropdown_options: {},
                     },
                 },
-                original: {
-                    dynamic_dropdown_options: {},
-                },
+                channelName: 'foo',
             },
-            channelName: 'foo',
-        };
+            AUTH_TOKEN = 'fakeAuthToken';
 
         beforeEach(() => {
-            Jupyter.narrative = new Narrative();
-            if (TestUtil.getAuthToken()) {
-                document.cookie = 'kbase_session=' + TestUtil.getAuthToken();
-                Jupyter.narrative.authToken = TestUtil.getAuthToken();
-                Jupyter.narrative.userId = TestUtil.getUserId();
-            }
+            Mocks.setAuthToken(AUTH_TOKEN);
+            Jupyter.narrative = {
+                getAuthToken: () => AUTH_TOKEN,
+                userId: 'test_user',
+            };
         });
 
-        it('should be real!', () => {
+        afterEach(() => {
+            Mocks.clearAuthToken();
+            Jupyter.narrative = null;
+        });
+
+        it('should be defined', () => {
             expect(DynamicDropdownInput).not.toBeNull();
         });
 
         it('should instantiate with a test config', () => {
-            TestUtil.pendingIfNoToken();
             const widget = DynamicDropdownInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
-        it('should start up and stop correctly', (done) => {
-            TestUtil.pendingIfNoToken();
+        it('should start up and stop correctly', () => {
             const widget = DynamicDropdownInput.make(testConfig);
-            widget
-                .start({ node: document.createElement('div') })
+            const node = document.createElement('div');
+            return widget
+                .start({ node: node })
                 .then(() => {
+                    expect(node.innerHTML).toContain('input-container');
                     return widget.stop();
                 })
                 .then(() => {
-                    // no-op
-                })
-                .catch((error) => {
-                    console.error(JSON.stringify(error, null, 4));
-                    console.error(error.stack);
-                    done.fail();
-                })
-                .finally(() => {
-                    done();
+                    expect(node.innerHTML).not.toContain('input-container');
                 });
         });
     });

--- a/test/unit/spec/appWidgets/input/intInputSpec.js
+++ b/test/unit/spec/appWidgets/input/intInputSpec.js
@@ -1,8 +1,4 @@
-define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
-    IntInput,
-    Runtime,
-    TestUtil
-) => {
+define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runtime) => {
     'use strict';
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
@@ -41,14 +37,16 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
             window.kbaseRuntime = null;
         });
 
-        it('should be real!', () => {
+        it('should be defined', () => {
             expect(IntInput).not.toBeNull();
         });
 
-        it('should instantiate with a test config', () => {
-            TestUtil.pendingIfNoToken();
+        it('should be instantiable', () => {
             const widget = IntInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('should start and stop properly without initial value', (done) => {
@@ -117,11 +115,47 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
             });
         });
 
-        it('should show message when configured', (done) => {
+        it('should catch invalid string input', (done) => {
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            bus.on('validation', (msg) => {
+                expect(msg.isValid).toBeFalsy();
+                expect(msg.diagnosis).toBe('invalid');
+                done();
+            });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="int"]');
+                input.setAttribute('value', 'abracadabra');
+                input.dispatchEvent(new Event('change'));
+            });
+        });
+
+        it('should catch invalid float input', (done) => {
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            bus.on('validation', (msg) => {
+                expect(msg.isValid).toBeFalsy();
+                expect(msg.diagnosis).toBe('invalid');
+                done();
+            });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="int"]');
+                input.setAttribute('value', 12345.6);
+                input.dispatchEvent(new Event('change'));
+            });
+        });
+
+        it('should show message when configured, valid input', (done) => {
             testConfig.showOwnMessages = true;
             const widget = IntInput.make(testConfig);
             const node = document.createElement('div');
-            bus.on('validation', done);
+            bus.on('changed', (value) => {
+                expect(value).toEqual({ newValue: 5 });
+                // message node will be empty
+                const errorMsg = node.querySelector('[data-element="message"]');
+                expect(errorMsg.innerHTML).toBe('');
+                done();
+            });
             widget.start({ node: node }).then(() => {
                 const input = node.querySelector('input[data-type="int"]');
                 input.setAttribute('value', 5);
@@ -129,8 +163,33 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
             });
         });
 
-        it('should respond to update command', (done) => {
-            bus.on('validation', done);
+        it('should show message when configured, invalid input', (done) => {
+            testConfig.showOwnMessages = true;
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            bus.on('changed', (value) => {
+                expect(value).toEqual({ newValue: 123456 });
+                // check for an error message in the node
+                const errorMsg = node.querySelector('[data-element="message"]');
+                expect(errorMsg.innerHTML).toContain('ERROR');
+            });
+            bus.on('validation', (msg) => {
+                expect(msg.isValid).toBeFalsy();
+                expect(msg.diagnosis).toBe('invalid');
+                done();
+            });
+            widget.start({ node: node }).then(() => {
+                const input = node.querySelector('input[data-type="int"]');
+                // this value is out of the allowed range
+                input.setAttribute('value', 123456);
+                input.dispatchEvent(new Event('change'));
+            });
+        });
+
+        // this sets the model values but does nothing to the UI
+        // and cannot be assessed via the widget API
+        // => extremely hard to test
+        xit('should respond to update command', () => {
             const widget = IntInput.make(testConfig);
             const node = document.createElement('div');
             widget.start({ node: node }).then(() => {
@@ -138,14 +197,15 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
             });
         });
 
-        it('should respond to reset command'),
-            (done) => {
-                bus.on('validation', done);
-                const widget = IntInput.make(testConfig);
-                const node = document.createElement('div');
-                widget.start({ node: node }).then(() => {
-                    bus.emit('reset-to-defaults');
-                });
-            };
+        // this resets the model values but does nothing to the UI
+        // and cannot be assessed via the widget API
+        // => extremely hard to test
+        xit('should respond to reset command', () => {
+            const widget = IntInput.make(testConfig);
+            const node = document.createElement('div');
+            widget.start({ node: node }).then(() => {
+                bus.emit('reset-to-defaults');
+            });
+        });
     });
 });

--- a/test/unit/spec/appWidgets/input/selectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/selectInputSpec.js
@@ -1,22 +1,19 @@
 define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, SelectInput) => {
     'use strict';
-    let bus,
-        testConfig,
-        required = false,
-        runtime,
-        node,
+    let bus, testConfig, runtime, node;
+    const required = false,
         defaultValue = 'apple';
 
-    function buildTestConfig(required, defaultValue, bus) {
+    function buildTestConfig(_required, _defaultValue, _bus) {
         return {
-            bus: bus,
+            bus: _bus,
             parameterSpec: {
                 data: {
-                    defaultValue: defaultValue,
+                    defaultValue: _defaultValue,
                     nullValue: '',
                     constraints: {
-                        required: required,
-                        defaultValue: defaultValue,
+                        required: _required,
+                        defaultValue: _defaultValue,
                         options: [
                             {
                                 value: 'apple',
@@ -34,7 +31,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                     },
                 },
             },
-            channelName: bus.channelName,
+            channelName: _bus.channelName,
             initialValue: 'apple',
         };
     }
@@ -55,14 +52,20 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
             window.kbaseRuntime = null;
         });
 
-        it('Should load the widget', () => {
+        it('should be defined', () => {
             expect(SelectInput).not.toBeNull();
+        });
+
+        it('should be instantiable', () => {
+            const widget = SelectInput.make(testConfig);
+            expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('Should start and stop a widget', (done) => {
             const widget = SelectInput.make(testConfig);
-            expect(widget).toBeDefined();
-            expect(widget.start).toBeDefined();
 
             widget
                 .start({ node: node })
@@ -150,7 +153,6 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
             bus = runtime.bus().makeChannelBus();
             testConfig = buildTestConfig(true, '', bus);
             const widget = SelectInput.make(testConfig);
-            const inputText = null;
             let msgCount = 0,
                 okCount = 0;
             bus.on('validation', (message) => {

--- a/test/unit/spec/appWidgets/input/subdataInputSpec.js
+++ b/test/unit/spec/appWidgets/input/subdataInputSpec.js
@@ -1,9 +1,4 @@
-define([
-    'widgets/appWidgets2/input/subdataInput',
-    'base/js/namespace',
-    'kbaseNarrative',
-    'testUtil',
-], (SubdataInput, Jupyter, Narrative, TestUtil) => {
+define(['widgets/appWidgets2/input/subdataInput'], (SubdataInput) => {
     'use strict';
 
     describe('Test subobject data input widget', () => {
@@ -23,23 +18,20 @@ define([
             channelName: 'foo',
         };
 
-        beforeEach(() => {
-            Jupyter.narrative = new Narrative();
-            if (TestUtil.getAuthToken()) {
-                document.cookie = 'kbase_session=' + TestUtil.getAuthToken();
-                Jupyter.narrative.authToken = TestUtil.getAuthToken();
-                Jupyter.narrative.userId = TestUtil.getUserId();
-            }
+        afterEach(() => {
+            window.kbaseRuntime = null;
         });
 
-        it('should be real!', () => {
+        it('should be defined', () => {
             expect(SubdataInput).not.toBeNull();
         });
 
-        it('should instantiate with a test config', () => {
-            TestUtil.pendingIfNoToken();
+        it('should instantiate an object with start and stop functions', () => {
             const widget = SubdataInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/textInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textInputSpec.js
@@ -1,33 +1,30 @@
 define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, TextInput) => {
     'use strict';
-    let bus,
-        testConfig,
-        required = false,
-        runtime,
-        node,
+    let bus, testConfig, node;
+    const required = false,
         defaultValue = 'some test text';
 
-    function buildTestConfig(required, defaultValue, bus) {
+    function buildTestConfig(_required, _defaultValue, _bus) {
         return {
-            bus: bus,
+            bus: _bus,
             parameterSpec: {
                 data: {
-                    defaultValue: defaultValue,
+                    defaultValue: _defaultValue,
                     nullValue: '',
                     constraints: {
-                        required: required,
-                        defaultValue: defaultValue,
+                        required: _required,
+                        defaultValue: _defaultValue,
                     },
                 },
             },
-            channelName: bus.channelName,
+            channelName: _bus.channelName,
         };
     }
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     describe('Text Input tests', () => {
         beforeEach(() => {
-            runtime = Runtime.make();
+            const runtime = Runtime.make();
             node = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'text input testing',
@@ -40,14 +37,20 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
             window.kbaseRuntime = null;
         });
 
-        it('Should load the widget', () => {
+        it('should be defined', () => {
             expect(TextInput).not.toBeNull();
+        });
+
+        it('should be instantiable', () => {
+            const widget = TextInput.make(testConfig);
+            expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('Should start and stop a widget', (done) => {
             const widget = TextInput.make(testConfig);
-            expect(widget).toBeDefined();
-            expect(widget.start).toBeDefined();
 
             widget
                 .start({ node: node })

--- a/test/unit/spec/appWidgets/input/textareaInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textareaInputSpec.js
@@ -1,23 +1,20 @@
 define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, TextareaInput) => {
     'use strict';
-    let bus,
-        testConfig,
-        required = false,
-        runtime,
-        node,
+    let bus, testConfig, node;
+    const required = false,
         defaultValue = 'some test text',
         numRows = 3;
 
-    function buildTestConfig(required, defaultValue, bus) {
+    function buildTestConfig(_required, _defaultValue, _bus) {
         return {
-            bus: bus,
+            bus: _bus,
             parameterSpec: {
                 data: {
-                    defaultValue: defaultValue,
+                    defaultValue: _defaultValue,
                     nullValue: null,
                     constraints: {
-                        required: required,
-                        defaultValue: defaultValue,
+                        required: _required,
+                        defaultValue: _defaultValue,
                     },
                 },
                 ui: {
@@ -31,7 +28,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     describe('Textarea Input tests', () => {
         beforeEach(() => {
-            runtime = Runtime.make();
+            const runtime = Runtime.make();
             node = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'textarea testing',
@@ -44,8 +41,16 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
             window.kbaseRuntime = null;
         });
 
-        it('Should load the widget', () => {
+        it('should be defined', () => {
             expect(TextareaInput).not.toBeNull();
+        });
+
+        it('should be instantiable', () => {
+            const widget = TextareaInput.make(testConfig);
+            expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
         });
 
         it('Should start and stop a widget', (done) => {
@@ -122,19 +127,19 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
             });
         });
 
-        xit('Should respond to keyup change events with "changed"', (done) => {
+        xit('Should respond to keyup change events with "changed"', () => {
             const widget = TextareaInput.make(testConfig);
             const inputText = 'here is some text';
+            // event does not have e.target defined, so running this test emits
+            // Uncaught TypeError: Cannot read property 'dispatchEvent' of null thrown
             bus.on('changed', (message) => {
                 // expect(message.newValue).toBe(inputText);
                 expect(message.isValid).toBeTruthy();
                 // ...detect something?
-                console.log('Caught a change message!');
                 // done();
             });
             widget.start({ node: node }).then(() => {
                 const inputElem = node.querySelector('textarea');
-                console.log('here is the elem', inputElem);
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('keyup'));
             });

--- a/test/unit/spec/appWidgets/input/toggleButtonInputSpec.js
+++ b/test/unit/spec/appWidgets/input/toggleButtonInputSpec.js
@@ -3,28 +3,25 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
     ToggleButtonInput
 ) => {
     'use strict';
-    let bus,
-        testConfig,
-        required = false,
-        runtime,
-        node,
+    let bus, testConfig, runtime, node;
+    const required = false,
         defaultValue = true;
 
-    function buildTestConfig(required, defaultValue, bus) {
+    function buildTestConfig(_required, _defaultValue, _bus) {
         return {
-            bus: bus,
+            bus: _bus,
             parameterSpec: {
                 data: {
-                    defaultValue: defaultValue,
+                    defaultValue: _defaultValue,
                     nullValue: null,
                     constraints: {
-                        required: required,
+                        required: _required,
                     },
                 },
-                defaultValue: () => defaultValue,
-                required: () => required,
+                defaultValue: () => _defaultValue,
+                required: () => _required,
             },
-            channelName: bus.channelName,
+            channelName: _bus.channelName,
         };
     }
 
@@ -46,7 +43,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             window.kbaseRuntime = null;
         });
 
-        it('Should load the widget', () => {
+        it('should be defined', () => {
             expect(ToggleButtonInput).not.toBeNull();
         });
 

--- a/test/unit/spec/appWidgets/input/undefinedInputSpec.js
+++ b/test/unit/spec/appWidgets/input/undefinedInputSpec.js
@@ -6,7 +6,13 @@ define(['widgets/appWidgets2/input/undefinedInput'], (UndefinedInput) => {
             expect(UndefinedInput).not.toBeNull();
         });
 
-        it('Should be instantiable and have an element', () => {
+        it('Should be instantiable and have an "attach" function', () => {
+            const widget = UndefinedInput.make({});
+            expect(widget).toEqual(jasmine.any(Object));
+            expect(widget.attach).toEqual(jasmine.any(Function));
+        });
+
+        it('Should attach to a DOM node', () => {
             const widget = UndefinedInput.make({});
             const node = document.createElement('div');
             widget.attach(node);


### PR DESCRIPTION
# Description of PR purpose/changes

Continuing the fun theme of test fixes, this is a set of fixes to tests in the following directories:

- `test/unit/spec/appWidgets/input/`

This fixes tests where there were no expectations and adds in more stringent tests where the existing test was a bit meh.

I have removed some files from the original PR so some of the comments are outdated. I've marked them as resolved.

See inline comments for the details.

This has the prettier branch as the base branch to avoid all the reformatting crud.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions (except for the jobCommChannel tests)

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
