### PR TITLE
DATAUP-330 fix jobCommChannel tests

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
@@ -1,4 +1,3 @@
-/*global define*/
 /**
  * This is the Communication Channel that handles talking between the front end and the kernel.
  * It's used by creating a new JobCommChannel(), then running initCommChannel() on it.
@@ -40,7 +39,7 @@ define([
     'services/kernels/comm',
     'common/semaphore',
     'text!kbase/templates/job_panel/job_init_error.html'
-], function (
+], (
     Promise,
     $,
     Handlebars,
@@ -51,7 +50,7 @@ define([
     JupyterComm,
     Semaphore,
     JobInitErrorTemplate
-) {
+) => {
     'use strict';
 
     const COMM_NAME = 'KBaseJobs',
@@ -89,7 +88,7 @@ define([
          * @param {any} message
          */
         sendBusMessage(channelName, channelId, msgType, message) {
-            let channel = {};
+            const channel = {};
             channel[channelName] = channelId;
             this.runtime.bus().send(JSON.parse(JSON.stringify(message)), {
                 channel: channel,
@@ -105,7 +104,7 @@ define([
          * kernel.
          */
         handleBusMessages() {
-            let bus = this.runtime.bus();
+            const bus = this.runtime.bus();
 
             bus.on('ping-comm-channel', (message) => {
                 this.sendCommMessage('ping', null, {
@@ -174,7 +173,7 @@ define([
                     reject(new Error('Comm channel not initialized, not sending message.'));
                 }
 
-                var msg = {
+                let msg = {
                     target_name: COMM_NAME,
                     request_type: msgType
                 };
@@ -212,9 +211,9 @@ define([
          * @param {object} msg
          */
         handleCommMessages(msg) {
-            var msgType = msg.content.data.msg_type;
-            var msgData = msg.content.data.content;
-            var jobId = null;
+            const msgType = msg.content.data.msg_type,
+                msgData = msg.content.data.content;
+            let jobId = null;
             switch (msgType) {
             case 'start':
                 // console.log('START', msgData.time);
@@ -318,7 +317,8 @@ define([
                 this.sendBusMessage(CELL, msgData.cell_id, 'run-status', msgData);
                 break;
             case 'job_canceled':
-                var canceledId = msgData.job_id;
+                // eslint-disable-next-line no-case-declarations
+                const canceledId = msgData.job_id;
                 this.sendBusMessage(JOB, canceledId, 'job-canceled',
                                     { jobId: canceledId, via: 'job_canceled' });
                 break;
@@ -377,14 +377,16 @@ define([
                 /*
                  code, error, job_id (opt), message, name, source
                  */
-                var $modalBody = $(Handlebars.compile(JobInitErrorTemplate)(msgData));
-                var modal = new BootstrapDialog({
+                // eslint-disable-next-line no-case-declarations
+                const $modalBody = $(Handlebars.compile(JobInitErrorTemplate)(msgData));
+                // eslint-disable-next-line no-case-declarations
+                const modal = new BootstrapDialog({
                     title: 'Job Initialization Error',
                     body: $modalBody,
                     buttons: [
                         $('<a type="button" class="btn btn-default">')
                         .append('OK')
-                        .click(function (event) {
+                        .click(() => {
                             modal.hide();
                         })
                     ]
@@ -405,10 +407,8 @@ define([
                     }]
                 });
 
-                $modalBody.find('button#kb-job-err-report').click(function (e) {
-
-                });
-                modal.getElement().on('hidden.bs.modal', function () {
+                $modalBody.find('button#kb-job-err-report').click(() => {});
+                modal.getElement().on('hidden.bs.modal', () => {
                     modal.destroy();
                 });
                 modal.show();
@@ -440,9 +440,9 @@ define([
         initCommChannel() {
             const _this = this;
             _this.comm = null;
-            let commSemaphore = Semaphore.make();
+            const commSemaphore = Semaphore.make();
             commSemaphore.add('comm', false);
-            return new Promise((resolve, reject) => {
+            return new Promise((resolve) => {
                 // First we check to see if our comm channel already
                 // exists. If so, we do some funny business to create a
                 // new client side for it, register it, and set up our

--- a/test/unit/spec/narrative_core/jobCommChannel-spec.js
+++ b/test/unit/spec/narrative_core/jobCommChannel-spec.js
@@ -47,14 +47,14 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
     }
 
     describe('The jobCommChannel widget', () => {
+        let testBus;
         beforeEach(() => {
-            this.bus = Runtime.make().bus();
+            testBus = Runtime.make().bus();
             Jupyter.notebook = makeMockNotebook();
         });
 
         afterEach(() => {
             window.kbaseRuntime = null;
-            document.body.innerHTML = '';
         });
 
         it('Should load properly', () => {
@@ -120,7 +120,7 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                     .then(() => {
                         expect(comm.comm).not.toBeNull();
                         spyOn(comm.comm, 'send');
-                        this.bus.emit(testCase[0], testCase[1]);
+                        testBus.emit(testCase[0], testCase[1]);
                         return new Promise((resolve) => setTimeout(resolve, 100));
                     })
                     .then(() => {
@@ -175,11 +175,11 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                 };
 
             const comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
 
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(busMsg, {
+                expect(testBus.send).toHaveBeenCalledWith(busMsg, {
                     channel: { jobId: jobId },
                     key: { type: 'job-status' },
                 });
@@ -201,10 +201,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
             });
             const comm = new JobCommChannel();
             comm.jobStates['deletedJob'] = { state: { job_id: 'deletedJob' } };
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledTimes(3);
+                expect(testBus.send).toHaveBeenCalledTimes(3);
             });
         });
 
@@ -223,10 +223,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                 msg = makeCommMsg('job_info', jobStateMsg);
 
             const comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(busMsg, {
+                expect(testBus.send).toHaveBeenCalledWith(busMsg, {
                     channel: { jobId: jobId },
                     key: { type: 'job-info' },
                 });
@@ -242,10 +242,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                 },
                 msg = makeCommMsg('run_status', busMsg);
             const comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(busMsg, {
+                expect(testBus.send).toHaveBeenCalledWith(busMsg, {
                     channel: { cell: cellId },
                     key: { type: 'run-status' },
                 });
@@ -258,10 +258,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                     job_id: jobId,
                 });
             const comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(
+                expect(testBus.send).toHaveBeenCalledWith(
                     {
                         jobId: jobId,
                         via: 'job_canceled',
@@ -281,10 +281,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                     source: 'someSource',
                 }),
                 comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(
+                expect(testBus.send).toHaveBeenCalledWith(
                     {
                         jobId: jobId,
                         source: 'someSource',
@@ -305,10 +305,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                     logs: [{}],
                 }),
                 comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(
+                expect(testBus.send).toHaveBeenCalledWith(
                     {
                         jobId: jobId,
                         logs: msg.content.data.content,
@@ -339,10 +339,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                         message: errMsg,
                     }),
                     comm = new JobCommChannel();
-                spyOn(this.bus, 'send');
+                spyOn(testBus, 'send');
                 return comm.initCommChannel().then(() => {
                     comm.handleCommMessages(msg);
-                    expect(this.bus.send).toHaveBeenCalledWith(
+                    expect(testBus.send).toHaveBeenCalledWith(
                         {
                             jobId: jobId,
                             message: errMsg,
@@ -367,10 +367,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                 },
                 msg = makeCommMsg('job_comm_error', busMsg),
                 comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(
+                expect(testBus.send).toHaveBeenCalledWith(
                     {
                         jobId: jobId,
                         message: errMsg,
@@ -393,23 +393,24 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                         source: 'jobmanager',
                     }),
                     comm = new JobCommChannel();
-                jasmine.clock().install();
                 return comm
                     .initCommChannel()
                     .then(() => {
                         comm.handleCommMessages(msg);
+                        return new Promise((resolve) => { setTimeout(() => resolve(), 500)});
                     })
                     .then(() => {
-                        jasmine.clock().tick(5000);
                         expect(document.querySelector('.modal #kb-job-err-trace')).not.toBeNull();
                         // click the 'OK' button
                         document.querySelector('.modal a.btn.btn-default').click();
-                        jasmine.clock().tick(5000);
                         // expect it to be gone
+                        return new Promise((resolve) => { setTimeout(() => resolve(), 500)});
+                    })
+                    .then(() => {
                         expect(document.querySelector('.modal #kb-job-err-trace')).toBeNull();
                     })
                     .finally(() => {
-                        jasmine.clock().uninstall();
+                        document.body.innerHTML = '';
                     });
             });
         });
@@ -422,10 +423,10 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                 },
                 msg = makeCommMsg('result', busMsg),
                 comm = new JobCommChannel();
-            spyOn(this.bus, 'send');
+            spyOn(testBus, 'send');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(msg);
-                expect(this.bus.send).toHaveBeenCalledWith(busMsg, {
+                expect(testBus.send).toHaveBeenCalledWith(busMsg, {
                     channel: { cell: cellId },
                     key: { type: 'result' },
                 });

--- a/test/unit/spec/narrative_core/jobCommChannel-spec.js
+++ b/test/unit/spec/narrative_core/jobCommChannel-spec.js
@@ -54,6 +54,7 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
 
         afterEach(() => {
             window.kbaseRuntime = null;
+            document.body.innerHTML = '';
         });
 
         it('Should load properly', () => {
@@ -399,11 +400,11 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime'], (
                         comm.handleCommMessages(msg);
                     })
                     .then(() => {
-                        jasmine.clock().tick(2000);
+                        jasmine.clock().tick(5000);
                         expect(document.querySelector('.modal #kb-job-err-trace')).not.toBeNull();
                         // click the 'OK' button
                         document.querySelector('.modal a.btn.btn-default').click();
-                        jasmine.clock().tick(2000);
+                        jasmine.clock().tick(5000);
                         // expect it to be gone
                         expect(document.querySelector('.modal #kb-job-err-trace')).toBeNull();
                     })


### PR DESCRIPTION
# Description of PR purpose/changes

Fix timeout and async issues with the jobCommChannel tests. This essentially replaces any roundabout tests that make and use a Bus with a mock for the bus that tests that we send what we expect to send. 

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
