### PR TITLE
Fix app panel

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeAppPanel.js
@@ -939,7 +939,7 @@ define([
             ]);
 
             //custom click functions;
-            $card.find('.narrative-card-logo .kb-data-list-name').click((e) => {
+            $card.find('.narrative-card-row-main, .kb-data-list-name').click((e) => {
                 e.stopPropagation();
                 this.triggerApp(app);
             });

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -377,7 +377,7 @@ define([
             }, 1000);
         });
 
-        it('Should trigger the insert app function when clicking on an app', (done) => {
+        it('Should trigger the insert app function when triggerApp is called', (done) => {
             const appId = 'a_module/an_app',
                 dummySpec = {
                     info: {
@@ -398,6 +398,31 @@ define([
                 done();
             });
             appPanel.triggerApp(appId, 'release');
+        });
+
+        it('Should trigger the insert app function when an app card has its title clicked', (done) => {
+            const appId = 'a_module/an_app',
+                appName = APP_INFO.app_infos[appId].info.name,
+                dummySpec = {
+                    info: {
+                        id: appId,
+                        name: appName
+                    },
+                },
+                appTag = 'release';
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('narrative_method_store'),
+                response: [dummySpec],
+            });
+            // in actual usage, this event gets bound to either $(document) or some other
+            // widget that it percolates up to. Jasmine doesn't like that, so we bind it here
+            appPanel.on('appClicked.Narrative', (event, app, tag, params) => {
+                expect(app).toEqual(dummySpec);
+                expect(tag).toEqual(appTag);
+                expect(params).not.toBeDefined();
+                done();
+            });
+            $panel.find(`div.kb-data-list-name:contains("${appName}")`).click();
         });
 
         it('Should know how to show an error', () => {


### PR DESCRIPTION
# Description of PR purpose/changes

A bug was introduced that prevented apps from being added to the main working area when clicking on an app name, this fixes that bug and adds a unit test around it.

I couldn't get integration tests to run with any local stability - my internet connection is kinda horrid, and juggling timeouts doesn't seem to help. I'd appreciate a little help with this, or we can put it aside for now.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- ~Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)~
No ticket for this one, was a blocking bug that got introduced in CI.

# Testing Instructions
* Details for how to test the PR:
Open a narrative, try to click on any app - if it loads the proper cell, it works!
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)
Skipping release notes update - this bug is in CI, and won't be seen by users. Hopefully.
