### PR TITLE
DATAUP-330: Fixing empty specs in the dynamicTable and loadingWidget tests

### DIFF
--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -31,41 +31,44 @@ module.exports = function (config) {
             'nbextensions/appcell2/widgets/tabs/*.js': ['coverage'],
             'kbase-extension/static/kbase/js/*.js': ['coverage'],
         },
+        // karma defaults:
+        // included: true; nocache: false; served: true; watched: true;
         files: [
-            'kbase-extension/static/narrative_paths.js',
+            'node_modules/jasmine-ajax/lib/mock-ajax.js',
+            // tests and test resources
+            'test/unit/testUtil.js',
+            'test/unit/mocks.js',
+            'test/unit/test-main.js',
             { pattern: 'test/unit/spec/**/*.js', included: false },
-            { pattern: 'node_modules/jasmine-ajax/lib/mock-ajax.js', included: true },
-            {
-                pattern:
-                    'kbase-extension/static/ext_components/kbase-ui-plugin-catalog/src/plugin/modules/data/categories.yml',
-                included: false,
-                served: true,
-            },
-            { pattern: 'kbase-extension/static/**/*.css', included: false, served: true },
+            { pattern: 'test/testConfig.json', included: false, nocache: true },
+            { pattern: 'test/*.tok', included: false, nocache: true },
+            { pattern: 'test/data/**/*', included: false },
+            // JS files
+            'kbase-extension/static/narrative_paths.js',
+            { pattern: 'kbase-extension/static/**/*.js', included: false },
+            { pattern: 'nbextensions/appcell2/widgets/tabs/*.js', included: false },
+            // static resources
+            { pattern: 'kbase-extension/kbase_templates/*.html', included: false },
+            { pattern: 'kbase-extension/static/**/*.css', included: false },
+            { pattern: 'kbase-extension/static/**/*.gif', included: false },
             {
                 pattern: 'kbase-extension/static/kbase/templates/**/*.html',
                 included: false,
-                served: true,
             },
+            { pattern: 'kbase-extension/static/**/*.woff2', included: false },
             {
                 pattern: 'kbase-extension/static/kbase/config/**/*.json',
                 included: false,
-                served: true,
             },
             {
                 pattern: 'kbase-extension/static/kbase/config/**/*.yaml',
                 included: false,
-                served: true,
             },
-            { pattern: 'kbase-extension/static/**/*.js', included: false, served: true },
-            { pattern: 'kbase-extension/static/**/*.gif', included: false, served: true },
-            { pattern: 'nbextensions/appcell2/widgets/tabs/*.js', included: false },
-            { pattern: 'test/testConfig.json', included: false, served: true, nocache: true },
-            { pattern: 'test/*.tok', included: false, served: true, nocache: true },
-            { pattern: 'test/data/**/*', included: false, served: true },
-            'test/unit/testUtil.js',
-            'test/unit/mocks.js',
-            'test/unit/test-main.js',
+            {
+                pattern:
+                    'kbase-extension/static/ext_components/kbase-ui-plugin-catalog/src/plugin/modules/data/categories.yml',
+                included: false,
+            },
         ],
         exclude: [
             'kbase-extension/static/buildTools/*.js',
@@ -112,6 +115,7 @@ module.exports = function (config) {
         browserNoActivityTimeout: 30000,
         singleRun: true,
         proxies: {
+            '/kbase_templates/': '/base/kbase-extension/kbase_templates/',
             '/narrative/nbextensions': 'http://localhost:32323/narrative/nbextensions',
             '/narrative/static/': '/base/kbase-extension/static/',
             '/narrative/static/base': 'http://localhost:32323/narrative/static/base',

--- a/test/unit/spec/dynamicTableSpec.js
+++ b/test/unit/spec/dynamicTableSpec.js
@@ -1,10 +1,10 @@
 define(['jquery', 'bluebird', 'widgets/dynamicTable'], ($, Promise, DynamicTable) => {
     'use strict';
-    let dummyRows = [
+    const rows = [
             [1, 2, 3],
             [4, 5, 6],
         ],
-        dummyHeaders = [
+        headers = [
             {
                 id: 'col1',
                 text: 'Column 1',
@@ -20,19 +20,19 @@ define(['jquery', 'bluebird', 'widgets/dynamicTable'], ($, Promise, DynamicTable
                 text: 'Column 3',
                 isSortable: false,
             },
-        ],
-        $dummyDiv = $('<div>'),
-        dummyTable;
+        ];
 
-    describe('Test the DynamicTable widget', () => {
-        beforeEach(() => {
-            dummyTable = new DynamicTable($dummyDiv, {
-                headers: dummyHeaders,
-                updateFunction: function (pageNum, query, sortColId, sortColDir) {
+    describe('The DynamicTable widget', () => {
+        beforeEach(function () {
+            this.div = document.createElement('div');
+            this.dt = new DynamicTable($(this.div), {
+                headers: headers,
+                // args to updateFunction: pageNum, query, sortColId, sortColDir
+                updateFunction: function () {
                     return Promise.resolve({
                         start: 0,
-                        total: dummyRows.length,
-                        rows: dummyRows,
+                        total: rows.length,
+                        rows: rows,
                     });
                 },
             });
@@ -50,24 +50,35 @@ define(['jquery', 'bluebird', 'widgets/dynamicTable'], ($, Promise, DynamicTable
                 },
             });
             expect(dt).toEqual(jasmine.any(Object));
+            const table = $container[0].querySelector('table');
+            expect(table.id).toBe('dynamic_table');
         });
 
-        it('Should display data', () => {
-            expect(dummyTable).toEqual(jasmine.any(Object));
+        it('should have headers set correctly', function () {
+            expect(this.dt).toEqual(jasmine.any(Object));
+            const table = this.div.querySelector('table');
+            expect(table.id).toBe('dynamic_table');
+            const thElements = table.querySelectorAll('thead th');
+            expect(thElements.length).toBe(headers.length);
+            headers.forEach((header, index) => {
+                expect(thElements[index].innerHTML).toContain(header.text);
+            });
         });
 
-        it('Should paginate and show which page', () => {});
+        xit('Should display data', () => {});
 
-        it('Should show an error when pagination fails', () => {});
+        xit('Should paginate and show which page', () => {});
 
-        it('Should sort properly', () => {});
+        xit('Should show an error when pagination fails', () => {});
 
-        it('Should decorate rows properly', () => {});
+        xit('Should sort properly', () => {});
 
-        it('Should add outer widget classes properly', () => {});
+        xit('Should decorate rows properly', () => {});
 
-        it('Should add table styles properly', () => {});
+        xit('Should add outer widget classes properly', () => {});
 
-        it('Should have optional download buttons', () => {});
+        xit('Should add table styles properly', () => {});
+
+        xit('Should have optional download buttons', () => {});
     });
 });

--- a/test/unit/spec/loadingWidgetSpec.js
+++ b/test/unit/spec/loadingWidgetSpec.js
@@ -1,52 +1,66 @@
-define(['jquery', 'widgets/loadingWidget'], ($, LoadingWidget) => {
+define(['jquery', 'widgets/loadingWidget', 'text!/kbase_templates/loading.html'], (
+    $,
+    LoadingWidget,
+    LoadingTemplate
+) => {
     'use strict';
 
+    const templateHtml = LoadingTemplate.replace(
+        '{{ static_url("kbase/images/kbase_animated_logo.gif") }}',
+        '/narrative/static/kbase/images/kbase_animated_logo.gif'
+    );
     describe('Test the LoadingWidget module', () => {
-        let dummyNode, dummyNode2, widget;
-
-        beforeEach(() => {
-            dummyNode = document.createElement('div');
-            dummyNode2 = document.createElement('div');
-            dummyNode.querySelector = jasmine.createSpy('HTML Element').and.returnValue(dummyNode2);
-            dummyNode2.querySelector = jasmine
-                .createSpy('HTML Element')
-                .and.returnValue(dummyNode2);
-            widget = new LoadingWidget({ node: dummyNode });
-        });
-
-        afterEach(() => {
-            widget.remove();
+        beforeEach(function () {
+            this.node = document.createElement('div');
+            this.node.innerHTML = templateHtml;
         });
 
         it('Should instantiate with a null node', () => {
-            const widget = new LoadingWidget({ node: null });
-            expect(widget).not.toBeNull();
+            const noNodeWidget = new LoadingWidget({ node: null });
+            expect(noNodeWidget).not.toBeNull();
+            expect(noNodeWidget).toBeInstanceOf(LoadingWidget);
         });
 
-        it('Should be able to update its progress', () => {
+        it('Should be able to update its progress', function () {
+            const widget = new LoadingWidget({ node: this.node });
             widget.updateProgress('data', true);
+            // hidden checkmark that gets added once an element starts loading
+            expect(
+                this.node.querySelector('[data-element="data"] .kb-progress-stage').innerHTML
+            ).toContain('class="fa fa-check"');
+            // total progress indicator updated
+            expect(this.node.querySelector('.progress-bar').style.width).toBe('20%');
         });
 
-        it('Should be able to remove its container node', () => {
+        it('Should be able to remove its container node', function () {
             spyOn(LoadingWidget.prototype, 'remove');
-            widget = new LoadingWidget({ node: dummyNode });
+            const widget = new LoadingWidget({ node: this.node });
             ['data', 'narrative', 'jobs', 'apps', 'kernel'].forEach((name) => {
                 widget.updateProgress(name, true);
             });
             expect(widget.remove).toHaveBeenCalled();
         });
 
-        it('Should not show the loading warning when first starting', () => {
-            expect($($(dummyNode).find('.loading-warning')[0]).is(':visible')).toBeFalsy();
+        it('Should not show the loading warning when first starting', function () {
+            new LoadingWidget({ node: this.node });
+            expect($(this.node).find('.loading-warning').length).toBe(1);
+            expect($(this.node).find('.loading-warning:visible').length).toBe(0);
+            expect($(this.node).find('.loading-warning:hidden').length).toBe(1);
         });
 
-        it('Should show the loading warning after a timeout', (done) => {
-            spyOn(LoadingWidget.prototype, 'showTimeoutWarning');
-            widget = new LoadingWidget({ node: dummyNode, timeout: 1 });
+        it('Should show the loading warning after a timeout', function (done) {
+            spyOn(LoadingWidget.prototype, 'showTimeoutWarning').and.callThrough();
+            const widget = new LoadingWidget({ node: this.node, timeout: 1 });
+            const $warningNode = $(this.node).find('.loading-warning');
+            spyOn($warningNode.__proto__, 'fadeIn').and.callThrough();
+            expect(widget.timeoutShown).toBeFalse();
             setTimeout(() => {
+                expect($(this.node).find('.loading-warning').length).toBe(1);
                 expect(widget.showTimeoutWarning).toHaveBeenCalled();
+                expect($warningNode.fadeIn).toHaveBeenCalledOnceWith('fast');
+                expect(widget.timeoutShown).toBeTrue();
                 done();
-            }, 100);
+            }, 500);
         });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

Adding expectations to tests which were not testing things adequately, and disabling some empty tests.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by running `make test-frontend-unit`

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
