### PR TITLE
DATAUP-330: restore validate test from #2151

### DIFF
--- a/test/unit/spec/common/validate-Spec.js
+++ b/test/unit/spec/common/validate-Spec.js
@@ -147,7 +147,15 @@ define(['bluebird', 'common/validation'], (Promise, Validation) => {
                 workspaceServiceUrl: 'https://test.kbase.us/services/ws',
                 types: [wsObjType],
             }).then((result) => {
-                console.log(result);
+                expect(result).toEqual({
+                    isValid: true,
+                    messageId: undefined,
+                    errorMessage: undefined,
+                    diagnosis: 'valid',
+                    shortMessage: undefined,
+                    value: 'somename',
+                    parsedValue: 'somename',
+                });
                 done();
             });
         });


### PR DESCRIPTION
# Description of PR purpose/changes

port of the content of the validate-spec.js test from PR #2151 , since that branch has been used for other purposes

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by running `make test-frontend-unit`

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
