### PR TITLE
DATAUP-330: skip tests with no expectations

### DIFF
--- a/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-spec.js
+++ b/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-spec.js
@@ -118,13 +118,13 @@ define([
             });
         });
 
-        it('has a method "init" which returns a promise then null', () => {
+        xit('has a method "init" which returns a promise then null', () => {
             return mockAppCell.init().then(() => {
                 // something to see if it worked
             });
         });
 
-        it('has a method stop which returns a Promise', () => {
+        xit('has a method stop which returns a Promise', () => {
             return mockAppCell
                 .init()
                 .then(() => {
@@ -135,7 +135,7 @@ define([
                 });
         });
 
-        it('has a method detach which returns a Promise', () => {
+        xit('has a method detach which returns a Promise', () => {
             return mockAppCell
                 .init()
                 .then(() => {


### PR DESCRIPTION
# Description of PR purpose/changes

Skipping three app cell widget tests that have no expectations. They can be filled in at some mythical later date.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by running `make test-frontend-unit`

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
