### PR TITLE
add cache busting to minified bundle load

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto');
+
 module.exports = function (grunt) {
     'use strict';
     grunt.loadNpmTasks('grunt-regex-replace');
@@ -13,7 +15,8 @@ module.exports = function (grunt) {
                         name: 'requirejs-onefile',
                         search: 'narrativeMain.js',
                         replace: function () {
-                            return 'kbase-narrative-min.js';
+                            const cbString = crypto.randomBytes(4).toString('hex');
+                            return `kbase-narrative-min.js?cb=${cbString}`;
                         },
                         flags: '',
                     },


### PR DESCRIPTION
# Description of PR purpose/changes

Not having cache-busting has bit us hard in the past. Even with modern browsers, this ensures the latest bundle is loaded.

# Jira Ticket / Issue #
- no ticket for this one

# Testing Instructions
* Details for how to test the PR:
- run the build, `notebook.html` should load `kbase-narrative-min.js?cb=asdfasdf`
- loading the narrative at this point should work seamlessly
- [ ] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
