### PR TITLE
Set dependabot alerts to check monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,18 @@ updates:
 - package-ecosystem: pip
   directory: "/src"
   schedule:
-    interval: weekly
+    interval: monthly
     time: '11:00'
   open-pull-requests-limit: 20
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: '11:00'
   open-pull-requests-limit: 20
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
     time: '11:00'
   open-pull-requests-limit: 20


### PR DESCRIPTION
Set as monthly checks instead of weekly checks, as the signal-noise ratio is getting to be excessive.
Based on request from @sychan & @briehl.

# Description of PR purpose/changes

* Please include a summary of the change and which issue is fixed.
* Please also include relevant motivation and context.
* List any dependencies that are required for this change.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
