### PR TITLE
DATAUP-330 fix integration test selector

### DIFF
--- a/test/integration/specs/kbaseNarrativeDataPanel_test.js
+++ b/test/integration/specs/kbaseNarrativeDataPanel_test.js
@@ -254,7 +254,7 @@ describe('Tabbing within the data panel should work', () => {
         // Make sure the main elements of the import tab have been rendered.
         const fileDropZone = await tabPanel.$('.kb-dropzone');
         await fileDropZone.waitForExist();
-        const fileListContainer = await tabPanel.$('#kb-data-staging-table_wrapper');
+        const fileListContainer = await tabPanel.$('table.kb-staging-table');
         await fileListContainer.waitForExist();
     });
 


### PR DESCRIPTION
# Description of PR purpose/changes

There was a faulty selector in an integration test, that's not valid on the truss branch.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:
N/A - just changed a selector.
