### PR TITLE
Tweak test runner

### DIFF
--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function (config) {
                 DEFAULT_TIMEOUT_INTERVAL: 20000,
                 failSpecWithNoExpectations: true,
             },
-            requireJsShowNoTimestampsError: '^(?!.*(^/narrative/))',
+            requireJsShowNoTimestampsError: '^(?!.*(^/narrative|test/))',
             clearContext: false,
         },
         plugins: [

--- a/test/unit/test-main.js
+++ b/test/unit/test-main.js
@@ -3,7 +3,7 @@
 'use strict';
 const tests = [
     ...['text', 'json'],
-    ...Object.keys(window.__karma__.files).filter((file) => /[sS]pec\.js$/.test(file)),
+    ...Object.keys(window.__karma__.files).filter((file) => /^\/base\/test\/.*[sS]pec\.js$/.test(file)),
 ];
 
 // hack to make jed (the i18n library that Jupyter uses) happy.

--- a/test/unit/test-main.js
+++ b/test/unit/test-main.js
@@ -3,6 +3,8 @@
 'use strict';
 const tests = [
     ...['text', 'json'],
+    // Keep only the test spec files under the test directory.
+    // Karma prepends these with /base/, so make sure that's included.
     ...Object.keys(window.__karma__.files).filter((file) =>
         /^\/base\/test\/.*[sS]pec\.js$/.test(file)
     ),

--- a/test/unit/test-main.js
+++ b/test/unit/test-main.js
@@ -3,7 +3,9 @@
 'use strict';
 const tests = [
     ...['text', 'json'],
-    ...Object.keys(window.__karma__.files).filter((file) => /^\/base\/test\/.*[sS]pec\.js$/.test(file)),
+    ...Object.keys(window.__karma__.files).filter((file) =>
+        /^\/base\/test\/.*[sS]pec\.js$/.test(file)
+    ),
 ];
 
 // hack to make jed (the i18n library that Jupyter uses) happy.


### PR DESCRIPTION
# Description of PR purpose/changes

I noticed a couple of minor things with the test runner.
1. There's a series of "no timestamp available for..." errors for data files under the `/test/` directory.
2. The `test-main.js` file was letting a number of non-test js files through the filter, namely `parameterSpec.js` and `spec.js` - these likely weren't doing any harm as they don't have any test specs, but they don't need to be loaded, either.

This fixes both of those.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
Run the tests - shouldn't see "no timestamp" errors for the test data files.
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook