### PR TITLE
Independently merge narrative_version build into master

### DIFF
--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -5,6 +5,9 @@ export MY_APP=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export NARRATIVE_VERSION_NUM=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
+export MY_APP2="$MY_APP"_version
+
 
 docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker build --build-arg BUILD_DATE="$DATE" \
@@ -14,3 +17,17 @@ docker build --build-arg BUILD_DATE="$DATE" \
              --label us.kbase.vcs-pull-req="$PR" \
              -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
+
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
+
+docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
+                --build-arg BUILD_DATE=$DATE \
+                --build-arg VCS_REF=$COMMIT \
+                --build-arg BRANCH="$GITHUB_HEAD_REF" \
+                --build-arg PULL_REQUEST="$PR" \
+                --label us.kbase.vcs-pull-req="$PR" \
+                --build-arg NARRATIVE_VERSION=$NARRATIVE_VERSION_NUM \
+                -f Dockerfile2 \
+                .
+docker rmi kbase/narrative:tmp
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"

--- a/.github/workflows/scripts/build_test_pr.sh
+++ b/.github/workflows/scripts/build_test_pr.sh
@@ -5,6 +5,8 @@ export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-dev
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export NARRATIVE_VERSION_NUM=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
+export MY_APP2="$MY_APP"_version
 
 echo $DOCKER_TOKEN | docker login ghcr.io -u $DOCKER_ACTOR --password-stdin
 docker build --build-arg BUILD_DATE="$DATE" \
@@ -14,4 +16,17 @@ docker build --build-arg BUILD_DATE="$DATE" \
              --label us.kbase.vcs-pull-req="$PR" \
              -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
-	
+
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
+
+docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
+                --build-arg BUILD_DATE=$DATE \
+                --build-arg VCS_REF=$COMMIT \
+                --build-arg BRANCH="$GITHUB_HEAD_REF" \
+                --build-arg PULL_REQUEST="$PR" \
+                --label us.kbase.vcs-pull-req="$PR" \
+                --build-arg NARRATIVE_VERSION=$NARRATIVE_VERSION_NUM \
+                -f Dockerfile2 \
+                .
+docker rmi kbase/narrative:tmp
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"

--- a/.github/workflows/scripts/tag_prod_latest.sh
+++ b/.github/workflows/scripts/tag_prod_latest.sh
@@ -5,8 +5,13 @@ export MY_APP=$(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export MY_APP2="$MY_APP"_version
 
 docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
+
+docker pull ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"

--- a/.github/workflows/scripts/tag_test_latest.sh
+++ b/.github/workflows/scripts/tag_test_latest.sh
@@ -5,8 +5,13 @@ export MY_APP=$(echo $(echo "${GITHUB_REPOSITORY}" | awk -F / '{print $2}')"-dev
 export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
+export MY_APP2="$MY_APP"_version
 
 docker login -u "$DOCKER_ACTOR" -p "$DOCKER_TOKEN" ghcr.io
 docker pull ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"latest"
+
+docker pull ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"
+docker tag ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"
+docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"latest"


### PR DESCRIPTION
# Description of PR purpose/changes

    The narrative_version image build is working for the develop branch, but the new build scripts were never merged all the way into master, so there isn't an up to date narrative_version image built. This bit us this morning when we restarted rancher and it ended up refreshing the narrative_version image with the old version number.
   This PR recreates the edits in the narrative_version branch, so that we can get a proper narrative_version built without pulling in all of the rest of the commits in develop.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
