### PR TITLE
DATAUP-330: Prevent widgets from calling external resources during tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "jasmine-core": "^3.6.0",
                 "jasmine-jquery": "2.1.1",
                 "karma": "^6.1.1",
+                "karma-brief-reporter": "^0.2.1",
                 "karma-chrome-launcher": "^3.1.0",
                 "karma-coverage": "2.0.3",
                 "karma-es6-shim": "1.0.0",
@@ -83,23 +84,23 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-            "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+            "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
             "dev": true
         },
         "node_modules/@babel/core": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
-            "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
+            "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.0",
-                "@babel/helper-compilation-targets": "^7.13.8",
+                "@babel/generator": "^7.13.9",
+                "@babel/helper-compilation-targets": "^7.13.10",
                 "@babel/helper-module-transforms": "^7.13.0",
-                "@babel/helpers": "^7.13.0",
-                "@babel/parser": "^7.13.4",
+                "@babel/helpers": "^7.13.10",
+                "@babel/parser": "^7.13.10",
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.13.0",
                 "@babel/types": "^7.13.0",
@@ -149,9 +150,9 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
-            "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+            "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.13.8",
@@ -279,9 +280,9 @@
             "dev": true
         },
         "node_modules/@babel/helpers": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-            "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+            "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.12.13",
@@ -290,9 +291,9 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-            "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+            "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.12.11",
@@ -363,9 +364,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.13.9",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
-            "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
+            "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -460,6 +461,21 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "12.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+            "dev": true,
+            "dependencies": {
+                "type-fest": "^0.8.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -483,6 +499,15 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@istanbuljs/schema": {
@@ -780,9 +805,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "14.14.31",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-            "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+            "version": "14.14.34",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.34.tgz",
+            "integrity": "sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -1299,9 +1324,9 @@
             }
         },
         "node_modules/archiver": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
-            "integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
+            "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
             "dev": true,
             "dependencies": {
                 "archiver-utils": "^2.1.0",
@@ -1309,8 +1334,8 @@
                 "buffer-crc32": "^0.2.1",
                 "readable-stream": "^3.6.0",
                 "readdir-glob": "^1.0.0",
-                "tar-stream": "^2.1.4",
-                "zip-stream": "^4.0.4"
+                "tar-stream": "^2.2.0",
+                "zip-stream": "^4.1.0"
             },
             "engines": {
                 "node": ">= 10"
@@ -1355,6 +1380,22 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/archiver/node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dev": true,
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/argparse": {
@@ -1514,14 +1555,14 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.4.tgz",
-            "integrity": "sha512-DCCdUQiMD+P/as8m3XkeTUkUKuuRqLGcwD0nll7wevhqoJfMRpJlkFd1+MQh1pvupjiQuip42lc/VFvfUTMSKw==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.5.tgz",
+            "integrity": "sha512-7H4AJZXvSsn62SqZyJCP+1AWwOuoYpUfK6ot9vm0e87XD6mT8lDywc9D9OTJPMULyGcvmIxzTAMeG2Cc+YX+fA==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.16.1",
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
+                "browserslist": "^4.16.3",
+                "caniuse-lite": "^1.0.30001196",
+                "colorette": "^1.2.2",
                 "fraction.js": "^4.0.13",
                 "normalize-range": "^0.1.2",
                 "postcss-value-parser": "^4.1.0"
@@ -2101,9 +2142,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001194",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
-            "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==",
+            "version": "1.0.30001200",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
+            "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
             "dev": true
         },
         "node_modules/chalk": {
@@ -2372,6 +2413,29 @@
                 "node": ">=6"
             }
         },
+        "node_modules/cli-color": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+            "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^2.1.1",
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "memoizee": "^0.4.14",
+                "timers-ext": "^0.1.5"
+            }
+        },
+        "node_modules/cli-color/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -2565,9 +2629,9 @@
             "dev": true
         },
         "node_modules/color-string": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-            "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
             "dev": true,
             "dependencies": {
                 "color-name": "^1.0.0",
@@ -2617,9 +2681,9 @@
             "dev": true
         },
         "node_modules/compress-commons": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-            "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.0.tgz",
+            "integrity": "sha512-ofaaLqfraD1YRTkrRKPCrGJ1pFeDG/MVCkVVV2FNGeWquSlqw5wOrwOfPQ1xF2u+blpeWASie5EubHz+vsNIgA==",
             "dev": true,
             "dependencies": {
                 "buffer-crc32": "^0.2.13",
@@ -3469,6 +3533,16 @@
             "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
             "dev": true
         },
+        "node_modules/d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "dependencies": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "node_modules/date-format": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
@@ -3874,9 +3948,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.678",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.678.tgz",
-            "integrity": "sha512-E5ha1pE9+aWWrT2fUD5wdPBWUnYtKnEnloewbtVyrkAs79HvodOiNO4rMR94+hKbxgMFQG4fnPQACOc1cfMfBg==",
+            "version": "1.3.687",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+            "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -3976,22 +4050,27 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.17.7",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-            "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+            "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
             "dev": true,
             "dependencies": {
+                "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
                 "has": "^1.0.3",
-                "has-symbols": "^1.0.1",
-                "is-callable": "^1.2.2",
-                "is-regex": "^1.1.1",
-                "object-inspect": "^1.8.0",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.2",
+                "is-string": "^1.0.5",
+                "object-inspect": "^1.9.0",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.1",
-                "string.prototype.trimend": "^1.0.1",
-                "string.prototype.trimstart": "^1.0.1"
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4017,6 +4096,17 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "dependencies": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
         "node_modules/es5-shim": {
             "version": "4.5.15",
             "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.15.tgz",
@@ -4026,11 +4116,44 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "node_modules/es6-shim": {
             "version": "0.35.6",
             "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
             "integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==",
             "dev": true
+        },
+        "node_modules/es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "dependencies": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "node_modules/es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
+            }
         },
         "node_modules/escalade": {
             "version": "3.1.1",
@@ -4057,9 +4180,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-            "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+            "version": "7.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+            "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
@@ -4079,7 +4202,7 @@
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^5.0.0",
-                "globals": "^12.1.0",
+                "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
@@ -4087,7 +4210,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -4287,6 +4410,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "dependencies": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "node_modules/event-stream": {
@@ -4527,6 +4660,21 @@
                 "expect": "^26.5.3",
                 "jest-matcher-utils": "^26.5.2"
             }
+        },
+        "node_modules/ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "dependencies": {
+                "type": "^2.0.0"
+            }
+        },
+        "node_modules/ext/node_modules/type": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+            "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+            "dev": true
         },
         "node_modules/extend": {
             "version": "3.0.2",
@@ -5137,9 +5285,9 @@
             }
         },
         "node_modules/glob-parent": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -5187,12 +5335,12 @@
             }
         },
         "node_modules/globals": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+            "version": "13.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.6.0.tgz",
+            "integrity": "sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==",
             "dev": true,
             "dependencies": {
-                "type-fest": "^0.8.1"
+                "type-fest": "^0.20.2"
             },
             "engines": {
                 "node": ">=8"
@@ -6641,9 +6789,9 @@
             }
         },
         "node_modules/is-path-inside": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-            "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -6669,6 +6817,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-promise": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+            "dev": true
         },
         "node_modules/is-regex": {
             "version": "1.1.2",
@@ -7236,9 +7390,9 @@
             }
         },
         "node_modules/karma": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-6.1.1.tgz",
-            "integrity": "sha512-vVDFxFGAsclgmFjZA/qGw5xqWdZIWxVD7xLyCukYUYd5xs/uGzYbXGOT5zOruVBQleKEmXIr4H2hzGCTn+M9Cg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-6.2.0.tgz",
+            "integrity": "sha512-pCB8eNxGgdIdZeC885rbhZ/VyuOPNHUIDNL9EaaMf1NVzpvTjMO8a7zRTn51ZJhOOOxCSpalUdT1A8x76LyVqg==",
             "dev": true,
             "dependencies": {
                 "body-parser": "^1.19.0",
@@ -7270,6 +7424,43 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/karma-brief-reporter": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/karma-brief-reporter/-/karma-brief-reporter-0.2.1.tgz",
+            "integrity": "sha512-At7qOaVbj9Co2sl5Esvmn6ZGz7L3ZmUtER3jcBdN+N3IoxVTvqvLnThK6qJa2tExsl1A7sEGQL3+AgSs6TsLvw==",
+            "dev": true,
+            "dependencies": {
+                "cli-color": "1.4.0",
+                "mkdirp": "0.5.1",
+                "pad-left": "2.1.0",
+                "pad-right": "0.2.2"
+            },
+            "engines": {
+                "node": ">= 6"
+            },
+            "peerDependencies": {
+                "karma": ">=4.3"
+            }
+        },
+        "node_modules/karma-brief-reporter/node_modules/minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "node_modules/karma-brief-reporter/node_modules/mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+            "dev": true,
+            "dependencies": {
+                "minimist": "0.0.8"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
             }
         },
         "node_modules/karma-chrome-launcher": {
@@ -8121,6 +8312,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+            "dev": true,
+            "dependencies": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8286,6 +8486,28 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/memoizee": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+            "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+            "dev": true,
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.53",
+                "es6-weak-map": "^2.0.3",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.2.2",
+                "lru-queue": "^0.1.0",
+                "next-tick": "^1.1.0",
+                "timers-ext": "^0.1.7"
+            }
+        },
+        "node_modules/memoizee/node_modules/next-tick": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+            "dev": true
         },
         "node_modules/meow": {
             "version": "3.7.0",
@@ -8492,9 +8714,9 @@
             "dev": true
         },
         "node_modules/mocha": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-            "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
+            "integrity": "sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==",
             "dev": true,
             "dependencies": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -8683,6 +8905,12 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+            "dev": true
         },
         "node_modules/node-fetch": {
             "version": "2.6.1",
@@ -8981,36 +9209,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/object.getownpropertydescriptors/node_modules/es-abstract": {
-            "version": "1.18.0-next.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-            "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.2",
-                "is-callable": "^1.2.3",
-                "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.2",
-                "is-string": "^1.0.5",
-                "object-inspect": "^1.9.0",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.2",
-                "string.prototype.trimend": "^1.0.4",
-                "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/object.map": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -9046,36 +9244,6 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.18.0-next.2",
                 "has": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object.values/node_modules/es-abstract": {
-            "version": "1.18.0-next.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-            "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "es-to-primitive": "^1.2.1",
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.2",
-                "is-callable": "^1.2.3",
-                "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.2",
-                "is-string": "^1.0.5",
-                "object-inspect": "^1.9.0",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.2",
-                "string.prototype.trimend": "^1.0.4",
-                "string.prototype.trimstart": "^1.0.4",
-                "unbox-primitive": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9166,9 +9334,9 @@
             }
         },
         "node_modules/p-cancelable": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-            "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
+            "integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -9226,6 +9394,30 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pad-left": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+            "integrity": "sha1-FuajstRKjhOMsIOMx8tAOk/J6ZQ=",
+            "dev": true,
+            "dependencies": {
+                "repeat-string": "^1.5.4"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pad-right": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+            "dev": true,
+            "dependencies": {
+                "repeat-string": "^1.5.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/pako": {
@@ -9603,12 +9795,12 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.2.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.6.tgz",
-            "integrity": "sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==",
+            "version": "8.2.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
+            "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
             "dev": true,
             "dependencies": {
-                "colorette": "^1.2.1",
+                "colorette": "^1.2.2",
                 "nanoid": "^3.1.20",
                 "source-map": "^0.6.1"
             },
@@ -13226,12 +13418,12 @@
             }
         },
         "node_modules/postcss-scss": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.4.tgz",
-            "integrity": "sha512-BAkBZ35aXhCeBRmliHylYqTN1PvNJyh9aBPQHUmk9SdDdbk7n3GExm7cQivDckOgJpB+agyig9TwRAmf6WnvfA==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.5.tgz",
+            "integrity": "sha512-3e0qYk87eczfzg5P73ZVuuxEGCBfatRhPze6KrSaIbEKVtmnFI1RYp1Fv+AyZi+w8kcNRSPeNX6ap4b65zEkiA==",
             "dev": true,
             "dependencies": {
-                "postcss": "^8.1.6"
+                "postcss": "^8.2.7"
             },
             "engines": {
                 "node": ">=10.0"
@@ -14601,9 +14793,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.2.0.tgz",
-            "integrity": "sha512-ijLyszTMmUrXvjSooucVQwimGUk84eRcmCuLV8Xghe3UO85mjUtRAHRyoMM6XtyqbECaXuBWx18La3523sXINA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
             "dev": true
         },
         "node_modules/rgb-regex": {
@@ -14817,18 +15009,6 @@
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/serialize-error/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15813,9 +15993,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "13.11.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.11.0.tgz",
-            "integrity": "sha512-DhrKSWDWGZkCiQMtU+VroXM6LWJVC8hSK24nrUngTSQvXGK75yZUq4yNpynqrxD3a/fzKMED09V+XxO4z4lTbw==",
+            "version": "13.12.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
+            "integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
             "dev": true,
             "dependencies": {
                 "@stylelint/postcss-css-in-js": "^0.37.2",
@@ -15828,7 +16008,7 @@
                 "execall": "^2.0.0",
                 "fast-glob": "^3.2.5",
                 "fastest-levenshtein": "^1.0.12",
-                "file-entry-cache": "^6.0.0",
+                "file-entry-cache": "^6.0.1",
                 "get-stdin": "^8.0.0",
                 "global-modules": "^2.0.0",
                 "globby": "^11.0.2",
@@ -15838,7 +16018,7 @@
                 "import-lazy": "^4.0.0",
                 "imurmurhash": "^0.1.4",
                 "known-css-properties": "^0.21.0",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "log-symbols": "^4.0.0",
                 "mathml-tag-names": "^2.1.3",
                 "meow": "^9.0.0",
@@ -15858,7 +16038,7 @@
                 "resolve-from": "^5.0.0",
                 "slash": "^3.0.0",
                 "specificity": "^0.4.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.2",
                 "strip-ansi": "^6.0.0",
                 "style-search": "^0.1.0",
                 "sugarss": "^2.0.0",
@@ -16306,9 +16486,9 @@
             }
         },
         "node_modules/stylelint/node_modules/hosted-git-info": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
-            "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+            "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -16382,12 +16562,15 @@
             }
         },
         "node_modules/stylelint/node_modules/map-obj": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-            "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.0.tgz",
+            "integrity": "sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/stylelint/node_modules/meow": {
@@ -16416,25 +16599,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/stylelint/node_modules/meow/node_modules/type-fest": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/stylelint/node_modules/normalize-package-data": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-            "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+            "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
             "dev": true,
             "dependencies": {
-                "hosted-git-info": "^3.0.6",
+                "hosted-git-info": "^4.0.0",
                 "resolve": "^1.17.0",
                 "semver": "^7.3.2",
                 "validate-npm-package-license": "^3.0.1"
@@ -16585,6 +16756,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/stylelint/node_modules/read-pkg-up/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/stylelint/node_modules/read-pkg/node_modules/hosted-git-info": {
             "version": "2.8.8",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -16683,6 +16863,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/stylelint/node_modules/type-fest": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/suffix": {
@@ -16939,9 +17131,9 @@
             }
         },
         "node_modules/table/node_modules/ajv": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
-            "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz",
+            "integrity": "sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -17073,6 +17265,16 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
+        },
+        "node_modules/timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "dev": true,
+            "dependencies": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
+            }
         },
         "node_modules/timsort": {
             "version": "0.3.0",
@@ -17215,6 +17417,12 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
+        "node_modules/type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -17228,12 +17436,15 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/type-is": {
@@ -17379,9 +17590,9 @@
             }
         },
         "node_modules/unist-util-is": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.4.tgz",
-            "integrity": "sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -17538,9 +17749,9 @@
             }
         },
         "node_modules/v8-compile-cache": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-            "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
         },
         "node_modules/v8flags": {
@@ -17854,9 +18065,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-            "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+            "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
             "dev": true,
             "engines": {
                 "node": ">=8.3.0"
@@ -17912,9 +18123,9 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true,
             "engines": {
                 "node": ">= 6"
@@ -18120,13 +18331,13 @@
             }
         },
         "node_modules/zip-stream": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-            "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
+            "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
             "dev": true,
             "dependencies": {
                 "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.0.2",
+                "compress-commons": "^4.1.0",
                 "readable-stream": "^3.6.0"
             },
             "engines": {
@@ -18169,23 +18380,23 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-            "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.11.tgz",
+            "integrity": "sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
-            "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
+            "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.0",
-                "@babel/helper-compilation-targets": "^7.13.8",
+                "@babel/generator": "^7.13.9",
+                "@babel/helper-compilation-targets": "^7.13.10",
                 "@babel/helper-module-transforms": "^7.13.0",
-                "@babel/helpers": "^7.13.0",
-                "@babel/parser": "^7.13.4",
+                "@babel/helpers": "^7.13.10",
+                "@babel/parser": "^7.13.10",
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.13.0",
                 "@babel/types": "^7.13.0",
@@ -18227,9 +18438,9 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
-            "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+            "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
             "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.13.8",
@@ -18353,9 +18564,9 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-            "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+            "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.12.13",
@@ -18364,9 +18575,9 @@
             }
         },
         "@babel/highlight": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
-            "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+            "version": "7.13.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+            "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.12.11",
@@ -18427,9 +18638,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.13.9",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
-            "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
+            "version": "7.13.11",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.11.tgz",
+            "integrity": "sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==",
             "dev": true
         },
         "@babel/template": {
@@ -18516,6 +18727,15 @@
                 "strip-json-comments": "^3.1.1"
             },
             "dependencies": {
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.8.1"
+                    }
+                },
                 "import-fresh": {
                     "version": "3.3.0",
                     "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -18530,6 +18750,12 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
                     "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                },
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
                     "dev": true
                 }
             }
@@ -18790,9 +19016,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.31",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-            "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
+            "version": "14.14.34",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.34.tgz",
+            "integrity": "sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -19206,9 +19432,9 @@
             }
         },
         "archiver": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
-            "integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.0.tgz",
+            "integrity": "sha512-iUw+oDwK0fgNpvveEsdQ0Ase6IIKztBJU2U0E9MzszMfmVVUyv1QJhS2ITW9ZCqx8dktAxVAjWWkKehuZE8OPg==",
             "dev": true,
             "requires": {
                 "archiver-utils": "^2.1.0",
@@ -19216,8 +19442,8 @@
                 "buffer-crc32": "^0.2.1",
                 "readable-stream": "^3.6.0",
                 "readdir-glob": "^1.0.0",
-                "tar-stream": "^2.1.4",
-                "zip-stream": "^4.0.4"
+                "tar-stream": "^2.2.0",
+                "zip-stream": "^4.1.0"
             },
             "dependencies": {
                 "async": {
@@ -19235,6 +19461,19 @@
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
                         "util-deprecate": "^1.0.1"
+                    }
+                },
+                "tar-stream": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+                    "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+                    "dev": true,
+                    "requires": {
+                        "bl": "^4.0.3",
+                        "end-of-stream": "^1.4.1",
+                        "fs-constants": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^3.1.1"
                     }
                 }
             }
@@ -19366,14 +19605,14 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.4.tgz",
-            "integrity": "sha512-DCCdUQiMD+P/as8m3XkeTUkUKuuRqLGcwD0nll7wevhqoJfMRpJlkFd1+MQh1pvupjiQuip42lc/VFvfUTMSKw==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.5.tgz",
+            "integrity": "sha512-7H4AJZXvSsn62SqZyJCP+1AWwOuoYpUfK6ot9vm0e87XD6mT8lDywc9D9OTJPMULyGcvmIxzTAMeG2Cc+YX+fA==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.16.1",
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
+                "browserslist": "^4.16.3",
+                "caniuse-lite": "^1.0.30001196",
+                "colorette": "^1.2.2",
                 "fraction.js": "^4.0.13",
                 "normalize-range": "^0.1.2",
                 "postcss-value-parser": "^4.1.0"
@@ -19815,9 +20054,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001194",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
-            "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==",
+            "version": "1.0.30001200",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001200.tgz",
+            "integrity": "sha512-ic/jXfa6tgiPBAISWk16jRI2q8YfjxHnSG7ddSL1ptrIP8Uy11SayFrjXRAk3NumHpDb21fdTkbTxb/hOrFrnQ==",
             "dev": true
         },
         "chalk": {
@@ -20030,6 +20269,28 @@
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true
         },
+        "cli-color": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+            "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.1.1",
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "memoizee": "^0.4.14",
+                "timers-ext": "^0.1.5"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                }
+            }
+        },
         "cli-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -20203,9 +20464,9 @@
             "dev": true
         },
         "color-string": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
-            "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
             "dev": true,
             "requires": {
                 "color-name": "^1.0.0",
@@ -20237,9 +20498,9 @@
             "dev": true
         },
         "compress-commons": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-            "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.0.tgz",
+            "integrity": "sha512-ofaaLqfraD1YRTkrRKPCrGJ1pFeDG/MVCkVVV2FNGeWquSlqw5wOrwOfPQ1xF2u+blpeWASie5EubHz+vsNIgA==",
             "dev": true,
             "requires": {
                 "buffer-crc32": "^0.2.13",
@@ -20922,6 +21183,16 @@
             "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
             "dev": true
         },
+        "d": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
+            }
+        },
         "date-format": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
@@ -21234,9 +21505,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.678",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.678.tgz",
-            "integrity": "sha512-E5ha1pE9+aWWrT2fUD5wdPBWUnYtKnEnloewbtVyrkAs79HvodOiNO4rMR94+hKbxgMFQG4fnPQACOc1cfMfBg==",
+            "version": "1.3.687",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.687.tgz",
+            "integrity": "sha512-IpzksdQNl3wdgkzf7dnA7/v10w0Utf1dF2L+B4+gKrloBrxCut+au+kky3PYvle3RMdSxZP+UiCZtLbcYRxSNQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -21324,22 +21595,27 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.7",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-            "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+            "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
             "dev": true,
             "requires": {
+                "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
                 "has": "^1.0.3",
-                "has-symbols": "^1.0.1",
-                "is-callable": "^1.2.2",
-                "is-regex": "^1.1.1",
-                "object-inspect": "^1.8.0",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.2",
+                "is-string": "^1.0.5",
+                "object-inspect": "^1.9.0",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.1",
-                "string.prototype.trimend": "^1.0.1",
-                "string.prototype.trimstart": "^1.0.1"
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.0"
             }
         },
         "es-to-primitive": {
@@ -21353,17 +21629,61 @@
                 "is-symbol": "^1.0.2"
             }
         },
+        "es5-ext": {
+            "version": "0.10.53",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.3",
+                "next-tick": "~1.0.0"
+            }
+        },
         "es5-shim": {
             "version": "4.5.15",
             "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.15.tgz",
             "integrity": "sha512-FYpuxEjMeDvU4rulKqFdukQyZSTpzhg4ScQHrAosrlVpR6GFyaw14f74yn2+4BugniIS0Frpg7TvwZocU4ZMTw==",
             "dev": true
         },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
+            }
+        },
         "es6-shim": {
             "version": "0.35.6",
             "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.6.tgz",
             "integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==",
             "dev": true
+        },
+        "es6-symbol": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "es6-symbol": "^3.1.1"
+            }
         },
         "escalade": {
             "version": "3.1.1",
@@ -21384,9 +21704,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-            "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+            "version": "7.22.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+            "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
@@ -21406,7 +21726,7 @@
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^5.0.0",
-                "globals": "^12.1.0",
+                "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
@@ -21414,7 +21734,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -21556,6 +21876,16 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
+            "requires": {
+                "d": "1",
+                "es5-ext": "~0.10.14"
+            }
         },
         "event-stream": {
             "version": "3.3.4",
@@ -21755,6 +22085,23 @@
             "requires": {
                 "expect": "^26.5.3",
                 "jest-matcher-utils": "^26.5.2"
+            }
+        },
+        "ext": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+            "dev": true,
+            "requires": {
+                "type": "^2.0.0"
+            },
+            "dependencies": {
+                "type": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+                    "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -22223,9 +22570,9 @@
             }
         },
         "glob-parent": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
@@ -22263,12 +22610,12 @@
             }
         },
         "globals": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-            "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+            "version": "13.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.6.0.tgz",
+            "integrity": "sha512-YFKCX0SiPg7l5oKYCJ2zZGxcXprVXHcSnVuvzrT3oSENQonVLqM5pf9fN5dLGZGyCjhw8TN8Btwe/jKnZ0pjvQ==",
             "dev": true,
             "requires": {
-                "type-fest": "^0.8.1"
+                "type-fest": "^0.20.2"
             }
         },
         "globby": {
@@ -23344,9 +23691,9 @@
             "dev": true
         },
         "is-path-inside": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-            "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true
         },
         "is-plain-obj": {
@@ -23363,6 +23710,12 @@
             "requires": {
                 "isobject": "^3.0.1"
             }
+        },
+        "is-promise": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+            "dev": true
         },
         "is-regex": {
             "version": "1.1.2",
@@ -23814,9 +24167,9 @@
             }
         },
         "karma": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-6.1.1.tgz",
-            "integrity": "sha512-vVDFxFGAsclgmFjZA/qGw5xqWdZIWxVD7xLyCukYUYd5xs/uGzYbXGOT5zOruVBQleKEmXIr4H2hzGCTn+M9Cg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-6.2.0.tgz",
+            "integrity": "sha512-pCB8eNxGgdIdZeC885rbhZ/VyuOPNHUIDNL9EaaMf1NVzpvTjMO8a7zRTn51ZJhOOOxCSpalUdT1A8x76LyVqg==",
             "dev": true,
             "requires": {
                 "body-parser": "^1.19.0",
@@ -23863,6 +24216,35 @@
                     "dev": true,
                     "requires": {
                         "rimraf": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "karma-brief-reporter": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/karma-brief-reporter/-/karma-brief-reporter-0.2.1.tgz",
+            "integrity": "sha512-At7qOaVbj9Co2sl5Esvmn6ZGz7L3ZmUtER3jcBdN+N3IoxVTvqvLnThK6qJa2tExsl1A7sEGQL3+AgSs6TsLvw==",
+            "dev": true,
+            "requires": {
+                "cli-color": "1.4.0",
+                "mkdirp": "0.5.1",
+                "pad-left": "2.1.0",
+                "pad-right": "0.2.2"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
                     }
                 }
             }
@@ -24563,6 +24945,15 @@
                 "yallist": "^4.0.0"
             }
         },
+        "lru-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.2"
+            }
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -24684,6 +25075,30 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
+        },
+        "memoizee": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+            "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+            "dev": true,
+            "requires": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.53",
+                "es6-weak-map": "^2.0.3",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.2.2",
+                "lru-queue": "^0.1.0",
+                "next-tick": "^1.1.0",
+                "timers-ext": "^0.1.7"
+            },
+            "dependencies": {
+                "next-tick": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+                    "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+                    "dev": true
+                }
+            }
         },
         "meow": {
             "version": "3.7.0",
@@ -24831,9 +25246,9 @@
             "dev": true
         },
         "mocha": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-            "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
+            "integrity": "sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -24976,6 +25391,12 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
             "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-fetch": {
@@ -25209,32 +25630,6 @@
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.18.0-next.2"
-            },
-            "dependencies": {
-                "es-abstract": {
-                    "version": "1.18.0-next.3",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-                    "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
-                    "dev": true,
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.2",
-                        "is-callable": "^1.2.3",
-                        "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.2",
-                        "is-string": "^1.0.5",
-                        "object-inspect": "^1.9.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.0"
-                    }
-                }
             }
         },
         "object.map": {
@@ -25266,32 +25661,6 @@
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.18.0-next.2",
                 "has": "^1.0.3"
-            },
-            "dependencies": {
-                "es-abstract": {
-                    "version": "1.18.0-next.3",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-                    "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
-                    "dev": true,
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.2",
-                        "is-callable": "^1.2.3",
-                        "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.2",
-                        "is-string": "^1.0.5",
-                        "object-inspect": "^1.9.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.0"
-                    }
-                }
             }
         },
         "on-finished": {
@@ -25358,9 +25727,9 @@
             }
         },
         "p-cancelable": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-            "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
+            "integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
             "dev": true
         },
         "p-limit": {
@@ -25395,6 +25764,24 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
+        },
+        "pad-left": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
+            "integrity": "sha1-FuajstRKjhOMsIOMx8tAOk/J6ZQ=",
+            "dev": true,
+            "requires": {
+                "repeat-string": "^1.5.4"
+            }
+        },
+        "pad-right": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+            "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+            "dev": true,
+            "requires": {
+                "repeat-string": "^1.5.2"
+            }
         },
         "pako": {
             "version": "1.0.11",
@@ -25674,12 +26061,12 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.2.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.6.tgz",
-            "integrity": "sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==",
+            "version": "8.2.8",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
+            "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
             "dev": true,
             "requires": {
-                "colorette": "^1.2.1",
+                "colorette": "^1.2.2",
                 "nanoid": "^3.1.20",
                 "source-map": "^0.6.1"
             },
@@ -28554,12 +28941,12 @@
             }
         },
         "postcss-scss": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.4.tgz",
-            "integrity": "sha512-BAkBZ35aXhCeBRmliHylYqTN1PvNJyh9aBPQHUmk9SdDdbk7n3GExm7cQivDckOgJpB+agyig9TwRAmf6WnvfA==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-3.0.5.tgz",
+            "integrity": "sha512-3e0qYk87eczfzg5P73ZVuuxEGCBfatRhPze6KrSaIbEKVtmnFI1RYp1Fv+AyZi+w8kcNRSPeNX6ap4b65zEkiA==",
             "dev": true,
             "requires": {
-                "postcss": "^8.1.6"
+                "postcss": "^8.2.7"
             }
         },
         "postcss-selector-parser": {
@@ -29609,9 +29996,9 @@
             "dev": true
         },
         "rfdc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.2.0.tgz",
-            "integrity": "sha512-ijLyszTMmUrXvjSooucVQwimGUk84eRcmCuLV8Xghe3UO85mjUtRAHRyoMM6XtyqbECaXuBWx18La3523sXINA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
             "dev": true
         },
         "rgb-regex": {
@@ -29775,14 +30162,6 @@
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
-            },
-            "dependencies": {
-                "type-fest": {
-                    "version": "0.20.2",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-                    "dev": true
-                }
             }
         },
         "serialize-javascript": {
@@ -30594,9 +30973,9 @@
             }
         },
         "stylelint": {
-            "version": "13.11.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.11.0.tgz",
-            "integrity": "sha512-DhrKSWDWGZkCiQMtU+VroXM6LWJVC8hSK24nrUngTSQvXGK75yZUq4yNpynqrxD3a/fzKMED09V+XxO4z4lTbw==",
+            "version": "13.12.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
+            "integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
             "dev": true,
             "requires": {
                 "@stylelint/postcss-css-in-js": "^0.37.2",
@@ -30609,7 +30988,7 @@
                 "execall": "^2.0.0",
                 "fast-glob": "^3.2.5",
                 "fastest-levenshtein": "^1.0.12",
-                "file-entry-cache": "^6.0.0",
+                "file-entry-cache": "^6.0.1",
                 "get-stdin": "^8.0.0",
                 "global-modules": "^2.0.0",
                 "globby": "^11.0.2",
@@ -30619,7 +30998,7 @@
                 "import-lazy": "^4.0.0",
                 "imurmurhash": "^0.1.4",
                 "known-css-properties": "^0.21.0",
-                "lodash": "^4.17.20",
+                "lodash": "^4.17.21",
                 "log-symbols": "^4.0.0",
                 "mathml-tag-names": "^2.1.3",
                 "meow": "^9.0.0",
@@ -30639,7 +31018,7 @@
                 "resolve-from": "^5.0.0",
                 "slash": "^3.0.0",
                 "specificity": "^0.4.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.2",
                 "strip-ansi": "^6.0.0",
                 "style-search": "^0.1.0",
                 "sugarss": "^2.0.0",
@@ -30735,9 +31114,9 @@
                     "dev": true
                 },
                 "hosted-git-info": {
-                    "version": "3.0.8",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
-                    "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+                    "integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -30792,9 +31171,9 @@
                     }
                 },
                 "map-obj": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
-                    "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.0.tgz",
+                    "integrity": "sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ==",
                     "dev": true
                 },
                 "meow": {
@@ -30815,23 +31194,15 @@
                         "trim-newlines": "^3.0.0",
                         "type-fest": "^0.18.0",
                         "yargs-parser": "^20.2.3"
-                    },
-                    "dependencies": {
-                        "type-fest": {
-                            "version": "0.18.1",
-                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-                            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-                            "dev": true
-                        }
                     }
                 },
                 "normalize-package-data": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
-                    "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+                    "integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "^3.0.6",
+                        "hosted-git-info": "^4.0.0",
                         "resolve": "^1.17.0",
                         "semver": "^7.3.2",
                         "validate-npm-package-license": "^3.0.1"
@@ -30970,6 +31341,14 @@
                         "find-up": "^4.1.0",
                         "read-pkg": "^5.2.0",
                         "type-fest": "^0.8.1"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.8.1",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+                            "dev": true
+                        }
                     }
                 },
                 "redent": {
@@ -31016,6 +31395,12 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
                     "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+                    "dev": true
+                },
+                "type-fest": {
+                    "version": "0.18.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+                    "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
                     "dev": true
                 }
             }
@@ -31465,9 +31850,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "7.1.1",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
-                    "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
+                    "version": "7.2.1",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz",
+                    "integrity": "sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -31582,6 +31967,16 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
+        },
+        "timers-ext": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+            "dev": true,
+            "requires": {
+                "es5-ext": "~0.10.46",
+                "next-tick": "1"
+            }
         },
         "timsort": {
             "version": "0.3.0",
@@ -31700,6 +32095,12 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
             "dev": true
         },
+        "type": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
+            "dev": true
+        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -31710,9 +32111,9 @@
             }
         },
         "type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true
         },
         "type-is": {
@@ -31834,9 +32235,9 @@
             }
         },
         "unist-util-is": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.4.tgz",
-            "integrity": "sha512-3dF39j/u423v4BBQrk1AQ2Ve1FxY5W3JKwXxVFzBODQ6WEvccguhgp802qQLKSnxPODE6WuRZtV+ohlUg4meBA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
             "dev": true
         },
         "unist-util-stringify-position": {
@@ -31958,9 +32359,9 @@
             "dev": true
         },
         "v8-compile-cache": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-            "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
         },
         "v8flags": {
@@ -32209,9 +32610,9 @@
             }
         },
         "ws": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-            "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+            "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
             "dev": true,
             "requires": {}
         },
@@ -32244,9 +32645,9 @@
             "dev": true
         },
         "yaml": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-            "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+            "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "dev": true
         },
         "yargs": {
@@ -32401,13 +32802,13 @@
             "dev": true
         },
         "zip-stream": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-            "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
+            "integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
             "dev": true,
             "requires": {
                 "archiver-utils": "^2.1.0",
-                "compress-commons": "^4.0.2",
+                "compress-commons": "^4.1.0",
                 "readable-stream": "^3.6.0"
             },
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "jasmine-core": "^3.6.0",
         "jasmine-jquery": "2.1.1",
         "karma": "^6.1.1",
+        "karma-brief-reporter": "^0.2.1",
         "karma-chrome-launcher": "^3.1.0",
         "karma-coverage": "2.0.3",
         "karma-es6-shim": "1.0.0",

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -22,6 +22,8 @@ module.exports = function (config) {
             'karma-mocha-reporter',
             'karma-es6-shim',
             'karma-json-result-reporter',
+            'karma-brief-reporter',
+            'karma-jasmine-html-reporter',
         ],
         preprocessors: {
             'kbase-extension/static/kbase/js/**/!(api)/*.js': ['coverage'],
@@ -39,9 +41,9 @@ module.exports = function (config) {
         files: [
             'node_modules/jasmine-ajax/lib/mock-ajax.js',
             // tests and test resources
-            'test/unit/testUtil.js',
-            'test/unit/mocks.js',
-            'test/unit/test-main.js',
+            { pattern: 'test/unit/testUtil.js', nocache: true },
+            { pattern: 'test/unit/mocks.js', nocache: true },
+            { pattern: 'test/unit/test-main.js', nocache: true },
             { pattern: 'test/unit/spec/**/*.js', included: false, nocache: true },
             { pattern: 'test/testConfig.json', included: false, nocache: true },
             { pattern: 'test/*.tok', included: false, nocache: true },

--- a/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeStagingDataTab-spec.js
@@ -107,7 +107,7 @@ define(['jquery', 'kbaseNarrativeStagingDataTab', 'base/js/namespace'], (
 
         it('can deactivate its staging area viewer', async () => {
             await stagingWidget.render();
-            spyOn(stagingWidget.stagingAreaViewer, 'deactivate');
+            spyOn(stagingWidget.stagingAreaViewer, 'deactivate').and.callThrough();
             stagingWidget.activate();
             stagingWidget.deactivate();
             expect(stagingWidget.stagingAreaViewer.deactivate).toHaveBeenCalled();

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -6,33 +6,12 @@ define([
 ], ($, FileUploadWidget, Jupyter, Config) => {
     'use strict';
 
-    let fuWidget, $targetNode;
-    const fakeUser = 'notAUser';
-
-    const mockUploadEndpoint = (filename, username, isFolder) => {
-        jasmine.Ajax.stubRequest(Config.url('staging_api_url') + '/upload').andReturn({
-            status: 200,
-            statusText: 'HTTP/1.1 200 OK',
-            contentType: 'application/json',
-            responseText: JSON.stringify([
-                {
-                    name: filename,
-                    path: `${username}/${filename}`,
-                    mtime: 1596747139855,
-                    size: 1376,
-                    isFolder: isFolder,
-                },
-            ]),
-        });
-    };
-
-    const createMockFile = (filename) => {
-        const file = new File(['file contents'], filename, { type: 'text/html' });
-        return file;
-    };
+    const fakeUser = 'notAUser',
+        filename = 'foo.txt',
+        stagingUrl = Config.url('staging_api_url') + '/upload';
 
     describe('Test the fileUploadWidget', () => {
-        beforeEach(() => {
+        beforeEach(function () {
             jasmine.Ajax.install();
             Jupyter.narrative = {
                 userId: fakeUser,
@@ -46,13 +25,29 @@ define([
                 },
                 showDataOverlay: () => {},
             };
-            $targetNode = $('<div>');
-            fuWidget = new FileUploadWidget($targetNode, {
+            this.node = document.createElement('div');
+            this.fuWidget = new FileUploadWidget($(this.node), {
                 path: '/',
                 userInfo: {
                     user: fakeUser,
                     globusLinked: false,
                 },
+            });
+            this.mockFile = new File(['file contents'], filename, { type: 'text/html' });
+
+            jasmine.Ajax.stubRequest(stagingUrl).andReturn({
+                status: 200,
+                statusText: 'HTTP/1.1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify([
+                    {
+                        name: filename,
+                        path: `${fakeUser}/${filename}`,
+                        mtime: 1596747139855,
+                        size: 1376,
+                        isFolder: false,
+                    },
+                ]),
             });
         });
 
@@ -62,32 +57,28 @@ define([
         });
 
         it('Should be able to set and retrieve the path', () => {
-            const $node = $('<div>'),
-                fuw = new FileUploadWidget($node, {
-                    path: '/',
-                    userInfo: {
-                        user: fakeUser,
-                        globusLinked: true,
-                    },
-                });
+            const uploadWidget = new FileUploadWidget($('<div>'), {
+                path: '/',
+                userInfo: {
+                    user: fakeUser,
+                    globusLinked: true,
+                },
+            });
             const newPath = 'newPath';
-            fuw.setPath(newPath);
-            expect(fuw.getPath()).toEqual(newPath);
+            uploadWidget.setPath(newPath);
+            expect(uploadWidget.getPath()).toEqual(newPath);
         });
 
-        it('Should start and succeed on an upload when a file is given', (done) => {
-            const filename = 'foo.txt';
-            mockUploadEndpoint(filename, fakeUser, false);
-            const mockFile = createMockFile(filename);
+        it('Should start and succeed on an upload when a file is given', function (done) {
             const adderMock = jasmine.createSpy('adderMock');
             const successMock = jasmine.createSpy('successMock');
-            fuWidget.dropzone.on('addedfile', () => {
+            this.fuWidget.dropzone.on('addedfile', () => {
                 adderMock();
             });
-            fuWidget.dropzone.on('success', () => {
+            this.fuWidget.dropzone.on('success', () => {
                 successMock();
             });
-            fuWidget.dropzone.addFile(mockFile);
+            this.fuWidget.dropzone.addFile(this.mockFile);
             setTimeout(() => {
                 expect(adderMock).toHaveBeenCalled();
                 expect(successMock).toHaveBeenCalled();
@@ -95,48 +86,45 @@ define([
             });
         });
 
-        it('Should timeout an upload when configured', (done) => {
+        it('Should timeout an upload when configured', function (done) {
             // The default config gives an infinite timeout. Hard to test.
-            expect(fuWidget.dropzone.options.timeout).toBe(0);
+            expect(this.fuWidget.dropzone.options.timeout).toBe(0);
             // Let's set it shorter than disabled.
-            fuWidget.dropzone.options.timeout = 100; // ms
-            expect(fuWidget.dropzone.options.timeout).toBe(100);
-            const filename = 'foo.txt';
-            mockUploadEndpoint(filename, fakeUser, false);
-            const mockFile = createMockFile(filename);
-            fuWidget.dropzone.on('error', (file, errorMessage) => {
+            this.fuWidget.dropzone.options.timeout = 100; // ms
+            expect(this.fuWidget.dropzone.options.timeout).toBe(100);
+
+            this.fuWidget.dropzone.on('error', (file, errorMessage) => {
                 expect(errorMessage).toBeDefined();
                 done();
             });
-            fuWidget.dropzone.on('success', () => {
+            this.fuWidget.dropzone.on('success', () => {
                 const req = jasmine.Ajax.requests.mostRecent();
                 expect(req.url).toMatch(/\/upload/);
                 expect(req.method).toBe('POST');
                 done();
             });
-            fuWidget.dropzone.addFile(mockFile);
+            this.fuWidget.dropzone.addFile(this.mockFile);
         });
 
-        it('Should error when too large of a file is uploaded', (done) => {
+        it('Should error when too large of a file is uploaded', function (done) {
             // Set the file max size to 0
-            fuWidget.dropzone.options.maxFilesize = 1;
+            this.fuWidget.dropzone.options.maxFilesize = 1;
 
-            // Create file
-            const filename = 'foo.txt';
-            mockUploadEndpoint(filename, fakeUser, false);
-            const mockFile = createMockFile(filename);
-            Object.defineProperty(mockFile, 'size', { value: Math.pow(1024, 4), writable: false });
+            Object.defineProperty(this.mockFile, 'size', {
+                value: Math.pow(1024, 4),
+                writable: false,
+            });
 
             // Create mock calls
             const adderMock = jasmine.createSpy('adderMock');
             const errorMock = jasmine.createSpy('errorMock');
-            fuWidget.dropzone.on('addedfile', () => {
+            this.fuWidget.dropzone.on('addedfile', () => {
                 adderMock();
             });
-            fuWidget.dropzone.on('error', () => {
+            this.fuWidget.dropzone.on('error', () => {
                 errorMock();
             });
-            fuWidget.dropzone.addFile(mockFile);
+            this.fuWidget.dropzone.addFile(this.mockFile);
             setTimeout(() => {
                 expect(adderMock).toHaveBeenCalled();
                 expect(errorMock).toHaveBeenCalled();
@@ -144,25 +132,18 @@ define([
             });
         });
 
-        it('Should render properly when a file upload error occurs', (done) => {
+        it('Should render properly when a file upload error occurs', function (done) {
             // Set the file max size to 0
-            fuWidget.dropzone.options.maxFilesize = 1;
+            this.fuWidget.dropzone.options.maxFilesize = 1;
 
-            // Create file
-            const filename = 'foo.txt';
-            mockUploadEndpoint(filename, fakeUser, false);
-            const mockFile = createMockFile(filename);
-            Object.defineProperty(mockFile, 'size', { value: Math.pow(1024, 4), writable: false });
-
-            // Create mock calls
-            const adderMock = jasmine.createSpy('adderMock');
-            fuWidget.dropzone.on('addedfile', () => {
-                adderMock();
+            Object.defineProperty(this.mockFile, 'size', {
+                value: Math.pow(1024, 4),
+                writable: false,
             });
 
-            fuWidget.dropzone.addFile(mockFile);
+            this.fuWidget.dropzone.addFile(this.mockFile);
             setTimeout(() => {
-                const $fileTemplate = fuWidget.$elem;
+                const $fileTemplate = this.fuWidget.$elem;
                 expect(document.getElementById('clear_all_button')).toBeDefined();
                 expect($fileTemplate.find('#upload_progress_and_cancel').css('display')).toEqual(
                     'none'
@@ -175,9 +156,8 @@ define([
             });
         });
 
-        it('Should provide a link to a globus accout when file upload maxfile size error occurs', (done) => {
-            $targetNode = $('<div>');
-            const uploadWidget = new FileUploadWidget($targetNode, {
+        it('Should provide a link to a globus account when file upload maxfile size error occurs', function (done) {
+            const uploadWidget = new FileUploadWidget($('<div>'), {
                 path: '/',
                 userInfo: {
                     user: fakeUser,
@@ -187,20 +167,12 @@ define([
 
             // Set the file max size to 0
             uploadWidget.dropzone.options.maxFilesize = 1;
-
-            // Create file
-            const filename = 'foo.txt';
-            mockUploadEndpoint(filename, fakeUser, false);
-            const mockFile = createMockFile(filename);
-            Object.defineProperty(mockFile, 'size', { value: Math.pow(1024, 4), writable: false });
-
-            // Create mock calls
-            const adderMock = jasmine.createSpy('adderMock');
-            uploadWidget.dropzone.on('addedfile', () => {
-                adderMock();
+            Object.defineProperty(this.mockFile, 'size', {
+                value: Math.pow(1024, 4),
+                writable: false,
             });
 
-            uploadWidget.dropzone.addFile(mockFile);
+            uploadWidget.dropzone.addFile(this.mockFile);
             setTimeout(() => {
                 const $fileTemplate = uploadWidget.$elem;
                 expect($fileTemplate.find('#globus_error_link').attr('href')).toEqual(
@@ -211,30 +183,19 @@ define([
             });
         });
 
-        it('Should contain a cancel warning button', () => {
-            $targetNode = $('<div>');
-            let uploadWidget = new FileUploadWidget($targetNode, {
-                path: '/',
-                userInfo: {
-                    user: fakeUser,
-                    globusLinked: false,
-                },
+        it('Should contain a cancel warning button', function (done) {
+            document.body.appendChild(this.node);
+
+            this.fuWidget.dropzone.on('sending', () => {
+                const $cancelButton = this.fuWidget.$elem.find('.cancel');
+                expect($cancelButton).toBeDefined();
+                expect($cancelButton.attr('data-dz-remove')).toBeDefined();
+                // prevent the XHR from being submitted -- for some reason jasmine.ajax does not catch it
+                this.fuWidget.dropzone.disable();
+                done();
             });
 
-            // Create file
-            const filename = 'foo.txt';
-            mockUploadEndpoint(filename, fakeUser, false);
-            var mockFile = createMockFile(filename);
-
-            const adderMock = jasmine.createSpy('adderMock');
-            uploadWidget.dropzone.on('addedfile', () => {
-                adderMock();
-            });
-
-            uploadWidget.dropzone.addFile(mockFile);
-            let $cancelButton = uploadWidget.$elem.find('.cancel');
-            expect($cancelButton).toBeDefined();
-            expect($cancelButton.attr('data-dz-remove')).toBeDefined();
+            this.fuWidget.dropzone.addFile(this.mockFile);
         });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

Some quick patches to prevent tests from calling CI.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-330
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by running `make test-frontend-unit`

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
