### PR TITLE
DATAUP-314: add error type to the job status row

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateListRow.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStateListRow.js
@@ -22,20 +22,20 @@ define([
         let container, ui, jobId, jobState;
         const widgets = {};
 
-        function _createStatusLabel(jobStatus) {
+        function _createStatusLabel(jobStateObject) {
             return (
                 span({
-                    class: `fa fa-circle ${cssBaseClass}__icon--${jobStatus}`,
+                    class: `fa fa-circle ${cssBaseClass}__icon--${jobStateObject.status}`,
                 }) +
                 ' ' +
-                Jobs.jobLabel(jobStatus)
+                Jobs.jobLabel(jobStateObject)
             );
         }
 
-        function _createActionButton(jobStatus) {
+        function _createActionButton(jobStateObject) {
             return div(
                 {
-                    class: `${cssBaseClass}__cell_action--${jobStatus}`,
+                    class: `${cssBaseClass}__cell_action--${jobStateObject.status}`,
                     role: 'button',
                     // TODO: these actions need to be added
                     id: events.addEvent({
@@ -45,7 +45,7 @@ define([
                         },
                     }),
                 },
-                [Jobs.jobAction(jobStatus)]
+                [Jobs.jobAction(jobStateObject)]
             );
         }
 
@@ -97,8 +97,8 @@ define([
         // update the status and action columns
         function _updateRowStatus(jobStateObject) {
             jobState = jobStateObject;
-            ui.setContent('job-state', _createStatusLabel(jobState.status));
-            ui.setContent('job-action', _createActionButton(jobState.status));
+            ui.setContent('job-state', _createStatusLabel(jobState));
+            ui.setContent('job-action', _createActionButton(jobState));
         }
 
         function selectRow(e) {

--- a/kbase-extension/static/kbase/js/common/errorDisplay.js
+++ b/kbase-extension/static/kbase/js/common/errorDisplay.js
@@ -175,12 +175,11 @@ define(['bluebird', 'common/html'], (Promise, html) => {
     }
 
     function convertUnknownError(rawError) {
-        const errorObject = {
+        return {
             type: 'Unknown error',
             message: 'error in unknown format',
             errorDump: rawError,
         };
-        return errorObject;
     }
 
     function convertInternalError(rawError) {

--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -1,4 +1,9 @@
-define(['common/html', 'common/format', 'common/ui'], (html, format, UI) => {
+define(['common/html', 'common/format', 'common/ui', 'common/errorDisplay'], (
+    html,
+    format,
+    UI,
+    ErrorDisplay
+) => {
     'use strict';
 
     const t = html.tag,
@@ -95,11 +100,12 @@ define(['common/html', 'common/format', 'common/ui'], (html, format, UI) => {
     /**
      * Given a job state, return the appropriate action to offer in the UI
      *
-     * @param {string} jobStatus
+     * @param {object} jobState
      * @returns {string} label
      */
 
-    function jobAction(jobStatus) {
+    function jobAction(jobState) {
+        const jobStatus = jobState.status || 'does_not_exist';
         const cancel = 'Cancel',
             // statuses not listed here are 'error', 'terminated', and 'does_not_exist'
             // the action for all those should be 'Retry'
@@ -116,11 +122,12 @@ define(['common/html', 'common/format', 'common/ui'], (html, format, UI) => {
     /**
      * Convert a job state into a short string to present in the UI
      *
-     * @param {string} jobStatus
+     * @param {object} jobState
      * @returns {string} label
      */
 
-    function jobLabel(jobStatus) {
+    function jobLabel(jobState) {
+        const jobStatus = jobState.status || 'does_not_exist';
         // covers 'does_not_exist' or invalid job states
         let label = 'Job not found';
         switch (jobStatus) {
@@ -136,7 +143,7 @@ define(['common/html', 'common/format', 'common/ui'], (html, format, UI) => {
                 label = 'Success';
                 break;
             case 'error':
-                label = 'Failed';
+                label = 'Failed: ' + ErrorDisplay.normaliseErrorObject({ jobState: jobState }).type;
                 break;
             case 'terminated':
                 label = 'Cancelled';

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -174,7 +174,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistory, jobStrings.runHistory, jobStrings.error],
                 },
                 jobAction: jobStrings.action.retry,
-                jobLabel: 'Failed',
+                jobLabel: 'Failed: Server error',
                 niceState: {
                     class: 'kb-job-status__summary--error',
                     label: 'error',

--- a/test/unit/spec/common/jobsSpec.js
+++ b/test/unit/spec/common/jobsSpec.js
@@ -103,28 +103,26 @@ define(['common/jobs', '/test/data/jobsData'], (Jobs, JobsData) => {
             ['does_not_exist', 'Job not found'],
             ['estimating', 'Queued'],
             ['queued', 'Queued'],
-            ['error', 'Failed'],
+            ['error', 'Failed: Unknown error'], // no error object present
             ['terminated', 'Cancelled'],
             ['running', 'Running'],
         ];
         labelToState.forEach((entry) => {
             it(`should create an abbreviated label when given the job state ${entry[0]}`, () => {
-                expect(Jobs.jobLabel(entry[0])).toEqual(entry[1]);
+                expect(Jobs.jobLabel({ status: entry[0] })).toEqual(entry[1]);
             });
         });
     });
 
-    describe('jobAction, valid data', () => {
-        JobsData.allJobs.forEach((state) => {
-            it(`should generate a job action with the job state ${state.status}`, () => {
-                expect(Jobs.jobAction(state.status)).toEqual(state.meta.jobAction);
-            });
-        });
-    });
-    describe('jobAction, invalid data', () => {
+    describe('jobAction', () => {
         badStates.forEach((item) => {
             it(`should generate a retry action with the job state ${item}`, () => {
-                expect(Jobs.jobAction(item)).toEqual(JobsData.jobStrings.action.retry);
+                expect(Jobs.jobAction({ status: item })).toEqual(JobsData.jobStrings.action.retry);
+            });
+        });
+        JobsData.allJobs.forEach((state) => {
+            it(`should generate a job action with the job state ${state.status}`, () => {
+                expect(Jobs.jobAction(state)).toEqual(state.meta.jobAction);
             });
         });
     });
@@ -132,12 +130,12 @@ define(['common/jobs', '/test/data/jobsData'], (Jobs, JobsData) => {
     describe('jobLabel', () => {
         badStates.forEach((item) => {
             it(`creates an appropriate label with the input ${JSON.stringify(item)}`, () => {
-                expect(Jobs.jobLabel(item)).toEqual('Job not found');
+                expect(Jobs.jobLabel({ status: item })).toEqual('Job not found');
             });
         });
         JobsData.allJobs.forEach((state) => {
             it(`creates an appropriate label with input in state ${state.status}`, () => {
-                expect(Jobs.jobLabel(state.status)).toEqual(state.meta.jobLabel);
+                expect(Jobs.jobLabel(state)).toEqual(state.meta.jobLabel);
             });
         });
     });


### PR DESCRIPTION
# Description of PR purpose/changes

Adding in the type of error to the status row, as in the diagram:

![Screenshot 2021-03-17 at 14 49 46](https://user-images.githubusercontent.com/556057/111543279-0fe86300-8730-11eb-9419-9de4ea01a2ff.png)

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-314
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to a handy job status table to view the errors

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
