### PR TITLE
DATAUP-314: Batch job status line

### DIFF
--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -398,7 +398,7 @@ define([
         function updateJobState() {
             // TODO: this will need to be updated once the backend is in place
             const jobState = testDataModel.getItem('exec.jobState');
-            // controlPanel.setExecMessage(Jobs.createCombinedJobState(jobState));
+            controlPanel.setExecMessage(Jobs.createCombinedJobState(jobState));
         }
 
         /**

--- a/nbextensions/bulkImportCell/jobsData.js
+++ b/nbextensions/bulkImportCell/jobsData.js
@@ -9,7 +9,7 @@ define(['common/format'], (format) => {
 
     const jobStrings = {
         unknown: 'Determining job state...',
-        not_found: 'This job was not found, or may not have been registered with this Narrative.',
+        not_found: 'This job was not found, or may not have been registered with this narrative.',
         queued: 'In the queue since ' + format.niceTime(t.created),
         termination: 'Finished with cancellation at ' + format.niceTime(t.finished),
         running: 'Started running job at ' + format.niceTime(t.running),
@@ -19,9 +19,9 @@ define(['common/format'], (format) => {
         queueHistoryNoRun: 'Queued for ' + format.niceDuration(t.finished - t.created),
         runHistory: 'Ran for ' + format.niceDuration(t.finished - t.running),
         action: {
-            results: 'Go to results',
-            cancel: 'Cancel',
-            retry: 'Retry',
+            results: 'go to results',
+            cancel: 'cancel',
+            retry: 'retry',
         },
     };
 
@@ -44,7 +44,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queued],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Queued',
+                jobLabel: 'queued',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'created',
@@ -62,7 +62,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queued],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Queued',
+                jobLabel: 'queued',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'estimating',
@@ -81,7 +81,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queued],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Queued',
+                jobLabel: 'queued',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'queued',
@@ -101,7 +101,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistoryNoRun, jobStrings.termination],
                 },
                 jobAction: jobStrings.action.retry,
-                jobLabel: 'Cancelled',
+                jobLabel: 'cancelled',
                 niceState: {
                     class: 'kb-job-status__summary--terminated',
                     label: 'cancellation',
@@ -121,7 +121,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistory, jobStrings.running],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Running',
+                jobLabel: 'running',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'running',
@@ -146,7 +146,7 @@ define(['common/format'], (format) => {
                     ],
                 },
                 jobAction: jobStrings.action.retry,
-                jobLabel: 'Cancelled',
+                jobLabel: 'cancelled',
                 niceState: {
                     class: 'kb-job-status__summary--terminated',
                     label: 'cancellation',
@@ -174,11 +174,13 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistory, jobStrings.runHistory, jobStrings.error],
                 },
                 jobAction: jobStrings.action.retry,
-                jobLabel: 'Failed',
+                jobLabelIncludeError: 'failed: Server error',
+                jobLabel: 'failed',
                 niceState: {
                     class: 'kb-job-status__summary--error',
                     label: 'error',
                 },
+                errorString: 'Server error: Error code: -32000',
             },
         },
         {
@@ -195,7 +197,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistory, jobStrings.runHistory, jobStrings.success],
                 },
                 jobAction: jobStrings.action.results,
-                jobLabel: 'Success',
+                jobLabel: 'success',
                 niceState: {
                     class: 'kb-job-status__summary--completed',
                     label: 'success',
@@ -219,11 +221,11 @@ define(['common/format'], (format) => {
         another: 'key',
         meta: {
             createJobStatusLines: {
-                line: jobStrings.unknown,
-                history: [jobStrings.unknown],
+                line: jobStrings.not_found,
+                history: [jobStrings.not_found],
             },
             jobAction: jobStrings.action.retry,
-            jobLabel: 'Job not found',
+            jobLabel: 'not found',
             niceState: {
                 class: 'kb-job-status__summary--does_not_exist',
                 label: 'does not exist',

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -19,9 +19,9 @@ define(['common/format'], (format) => {
         queueHistoryNoRun: 'Queued for ' + format.niceDuration(t.finished - t.created),
         runHistory: 'Ran for ' + format.niceDuration(t.finished - t.running),
         action: {
-            results: 'Go to results',
-            cancel: 'Cancel',
-            retry: 'Retry',
+            results: 'go to results',
+            cancel: 'cancel',
+            retry: 'retry',
         },
     };
 
@@ -44,7 +44,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queued],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Queued',
+                jobLabel: 'queued',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'created',
@@ -62,7 +62,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queued],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Queued',
+                jobLabel: 'queued',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'estimating',
@@ -81,7 +81,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queued],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Queued',
+                jobLabel: 'queued',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'queued',
@@ -101,7 +101,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistoryNoRun, jobStrings.termination],
                 },
                 jobAction: jobStrings.action.retry,
-                jobLabel: 'Cancelled',
+                jobLabel: 'cancelled',
                 niceState: {
                     class: 'kb-job-status__summary--terminated',
                     label: 'cancellation',
@@ -121,7 +121,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistory, jobStrings.running],
                 },
                 jobAction: jobStrings.action.cancel,
-                jobLabel: 'Running',
+                jobLabel: 'running',
                 niceState: {
                     class: 'kb-job-status__summary',
                     label: 'running',
@@ -146,7 +146,7 @@ define(['common/format'], (format) => {
                     ],
                 },
                 jobAction: jobStrings.action.retry,
-                jobLabel: 'Cancelled',
+                jobLabel: 'cancelled',
                 niceState: {
                     class: 'kb-job-status__summary--terminated',
                     label: 'cancellation',
@@ -174,7 +174,8 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistory, jobStrings.runHistory, jobStrings.error],
                 },
                 jobAction: jobStrings.action.retry,
-                jobLabel: 'Failed: Server error',
+                jobLabelIncludeError: 'failed: Server error',
+                jobLabel: 'failed',
                 niceState: {
                     class: 'kb-job-status__summary--error',
                     label: 'error',
@@ -196,7 +197,7 @@ define(['common/format'], (format) => {
                     history: [jobStrings.queueHistory, jobStrings.runHistory, jobStrings.success],
                 },
                 jobAction: jobStrings.action.results,
-                jobLabel: 'Success',
+                jobLabel: 'success',
                 niceState: {
                     class: 'kb-job-status__summary--completed',
                     label: 'success',
@@ -224,7 +225,7 @@ define(['common/format'], (format) => {
                 history: [jobStrings.not_found],
             },
             jobAction: jobStrings.action.retry,
-            jobLabel: 'Job not found',
+            jobLabel: 'not found',
             niceState: {
                 class: 'kb-job-status__summary--does_not_exist',
                 label: 'does not exist',

--- a/test/unit/spec/common/cellTabs-spec.js
+++ b/test/unit/spec/common/cellTabs-spec.js
@@ -21,7 +21,7 @@ define(['common/cellComponents/cellTabs', 'common/runtime'], (CellTabs, Runtime)
         },
     };
     const toggleAction = (tab) => {
-        console.warn(`performing action on tab ${tab}`)
+        console.warn(`performing action on tab ${tab}`);
     };
 
     describe('The CellTabs module', () => {


### PR DESCRIPTION
# Description of PR purpose/changes

This PR adds in the job status line for batch cells.

![Screenshot 2021-03-23 at 11 28 44](https://user-images.githubusercontent.com/556057/112199032-faa98380-8bca-11eb-9da5-22caa0dd97a1.png)

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-314
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, finding your favourite batch upload cell, and checking out that status bar!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
