### PR TITLE
DATAUP-360 reports table tests

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseReportView.js
@@ -766,7 +766,11 @@ define([
             const div = html.tag('div'),
                 strong = html.tag('strong'),
                 br = html.tag('br', { close: false });
-            const errorDiv = div({ class: 'alert alert-danger' }, [strong('Error:'), br(), errString]);
+            const errorDiv = div({ class: 'alert alert-danger' }, [
+                strong('Error:'),
+                br(),
+                errString,
+            ]);
             this.$elem.empty().append(errorDiv);
         },
         /**

--- a/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
@@ -2,8 +2,46 @@ define([
     'common/cellComponents/tabs/results/reportWidget',
     'base/js/namespace',
     '/test/data/fakeResultsData',
-], (ReportWidget, Jupyter, ResultsData) => {
+    'narrativeConfig',
+    'narrativeMocks',
+], (ReportWidget, Jupyter, ResultsData, Config, Mocks) => {
     'use strict';
+
+    const FAKE_REPORT_OBJ = {
+        direct_html: 'Here is some direct html for your Narrative perusal.',
+        direct_html_link_index: 0,
+        file_links: [],
+        html_links: [],
+        html_window_height: null,
+        objects_created: [],
+        summary_window_height: null,
+        text_message: 'Here is an example report',
+        warnings: [],
+    };
+
+    function mockReportCalls() {
+        Mocks.mockJsonRpc1Call({
+            url: Config.url('workspace'),
+            body: /get_objects2/,
+            response: {
+                data: [
+                    {
+                        data: FAKE_REPORT_OBJ,
+                    },
+                ],
+            },
+        });
+        Mocks.mockJsonRpc1Call({
+            url: Config.url('workspace'),
+            body: /get_object_info_new/,
+            response: [],
+        });
+        Mocks.mockJsonRpc1Call({
+            url: Config.url('service_wizard'),
+            body: /ServiceWizard.get_service_status/,
+            response: { url: 'https://fake.kbase.us/services/fake_service' },
+        });
+    }
 
     describe('Test the app/bulk import cell report widget', () => {
         beforeAll(() => {
@@ -17,6 +55,7 @@ define([
         });
 
         beforeEach(function () {
+            jasmine.Ajax.install();
             this.node = document.createElement('div');
             document.body.appendChild(this.node);
             this.widget = ReportWidget.make();
@@ -24,6 +63,7 @@ define([
 
         afterEach(function () {
             this.node.remove();
+            jasmine.Ajax.uninstall();
         });
 
         it('should start and render with data', async function () {
@@ -51,6 +91,7 @@ define([
         });
 
         it('should expand and create a kbaseReportView widget on toggle', async function () {
+            mockReportCalls();
             // just take a single object to render
             const singleDataObject = ResultsData.objectData[0];
 
@@ -76,6 +117,7 @@ define([
         });
 
         it('should expand and collapse again on click', async function () {
+            mockReportCalls();
             // just take a single object to render
             const singleDataObject = ResultsData.objectData[0];
 


### PR DESCRIPTION
# Description of PR purpose/changes

This fixes a few tests so that workspace and service wizard calls are properly mocked. They don't actually need to be called (i.e., we don't need any real data), but they're getting invoked over the course of the tests, so that needs to be prevented to deal with timeout issues.

Done as part of the followup to DATAUP-360

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook