### PR TITLE
DATAUP-314: test DOM cleansing

### DIFF
--- a/kbase-extension/static/kbase/js/common/runtime.js
+++ b/kbase-extension/static/kbase/js/common/runtime.js
@@ -11,11 +11,12 @@ define([
 
     function factory(config = {}) {
         const busArgs = config.bus || {};
+        let clock, theBus;
 
         function createRuntime() {
-            const theBus = Bus.make(busArgs);
+            theBus = Bus.make(busArgs);
 
-            const clock = Clock.make({
+            clock = Clock.make({
                 bus: theBus,
                 resolution: 1000,
             });
@@ -32,6 +33,12 @@ define([
             };
         }
 
+        function destroy() {
+            clock.stop();
+            $(document).off('dataUpdated.Narrative');
+            theBus = null;
+            window.kbaseRuntime = null;
+        }
         /*
          * The runtime hooks into a window
          */
@@ -101,6 +108,7 @@ define([
             getEnv: getEnv,
             workspaceId: workspaceId,
             userId: userId,
+            destroy: destroy,
         };
     }
 

--- a/test/integration/specs/kbaseNarrativeSidePanel_test.js
+++ b/test/integration/specs/kbaseNarrativeSidePanel_test.js
@@ -36,10 +36,7 @@ async function clickSlideoutButton(slideout) {
 }
 
 async function clickAddDataButton() {
-    // Open a slideout by clicking it's toggle button
-    // const body = await $('body');
-    // console.log('*** body ***', body);
-    // const button = await body.selectByVisibleText('Add Data');
+    // Open a slideout by clicking its toggle button
     const button = await $('[data-test-id="add-data-button"]');
     await button.waitForDisplayed();
     await clickWhenReady(button);

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -52,7 +52,6 @@ define('narrativeMocks', ['jquery', 'uuid', 'narrativeConfig'], ($, UUID, Config
         };
 
         $cellContainer.append($toolbar).append(mockCell.input).append(mockCell.output);
-        $('body').append($cellContainer);
         return mockCell;
     }
 

--- a/test/unit/spec/api/upaApiSpec.js
+++ b/test/unit/spec/api/upaApiSpec.js
@@ -157,7 +157,6 @@ define(['api/upa', 'narrativeConfig'], (UpaApi, Config) => {
         });
 
         it('Should fail if the workspace id cannot be found.', () => {
-            history.pushState(null, null, '/narrative/');
             Config.config.workspaceId = undefined;
             try {
                 upaApi.deserialize('[1]/2/3');

--- a/test/unit/spec/appWidgets/commonSpec.js
+++ b/test/unit/spec/appWidgets/commonSpec.js
@@ -5,50 +5,48 @@ define(['common/events', 'common/ui', 'kb_common/html', 'widgets/appWidgets2/com
     WidgetCommon
 ) => {
     'use strict';
-    const div = html.tag('div');
-    const button = html.tag('button');
-    const container = document.createElement('div');
-    const events = Events.make({ node: container });
-    const ui = UI.make({ node: container });
+    const div = html.tag('div'),
+        button = html.tag('button');
+
     describe('Test WidgetCommon module', () => {
+        let container;
+        beforeEach(function () {
+            container = document.createElement('div');
+            this.events = Events.make({ node: container });
+            this.ui = UI.make({ node: container });
+        });
+        afterEach(() => {
+            container.remove();
+        });
+
         it('Should be loaded with the right functions', () => {
             expect(WidgetCommon).toBeDefined();
             expect(WidgetCommon.clipboardButton).toBeDefined();
             expect(WidgetCommon.containerContent).toBeDefined();
         });
 
-        it('Should be able to produce content with a clipboard icon', () => {
+        it('Should be able to produce content with a clipboard icon', function () {
             const input = document.createElement('div');
-            const content = WidgetCommon.containerContent(
+            container.innerHTML = WidgetCommon.containerContent(
                 div,
                 button,
-                events,
-                ui,
+                this.events,
+                this.ui,
                 container,
                 input
             );
-            container.innerHTML = content;
-            expect(
-                container
-                    .querySelectorAll('[data-element=icon]')[0]
-                    .classList.contains('fa-clipboard')
-            ).toBeTrue();
+            expect(container.querySelector('[data-element=icon]')).toHaveClass('fa-clipboard');
         });
 
-        it('Should be able to create the clipboard icon', () => {
-            const clipboardButton = WidgetCommon.clipboardButton(
+        it('Should be able to create the clipboard icon', function () {
+            container.innerHTML = WidgetCommon.clipboardButton(
                 div,
                 button,
-                events,
-                ui,
+                this.events,
+                this.ui,
                 container
             );
-            container.innerHTML = clipboardButton;
-            expect(
-                container
-                    .querySelectorAll('[data-element=icon]')[0]
-                    .classList.contains('fa-clipboard')
-            ).toBeTrue();
+            expect(container.querySelector('[data-element=icon]')).toHaveClass('fa-clipboard');
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/checkboxInputSpec.js
+++ b/test/unit/spec/appWidgets/input/checkboxInputSpec.js
@@ -5,13 +5,15 @@ define(['widgets/appWidgets2/input/checkboxInput', 'common/runtime'], (CheckboxI
     describe('Test checkbox data input widget', () => {
         let testConfig = {},
             runtime,
-            bus;
+            bus,
+            container;
 
         beforeEach(() => {
             runtime = Runtime.make();
             bus = runtime.bus().makeChannelBus({
                 description: 'checkbox testing',
             });
+            container = document.createElement('div');
             testConfig = {
                 bus: bus,
                 parameterSpec: {
@@ -33,6 +35,7 @@ define(['widgets/appWidgets2/input/checkboxInput', 'common/runtime'], (CheckboxI
         afterEach(() => {
             bus.stop();
             window.kbaseRuntime = null;
+            container.remove();
         });
 
         it('should be defined', () => {
@@ -49,36 +52,34 @@ define(['widgets/appWidgets2/input/checkboxInput', 'common/runtime'], (CheckboxI
 
         it('should start and stop properly without initial value', () => {
             const widget = CheckboxInput.make(testConfig);
-            const node = document.createElement('div');
             return widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
-                    expect(node.childElementCount).toBeGreaterThan(0);
-                    const input = node.querySelector('input[type="checkbox"]');
+                    expect(container.childElementCount).toBeGreaterThan(0);
+                    const input = container.querySelector('input[type="checkbox"]');
                     expect(input).toBeDefined();
                     expect(input.getAttribute('checked')).toBeNull();
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                 });
         });
 
         it('should start and stop properly with initial value', () => {
             testConfig.initialValue = 1;
             const widget = CheckboxInput.make(testConfig);
-            const node = document.createElement('div');
             return widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
-                    expect(node.childElementCount).toBeGreaterThan(0);
-                    const input = node.querySelector('input[type="checkbox"]');
+                    expect(container.childElementCount).toBeGreaterThan(0);
+                    const input = container.querySelector('input[type="checkbox"]');
                     expect(input).toBeDefined();
                     expect(input.getAttribute('checked')).not.toBeNull();
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                 });
         });
 
@@ -88,9 +89,8 @@ define(['widgets/appWidgets2/input/checkboxInput', 'common/runtime'], (CheckboxI
                 done();
             });
             const widget = CheckboxInput.make(testConfig);
-            const node = document.createElement('div');
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[type="checkbox"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[type="checkbox"]');
                 input.setAttribute('checked', true);
                 input.dispatchEvent(new Event('change'));
             });

--- a/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
+++ b/test/unit/spec/appWidgets/input/dynamicDropdownInputSpec.js
@@ -22,8 +22,10 @@ define(['widgets/appWidgets2/input/dynamicDropdownInput', 'base/js/namespace', '
                 channelName: 'foo',
             },
             AUTH_TOKEN = 'fakeAuthToken';
+        let container;
 
         beforeEach(() => {
+            container = document.createElement('div');
             Mocks.setAuthToken(AUTH_TOKEN);
             Jupyter.narrative = {
                 getAuthToken: () => AUTH_TOKEN,
@@ -32,6 +34,7 @@ define(['widgets/appWidgets2/input/dynamicDropdownInput', 'base/js/namespace', '
         });
 
         afterEach(() => {
+            container.remove();
             Mocks.clearAuthToken();
             Jupyter.narrative = null;
         });
@@ -50,15 +53,14 @@ define(['widgets/appWidgets2/input/dynamicDropdownInput', 'base/js/namespace', '
 
         it('should start up and stop correctly', () => {
             const widget = DynamicDropdownInput.make(testConfig);
-            const node = document.createElement('div');
             return widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
-                    expect(node.innerHTML).toContain('input-container');
+                    expect(container.innerHTML).toContain('input-container');
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(node.innerHTML).not.toContain('input-container');
+                    expect(container.innerHTML).not.toContain('input-container');
                 });
         });
     });

--- a/test/unit/spec/appWidgets/input/floatInputSpec.js
+++ b/test/unit/spec/appWidgets/input/floatInputSpec.js
@@ -5,7 +5,8 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
     describe('Test float data input widget', () => {
         let testConfig = {},
             runtime,
-            bus;
+            bus,
+            container;
 
         beforeEach(() => {
             runtime = Runtime.make();
@@ -29,9 +30,11 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
                 },
                 channelName: bus.channelName,
             };
+            container = document.createElement('div');
         });
 
         afterEach(() => {
+            container.remove();
             bus.stop();
             window.kbaseRuntime = null;
         });
@@ -50,18 +53,17 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
 
         it('should start and stop properly without initial value', (done) => {
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
             widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
-                    expect(node.childElementCount).toBeGreaterThan(0);
-                    const input = node.querySelector('input[data-type="float"]');
+                    expect(container.childElementCount).toBeGreaterThan(0);
+                    const input = container.querySelector('input[data-type="float"]');
                     expect(input).toBeDefined();
                     expect(input.getAttribute('value')).toBeNull();
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 });
         });
@@ -69,18 +71,17 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
         it('should start and stop properly with initial value', (done) => {
             testConfig.initialValue = 10.0;
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
             widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
-                    expect(node.childElementCount).toBeGreaterThan(0);
-                    const input = node.querySelector('input[data-type="float"]');
+                    expect(container.childElementCount).toBeGreaterThan(0);
+                    const input = container.querySelector('input[data-type="float"]');
                     expect(input).toBeDefined();
                     expect(input.getAttribute('value')).toBe(String(testConfig.initialValue));
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 });
         });
@@ -91,9 +92,8 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
                 done();
             });
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="float"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="float"]');
                 input.setAttribute('value', 1.2);
                 input.dispatchEvent(new Event('change'));
             });
@@ -101,13 +101,12 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
 
         xit('should update model properly with keyup/touch event', (done) => {
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="float"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="float"]');
                 input.setAttribute('value', 1.23);
                 input.dispatchEvent(new Event('keyup'));
             });
@@ -115,14 +114,13 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
 
         it('should catch invalid string input', (done) => {
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('validation', (msg) => {
                 expect(msg.isValid).toBeFalsy();
                 expect(msg.diagnosis).toBe('invalid');
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="float"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="float"]');
                 input.setAttribute('value', 'abracadabra');
                 input.dispatchEvent(new Event('change'));
             });
@@ -131,16 +129,15 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
         it('should show message when configured, valid input', (done) => {
             testConfig.showOwnMessages = true;
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('changed', (value) => {
                 expect(value).toEqual({ newValue: 123.456 });
                 // No error message
-                const errorMsg = node.querySelector('[data-element="message"]');
+                const errorMsg = container.querySelector('[data-element="message"]');
                 expect(errorMsg.innerHTML).toBe('');
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="float"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="float"]');
                 input.setAttribute('value', 123.456);
                 input.dispatchEvent(new Event('change'));
             });
@@ -149,12 +146,10 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
         it('should show message when configured, invalid input', (done) => {
             testConfig.showOwnMessages = true;
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
-
             bus.on('changed', (value) => {
                 expect(value).toEqual({ newValue: 12345.6 });
                 // check for an error message in the node
-                const errorMsg = node.querySelector('[data-element="message"]');
+                const errorMsg = container.querySelector('[data-element="message"]');
                 expect(errorMsg.innerHTML).toContain('ERROR');
             });
 
@@ -164,8 +159,8 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
                 done();
             });
 
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="float"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="float"]');
                 // this value is out of the allowed range
                 input.setAttribute('value', 12345.6);
                 input.dispatchEvent(new Event('change'));
@@ -177,8 +172,7 @@ define(['widgets/appWidgets2/input/floatInput', 'common/runtime'], (FloatInput, 
         // interface, this test is disabled.
         xit('should respond to update command', () => {
             const widget = FloatInput.make(testConfig);
-            const node = document.createElement('div');
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: '12345.6' });
             });
         });

--- a/test/unit/spec/appWidgets/input/intInputSpec.js
+++ b/test/unit/spec/appWidgets/input/intInputSpec.js
@@ -5,7 +5,8 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
     describe('Test int data input widget', () => {
         let testConfig = {},
             runtime,
-            bus;
+            bus,
+            container;
 
         beforeEach(() => {
             runtime = Runtime.make();
@@ -30,11 +31,13 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
                 },
                 channelName: bus.channelName,
             };
+            container = document.createElement('div');
         });
 
         afterEach(() => {
             bus.stop();
             window.kbaseRuntime = null;
+            container.remove();
         });
 
         it('should be defined', () => {
@@ -51,18 +54,17 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
 
         it('should start and stop properly without initial value', (done) => {
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
             widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
-                    expect(node.childElementCount).toBeGreaterThan(0);
-                    const input = node.querySelector('input[data-type="int"]');
+                    expect(container.childElementCount).toBeGreaterThan(0);
+                    const input = container.querySelector('input[data-type="int"]');
                     expect(input).toBeDefined();
                     expect(input.getAttribute('value')).toBeNull();
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 });
         });
@@ -70,18 +72,17 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
         it('should start and stop properly with initial value', (done) => {
             testConfig.initialValue = 10;
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
             widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
-                    expect(node.childElementCount).toBeGreaterThan(0);
-                    const input = node.querySelector('input[data-type="int"]');
+                    expect(container.childElementCount).toBeGreaterThan(0);
+                    const input = container.querySelector('input[data-type="int"]');
                     expect(input).toBeDefined();
                     expect(input.getAttribute('value')).toBe(String(testConfig.initialValue));
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 });
         });
@@ -92,9 +93,8 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
                 done();
             });
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="int"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="int"]');
                 input.setAttribute('value', 1);
                 input.dispatchEvent(new Event('change'));
             });
@@ -102,13 +102,12 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
 
         xit('should update model properly with keyup/touch event', (done) => {
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeFalsy();
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="int"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="int"]');
                 input.value = 'foo';
                 input.setAttribute('value', 'foo');
                 input.dispatchEvent(new KeyboardEvent('keyup', { key: 3 }));
@@ -117,14 +116,13 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
 
         it('should catch invalid string input', (done) => {
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('validation', (msg) => {
                 expect(msg.isValid).toBeFalsy();
                 expect(msg.diagnosis).toBe('invalid');
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="int"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="int"]');
                 input.setAttribute('value', 'abracadabra');
                 input.dispatchEvent(new Event('change'));
             });
@@ -132,14 +130,13 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
 
         it('should catch invalid float input', (done) => {
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('validation', (msg) => {
                 expect(msg.isValid).toBeFalsy();
                 expect(msg.diagnosis).toBe('invalid');
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="int"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="int"]');
                 input.setAttribute('value', 12345.6);
                 input.dispatchEvent(new Event('change'));
             });
@@ -148,16 +145,15 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
         it('should show message when configured, valid input', (done) => {
             testConfig.showOwnMessages = true;
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('changed', (value) => {
                 expect(value).toEqual({ newValue: 5 });
                 // message node will be empty
-                const errorMsg = node.querySelector('[data-element="message"]');
+                const errorMsg = container.querySelector('[data-element="message"]');
                 expect(errorMsg.innerHTML).toBe('');
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="int"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="int"]');
                 input.setAttribute('value', 5);
                 input.dispatchEvent(new Event('change'));
             });
@@ -166,11 +162,10 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
         it('should show message when configured, invalid input', (done) => {
             testConfig.showOwnMessages = true;
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
             bus.on('changed', (value) => {
                 expect(value).toEqual({ newValue: 123456 });
                 // check for an error message in the node
-                const errorMsg = node.querySelector('[data-element="message"]');
+                const errorMsg = container.querySelector('[data-element="message"]');
                 expect(errorMsg.innerHTML).toContain('ERROR');
             });
             bus.on('validation', (msg) => {
@@ -178,8 +173,8 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
                 expect(msg.diagnosis).toBe('invalid');
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const input = node.querySelector('input[data-type="int"]');
+            widget.start({ node: container }).then(() => {
+                const input = container.querySelector('input[data-type="int"]');
                 // this value is out of the allowed range
                 input.setAttribute('value', 123456);
                 input.dispatchEvent(new Event('change'));
@@ -191,8 +186,7 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
         // => extremely hard to test
         xit('should respond to update command', () => {
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: 12345 });
             });
         });
@@ -202,8 +196,7 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime'], (IntInput, Runt
         // => extremely hard to test
         xit('should respond to reset command', () => {
             const widget = IntInput.make(testConfig);
-            const node = document.createElement('div');
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('reset-to-defaults');
             });
         });

--- a/test/unit/spec/appWidgets/input/newObjectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/newObjectInputSpec.js
@@ -265,11 +265,6 @@ define([
             });
             bus.on('sync', () => {
                 bus.emit('update', { value: inputStr });
-                // TestUtil.wait(500)
-                //     .then(() => {
-                //         let inputElem = container.querySelector('input[data-element="input"]');
-                //         inputElem.dispatchEvent(new Event('change'));
-                //     });
             });
             widget.start().then(() => {
                 bus.emit('run', { node: container });
@@ -334,11 +329,6 @@ define([
             });
             bus.on('sync', () => {
                 bus.emit('update', { value: inputStr });
-                // TestUtil.wait(500)
-                //     .then(() => {
-                //         let inputElem = container.querySelector('input[data-element="input"]');
-                //         inputElem.dispatchEvent(new Event('change'));
-                //     });
             });
             widget.start().then(() => {
                 bus.emit('run', { node: container });

--- a/test/unit/spec/appWidgets/input/newObjectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/newObjectInputSpec.js
@@ -66,7 +66,7 @@ define([
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     describe('New Object Input tests', () => {
-        let bus, testConfig, runtime, node;
+        let bus, testConfig, runtime, container;
         beforeEach(() => {
             runtime = Runtime.make();
             Mocks.setAuthToken(AUTH_TOKEN);
@@ -75,7 +75,7 @@ define([
                 userId: 'test_user',
             };
 
-            node = document.createElement('div');
+            container = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'select input testing - ' + Math.random().toString(36).substring(2),
             });
@@ -103,6 +103,7 @@ define([
             bus.stop();
             window.kbaseRuntime = null;
             Jupyter.narrative = null;
+            container.remove();
         });
 
         it('should be defined', () => {
@@ -119,12 +120,12 @@ define([
             const widget = NewObjectInput.make(testConfig);
 
             bus.on('sync', () => {
-                const inputElem = node.querySelector('input');
+                const inputElem = container.querySelector('input');
                 expect(inputElem).toBeDefined();
                 done();
             });
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -146,7 +147,7 @@ define([
 
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
-                const inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = container.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     expect(inputElem.value).toBe('foo');
                     done();
@@ -158,7 +159,7 @@ define([
             });
             const widget = NewObjectInput.make(testConfig);
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -179,7 +180,7 @@ define([
             });
 
             bus.on('validation', () => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = container.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     if (validationCount < 1) {
                         expect(inputElem.value).toBe('foobarbaz');
@@ -197,7 +198,7 @@ define([
 
             const widget = NewObjectInput.make(testConfig);
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -218,7 +219,7 @@ define([
             });
 
             bus.on('validation', () => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = container.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     if (validationCount < 1) {
                         expect(inputElem.value).toBe('foobarbaz');
@@ -236,7 +237,7 @@ define([
             });
             const widget = NewObjectInput.make(testConfig);
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -266,12 +267,12 @@ define([
                 bus.emit('update', { value: inputStr });
                 // TestUtil.wait(500)
                 //     .then(() => {
-                //         let inputElem = node.querySelector('input[data-element="input"]');
+                //         let inputElem = container.querySelector('input[data-element="input"]');
                 //         inputElem.dispatchEvent(new Event('change'));
                 //     });
             });
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -292,7 +293,7 @@ define([
             });
 
             bus.on('validation', () => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+                const inputElem = container.querySelector('input[data-element="input"]');
                 if (inputElem) {
                     inputElem.dispatchEvent(new Event('change'));
                 }
@@ -305,7 +306,7 @@ define([
                 done();
             });
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -335,12 +336,12 @@ define([
                 bus.emit('update', { value: inputStr });
                 // TestUtil.wait(500)
                 //     .then(() => {
-                //         let inputElem = node.querySelector('input[data-element="input"]');
+                //         let inputElem = container.querySelector('input[data-element="input"]');
                 //         inputElem.dispatchEvent(new Event('change'));
                 //     });
             });
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
     });

--- a/test/unit/spec/appWidgets/input/select2ObjectinputSpec.js
+++ b/test/unit/spec/appWidgets/input/select2ObjectinputSpec.js
@@ -96,13 +96,13 @@ define([
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     describe('Select 2 Object Input tests', () => {
-        let bus, testConfig;
+        let bus, testConfig, container;
         const required = false,
             defaultValue = 'apple',
             fakeServiceUrl = 'https://ci.kbase.us/services/fake_taxonomy_service';
 
-        beforeEach(function () {
-            this.node = document.createElement('div');
+        beforeEach(() => {
+            container = document.createElement('div');
             runtime = Runtime.make();
             Mocks.setAuthToken(AUTH_TOKEN);
             Jupyter.narrative = {
@@ -171,6 +171,7 @@ define([
             bus.stop();
             window.kbaseRuntime = null;
             Jupyter.narrative = null;
+            container.remove();
         });
 
         it('Should exist', () => {
@@ -189,17 +190,17 @@ define([
         describe('the started widget', () => {
             beforeEach(async function () {
                 this.widget = Select2ObjectInput.make(testConfig);
-                await this.widget.start({ node: this.node });
+                await this.widget.start({ node: container });
             });
 
             it('Should start and stop', async function () {
-                expect(this.node.childElementCount).toBeGreaterThan(0);
-                const input = this.node.querySelector('select[data-element="input"]');
+                expect(container.childElementCount).toBeGreaterThan(0);
+                const input = container.querySelector('select[data-element="input"]');
                 expect(input).toBeDefined();
                 expect(input.getAttribute('value')).toBeNull();
 
                 await this.widget.stop();
-                expect(this.node.childElementCount).toBe(0);
+                expect(container.childElementCount).toBe(0);
             });
 
             // this resets the model value but does not change the UI
@@ -227,14 +228,14 @@ define([
 
         // FIXME: it is unclear what the effect of these changes should be
         // More precise tests should be implemented
-        it('Should respond to changed select2 option', function (done) {
+        it('Should respond to changed select2 option', (done) => {
             const widget = Select2ObjectInput.make(testConfig);
             const nodeStructures = [];
             widget
-                .start({ node: this.node })
+                .start({ node: container })
                 .then(() => {
-                    nodeStructures.push(this.node.innerHTML);
-                    const $select = $(this.node).find('select');
+                    nodeStructures.push(container.innerHTML);
+                    const $select = $(container).find('select');
                     const $search =
                         $select.data('select2').dropdown.$search ||
                         $select.data('select2').selection.$search;
@@ -251,14 +252,14 @@ define([
                     return TestUtil.wait(1000);
                 })
                 .then(() => {
-                    nodeStructures.push(this.node.innerHTML);
+                    nodeStructures.push(container.innerHTML);
                     expect(nodeStructures[0]).not.toEqual(nodeStructures[1]);
-                    const $select = $(this.node).find('select');
+                    const $select = $(container).find('select');
                     $select.val('stuff').trigger('change');
                     return TestUtil.wait(1000);
                 })
                 .then(() => {
-                    nodeStructures.push(this.node.innerHTML);
+                    nodeStructures.push(container.innerHTML);
                     expect(nodeStructures[0]).not.toEqual(nodeStructures[2]);
                     done();
                 });

--- a/test/unit/spec/appWidgets/input/selectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/selectInputSpec.js
@@ -1,6 +1,6 @@
 define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, SelectInput) => {
     'use strict';
-    let bus, testConfig, runtime, node;
+    let bus, testConfig, runtime, container;
     const required = false,
         defaultValue = 'apple';
 
@@ -40,7 +40,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
     describe('Select Input tests', () => {
         beforeEach(() => {
             runtime = Runtime.make();
-            node = document.createElement('div');
+            container = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'select input testing',
             });
@@ -50,6 +50,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
         afterEach(() => {
             bus.stop();
             window.kbaseRuntime = null;
+            container.remove();
         });
 
         it('should be defined', () => {
@@ -68,16 +69,16 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
             const widget = SelectInput.make(testConfig);
 
             widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
                     // verify it's there.
-                    const inputElem = node.querySelector('select[data-element="input"]');
+                    const inputElem = container.querySelector('select[data-element="input"]');
                     expect(inputElem).toBeDefined();
                     return widget.stop();
                 })
                 .then(() => {
                     // verify it's gone.
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 });
         });
@@ -91,7 +92,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                 done();
             });
             const widget = SelectInput.make(testConfig);
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: 'banana' });
             });
         });
@@ -102,7 +103,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                 done();
             });
             const widget = SelectInput.make(testConfig);
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('reset-to-defaults');
             });
         });
@@ -113,8 +114,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                 expect(message.newValue).toEqual('banana');
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('select[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('select[data-element="input"]');
                 inputElem.selectedIndex = 2;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -127,8 +128,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('select[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('select[data-element="input"]');
                 inputElem.selectedIndex = 1;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -142,8 +143,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                 // ...detect something?
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('select[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('select[data-element="input"]');
                 inputElem.value = 'banana';
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -170,8 +171,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                     done();
                 }
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('select[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('select[data-element="input"]');
                 inputElem.selectedIndex = -1;
                 inputElem.dispatchEvent(new Event('change'));
             });

--- a/test/unit/spec/appWidgets/input/taxonomyRefInputSpec.js
+++ b/test/unit/spec/appWidgets/input/taxonomyRefInputSpec.js
@@ -38,9 +38,9 @@ define([
         const required = false,
             defaultValue = 'apple',
             fakeServiceUrl = 'https://ci.kbase.us/services/fake_taxonomy_service';
-        let bus, testConfig;
+        let bus, testConfig, container;
 
-        beforeEach(function () {
+        beforeEach(() => {
             const runtime = Runtime.make();
             Mocks.setAuthToken(AUTH_TOKEN);
             Jupyter.narrative = {
@@ -48,7 +48,7 @@ define([
                 userId: 'test_user',
             };
 
-            this.node = document.createElement('div');
+            container = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'select input testing',
             });
@@ -109,6 +109,7 @@ define([
             bus.stop();
             window.kbaseRuntime = null;
             Jupyter.narrative = null;
+            container.remove();
         });
 
         it('Should be instantiable', () => {
@@ -120,19 +121,19 @@ define([
             });
         });
 
-        it('Should start and stop', function (done) {
+        it('Should start and stop', (done) => {
             const widget = TaxonomyRefInput.make(testConfig);
             widget
-                .start({ node: this.node })
+                .start({ node: container })
                 .then(() => {
-                    expect(this.node.childElementCount).toBeGreaterThan(0);
-                    const input = this.node.querySelector('select[data-element="input"]');
+                    expect(container.childElementCount).toBeGreaterThan(0);
+                    const input = container.querySelector('select[data-element="input"]');
                     expect(input).toBeDefined();
                     expect(input.getAttribute('value')).toBeNull();
                     return widget.stop();
                 })
                 .then(() => {
-                    expect(this.node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 })
                 .catch((err) => {
@@ -143,7 +144,7 @@ define([
         // this resets the model value but does not change the UI
         // or emit a message via the bus
         // ==> cannot easily be tested
-        xit('Should set model value by bus', function (done) {
+        xit('Should set model value by bus', (done) => {
             const widget = TaxonomyRefInput.make(testConfig);
             bus.on('validation', (msg) => {
                 expect(msg.errorMessage).toBeNull();
@@ -151,7 +152,7 @@ define([
                 done();
             });
 
-            widget.start({ node: this.node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: 'foo' });
             });
         });
@@ -159,7 +160,7 @@ define([
         // this resets the model value but does not change the UI
         // or emit a message via the bus
         // ==> cannot easily be tested
-        xit('Should reset model value by bus', function (done) {
+        xit('Should reset model value by bus', (done) => {
             const widget = TaxonomyRefInput.make(testConfig);
             bus.on('validation', (msg) => {
                 expect(msg.errorMessage).toBeNull();
@@ -167,21 +168,21 @@ define([
                 done();
             });
 
-            widget.start({ node: this.node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('reset-to-defaults');
             });
         });
 
         // FIXME: it is unclear what the effect of these changes should be
         // More precise tests should be implemented
-        it('Should respond to changed select2 option', function (done) {
+        it('Should respond to changed select2 option', (done) => {
             const widget = TaxonomyRefInput.make(testConfig);
             const nodeStructures = [];
             widget
-                .start({ node: this.node })
+                .start({ node: container })
                 .then(() => {
-                    nodeStructures.push(this.node.innerHTML);
-                    const $select = $(this.node).find('select');
+                    nodeStructures.push(container.innerHTML);
+                    const $select = $(container).find('select');
                     const $search =
                         $select.data('select2').dropdown.$search ||
                         $select.data('select2').selection.$search;
@@ -197,14 +198,14 @@ define([
                     });
                 })
                 .then(() => {
-                    nodeStructures.push(this.node.innerHTML);
+                    nodeStructures.push(container.innerHTML);
                     expect(nodeStructures[0]).not.toEqual(nodeStructures[1]);
-                    const $select = $(this.node).find('select');
+                    const $select = $(container).find('select');
                     $select.val('stuff').trigger('change');
                     return TestUtil.wait(1000);
                 })
                 .then(() => {
-                    nodeStructures.push(this.node.innerHTML);
+                    nodeStructures.push(container.innerHTML);
                     expect(nodeStructures[0]).not.toEqual(nodeStructures[2]);
                     done();
                 });

--- a/test/unit/spec/appWidgets/input/textInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textInputSpec.js
@@ -1,6 +1,6 @@
 define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, TextInput) => {
     'use strict';
-    let bus, testConfig, container;
+    let testConfig;
     const required = false,
         defaultValue = 'some test text';
 
@@ -21,8 +21,17 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
         };
     }
 
+    function startWidgetAndSetTextField(widget, container, inputText) {
+        widget.start({ node: container }).then(() => {
+            const inputElem = container.querySelector('input[data-element="input"]');
+            inputElem.value = inputText;
+            inputElem.dispatchEvent(new Event('change'));
+        });
+    }
+
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
-    describe('Text Input tests', () => {
+    describe('The Text Input widget', () => {
+        let bus, widget, container;
         beforeEach(() => {
             const runtime = Runtime.make();
             container = document.createElement('div');
@@ -30,6 +39,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 description: 'text input testing',
             });
             testConfig = buildTestConfig(required, defaultValue, bus);
+            widget = TextInput.make(testConfig);
         });
 
         afterEach(() => {
@@ -43,7 +53,6 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
         });
 
         it('should be instantiable', () => {
-            const widget = TextInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
             ['start', 'stop'].forEach((fn) => {
                 expect(widget[fn]).toEqual(jasmine.any(Function));
@@ -51,8 +60,6 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
         });
 
         it('Should start and stop a widget', (done) => {
-            const widget = TextInput.make(testConfig);
-
             widget
                 .start({ node: container })
                 .then(() => {
@@ -75,7 +82,6 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            const widget = TextInput.make(testConfig);
             widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: 'some text' });
             });
@@ -86,43 +92,31 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            const widget = TextInput.make(testConfig);
             widget.start({ node: container }).then(() => {
                 bus.emit('reset-to-defaults');
             });
         });
 
         it('Should respond to input change events with "changed"', (done) => {
-            const widget = TextInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('changed', (message) => {
                 expect(message.newValue).toEqual(inputText);
                 done();
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('input[data-element="input"]');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextField(widget, container, inputText);
         });
 
         it('Should respond to input change events with "validation"', (done) => {
-            const widget = TextInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('input[data-element="input"]');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextField(widget, container, inputText);
         });
 
         xit('Should respond to keyup change events with "validation"', (done) => {
-            const widget = TextInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
@@ -138,23 +132,19 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
 
         it('Should show message when configured', (done) => {
             testConfig.showOwnMessages = true;
-            const widget = TextInput.make(testConfig);
+            widget = TextInput.make(testConfig);
             const inputText = 'some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 // ...detect something?
                 done();
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('input[data-element="input"]');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextField(widget, container, inputText);
         });
 
         it('Should return a diagnosis of required-missing if so', (done) => {
             testConfig = buildTestConfig(true, '', bus);
-            const widget = TextInput.make(testConfig);
+            widget = TextInput.make(testConfig);
             const inputText = null;
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeFalsy();
@@ -162,11 +152,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 // ...detect something?
                 done();
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('input[data-element="input"]');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextField(widget, container, inputText);
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/textInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textInputSpec.js
@@ -1,6 +1,6 @@
 define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, TextInput) => {
     'use strict';
-    let bus, testConfig, node;
+    let bus, testConfig, container;
     const required = false,
         defaultValue = 'some test text';
 
@@ -25,7 +25,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
     describe('Text Input tests', () => {
         beforeEach(() => {
             const runtime = Runtime.make();
-            node = document.createElement('div');
+            container = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'text input testing',
             });
@@ -35,6 +35,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
         afterEach(() => {
             bus.stop();
             window.kbaseRuntime = null;
+            container.remove();
         });
 
         it('should be defined', () => {
@@ -53,16 +54,16 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
             const widget = TextInput.make(testConfig);
 
             widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
                     // verify it's there.
-                    const inputElem = node.querySelector('input[data-element="input"]');
+                    const inputElem = container.querySelector('input[data-element="input"]');
                     expect(inputElem).toBeDefined();
                     return widget.stop();
                 })
                 .then(() => {
                     // verify it's gone.
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 });
         });
@@ -75,7 +76,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 done();
             });
             const widget = TextInput.make(testConfig);
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: 'some text' });
             });
         });
@@ -86,7 +87,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 done();
             });
             const widget = TextInput.make(testConfig);
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('reset-to-defaults');
             });
         });
@@ -98,8 +99,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 expect(message.newValue).toEqual(inputText);
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('input[data-element="input"]');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -113,8 +114,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('input[data-element="input"]');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -128,8 +129,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('input[data-element="input"]');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('keyup'));
             });
@@ -144,8 +145,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 // ...detect something?
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('input[data-element="input"]');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -161,8 +162,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textInput'], (Runtime, Text
                 // ...detect something?
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('input[data-element="input"]');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('input[data-element="input"]');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });

--- a/test/unit/spec/appWidgets/input/textareaInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textareaInputSpec.js
@@ -1,6 +1,6 @@
 define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, TextareaInput) => {
     'use strict';
-    let bus, testConfig, node;
+    let bus, testConfig, container;
     const required = false,
         defaultValue = 'some test text',
         numRows = 3;
@@ -29,7 +29,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
     describe('Textarea Input tests', () => {
         beforeEach(() => {
             const runtime = Runtime.make();
-            node = document.createElement('div');
+            container = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'textarea testing',
             });
@@ -39,6 +39,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
         afterEach(() => {
             bus.stop();
             window.kbaseRuntime = null;
+            container.remove();
         });
 
         it('should be defined', () => {
@@ -59,17 +60,17 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
             expect(widget.start).toBeDefined();
 
             widget
-                .start({ node: node })
+                .start({ node: container })
                 .then(() => {
                     // verify it's there.
-                    const textarea = node.querySelector('textarea');
+                    const textarea = container.querySelector('textarea');
                     expect(textarea).toBeDefined();
                     expect(textarea.getAttribute('rows')).toBe(String(numRows));
                     return widget.stop();
                 })
                 .then(() => {
                     // verify it's gone.
-                    expect(node.childElementCount).toBe(0);
+                    expect(container.childElementCount).toBe(0);
                     done();
                 });
         });
@@ -82,7 +83,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 done();
             });
             const widget = TextareaInput.make(testConfig);
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: 'some text' });
             });
         });
@@ -93,7 +94,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 done();
             });
             const widget = TextareaInput.make(testConfig);
-            widget.start({ node: node }).then(() => {
+            widget.start({ node: container }).then(() => {
                 bus.emit('reset-to-defaults');
             });
         });
@@ -105,8 +106,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 expect(message.newValue).toEqual(inputText);
                 widget.stop().then(done);
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('textarea');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('textarea');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -120,8 +121,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('textarea');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('textarea');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -138,8 +139,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 // ...detect something?
                 // done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('textarea');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('textarea');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('keyup'));
             });
@@ -154,8 +155,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 // ...detect something?
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('textarea');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('textarea');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });
@@ -171,8 +172,8 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 // ...detect something?
                 done();
             });
-            widget.start({ node: node }).then(() => {
-                const inputElem = node.querySelector('textarea');
+            widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('textarea');
                 inputElem.value = inputText;
                 inputElem.dispatchEvent(new Event('change'));
             });

--- a/test/unit/spec/appWidgets/input/textareaInputSpec.js
+++ b/test/unit/spec/appWidgets/input/textareaInputSpec.js
@@ -1,6 +1,6 @@
 define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, TextareaInput) => {
     'use strict';
-    let bus, testConfig, container;
+    let testConfig;
     const required = false,
         defaultValue = 'some test text',
         numRows = 3;
@@ -21,12 +21,21 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                     nRows: numRows,
                 },
             },
-            channelName: bus.channelName,
+            channelName: _bus.channelName,
         };
+    }
+
+    function startWidgetAndSetTextarea(widget, container, inputText) {
+        widget.start({ node: container }).then(() => {
+            const inputElem = container.querySelector('textarea');
+            inputElem.value = inputText;
+            inputElem.dispatchEvent(new Event('change'));
+        });
     }
 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
     describe('Textarea Input tests', () => {
+        let widget, bus, container;
         beforeEach(() => {
             const runtime = Runtime.make();
             container = document.createElement('div');
@@ -34,6 +43,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 description: 'textarea testing',
             });
             testConfig = buildTestConfig(required, defaultValue, bus);
+            widget = TextareaInput.make(testConfig);
         });
 
         afterEach(() => {
@@ -47,7 +57,6 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
         });
 
         it('should be instantiable', () => {
-            const widget = TextareaInput.make(testConfig);
             expect(widget).toEqual(jasmine.any(Object));
             ['start', 'stop'].forEach((fn) => {
                 expect(widget[fn]).toEqual(jasmine.any(Function));
@@ -55,7 +64,6 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
         });
 
         it('Should start and stop a widget', (done) => {
-            const widget = TextareaInput.make(testConfig);
             expect(widget).toBeDefined();
             expect(widget.start).toBeDefined();
 
@@ -82,7 +90,6 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            const widget = TextareaInput.make(testConfig);
             widget.start({ node: container }).then(() => {
                 bus.emit('update', { value: 'some text' });
             });
@@ -93,43 +100,31 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 expect(message.isValid).toBeTruthy();
                 done();
             });
-            const widget = TextareaInput.make(testConfig);
             widget.start({ node: container }).then(() => {
                 bus.emit('reset-to-defaults');
             });
         });
 
         it('Should respond to input change events with "changed"', (done) => {
-            const widget = TextareaInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('changed', (message) => {
                 expect(message.newValue).toEqual(inputText);
                 widget.stop().then(done);
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('textarea');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextarea(widget, container, inputText);
         });
 
         it('Should respond to input change events with "validation"', (done) => {
-            const widget = TextareaInput.make(testConfig);
             const inputText = 'here is some text';
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeTruthy();
                 expect(message.errorMessage).toBeUndefined();
                 done();
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('textarea');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextarea(widget, container, inputText);
         });
 
         xit('Should respond to keyup change events with "changed"', () => {
-            const widget = TextareaInput.make(testConfig);
             const inputText = 'here is some text';
             // event does not have e.target defined, so running this test emits
             // Uncaught TypeError: Cannot read property 'dispatchEvent' of null thrown
@@ -148,23 +143,19 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
 
         it('Should show message when configured', (done) => {
             testConfig.showOwnMessages = true;
-            const widget = TextareaInput.make(testConfig);
+            widget = TextareaInput.make(testConfig);
             const inputText = 'some text';
             bus.on('changed', (message) => {
                 expect(message.newValue).toBe(inputText);
                 // ...detect something?
                 done();
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('textarea');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextarea(widget, container, inputText);
         });
 
         it('Should return a diagnosis of required-missing if so', (done) => {
             testConfig = buildTestConfig(true, '', bus);
-            const widget = TextareaInput.make(testConfig);
+            widget = TextareaInput.make(testConfig);
             const inputText = null;
             bus.on('validation', (message) => {
                 expect(message.isValid).toBeFalsy();
@@ -172,11 +163,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/textareaInput'], (Runtime, 
                 // ...detect something?
                 done();
             });
-            widget.start({ node: container }).then(() => {
-                const inputElem = container.querySelector('textarea');
-                inputElem.value = inputText;
-                inputElem.dispatchEvent(new Event('change'));
-            });
+            startWidgetAndSetTextarea(widget, container, inputText);
         });
     });
 });

--- a/test/unit/spec/appWidgets/input/toggleButtonInputSpec.js
+++ b/test/unit/spec/appWidgets/input/toggleButtonInputSpec.js
@@ -3,7 +3,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
     ToggleButtonInput
 ) => {
     'use strict';
-    let bus, testConfig, runtime, node;
+    let bus, testConfig, runtime, container;
     const required = false,
         defaultValue = true;
 
@@ -32,7 +32,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
     xdescribe('ToggleButtonInput tests', () => {
         beforeEach(() => {
             runtime = Runtime.make();
-            node = document.createElement('div');
+            container = document.createElement('div');
             bus = runtime.bus().makeChannelBus({
                 description: 'toggle button testing',
             });
@@ -41,6 +41,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
         afterEach(() => {
             bus.stop();
             window.kbaseRuntime = null;
+            container.remove();
         });
 
         it('should be defined', () => {
@@ -55,10 +56,10 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             // fires 'sync' after starting, then we can tell it to 'update',
             // which does the rendering. THEN we can examine that it's rendered right.
             bus.on('sync', () => {
-                expect(node.querySelector('[data-element="main-panel"]')).toBeDefined();
+                expect(container.querySelector('[data-element="main-panel"]')).toBeDefined();
                 bus.emit('update', { value: true });
                 setTimeout(() => {
-                    const inputElem = node.querySelector('input[type="checkbox"]');
+                    const inputElem = container.querySelector('input[type="checkbox"]');
                     expect(inputElem).toBeDefined();
                     expect(inputElem.getAttribute('checked')).not.toBeNull();
                     done();
@@ -66,7 +67,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             });
 
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -76,7 +77,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             const widget = ToggleButtonInput.make(testConfig);
 
             bus.on('validation', () => {
-                const inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = container.querySelector('input[type="checkbox"]');
                 expect(inputElem.getAttribute('checked')).not.toBeNull();
                 done();
             });
@@ -85,7 +86,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
                 bus.emit('update', { value: defaultValue }); // no change, just verify it's there.
             });
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -93,7 +94,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             const widget = ToggleButtonInput.make(testConfig);
             let validationCount = 0;
             bus.on('validation', () => {
-                const inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = container.querySelector('input[type="checkbox"]');
                 if (inputElem) {
                     if (validationCount < 1) {
                         expect(inputElem.getAttribute('checked')).toBeNull();
@@ -109,7 +110,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
                 bus.emit('update', { value: false });
             });
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -120,7 +121,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
                 bus.emit('update', { value: defaultValue });
             });
             bus.on('validation', () => {
-                const inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = container.querySelector('input[type="checkbox"]');
                 if (inputElem) {
                     expect(inputElem.getAttribute('checked')).not.toBeNull();
                     inputElem.dispatchEvent(new Event('change'));
@@ -132,7 +133,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             });
 
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
 
@@ -142,7 +143,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             bus.on('validation', (message) => {
                 expect(message.errorMessage).toBeUndefined();
                 expect(message.diagnosis).toBe('valid');
-                const inputElem = node.querySelector('input[type="checkbox"]');
+                const inputElem = container.querySelector('input[type="checkbox"]');
                 if (inputElem) {
                     expect(inputElem.getAttribute('checked')).not.toBeNull();
                     inputElem.dispatchEvent(new Event('change'));
@@ -159,7 +160,7 @@ define(['common/runtime', 'widgets/appWidgets2/input/toggleButtonInput'], (
             });
 
             widget.start().then(() => {
-                bus.emit('run', { node: node });
+                bus.emit('run', { node: container });
             });
         });
     });

--- a/test/unit/spec/appWidgets/input/undefinedInputSpec.js
+++ b/test/unit/spec/appWidgets/input/undefinedInputSpec.js
@@ -2,6 +2,14 @@ define(['widgets/appWidgets2/input/undefinedInput'], (UndefinedInput) => {
     'use strict';
 
     describe('Undefined Input Widget test', () => {
+        let container;
+
+        beforeEach(() => {
+            container = document.createElement('div');
+        });
+        afterEach(() => {
+            container.remove();
+        });
         it('Should be loaded', () => {
             expect(UndefinedInput).not.toBeNull();
         });
@@ -14,9 +22,8 @@ define(['widgets/appWidgets2/input/undefinedInput'], (UndefinedInput) => {
 
         it('Should attach to a DOM node', () => {
             const widget = UndefinedInput.make({});
-            const node = document.createElement('div');
-            widget.attach(node);
-            expect(node.innerHTML).toContain('Undefined widget');
+            widget.attach(container);
+            expect(container.innerHTML).toContain('Undefined widget');
         });
     });
 });

--- a/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
@@ -19,6 +19,7 @@ define([
     });
 
     describe('The Field Table Cell Widget instance', () => {
+        let container;
         const parameterSpec = {
             data: {
                 constraints: {
@@ -85,10 +86,9 @@ define([
         });
 
         beforeEach(async function () {
-            this.parent = document.createElement('div');
+            container = document.createElement('div');
             this.node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(this.parent);
-            this.parent.appendChild(this.node);
+            container.appendChild(this.node);
 
             const model = Props.make({
                 data: TestAppObject,
@@ -126,7 +126,7 @@ define([
                     );
                 });
             }
-            this.parent.remove();
+            container.remove();
             window.kbaseRuntime = null;
         });
 

--- a/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
@@ -19,6 +19,7 @@ define([
     });
 
     describe('The file path widget instance', () => {
+        let container;
         beforeAll(() => {
             window.kbaseRuntime = null;
             Jupyter.narrative = {
@@ -32,10 +33,9 @@ define([
 
         beforeEach(function () {
             const bus = Runtime.make().bus();
-            this.parent = document.createElement('div');
+            container = document.createElement('div');
             this.node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(this.parent);
-            this.parent.appendChild(this.node);
+            container.appendChild(this.node);
 
             this.spec = Spec.make({
                 appSpec: TestSpec,
@@ -54,8 +54,8 @@ define([
             });
         });
 
-        afterEach(function () {
-            this.parent.remove();
+        afterEach(() => {
+            container.remove();
             window.kbaseRuntime = null;
         });
 

--- a/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
@@ -19,6 +19,7 @@ define([
     });
 
     describe('The Parameter instance', () => {
+        let container;
         beforeAll(() => {
             window.kbaseRuntime = null;
             Jupyter.narrative = {
@@ -33,10 +34,9 @@ define([
         beforeEach(async function () {
             const bus = Runtime.make().bus();
 
-            this.parent = document.createElement('div');
+            container = document.createElement('div');
             this.node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(this.parent);
-            this.parent.appendChild(this.node);
+            container.appendChild(this.node);
 
             const model = Props.make({
                 data: TestAppObject,
@@ -69,7 +69,7 @@ define([
                 await this.paramsWidgetInstance.stop();
             }
             window.kbaseRuntime = null;
-            this.parent.remove();
+            container.remove();
         });
 
         it('should render the correct parameters', function () {

--- a/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
@@ -44,13 +44,17 @@ define(['common/cellComponents/tabs/infoTab'], (InfoTab) => {
         };
         const appSpec = model.getItem('app.spec');
         const infoTabInstance = InfoTab.make({ model });
-        let node, infoTabPromise, infoTab;
+        let container, infoTabPromise, infoTab;
 
         beforeEach(async () => {
-            node = document.createElement('div');
-            infoTabPromise = infoTabInstance.start({ node });
+            container = document.createElement('div');
+            infoTabPromise = infoTabInstance.start({ node: container });
             infoTab = await infoTabPromise;
             return infoTab; // to use infoTab for linter
+        });
+
+        afterEach(() => {
+            container.remove();
         });
 
         it('has a factory which can be invoked', () => {

--- a/test/unit/spec/common/cellComponents/tabs/jobStateList-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStateList-Spec.js
@@ -31,13 +31,14 @@ define([
     });
 
     describe('The job state list instance', () => {
+        let container;
         beforeEach(function () {
-            this.node = document.createElement('div');
+            container = document.createElement('div');
             this.jobStateListInstance = createInstance();
         });
 
-        afterEach(function () {
-            this.node.remove();
+        afterEach(() => {
+            container.remove();
         });
         it('has a make function that returns an object', function () {
             expect(this.jobStateListInstance).not.toBe(null);
@@ -52,30 +53,31 @@ define([
         });
 
         it('should start, and populate a node', async function () {
-            expect(this.node.children.length).toBe(0);
+            expect(container.children.length).toBe(0);
             await this.jobStateListInstance.start({
-                node: this.node,
+                node: container,
                 jobState: model.getItem('exec.jobState'),
             });
-            expect(this.node.children.length).toBeGreaterThan(0);
+            expect(container.children.length).toBeGreaterThan(0);
         });
     });
 
     describe('the job state list structure and content', () => {
         const cssBaseClass = jobStateList.cssBaseClass;
+        let container;
 
         beforeAll(async function () {
             this.jobStateListInstance = createInstance();
-            this.node = document.createElement('div');
+            container = document.createElement('div');
             await this.jobStateListInstance.start({
-                node: this.node,
+                node: container,
                 jobState: model.getItem('exec.jobState'),
             });
         });
 
         afterAll(async function () {
             await this.jobStateListInstance.stop();
-            this.node.remove();
+            container.remove();
         });
 
         const classContents = [
@@ -88,13 +90,13 @@ define([
         ];
 
         classContents.forEach((item) => {
-            it(`should have an element with class ${item}`, function () {
-                expect(this.node.querySelectorAll(`.${item}`).length).toBeGreaterThan(0);
+            it(`should have an element with class ${item}`, () => {
+                expect(container.querySelectorAll(`.${item}`).length).toBeGreaterThan(0);
             });
         });
 
-        it('should generate a row for each job', function () {
-            expect(this.node.querySelectorAll(`.${cssBaseClass}__row`).length).toEqual(
+        it('should generate a row for each job', () => {
+            expect(container.querySelectorAll(`.${cssBaseClass}__row`).length).toEqual(
                 TestAppObject.exec.jobState.child_jobs.length
             );
         });

--- a/test/unit/spec/common/cellComponents/tabs/jobStateListRow-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStateListRow-Spec.js
@@ -174,16 +174,23 @@ define([
 
     JobsData.validJobs.forEach((job) => {
         describe(`the job state list initial row structure and content for "${job.job_id}"`, () => {
+            let container;
             beforeEach(async function () {
+                container = document.createElement('tr');
+                this.row = container;
                 this.job = job;
-                this.row = document.createElement('tr');
                 this.jobStateListRowInstance = createInstance();
                 await this.jobStateListRowInstance.start({
-                    node: this.row,
+                    node: container,
                     jobState: this.job,
                     name: 'testObject',
                 });
             });
+
+            afterEach(() => {
+                container.remove();
+            });
+
             itHasRowStructure();
         });
     });

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTab-Spec.js
@@ -24,11 +24,16 @@ define([
     });
 
     describe('The job status tab instance', () => {
+        let container;
         beforeEach(function () {
-            this.node = document.createElement('div');
+            container = document.createElement('div');
             this.jobStatusTabInstance = JobStatusTab.make({
                 model: model,
             });
+        });
+
+        afterEach(() => {
+            container.remove();
         });
 
         it('has a make function that returns an object', function () {
@@ -44,14 +49,14 @@ define([
         });
 
         it('should start the job status tab widget', async function () {
-            expect(this.node.classList.length).toBe(0);
+            expect(container.classList.length).toBe(0);
             spyOn(JobStateList, 'make').and.callThrough();
-            await this.jobStatusTabInstance.start({ node: this.node });
+            await this.jobStatusTabInstance.start({ node: container });
 
-            expect(this.node).toHaveClass(jobTabContainerClass);
-            expect(this.node.childNodes.length).toBe(1);
+            expect(container).toHaveClass(jobTabContainerClass);
+            expect(container.childNodes.length).toBe(1);
 
-            const [firstChild] = this.node.childNodes;
+            const [firstChild] = container.childNodes;
             expect(firstChild).toHaveClass('kb-job__container');
             expect(firstChild.getAttribute('data-element')).toEqual('kb-job-list-wrapper');
 
@@ -59,15 +64,15 @@ define([
         });
 
         it('should stop when requested to', async function () {
-            expect(this.node.classList.length).toBe(0);
+            expect(container.classList.length).toBe(0);
             spyOn(JobStateList, 'make').and.callThrough();
 
-            await this.jobStatusTabInstance.start({ node: this.node });
-            expect(this.node).toHaveClass(jobTabContainerClass);
+            await this.jobStatusTabInstance.start({ node: container });
+            expect(container).toHaveClass(jobTabContainerClass);
             expect(JobStateList.make).toHaveBeenCalled();
 
             await this.jobStatusTabInstance.stop();
-            expect(this.node.innerHTML).toBe('');
+            expect(container.innerHTML).toBe('');
         });
     });
 });

--- a/test/unit/spec/common/cellComponents/tabs/results/outputWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/outputWidget-spec.js
@@ -6,54 +6,54 @@ define([
     'use strict';
 
     describe('test the created objects viewer', () => {
+        let container;
         beforeEach(function () {
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
             };
-            this.node = document.createElement('div');
-            document.body.appendChild(this.node);
+            container = document.createElement('div');
             this.widget = OutputWidget.make();
         });
 
-        afterEach(function () {
+        afterEach(() => {
             Jupyter.narrative = null;
-            this.node.remove();
+            container.remove();
         });
 
         it('should start and render with data', async function () {
             await this.widget.start({
-                node: this.node,
+                node: container,
                 objectData: ResultsData.objectData,
             });
             // we should have a table with a header and two rows.
-            expect(this.node.querySelectorAll('tr').length).toBe(3);
-            expect(this.node.innerHTML).toContain('Objects');
+            expect(container.querySelectorAll('tr').length).toBe(3);
+            expect(container.innerHTML).toContain('Objects');
             ResultsData.objectData.forEach((obj) => {
-                expect(this.node.innerHTML).toContain(obj.name);
+                expect(container.innerHTML).toContain(obj.name);
             });
         });
 
         it('should start and render an empty area with a message saying there is no data', async function () {
             await this.widget.start({
-                node: this.node,
+                node: container,
                 objectData: [],
             });
             // should make an outer, classed node with nothing in it
-            const objNode = this.node.querySelector('div.kb-created-objects');
+            const objNode = container.querySelector('div.kb-created-objects');
             expect(objNode).toBeDefined();
             expect(objNode.innerHTML).toContain('No objects created');
         });
 
         it('should stop and clear its node', async function () {
             await this.widget.start({
-                node: this.node,
+                node: container,
                 objectData: ResultsData.objectData,
             });
             // just double check it was made and the node was modified,
             // deeper tests are above
-            expect(this.node.innerHTML).toContain('Objects');
+            expect(container.innerHTML).toContain('Objects');
             await this.widget.stop();
-            expect(this.node.innerHTML).toEqual('');
+            expect(container.innerHTML).toEqual('');
         });
     });
 });

--- a/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
@@ -44,6 +44,7 @@ define([
     }
 
     describe('Test the app/bulk import cell report widget', () => {
+        let container;
         beforeAll(() => {
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
@@ -56,38 +57,37 @@ define([
 
         beforeEach(function () {
             jasmine.Ajax.install();
-            this.node = document.createElement('div');
-            document.body.appendChild(this.node);
+            container = document.createElement('div');
             this.widget = ReportWidget.make();
         });
 
-        afterEach(function () {
-            this.node.remove();
+        afterEach(() => {
+            container.remove();
             jasmine.Ajax.uninstall();
         });
 
         it('should start and render with data', async function () {
             await this.widget.start({
-                node: this.node,
+                node: container,
                 objectData: ResultsData.objectData,
             });
             // we should have a div with two <a> elements, each with the
             // name of an object
-            expect(this.node.querySelectorAll('a').length).toBe(2);
-            expect(this.node.innerHTML).toContain('Reports');
+            expect(container.querySelectorAll('a').length).toBe(2);
+            expect(container.innerHTML).toContain('Reports');
             ResultsData.objectData.forEach((obj) => {
-                expect(this.node.innerHTML).toContain(obj.name);
+                expect(container.innerHTML).toContain(obj.name);
             });
         });
 
         it('should clear itself after stopping', async function () {
             await this.widget.start({
-                node: this.node,
+                node: container,
                 objectData: ResultsData.objectData,
             });
-            expect(this.node.innerHTML).toContain('Reports');
+            expect(container.innerHTML).toContain('Reports');
             await this.widget.stop();
-            expect(this.node.innerHTML).toBe('');
+            expect(container.innerHTML).toBe('');
         });
 
         it('should expand and create a kbaseReportView widget on toggle', async function () {
@@ -96,13 +96,13 @@ define([
             const singleDataObject = ResultsData.objectData[0];
 
             await this.widget.start({
-                node: this.node,
+                node: container,
                 objectData: [singleDataObject],
             });
             // there should be only one
-            expect(this.node.querySelectorAll('a.kb-report__toggle').length).toBe(1);
+            expect(container.querySelectorAll('a.kb-report__toggle').length).toBe(1);
             // get a handle on it
-            const toggleNode = this.node.querySelector('a.kb-report__toggle');
+            const toggleNode = container.querySelector('a.kb-report__toggle');
             // expect it to be collapsed and not to have any siblings
             expect(toggleNode).toHaveClass('collapsed');
             expect(toggleNode.nextSibling).toBeNull();
@@ -122,10 +122,10 @@ define([
             const singleDataObject = ResultsData.objectData[0];
 
             await this.widget.start({
-                node: this.node,
+                node: container,
                 objectData: [singleDataObject],
             });
-            const toggleNode = this.node.querySelector('a.kb-report__toggle');
+            const toggleNode = container.querySelector('a.kb-report__toggle');
             // expect it to be collapsed and not to have any siblings
             expect(toggleNode).toHaveClass('collapsed');
             expect(toggleNode.nextSibling).toBeNull();

--- a/test/unit/spec/common/cellComponents/tabs/results/resultsTab-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/resultsTab-spec.js
@@ -32,6 +32,7 @@ define([
     ];
 
     describe('test the bulk import cell results tab', () => {
+        let container;
         beforeAll(() => {
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
@@ -44,16 +45,15 @@ define([
                 get_objects2: () => Promise.resolve({ data: [] }),
                 get_object_info_new: () => Promise.resolve([]),
             };
-            this.node = document.createElement('div');
+            container = document.createElement('div');
             this.model = Props.make({
                 data: TestAppObject,
                 onUpdate: () => {},
             });
-            document.body.appendChild(this.node);
         });
 
-        afterEach(function () {
-            this.node.remove();
+        afterEach(() => {
+            container.remove();
         });
 
         afterAll(() => {
@@ -67,12 +67,12 @@ define([
             });
             return resultsTabInstance
                 .start({
-                    node: this.node,
+                    node: container,
                 })
                 .then(() => {
                     // just make sure it renders the "Objects" and "Report" headers
-                    expect(this.node.innerHTML).toContain('Objects');
-                    expect(this.node.innerHTML).toContain('Report');
+                    expect(container.innerHTML).toContain('Objects');
+                    expect(container.innerHTML).toContain('Report');
                 });
         });
 
@@ -83,13 +83,13 @@ define([
             });
             return resultsTabInstance
                 .start({
-                    node: this.node,
+                    node: container,
                 })
                 .then(() => {
                     return resultsTabInstance.stop();
                 })
                 .then(() => {
-                    expect(this.node.innerHTML).toEqual('');
+                    expect(container.innerHTML).toEqual('');
                 });
         });
 
@@ -107,16 +107,16 @@ define([
             });
             return resultsTabInstance
                 .start({
-                    node: this.node,
+                    node: container,
                 })
                 .then(() => {
                     // don't go into detail here - that's for the other unit tests,
                     // just verify that we're rendering data.
-                    const objNode = this.node.querySelector('div.kb-created-objects');
+                    const objNode = container.querySelector('div.kb-created-objects');
                     expect(objNode).toBeDefined();
                     expect(objNode.innerHTML).toContain('Test_contigs');
 
-                    const reportNode = this.node.querySelector('div.kb-reports-view');
+                    const reportNode = container.querySelector('div.kb-reports-view');
                     expect(reportNode).toBeDefined();
                     expect(reportNode.innerHTML).toContain('Test_contigs');
                 });

--- a/test/unit/spec/common/errorDisplay-Spec.js
+++ b/test/unit/spec/common/errorDisplay-Spec.js
@@ -41,11 +41,16 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
     });
 
     describe('An errorDisplay instance', () => {
-        let errorDisplayInstance;
+        let errorDisplayInstance, container;
         beforeEach(() => {
+            container = document.createElement('div');
             errorDisplayInstance = ErrorDisplay.make({
                 model: validInput,
             });
+        });
+
+        afterEach(() => {
+            container.remove();
         });
 
         it('has a make function that returns an object', () => {
@@ -60,27 +65,34 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
         });
 
         it('should start and render an error', async () => {
-            const node = document.createElement('div');
             cssBaseClass = ErrorDisplay.cssBaseClass;
 
-            await errorDisplayInstance.start({ node: node });
-            expect(node.classList).toContain(`${cssBaseClass}__container`);
-            expect(node.innerHTML).toContain('Error stacktrace');
+            await errorDisplayInstance.start({ node: container });
+            expect(container.classList).toContain(`${cssBaseClass}__container`);
+            expect(container.innerHTML).toContain('Error stacktrace');
         });
 
         it('should clean up after itself', async () => {
-            const node = document.createElement('div');
             cssBaseClass = ErrorDisplay.cssBaseClass;
 
-            await errorDisplayInstance.start({ node: node });
-            expect(node.classList).toContain(`${cssBaseClass}__container`);
+            await errorDisplayInstance.start({ node: container });
+            expect(container.classList).toContain(`${cssBaseClass}__container`);
             await errorDisplayInstance.stop();
-            expect(node.innerHTML).toBe('');
+            expect(container.innerHTML).toBe('');
         });
     });
 
     describe('The ErrorDisplay module should render different errors', () => {
         const invalidArgs = [null, undefined, {}, { this: 'that' }, Props.make({})];
+        let container;
+        beforeEach(() => {
+            container = document.createElement('div');
+        });
+
+        afterEach(() => {
+            container.remove();
+        });
+
         invalidArgs.forEach((input) => {
             it(`should throw an error with invalid input ${JSON.stringify(input)}`, () => {
                 // it is unclear why, but the standard `toThrow` or `toThrowError`
@@ -97,7 +109,7 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
             xit(`should pass a toThrow(Error, /regex/) test with invalid input ${JSON.stringify(
                 input
             )}`, () => {
-                expect(ErrorDisplay.make(input)).toThrow(
+                expect(() => ErrorDisplay.make(input)).toThrow(
                     Error,
                     /Invalid input for the ErrorDisplay module/
                 );
@@ -252,7 +264,6 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
         cssBaseClass = ErrorDisplay.cssBaseClass;
 
         testErrors.forEach((test) => {
-            const node = document.createElement('div');
             const errorDisplayInstance = ErrorDisplay.make({
                 model: test.in,
             });
@@ -274,11 +285,11 @@ define(['common/errorDisplay', 'common/props'], (ErrorDisplay, Props) => {
 
             it(`should present an error of type ${test.desc}`, async () => {
                 const expected = test.outDisplay || test.out;
-                await errorDisplayInstance.start({ node: node });
+                await errorDisplayInstance.start({ node: container });
                 Object.keys(dataToClass)
                     .sort()
                     .forEach((datum) => {
-                        const matchingElements = node.getElementsByClassName(
+                        const matchingElements = container.getElementsByClassName(
                             `${cssBaseClass}__${dataToClass[datum]}`
                         );
                         if (expected[datum]) {

--- a/test/unit/spec/common/jobsSpec.js
+++ b/test/unit/spec/common/jobsSpec.js
@@ -66,21 +66,27 @@ define(['common/jobs', '/test/data/jobsData'], (Jobs, JobsData) => {
     });
 
     describe('createJobStatusLines', () => {
-        const div = document.createElement('div');
+        let container;
+        beforeAll(() => {
+            container = document.createElement('div');
+        });
+        afterAll(() => {
+            container.remove();
+        });
         const args = [false, true];
         JobsData.allJobs.forEach((state) => {
             it(`should create an appropriate status string for ${state.job_id}`, () => {
                 const statusLines = Jobs.createJobStatusLines(state);
-                div.innerHTML = arrayToHTML(statusLines);
-                expect(div.textContent).toContain(state.meta.createJobStatusLines.line);
+                container.innerHTML = arrayToHTML(statusLines);
+                expect(container.textContent).toContain(state.meta.createJobStatusLines.line);
             });
         });
         JobsData.allJobs.forEach((state) => {
             it(`should create an appropriate array in history mode for ${state.job_id}`, () => {
                 const statusLines = Jobs.createJobStatusLines(state, true);
-                div.innerHTML = arrayToHTML(statusLines);
+                container.innerHTML = arrayToHTML(statusLines);
                 state.meta.createJobStatusLines.history.forEach((historyLine) => {
-                    expect(div.textContent).toContain(historyLine);
+                    expect(container.textContent).toContain(historyLine);
                 });
             });
         });
@@ -91,8 +97,8 @@ define(['common/jobs', '/test/data/jobsData'], (Jobs, JobsData) => {
             // history is shown
             args.forEach((arg) => {
                 const statusLines = Jobs.createJobStatusLines(state, arg);
-                div.innerHTML = arrayToHTML(statusLines);
-                expect(div.textContent).toContain(JobsData.jobStrings.not_found);
+                container.innerHTML = arrayToHTML(statusLines);
+                expect(container.textContent).toContain(JobsData.jobStrings.not_found);
             });
         });
 
@@ -100,8 +106,8 @@ define(['common/jobs', '/test/data/jobsData'], (Jobs, JobsData) => {
             JobsData.invalidJobs.forEach((state) => {
                 args.forEach((arg) => {
                     const statusLines = Jobs.createJobStatusLines(state, arg);
-                    div.innerHTML = arrayToHTML(statusLines);
-                    expect(div.textContent).toContain(JobsData.jobStrings.unknown);
+                    container.innerHTML = arrayToHTML(statusLines);
+                    expect(container.textContent).toContain(JobsData.jobStrings.unknown);
                 });
             });
         });
@@ -158,12 +164,17 @@ define(['common/jobs', '/test/data/jobsData'], (Jobs, JobsData) => {
     });
 
     describe('niceState', () => {
-        const div = document.createElement('div');
-
+        let container;
+        beforeAll(() => {
+            container = document.createElement('div');
+        });
+        afterAll(() => {
+            container.remove();
+        });
         badStates.forEach((item) => {
             it(`should generate a nice state for the input ${item}`, () => {
-                div.innerHTML = Jobs.niceState(item);
-                const span = div.querySelector('span');
+                container.innerHTML = Jobs.niceState(item);
+                const span = container.querySelector('span');
                 expect(span).toHaveClass('kb-job-status__summary');
                 expect(span.textContent).toContain('invalid');
             });
@@ -171,8 +182,8 @@ define(['common/jobs', '/test/data/jobsData'], (Jobs, JobsData) => {
 
         JobsData.allJobs.forEach((state) => {
             it(`should generate a nice state for ${state.status}`, () => {
-                div.innerHTML = Jobs.niceState(state.status);
-                const span = div.querySelector('span');
+                container.innerHTML = Jobs.niceState(state.status);
+                const span = container.querySelector('span');
                 expect(span).toHaveClass(state.meta.niceState.class);
                 expect(span.textContent).toContain(state.meta.niceState.label);
             });

--- a/test/unit/spec/common/runtime-spec.js
+++ b/test/unit/spec/common/runtime-spec.js
@@ -209,15 +209,17 @@ define(['common/runtime', 'base/js/namespace', 'narrativeConfig'], (Runtime, Jup
     });
 
     describe('bus creation', () => {
+        let runtime;
         beforeAll(() => {
             window.kbaseRuntime = null;
         });
         afterEach(() => {
+            runtime.destroy();
             window.kbaseRuntime = null;
         });
 
         it('should pass on arguments to the bus, strict mode', () => {
-            const runtime = Runtime.make({ bus: { strict: true } });
+            runtime = Runtime.make({ bus: { strict: true } });
             try {
                 // in strict mode, a channel without a description will throw an error
                 runtime.bus().makeChannel({});
@@ -229,7 +231,7 @@ define(['common/runtime', 'base/js/namespace', 'narrativeConfig'], (Runtime, Jup
         });
 
         it('should pass on arguments to the bus, verbose', () => {
-            const runtime = Runtime.make({ bus: { verbose: true } });
+            runtime = Runtime.make({ bus: { verbose: true } });
 
             // in verbose mode, a channel without a description will emit a warning
             spyOn(console, 'warn').and.callThrough();

--- a/test/unit/spec/common/ui-Spec.js
+++ b/test/unit/spec/common/ui-Spec.js
@@ -150,27 +150,27 @@ define(['common/ui'], (UI) => {
 
     describe('the loading function', () => {
         const requiredClasses = ['fa', 'fa-spinner', 'fa-pulse', 'fa-fw'];
-        let div;
+        let container;
 
         beforeEach(() => {
-            div = document.createElement('div');
-        });
-        afterEach(() => {
-            div.remove();
+            container = document.createElement('div');
         });
 
+        afterEach(() => {
+            container.remove();
+        });
         it('should produce a spinning FontAwesome icon without any args', () => {
-            div.innerHTML = UI.loading();
-            expect(div.getElementsByTagName('span').length).toEqual(1);
-            expect(div.getElementsByTagName('span')[0].childNodes.length).toEqual(1);
-            expect(div.getElementsByTagName('i').length).toEqual(1);
-            const spinner = div.getElementsByTagName('i')[0];
+            container.innerHTML = UI.loading();
+            expect(container.getElementsByTagName('span').length).toEqual(1);
+            expect(container.getElementsByTagName('span')[0].childNodes.length).toEqual(1);
+            expect(container.getElementsByTagName('i').length).toEqual(1);
+            const spinner = container.getElementsByTagName('i')[0];
             requiredClasses.forEach((cl) => {
                 expect(spinner).toHaveClass(cl);
             });
             // there should be no text content
             expect(spinner.textContent).not.toMatch(/\S/);
-            expect(div.getElementsByTagName('span')[0].textContent).not.toMatch(/\S/);
+            expect(container.getElementsByTagName('span')[0].textContent).not.toMatch(/\S/);
         });
 
         it('should produce a different spinning icon with args', () => {
@@ -185,10 +185,10 @@ define(['common/ui'], (UI) => {
                     class: iconClass,
                 }),
                 allClasses = requiredClasses.concat([`fa-${iconSize}`, iconClass]);
-            div.innerHTML = iconStr;
+            container.innerHTML = iconStr;
             expect(iconStr).toMatch(/style.*?color.*?deepskyblue/);
-            expect(div.textContent).toContain(`${iconMessage}...`);
-            const spinner = div.getElementsByTagName('i')[0];
+            expect(container.textContent).toContain(`${iconMessage}...`);
+            const spinner = container.getElementsByTagName('i')[0];
             allClasses.forEach((cl) => {
                 expect(spinner).toHaveClass(cl);
             });

--- a/test/unit/spec/dynamicTableSpec.js
+++ b/test/unit/spec/dynamicTableSpec.js
@@ -23,9 +23,10 @@ define(['jquery', 'bluebird', 'widgets/dynamicTable'], ($, Promise, DynamicTable
         ];
 
     describe('The DynamicTable widget', () => {
+        let container;
         beforeEach(function () {
-            this.div = document.createElement('div');
-            this.dt = new DynamicTable($(this.div), {
+            container = document.createElement('div');
+            this.dt = new DynamicTable($(container), {
                 headers: headers,
                 // args to updateFunction: pageNum, query, sortColId, sortColDir
                 updateFunction: function () {
@@ -37,10 +38,13 @@ define(['jquery', 'bluebird', 'widgets/dynamicTable'], ($, Promise, DynamicTable
                 },
             });
         });
+        afterEach(() => {
+            container.remove();
+        });
 
         it('Should instantiate with essentially empty data', () => {
-            const $container = $('<div>');
-            const dt = new DynamicTable($container, {
+            container = document.createElement('div');
+            const dt = new DynamicTable($(container), {
                 updateFunction: () => {
                     return Promise.resolve({
                         start: 0,
@@ -50,13 +54,13 @@ define(['jquery', 'bluebird', 'widgets/dynamicTable'], ($, Promise, DynamicTable
                 },
             });
             expect(dt).toEqual(jasmine.any(Object));
-            const table = $container[0].querySelector('table');
+            const table = container.querySelector('table');
             expect(table.id).toBe('dynamic_table');
         });
 
         it('should have headers set correctly', function () {
             expect(this.dt).toEqual(jasmine.any(Object));
-            const table = this.div.querySelector('table');
+            const table = container.querySelector('table');
             expect(table.id).toBe('dynamic_table');
             const thElements = table.querySelectorAll('thead th');
             expect(thElements.length).toBe(headers.length);

--- a/test/unit/spec/function_output/kbaseReportView-spec.js
+++ b/test/unit/spec/function_output/kbaseReportView-spec.js
@@ -114,6 +114,7 @@ define(['kbaseReportView', 'base/js/namespace', 'jquery', 'narrativeMocks', 'nar
     }
 
     describe('The kbaseReportView widget', () => {
+        let container;
         beforeAll(() => {
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
@@ -126,18 +127,18 @@ define(['kbaseReportView', 'base/js/namespace', 'jquery', 'narrativeMocks', 'nar
 
         beforeEach(function () {
             jasmine.Ajax.install();
-            this.$node = $('<div>');
+            container = document.createElement('div');
+            this.$node = $(container);
             Mocks.mockJsonRpc1Call({
                 url: Config.url('service_wizard'),
                 body: /ServiceWizard.get_service_status/,
                 response: { url: FAKE_SERV_URL },
             });
-            $(document.body).append(this.$node);
         });
 
-        afterEach(function () {
+        afterEach(() => {
             jasmine.Ajax.uninstall();
-            this.$node.remove();
+            container.remove();
         });
 
         it('should be defined', () => {

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -16,7 +16,7 @@ define([
         TEST_USER = 'some_user';
 
     describe('Test the kbaseNarrative module', () => {
-        const loginDiv = $('<div>');
+        let container;
         let narr;
 
         beforeAll(() => {
@@ -99,7 +99,8 @@ define([
 
             // The NarrativeLogin.init call invokes both of the above token/user profile calls.
             // It's called before the creation of the Narrative object. So that needs to happen here.
-            await NarrativeLogin.init(loginDiv);
+            container = document.createElement('div');
+            await NarrativeLogin.init($(container));
             narr = new Narrative();
         });
 
@@ -114,6 +115,7 @@ define([
             NarrativeLogin.destroy();
             Mocks.clearAuthToken();
             // clear all jquery event listeners set up by either NarrativeLogin or anything else
+            container.remove();
             $(document).off();
             $([Jupyter.events]).off();
         });
@@ -131,12 +133,16 @@ define([
             $([Jupyter.events]).trigger('kernel_connected.Kernel');
         });
 
+        // creates a dialog that hangs around in the UI
         it('init should fail as expected when the job connection fails', (done) => {
             Jupyter.notebook.kernel.comm_info = () => {
                 throw new Error('an error happened');
             };
             const jobsReadyCallback = (err) => {
+                // returns an object in the form {error: ErrorObject}
                 expect(err).toBeDefined();
+                expect(err.error).toEqual(jasmine.any(Error));
+                expect(err.error.toString()).toEqual('Error: an error happened');
                 done();
             };
             narr.init(jobsReadyCallback);

--- a/test/unit/spec/loadingWidgetSpec.js
+++ b/test/unit/spec/loadingWidgetSpec.js
@@ -11,15 +11,14 @@ define([
         '/narrative/static/kbase/images/kbase_animated_logo.gif'
     );
     describe('Test the LoadingWidget module', () => {
-        beforeEach(function () {
-            this.node = document.createElement('div');
-            document.body.appendChild(this.node);
-            this.node.innerHTML = templateHtml;
+        let container;
+        beforeEach(() => {
+            container = document.createElement('div');
+            container.innerHTML = templateHtml;
         });
 
-        afterEach(function () {
-            this.node.remove();
-            this.node = null;
+        afterEach(() => {
+            container.remove();
         });
 
         it('Should instantiate with a null node', () => {
@@ -29,40 +28,40 @@ define([
             noNodeWidget.clearTimeout();
         });
 
-        it('Should be able to update its progress', function () {
-            const widget = new LoadingWidget({ node: this.node });
+        it('Should be able to update its progress', () => {
+            const widget = new LoadingWidget({ node: container });
             widget.updateProgress('data', true);
             // hidden checkmark that gets added once an element starts loading
             expect(
-                this.node.querySelector('[data-element="data"] .kb-progress-stage').innerHTML
+                container.querySelector('[data-element="data"] .kb-progress-stage').innerHTML
             ).toContain('class="fa fa-check"');
             // total progress indicator updated
-            expect(this.node.querySelector('.progress-bar').style.width).toBe('20%');
+            expect(container.querySelector('.progress-bar').style.width).toBe('20%');
             widget.clearTimeout();
         });
 
-        it('Should be able to remove its container node', function () {
+        it('Should be able to remove its container node', () => {
             spyOn(LoadingWidget.prototype, 'remove').and.callThrough();
-            const widget = new LoadingWidget({ node: this.node });
+            const widget = new LoadingWidget({ node: container });
             ['data', 'narrative', 'jobs', 'apps', 'kernel'].forEach((name) => {
                 widget.updateProgress(name, true);
             });
             expect(widget.remove).toHaveBeenCalled();
         });
 
-        it('Should not show the loading warning when first starting', function () {
-            const widget = new LoadingWidget({ node: this.node });
-            const $warning = $(this.node).find('.kb-loading-blocker__text--warning');
+        it('Should not show the loading warning when first starting', () => {
+            const widget = new LoadingWidget({ node: container });
+            const $warning = $(container).find('.kb-loading-blocker__text--warning');
             expect($warning.length).toBe(1);
             expect($warning.is(':visible')).toBeFalsy();
             widget.clearTimeout();
             widget.remove();
         });
 
-        it('Should show the loading warning after a timeout', function (done) {
-            const widget = new LoadingWidget({ node: this.node, timeout: 1 });
+        it('Should show the loading warning after a timeout', (done) => {
+            const widget = new LoadingWidget({ node: container, timeout: 1 });
             spyOn(widget, 'showTimeoutWarning').and.callThrough();
-            const $warningNode = $(this.node).find('.kb-loading-blocker__text--warning');
+            const $warningNode = $(container).find('.kb-loading-blocker__text--warning');
             expect($warningNode.length).toBe(1);
             spyOn($warningNode.__proto__, 'fadeIn').and.callThrough();
             expect(widget.timeoutShown).toBeFalse();

--- a/test/unit/spec/narrativeLoginSpec.js
+++ b/test/unit/spec/narrativeLoginSpec.js
@@ -9,14 +9,14 @@ define(['jquery', 'narrativeLogin', 'narrativeConfig', 'narrativeMocks'], (
     const FAKE_TOKEN = 'some_fake_token';
 
     describe('Test the narrativeLogin module', () => {
-        let $node;
+        let $container;
         beforeEach(() => {
             // remove any jquery events that get bound to document,
             // including login and logout listeners
             $(document).off();
             Mocks.setAuthToken(FAKE_TOKEN);
             jasmine.Ajax.install();
-            $node = $('<div>');
+            $container = $('<div>');
         });
 
         afterEach(() => {
@@ -25,7 +25,7 @@ define(['jquery', 'narrativeLogin', 'narrativeConfig', 'narrativeMocks'], (
             $(document).off();
             jasmine.Ajax.uninstall();
             Mocks.clearAuthToken();
-            $node.remove();
+            $container.remove();
         });
 
         it('Should instantiate and have expected functions', () => {
@@ -69,14 +69,14 @@ define(['jquery', 'narrativeLogin', 'narrativeConfig', 'narrativeMocks'], (
                 url: Config.url('user_profile'),
                 response: [{}],
             });
-            return Login.init($node, true) // true here means there's no kernel
+            return Login.init($container, true) // true here means there's no kernel
                 .finally(() => {
                     const request = jasmine.Ajax.requests.mostRecent();
                     expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);
                     // test that the user menu was created by checking for the username and id
                     // embedded in the node
-                    expect($node.text()).toContain(fakeName);
-                    expect($node.text()).toContain(fakeUser);
+                    expect($container.text()).toContain(fakeName);
+                    expect($container.text()).toContain(fakeUser);
                     Login.clearTokenCheckTimers();
                     Login.destroy();
                 });
@@ -85,7 +85,7 @@ define(['jquery', 'narrativeLogin', 'narrativeConfig', 'narrativeMocks'], (
         it('Should throw an error when instantiating with a bad token', () => {
             Mocks.mockAuthRequest('token', { error: {} }, 401);
             Mocks.mockAuthRequest('me', { error: {} }, 401);
-            return Login.init($node, true) // true here means there's no kernel
+            return Login.init($container, true) // true here means there's no kernel
                 .then(() => {
                     const request = jasmine.Ajax.requests.mostRecent();
                     expect(request.requestHeaders.Authorization).toEqual(FAKE_TOKEN);

--- a/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
+++ b/test/unit/spec/narrative_core/kbaseCellToolbarMenu-spec.js
@@ -50,7 +50,7 @@ define(['jquery', 'kbaseCellToolbarMenu', 'base/js/namespace'], ($, Widget, Jupy
         };
 
         // This test might better be served through Snapshot Testing
-        // This test might want to check to see if each buttton has the correct fa-* class
+        // This test might want to check to see if each button has the correct fa-* class
         it('Should render the correct app cell buttons in the correct order', () => {
             const testToolBar = mockToolbarDataTestNodes('success', '', 'maximized');
             const expectedButtonOrder = [

--- a/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeOutputCell-spec.js
@@ -22,8 +22,7 @@ define([
             },
             testData = { foo: 'bar', baz: [1, 2, 3] },
             cellId = 'a-cell-id';
-        let $target = $('<div>'),
-            myWidget = null;
+        let $container, $target, myWidget;
 
         const validateUpas = function (source, comparison) {
             Object.keys(comparison).forEach((upaKey) => {
@@ -48,7 +47,8 @@ define([
 
             Config.config.workspaceId = 10;
             $target = $('<div>');
-            $('body').append($('<div id="notebook-container">').append($target));
+            $container = $('<div id="notebook-container">').append($target);
+            $('body').append($container);
             myWidget = new Widget($target, {
                 widget: testWidget,
                 data: testData,
@@ -70,7 +70,7 @@ define([
             Mocks.clearAuthToken();
             Jupyter.narrative = null;
             jasmine.Ajax.uninstall();
-            $('#notebook-container').remove();
+            $container.remove();
         });
 
         it('Should load properly with a dummy UPA', () => {

--- a/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeWorkspace-spec.js
@@ -8,15 +8,16 @@ define([
 ], (KBaseNarrativeWorkspace, $, Jupyter, Mocks, Runtime, AppSpec) => {
     'use strict';
     describe('Test the kbaseNarrativeWorkspace widget', () => {
-        let $node;
+        let $node, $container;
         beforeAll(() => {
             $(document).off();
         });
 
         beforeEach(() => {
             jasmine.Ajax.install();
-            $node = $('div');
-            $('body').append($node);
+            $node = $(document.createElement('div'));
+            $container = $(document.createElement('div')).append($node);
+            $('body').append($container);
             Jupyter.notebook = Mocks.buildMockNotebook({
                 readOnly: false,
             });
@@ -41,7 +42,7 @@ define([
 
         afterEach(() => {
             jasmine.Ajax.uninstall();
-            $node.detach();
+            $container.remove();
             $(document).off();
         });
 
@@ -80,8 +81,10 @@ define([
         });
 
         it('buildAppCodeCell should fail without a spec', () => {
+            spyOn(window, 'alert');
             const widget = new KBaseNarrativeWorkspace($node);
             expect(widget.buildAppCodeCell()).toBeUndefined();
+            expect(window.alert).toHaveBeenCalled();
         });
 
         it('buildViewerCell should work by direct call', () => {
@@ -136,7 +139,7 @@ define([
                 rebuild_all: () => {},
             };
             // included in the main templates, mocked here
-            $('body').append('<button id="kb-view-mode">');
+            $container.append('<button id="kb-view-mode">');
             const widget = new KBaseNarrativeWorkspace($node);
             expect(widget.narrativeIsReadOnly).toBeFalsy();
             expect(widget.uiMode).toEqual('edit');
@@ -178,6 +181,7 @@ define([
             widget.deleteCell(0);
         });
 
+        // this test occasionally fails due to the modal not being present
         it('should delete KBase extension cells by direct call by dialog', (done) => {
             Jupyter.notebook = Mocks.buildMockNotebook({
                 readOnly: false,

--- a/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
+++ b/test/unit/spec/narrative_core/staticNarrativesManager-spec.js
@@ -150,21 +150,21 @@ define([
         }
     }
 
-    function validateHtmlNoStatic(node) {
-        expect(node.html()).toContain('No static version exists for this Narrative yet!');
+    function validateHtmlNoStatic(container) {
+        expect(container.html()).toContain('No static version exists for this Narrative yet!');
     }
 
-    function validateHtmlStatic(node) {
-        expect(node.html()).toContain('Existing static Narrative');
-        expect(node.html()).toContain('Made from version ' + staticVer);
+    function validateHtmlStatic(container) {
+        expect(container.html()).toContain('Existing static Narrative');
+        expect(container.html()).toContain('Made from version ' + staticVer);
     }
 
-    function validateHtmlError(node) {
-        expect(node.html()).toContain('Static Narrative Error');
+    function validateHtmlError(container) {
+        expect(container.html()).toContain('Static Narrative Error');
     }
 
     describe('The Static Narrative manager widget', () => {
-        let node;
+        let container;
 
         beforeEach(() => {
             const AUTH_TOKEN = 'fakeAuthToken';
@@ -174,7 +174,7 @@ define([
                 userId: userId,
                 documentVersionInfo: narrDocInfo,
             };
-            node = $(document.createElement('div'));
+            container = $(document.createElement('div'));
 
             jasmine.Ajax.install();
         });
@@ -183,6 +183,7 @@ define([
             Mocks.clearAuthToken();
             Jupyter.narrative = null;
             jasmine.Ajax.uninstall();
+            container.remove();
         });
 
         it('Should exist', () => {
@@ -190,7 +191,7 @@ define([
         });
 
         it('Should be instantiable', () => {
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             expect(widget).toBeDefined();
             expect(widget.refresh).toBeDefined();
         });
@@ -199,9 +200,9 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.render().then(() => {
-                validateHtmlNoStatic(node);
+                validateHtmlNoStatic(container);
             });
         });
 
@@ -209,9 +210,9 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.render().then(() => {
-                validateHtmlStatic(node);
+                validateHtmlStatic(container);
             });
         });
 
@@ -219,9 +220,9 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.refresh().then(() => {
-                validateHtmlNoStatic(node);
+                validateHtmlNoStatic(container);
             });
         });
 
@@ -229,15 +230,15 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
-            expect(node.html()).toBe('');
-            const widget = new StaticNarrativesManager(node);
+            expect(container.html()).toBe('');
+            const widget = new StaticNarrativesManager(container);
             return widget
                 .render()
                 .then(() => {
                     return widget.detach();
                 })
                 .then(() => {
-                    expect(node.html()).toBe('<div></div>');
+                    expect(container.html()).toBe('<div></div>');
                 });
         });
 
@@ -245,8 +246,8 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(false);
             mockPermissions(true, true);
-            expect(node.html()).toBe('');
-            const widget = new StaticNarrativesManager(node);
+            expect(container.html()).toBe('');
+            const widget = new StaticNarrativesManager(container);
             return widget
                 .render()
                 .then(() => widget.detach())
@@ -255,7 +256,7 @@ define([
                 .then(() => widget.render())
                 .then(() => widget.detach())
                 .then(() => {
-                    expect(node.html()).toBe('<div></div>');
+                    expect(container.html()).toBe('<div></div>');
                 });
         });
 
@@ -264,10 +265,10 @@ define([
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
             mockCreateStaticNarrative();
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             spyOn(widget, 'saveStaticNarrative');
             return widget.render().then(() => {
-                node.find('button').click();
+                container.find('button').click();
                 expect(widget.saveStaticNarrative).toHaveBeenCalled();
             });
         });
@@ -277,14 +278,14 @@ define([
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
             mockCreateStaticNarrative();
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget
                 .render()
                 .then(() => {
                     return widget.saveStaticNarrative();
                 })
                 .then(() => {
-                    validateHtmlStatic(node);
+                    validateHtmlStatic(container);
                 });
         });
 
@@ -293,14 +294,14 @@ define([
             mockGetStaticNarrativeInfo(true);
             mockPermissions(true, true);
             mockCreateStaticNarrative(true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget
                 .render()
                 .then(() => {
                     return widget.saveStaticNarrative();
                 })
                 .then(() => {
-                    validateHtmlError(node);
+                    validateHtmlError(container);
                 });
         });
 
@@ -308,9 +309,9 @@ define([
             mockPermissions(true, true);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true, true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.render().then(() => {
-                validateHtmlError(node);
+                validateHtmlError(container);
             });
         });
 
@@ -319,9 +320,9 @@ define([
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
             Jupyter.narrative.documentVersionInfo = null;
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.render().then(() => {
-                validateHtmlError(node);
+                validateHtmlError(container);
             });
         });
 
@@ -329,11 +330,11 @@ define([
             mockPermissions(false, true);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.render().then(() => {
-                expect(node.html()).toContain('Not an admin');
-                expect(node.html()).not.toContain('Not public');
-                expect(node.html()).not.toContain('Create static narrative');
+                expect(container.html()).toContain('Not an admin');
+                expect(container.html()).not.toContain('Not public');
+                expect(container.html()).not.toContain('Create static narrative');
             });
         });
 
@@ -341,11 +342,11 @@ define([
             mockPermissions(true, false);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.render().then(() => {
-                expect(node.html()).not.toContain('Not an admin');
-                expect(node.html()).toContain('Not public');
-                expect(node.html()).not.toContain('Create static narrative');
+                expect(container.html()).not.toContain('Not an admin');
+                expect(container.html()).toContain('Not public');
+                expect(container.html()).not.toContain('Create static narrative');
             });
         });
 
@@ -353,11 +354,11 @@ define([
             mockPermissions(false, false);
             mockGoodServiceWizard();
             mockGetStaticNarrativeInfo(true);
-            const widget = new StaticNarrativesManager(node);
+            const widget = new StaticNarrativesManager(container);
             return widget.render().then(() => {
-                expect(node.html()).toContain('Not an admin');
-                expect(node.html()).toContain('Not public');
-                expect(node.html()).not.toContain('Create static narrative');
+                expect(container.html()).toContain('Not an admin');
+                expect(container.html()).toContain('Not public');
+                expect(container.html()).not.toContain('Create static narrative');
             });
         });
     });

--- a/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
+++ b/test/unit/spec/narrative_core/upload/fileUploadWidget-spec.js
@@ -11,6 +11,7 @@ define([
         stagingUrl = Config.url('staging_api_url') + '/upload';
 
     describe('Test the fileUploadWidget', () => {
+        let container;
         beforeEach(function () {
             jasmine.Ajax.install();
             Jupyter.narrative = {
@@ -25,8 +26,8 @@ define([
                 },
                 showDataOverlay: () => {},
             };
-            this.node = document.createElement('div');
-            this.fuWidget = new FileUploadWidget($(this.node), {
+            container = document.createElement('div');
+            this.fuWidget = new FileUploadWidget($(container), {
                 path: '/',
                 userInfo: {
                     user: fakeUser,
@@ -54,6 +55,7 @@ define([
         afterEach(() => {
             jasmine.Ajax.requests.reset();
             jasmine.Ajax.uninstall();
+            container.remove();
         });
 
         it('Should be able to set and retrieve the path', () => {
@@ -184,8 +186,6 @@ define([
         });
 
         it('Should contain a cancel warning button', function (done) {
-            document.body.appendChild(this.node);
-
             this.fuWidget.dropzone.on('sending', () => {
                 const $cancelButton = this.fuWidget.$elem.find('.cancel');
                 expect($cancelButton).toBeDefined();

--- a/test/unit/spec/nbextensions/bulkImportCell/fileTypePanel-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/fileTypePanel-spec.js
@@ -21,6 +21,13 @@ define([
         label: 'File Header',
     };
     describe('test the file type panel', () => {
+        let container;
+        beforeEach(() => {
+            container = document.createElement('div');
+        });
+        afterEach(() => {
+            container.remove();
+        });
         it('should load and start properly with the right available functions', () => {
             const panel = FileTypePanel.make({
                 bus: Runtime.make().bus(),
@@ -31,16 +38,15 @@ define([
             expect(panel.start).toBeDefined();
             expect(panel.stop).toBeDefined();
             expect(panel.updateState).toBeDefined();
-            const node = document.createElement('div');
             return panel
                 .start({
-                    node: node,
+                    node: container,
                     state: {},
                 })
                 .then(() => {
-                    expect(node.innerHTML).toContain(header.label);
+                    expect(container.innerHTML).toContain(header.label);
                     for (const cat of Object.keys(fileTypes)) {
-                        expect(node.innerHTML).toContain(fileTypes[cat].label);
+                        expect(container.innerHTML).toContain(fileTypes[cat].label);
                     }
                 });
         });
@@ -52,17 +58,16 @@ define([
                 header: header,
                 toggleAction: () => {},
             });
-            const node = document.createElement('div');
             return panel
                 .start({
-                    node: node,
+                    node: container,
                     state: {}, // start with no state, nothing selected, nothing completed
                 })
                 .then(() => {
                     const beforeNode = {},
                         beforeIcon = {};
                     for (const cat of Object.keys(fileTypes)) {
-                        const elem = node.querySelector(`[data-element="${cat}"]`);
+                        const elem = container.querySelector(`[data-element="${cat}"]`);
                         beforeNode[cat] = elem.outerHTML;
                         beforeIcon[cat] = elem.querySelector('[data-element="icon"]').outerHTML;
                     }
@@ -70,7 +75,7 @@ define([
                         selected: 'file1',
                     });
                     for (const cat of Object.keys(fileTypes)) {
-                        const elem = node.querySelector(`[data-element="${cat}"]`);
+                        const elem = container.querySelector(`[data-element="${cat}"]`);
                         if (cat === 'file1') {
                             // try to black-box test, so we can just know that it should be
                             // different. (really I shouldn't even use the selector, but
@@ -86,7 +91,7 @@ define([
                         },
                     });
                     for (const cat of Object.keys(fileTypes)) {
-                        const iconElem = node.querySelector(
+                        const iconElem = container.querySelector(
                             `[data-element="${cat}"] [data-element="icon"]`
                         );
                         if (cat === 'file2') {
@@ -106,18 +111,17 @@ define([
                 header: header,
                 toggleAction: clickSpy,
             });
-            const node = document.createElement('div');
             return panel
                 .start({
-                    node: node,
+                    node: container,
                     state: {
                         selected: 'file1',
                     },
                 })
                 .then(() => {
-                    node.querySelector('[data-element="file1"]').click();
+                    container.querySelector('[data-element="file1"]').click();
                     expect(clickSpy).not.toHaveBeenCalled();
-                    node.querySelector('[data-element="file2"]').click();
+                    container.querySelector('[data-element="file2"]').click();
                     expect(clickSpy).toHaveBeenCalled();
                 });
         });
@@ -129,10 +133,9 @@ define([
                 header: header,
                 toggleAction: () => {},
             });
-            const node = document.createElement('div');
             return panel
                 .start({
-                    node: node,
+                    node: container,
                     state: {},
                 })
                 .then(() => {

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -9,6 +9,7 @@ define([
     'use strict';
 
     describe('test the bulk import cell configure tab', () => {
+        let bus, container;
         beforeAll(() => {
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
@@ -20,15 +21,20 @@ define([
             };
         });
 
+        beforeEach(() => {
+            bus = Runtime.make().bus();
+            container = document.createElement('div');
+        });
+
+        afterEach(() => {
+            container.remove();
+        });
+
         afterAll(() => {
             Jupyter.narrative = null;
         });
 
         it('should start and render itself', () => {
-            const bus = Runtime.make().bus();
-            const node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(node);
-
             const model = Props.make({
                 data: TestAppObject,
                 onUpdate: () => {},
@@ -40,19 +46,16 @@ define([
             const configure = ConfigureTab.make({ bus, model, spec, fileType: 'fastq_reads' });
             return configure
                 .start({
-                    node: node,
+                    node: container,
                 })
                 .then(() => {
                     // just make sure it renders the "File Paths" and "Parameters" headers
-                    expect(node.innerHTML).toContain('Parameters');
-                    expect(node.innerHTML).toContain('File Paths');
+                    expect(container.innerHTML).toContain('Parameters');
+                    expect(container.innerHTML).toContain('File Paths');
                 });
         });
 
         it('should stop itself and empty the node it was in', () => {
-            const bus = Runtime.make().bus();
-            const node = document.createElement('div');
-            document.getElementsByTagName('body')[0].appendChild(node);
             const model = Props.make({
                 data: TestAppObject,
                 onUpdate: () => {},
@@ -64,15 +67,15 @@ define([
             const configure = ConfigureTab.make({ bus, model, spec, fileType: 'fastq_reads' });
             return configure
                 .start({
-                    node: node,
+                    node: container,
                 })
                 .then(() => {
                     // just make sure it renders the "File Paths" and "Parameters" headers
-                    expect(node.innerHTML).toContain('Parameters');
+                    expect(container.innerHTML).toContain('Parameters');
                     return configure.stop();
                 })
                 .then(() => {
-                    expect(node.innerHTML).toEqual('');
+                    expect(container.innerHTML).toEqual('');
                 });
         });
     });

--- a/test/unit/spec/util/BootstrapSearchSpec.js
+++ b/test/unit/spec/util/BootstrapSearchSpec.js
@@ -1,27 +1,27 @@
 define(['jquery', 'util/bootstrapSearch', 'base/js/namespace'], ($, BootstrapSearch, Jupyter) => {
     'use strict';
-    let $targetElem;
 
     describe('Test the BootstrapSearch module', () => {
+        let $container;
         beforeEach(() => {
-            $targetElem = $('<div>');
+            $container = $('<div>');
             Jupyter.narrative = {
                 disableKeyboardManager: () => {},
             };
         });
 
         afterEach(() => {
-            $targetElem.remove();
+            $container.remove();
             Jupyter.narrative = null;
         });
 
         it('Should create a new search object', () => {
-            const bsSearch = new BootstrapSearch($targetElem, {});
+            const bsSearch = new BootstrapSearch($container, {});
             expect(bsSearch).not.toBeNull();
         });
 
         it('Should fire an input function when triggered by input', (done) => {
-            const bsSearch = new BootstrapSearch($targetElem, {
+            const bsSearch = new BootstrapSearch($container, {
                 inputFunction: (event) => {
                     expect(event.type).toBe('input');
                     done();
@@ -34,11 +34,11 @@ define(['jquery', 'util/bootstrapSearch', 'base/js/namespace'], ($, BootstrapSea
             const emptyFa = 'fa-battery-0',
                 filledFa = 'fa-battery-4';
 
-            const bsSearch = new BootstrapSearch($targetElem, {
+            const bsSearch = new BootstrapSearch($container, {
                 emptyIcon: emptyFa,
                 filledIcon: filledFa,
             });
-            const addon = $targetElem.find('span.input-group-addon > span');
+            const addon = $container.find('span.input-group-addon > span');
             expect(addon.hasClass(emptyFa)).toBe(true);
             bsSearch.val('stuff');
             expect(addon.hasClass(filledFa)).toBe(true);
@@ -52,11 +52,11 @@ define(['jquery', 'util/bootstrapSearch', 'base/js/namespace'], ($, BootstrapSea
                 filled = 'battery-4',
                 filledFa = 'fa-battery-4';
 
-            const bsSearch = new BootstrapSearch($targetElem, {
+            const bsSearch = new BootstrapSearch($container, {
                 emptyIcon: empty,
                 filledIcon: filled,
             });
-            const addon = $targetElem.find('span.input-group-addon > span');
+            const addon = $container.find('span.input-group-addon > span');
             expect(addon.hasClass(emptyFa)).toBe(true);
             bsSearch.val('stuff');
             expect(addon.hasClass(filledFa)).toBe(true);
@@ -65,34 +65,35 @@ define(['jquery', 'util/bootstrapSearch', 'base/js/namespace'], ($, BootstrapSea
         });
 
         it('Should clear input by default when clicking addon', () => {
-            const bsSearch = new BootstrapSearch($targetElem);
+            const bsSearch = new BootstrapSearch($container);
             bsSearch.val('stuff');
-            $targetElem.find('span.input-group-addon').click();
+            $container.find('span.input-group-addon').click();
             expect(bsSearch.val()).toBeFalsy();
         });
 
         it('Should fire a function when clicking the addon - overrides default clear', (done) => {
-            const bsSearch = new BootstrapSearch($targetElem, {
+            const bsSearch = new BootstrapSearch($container, {
                 addonFunction: () => {
                     expect(bsSearch.val()).toEqual('stuff');
                     done();
                 },
             });
             bsSearch.val('stuff');
-            $targetElem.find('span.input-group-addon').click();
+            $container.find('span.input-group-addon').click();
         });
 
         it('Should have a val function that works as in vanilla JS', () => {
-            const bsSearch = new BootstrapSearch($targetElem);
+            const bsSearch = new BootstrapSearch($container);
             bsSearch.val('stuff');
             expect(bsSearch.val()).toEqual('stuff');
         });
 
+        // this test times out sporadically
         it('Should have a working focus function', (done) => {
-            const bsSearch = new BootstrapSearch($targetElem);
-            $('body').append($targetElem);
+            const bsSearch = new BootstrapSearch($container);
+            $('body').append($container);
             spyOn(Jupyter.narrative, 'disableKeyboardManager');
-            $targetElem.find('input[type="text"]').on('focus', (event) => {
+            $container.find('input[type="text"]').on('focus', (event) => {
                 expect(event.type).toBe('focus');
                 expect(Jupyter.narrative.disableKeyboardManager).toHaveBeenCalled();
                 done();
@@ -102,14 +103,14 @@ define(['jquery', 'util/bootstrapSearch', 'base/js/namespace'], ($, BootstrapSea
 
         it('Should set placeholder text', () => {
             const placeholder = 'some text';
-            new BootstrapSearch($targetElem, {
+            new BootstrapSearch($container, {
                 placeholder: placeholder,
             });
-            expect($targetElem.find('input.form-control').attr('placeholder')).toEqual(placeholder);
+            expect($container.find('input.form-control').attr('placeholder')).toEqual(placeholder);
         });
 
         it('Should trigger an escape function', (done) => {
-            new BootstrapSearch($targetElem, {
+            new BootstrapSearch($container, {
                 escFunction: (event) => {
                     expect(event.type).toBe('keyup');
                     done();
@@ -118,7 +119,7 @@ define(['jquery', 'util/bootstrapSearch', 'base/js/namespace'], ($, BootstrapSea
             const e = $.Event('keyup');
             e.which = 27;
             e.keyCode = 27;
-            $targetElem.find('input.form-control').trigger(e);
+            $container.find('input.form-control').trigger(e);
         });
     });
 });

--- a/test/unit/spec/util/iconSpec.js
+++ b/test/unit/spec/util/iconSpec.js
@@ -146,6 +146,9 @@ define(['util/icon', 'narrativeConfig', 'jquery'], (Icon, narrativeConfig, $) =>
                 container = document.createElement('div');
                 $jqueryContainer = $('<div>');
             });
+            afterEach(() => {
+                container.remove();
+            });
 
             it('can build an icon with args: ' + test.args.join(', '), () => {
                 container.innerHTML = Icon.makeDataIcon(...test.args);
@@ -224,6 +227,9 @@ define(['util/icon', 'narrativeConfig', 'jquery'], (Icon, narrativeConfig, $) =>
 
             beforeEach(() => {
                 container = document.createElement('div');
+            });
+            afterEach(() => {
+                container.remove();
             });
 
             describe(`The Icon method ${methodName}`, () => {


### PR DESCRIPTION
# Description of PR purpose/changes

Standardising the approach the tests take to DOM interactions:
- have a `container` variable that any DOM elements are added to, and make sure that `container.remove()` is called after each test
- only add `container` to the document body if it is strictly necessary (lessens the likelihood of cross-contamination)
- a few misc other fixes I found whilst looking through these DOM tests

There are some files that I haven't yet tackled; they will be next up:

- 'narrativeLoginSpec.js',
- 'appWidgets/input/select2ObjectinputSpec.js',
- 'appWidgets/input/taxonomyRefInputSpec.js',
- 'narrative_core/jobCommChannel-spec.js',
- 'util/BootstrapDialogSpec.js',
- 'util/jobLogViewerSpec.js',

There are a couple of DOM tests in this batch that occasionally time out; I've commented them in the files, and will revisit them anon.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-314
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by running the test suite, ideally with the jasmine html reporter

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
