### PR TITLE
DATAUP-314: test modal elimination II

### DIFF
--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -333,17 +333,17 @@ define([
      * after there's a visible DOM element for it to render in.
      */
     Narrative.prototype.initSharePanel = function () {
-        let sharePanel = $(
+        const sharePanel = $(
                 '<div style="text-align:center"><br><br><img src="' +
                     Config.get('loading_gif') +
                     '"></div>'
             ),
-            shareWidget = null,
             shareDialog = new BootstrapDialog({
                 title: 'Change Share Settings',
                 body: sharePanel,
                 closeButton: true,
             });
+        let shareWidget = null;
         shareDialog.getElement().one('shown.bs.modal', () => {
             shareWidget = new KBaseNarrativeSharePanel(sharePanel.empty(), {
                 ws_name_or_id: this.getWorkspaceName(),
@@ -713,8 +713,8 @@ define([
             open: function () {
                 const that = $(this);
                 // Upon ENTER, click the OK button.
-                that.find('input[type="text"]').keydown((event) => {
-                    if (event.which === Keyboard.keycodes.enter) {
+                that.find('input[type="text"]').keydown((_event) => {
+                    if (_event.which === Keyboard.keycodes.enter) {
                         that.find('.btn-primary').first().click();
                     }
                 });
@@ -936,11 +936,9 @@ define([
             }).show();
             return;
         }
-        let cell = Jupyter.notebook.get_selected_cell(),
-            nearIdx = 0;
-        if (cell) {
-            nearIdx = Jupyter.notebook.find_cell_index(cell);
-        }
+        const cell = Jupyter.notebook.get_selected_cell(),
+            nearIdx = cell ? Jupyter.notebook.find_cell_index(cell) : 0;
+
         let objInfo = {};
         // If a string, expect a ref, and fetch the info.
         if (typeof obj === 'string') {
@@ -1003,7 +1001,7 @@ define([
                 const newWidget = new KBaseNarrativeMethodCell(
                     $('#' + $(newCell.get_text())[0].id)
                 );
-                var updateStateAndRun = function () {
+                const updateStateAndRun = function () {
                     if (newWidget.$inputWidget) {
                         // if the $inputWidget is not null, we are good to go, so set the parameters
                         newWidget.loadState(parameters);

--- a/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrativePrestart.js
@@ -129,7 +129,7 @@ define(['kbwidget', 'bootstrap', 'jquery', 'narrativeConfig', 'common/runtime', 
          * for the function.
          */
         window.KBError = function (where, what) {
-            return KBFail(false, where, what);
+            return window.KBFail(false, where, what);
         };
 
         /**
@@ -141,7 +141,7 @@ define(['kbwidget', 'bootstrap', 'jquery', 'narrativeConfig', 'common/runtime', 
          * @param what  (string) What happened
          */
         window.KBFatal = function (where, what) {
-            const res = KBFail(true, where, what);
+            window.KBFail(true, where, what);
 
             const version = Config.get('version') || 'unknown';
             const hash = Config.get('git_commit_hash') || 'unknown';
@@ -153,7 +153,7 @@ define(['kbwidget', 'bootstrap', 'jquery', 'narrativeConfig', 'common/runtime', 
                     full_version = version + ' (hash=' + hash + ')';
                 }
             }
-            var $fatal = $(
+            const $fatal = $(
                 '<div tabindex=-1 role="dialog" aria-labelledby="kb-fatal-error" aria-hidden="true">'
             )
                 .addClass('modal fade')
@@ -321,9 +321,9 @@ define(['kbwidget', 'bootstrap', 'jquery', 'narrativeConfig', 'common/runtime', 
                 Jupyter.keyboard_manager.actions.register(
                     {
                         handler: function (env, event) {
-                            let index = env.notebook.get_selected_index(),
+                            let cm = env.notebook.get_selected_cell().code_mirror;
+                            const index = env.notebook.get_selected_index(),
                                 cell = env.notebook.get_cell(index),
-                                cm = env.notebook.get_selected_cell().code_mirror,
                                 cur = cm.getCursor();
                             if (cell && cell.at_top() && index !== 0 && cur.ch === 0) {
                                 if (event) {

--- a/kbase-extension/static/kbase/js/util/bootstrapDialog.js
+++ b/kbase-extension/static/kbase/js/util/bootstrapDialog.js
@@ -139,7 +139,18 @@ define(['jquery', 'bootstrap'], ($) => {
      * Removes this modal from the DOM and removes any associated content.
      */
     BootstrapDialog.prototype.destroy = function () {
-        this.$modal.remove();
+        try {
+            this.$modal.remove();
+        } catch (e) {
+            // eslint-disable-next-line no-empty
+        }
+
+        // clean up any backdrop items
+        if (document.querySelector('.modal-backdrop')) {
+            document.querySelector('.modal-backdrop').remove();
+        }
+        document.body.classList.remove('modal-open');
+
         this.$modal = null;
         return null;
     };

--- a/test/unit/spec/common/monoBus-Spec.js
+++ b/test/unit/spec/common/monoBus-Spec.js
@@ -71,7 +71,7 @@ define(['common/monoBus'], (Bus) => {
             const bus = Bus.make();
             bus.respond({
                 key: { type: 'test' },
-                handle: function (message) {
+                handle: function () {
                     return { reply: 'this is my reply' };
                 },
             });
@@ -184,7 +184,7 @@ define(['common/monoBus'], (Bus) => {
 
             myBus.bus().listen({
                 channel: 'my-new-channel',
-                test: function (message) {
+                test: function () {
                     return true;
                 },
                 handle: function (message) {
@@ -224,7 +224,6 @@ define(['common/monoBus'], (Bus) => {
         it('Channel bus Request/response', (done) => {
             const bus = Bus.make(),
                 bus1 = bus.makeChannelBus(),
-                bus2 = bus.makeChannelBus(),
                 data = {
                     key1: 'value1',
                 };
@@ -278,7 +277,7 @@ define(['common/monoBus'], (Bus) => {
                 key: {
                     type: 'get-value',
                 },
-                handle: function (message) {
+                handle: function () {
                     return bus1.request(
                         {
                             propertyName: 'key1',
@@ -353,8 +352,8 @@ define(['common/monoBus'], (Bus) => {
         }, 5000);
 
         it('Send and receive a keyed, persistent message over a channel, send first, then update', (done) => {
-            let bus = Bus.make(),
-                times = 0;
+            const bus = Bus.make();
+            let times = 0;
             bus.set(
                 {
                     name: 'Winnie',
@@ -390,8 +389,8 @@ define(['common/monoBus'], (Bus) => {
         }, 5000);
 
         it('Create a working test based message route, then remove the listener, should fail.', (done) => {
-            var bus = Bus.make(),
-                count = 0,
+            let count = 0;
+            const bus = Bus.make(),
                 listener = bus.listen({
                     test: function (message) {
                         return message.what === 'test';
@@ -430,15 +429,15 @@ define(['common/monoBus'], (Bus) => {
         });
     });
 
-    it('A connection should destroy all listenrs upon stop', (done) => {
+    it('A connection should destroy all listeners upon stop', (done) => {
         const bus = Bus.make(),
             connection = bus.connect();
 
-        connection.channel('test').on('test', (message) => {
+        connection.channel('test').on('test', () => {
             // do nothing...
         });
 
-        connection.channel('test').on('my-message', (message) => {
+        connection.channel('test').on('my-message', () => {
             // expect(message.msg).toEqual('greetings');
             expect(connection.stats().listeners.active).toEqual(2);
             connection.stop();
@@ -477,8 +476,8 @@ define(['common/monoBus'], (Bus) => {
             .when('my-message')
             .then((message) => {
                 expect(message.msg).toEqual('greetings');
-                connection.channel('test').on('my-message', (message) => {
-                    expect(message.msg).toEqual('goodbye');
+                connection.channel('test').on('my-message', (_message) => {
+                    expect(_message.msg).toEqual('goodbye');
                     connection.stop();
                     done();
                 });
@@ -492,7 +491,7 @@ define(['common/monoBus'], (Bus) => {
         });
     });
 
-    it('Set a persistent message and get it syncronously', (done) => {
+    it('Set a persistent message and get it synchronously', (done) => {
         const bus = Bus.make(),
             connection = bus.connect();
 
@@ -507,7 +506,7 @@ define(['common/monoBus'], (Bus) => {
         connection.stop();
     });
 
-    it('Set a persistent message and get it syncronously, failed', (done) => {
+    it('Set a persistent message and get it synchronously, failed', (done) => {
         const bus = Bus.make(),
             connection = bus.connect();
 
@@ -522,7 +521,7 @@ define(['common/monoBus'], (Bus) => {
         connection.stop();
     });
 
-    it('Set a persistent message and get it syncronously, set after get, should get default value', (done) => {
+    it('Set a persistent message and get it synchronously, set after get, should get default value', (done) => {
         const bus = Bus.make(),
             connection = bus.connect();
 
@@ -544,15 +543,6 @@ define(['common/monoBus'], (Bus) => {
         const started = new Date().getTime();
 
         // var test2Called = 0;
-
-        const test2 = connection.channel('test').plisten({
-            key: {
-                type: 'my-message',
-            },
-            handle: function (message) {
-                done.fail();
-            },
-        });
 
         // var test3 = connection.channel('test').plisten({
         //     key: {

--- a/test/unit/spec/function_output/kbaseSampleSet-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleSet-spec.js
@@ -105,7 +105,7 @@ define(['jquery', 'kbaseSampleSetView', 'base/js/namespace', 'narrativeConfig'],
                     ],
                 }),
             });
-            const w = new Widget($div, { upas: { id: 'fake' } });
+            new Widget($div, { upas: { id: 'fake' } });
             setTimeout(() => {
                 ['Description', 'KBase Object Name', 'This is a test sample set.'].forEach(
                     (str) => {

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -133,12 +133,14 @@ define([
             $([Jupyter.events]).trigger('kernel_connected.Kernel');
         });
 
-        // creates a dialog that hangs around in the UI
         it('init should fail as expected when the job connection fails', (done) => {
+            // spy on KBFatal and prevent an error dialog from being created
+            spyOn(window, 'KBFatal');
             Jupyter.notebook.kernel.comm_info = () => {
                 throw new Error('an error happened');
             };
             const jobsReadyCallback = (err) => {
+                expect(window.KBFatal).toHaveBeenCalled();
                 // returns an object in the form {error: ErrorObject}
                 expect(err).toBeDefined();
                 expect(err.error).toEqual(jasmine.any(Error));

--- a/test/unit/spec/util/BootstrapDialogSpec.js
+++ b/test/unit/spec/util/BootstrapDialogSpec.js
@@ -22,11 +22,9 @@ define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
     describe('Test the BootstrapDialog module', () => {
         let simpleDialog;
         afterEach(() => {
-            try {
+            if (simpleDialog) {
                 simpleDialog.destroy();
-                // eslint-disable-next-line no-empty
-            } catch (err) {}
-            simpleDialog = null;
+            }
         });
 
         it('Should create a new dialog object', () => {
@@ -34,10 +32,13 @@ define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
             expect(simpleDialog).toEqual(jasmine.any(Object));
         });
 
-        it('Should show on command', () => {
+        it('Should show on command', (done) => {
             simpleDialog = createSimpleDialog();
+            simpleDialog.$modal.on('shown.bs.modal', () => {
+                expect(simpleDialog.$modal.is(':visible')).toBeTruthy();
+                done();
+            });
             simpleDialog.show();
-            expect($($.find('.fade.in')).is(':visible')).toBeTruthy();
         });
 
         it('Should hide on command', (done) => {
@@ -46,8 +47,11 @@ define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
                 expect(simpleDialog.$modal.is(':visible')).toBeFalsy();
                 done();
             });
+            simpleDialog.$modal.on('shown.bs.modal', () => {
+                expect(simpleDialog.$modal.is(':visible')).toBeTruthy();
+                simpleDialog.hide();
+            });
             simpleDialog.show();
-            simpleDialog.hide();
         });
 
         it('Should get a title string back', () => {
@@ -98,10 +102,11 @@ define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
             simpleDialog = new Dialog({
                 title: 'Test for command on enter keypress',
                 body: $('<div>'),
-                buttons: [$('<button>').append('Clickable button').click(btnFn)],
+                buttons: [
+                    $('<button data-dismiss="modal">').append('Clickable button').click(btnFn),
+                ],
                 enterToTrigger: true,
             });
-            simpleDialog.show();
             expect(wasTriggered).toBe(false);
             const e = $.Event('keypress');
             e.which = 13;
@@ -133,8 +138,10 @@ define(['jquery', 'util/bootstrapDialog'], ($, Dialog) => {
         it('Should destroy the modal on command', () => {
             simpleDialog = createSimpleDialog();
             const ret = simpleDialog.destroy();
-            expect(ret).toBe(null);
-            expect(simpleDialog.getElement()).toBe(null);
+            expect(ret).toBeNull();
+            expect(simpleDialog.getElement()).toBeNull();
+            expect(document.querySelectorAll('.modal-backdrop').length).toBe(0);
+            expect(document.body).not.toHaveClass('modal-open');
         });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

Preventing tests from leaving modals cluttering up the DOM.

A few eslint fixes that I noticed whilst working on these test files.

Codacy has failed, but everything else has passed.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-314
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local instance and seeing that it all looks just as mundane as before.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
