### PR TITLE
DATAUP-314: test modal elimination III

### DIFF
--- a/nbextensions/bulkImportCell/main.js
+++ b/nbextensions/bulkImportCell/main.js
@@ -36,9 +36,7 @@ define([
                         BulkImportCell.make({ cell });
                     } catch (error) {
                         // If we have an error here, there is a serious problem setting up the cell and it is not usable.
-                        // What to do? The safest thing to do is inform the user, and then strip out the cell, leaving
-                        // in it's place a markdown cell with the error info.
-                        // For now, just pop up an error dialog;
+                        // Inform the user via an error dialog.
 
                         Error.reportCellError(
                             'Error starting bulk import cell',


### PR DESCRIPTION
# Description of PR purpose/changes

More modals eliminated!

Integration tests timed out, but unit tests have passed.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-314
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and seeing that nothing has changed. How boring!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
