### PR TITLE
DATAUP-314: test timeout fix

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -7,6 +7,7 @@
 - [Long Version](#long-version)
   - [About](#about)
   - [How to Run Tests](#how-to-run-tests)
+  - [Frontend Unit Tests](#frontend-unit-tests)
   - [Add Credentials for Tests](#add-credentials-for-tests)
   - [Testing with Travis-CI and Coveralls](#testing-with-travis-ci-and-coveralls)
   - [Adding Your Own Tests](#adding-your-own-tests)
@@ -42,9 +43,31 @@ Then, simply run (from the narrative root directory) `make test`.
 This calls a few subcommands, and those can be run independently for specific uses:
 
 - `make test-frontend-unit` will run only the unit tests on the frontend (i.e. those with the Karma runner)
-- `make test-integration` will run the frontend integration tests that make use of webdriver.io to simulate the browser on a locally instantiated Narrative, but running against live KBase services. Note that this currently requires an authentication token. 
+- `make test-integration` will run the frontend integration tests that make use of webdriver.io to simulate the browser on a locally instantiated Narrative, but running against live KBase services. Note that this currently requires an authentication token.
 - `make test-frontend` will run both the frontend unit tests and integration tests as above.
 - `make test-backend` will run only the backend Python tests.
+
+#### Frontend Unit Tests
+
+You can run the frontend unit tests interactively by launching a headless instance of the narrative and then starting Karma, the unit test runner. There are aliases provided to make this easier.
+
+To start the headless narrative:
+```
+npm run headless
+```
+
+To run tests in Firefox:
+```
+npm run test_firefox
+```
+
+To run tests in Chrome:
+```
+npm run test_chrome
+```
+
+There is an additional Karma config file suitable for running tests locally, which turns off Karma's file caching so that you can run tests in Firefox or Chrome by repeatedly refreshing the browser.
+
 
 ### Add Credentials for Tests
 
@@ -69,7 +92,7 @@ This just needs the path to the token file, which should be kept in the `test` d
 #### ***Frontend Integration Tests***
 
 There are currently two options here.
-1. Set your token in the `KBASE_TEST_TOKEN` environment variable before running integration tests. 
+1. Set your token in the `KBASE_TEST_TOKEN` environment variable before running integration tests.
 2. Use the same token file as described above.
 
 These are checked in that order. That is, if there's a `KBASE_TEST_TOKEN` variable, that gets used. Otherwise, it checks for the token file referenced in `test/testConfig.json`. If both of those are absent, a fake test token is used, which might cause failures if your tests include authenticated services.
@@ -137,19 +160,13 @@ To debug using the Karma Debugger complete the following steps:
 - In one terminal tab enter:
 
 ```
-kbase-narrative --no-browser --NotebookApp.allow_origin="*" --ip=127.0.0.1 --port=32323
+npm run headless
 ```
 
 - Open a second tab and enter:
 
 ```
-export PATH=$PATH:./node_modules/.bin/
+npm run tdd
 ```
 
-- In the second tab enter:
-
-```
-karma start test/unit/karma.conf.js --browsers=Chrome --single-run=false
-```
-
-After running the third command, a chrome browser will open. Click on the debug button. This opens a second browser window where you can inspect the page and use chrome debugger tools.
+After running the second command, a Chrome browser will open. Click on the debug button. This opens a second browser window where you can inspect the page and use chrome debugger tools.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "grunt-stylelint": "^0.15.0",
                 "husky": "^5.1.1",
                 "jasmine-ajax": "4.0.0",
-                "jasmine-core": "^3.6.0",
+                "jasmine-core": "^3.7.1",
                 "jasmine-jquery": "2.1.1",
                 "karma": "^6.1.1",
                 "karma-brief-reporter": "^0.2.1",
@@ -7204,9 +7204,9 @@
             "dev": true
         },
         "node_modules/jasmine-core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
-            "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.7.1.tgz",
+            "integrity": "sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==",
             "dev": true
         },
         "node_modules/jasmine-jquery": {
@@ -24013,9 +24013,9 @@
             "dev": true
         },
         "jasmine-core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
-            "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.7.1.tgz",
+            "integrity": "sha512-DH3oYDS/AUvvr22+xUBW62m1Xoy7tUlY1tsxKEJvl5JeJ7q8zd1K5bUwiOxdH+erj6l2vAMM3hV25Xs9/WrmuQ==",
             "dev": true
         },
         "jasmine-jquery": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "grunt-stylelint": "^0.15.0",
         "husky": "^5.1.1",
         "jasmine-ajax": "4.0.0",
-        "jasmine-core": "^3.6.0",
+        "jasmine-core": "^3.7.1",
         "jasmine-jquery": "2.1.1",
         "karma": "^6.1.1",
         "karma-brief-reporter": "^0.2.1",
@@ -98,6 +98,7 @@
         "test_chrome": "karma start test/unit/karma.local.conf.js --browsers=Chrome --single-run=false",
         "test_firefox": "karma start test/unit/karma.local.conf.js --browsers=Firefox --single-run=false",
         "test": "karma start test/unit/karma.conf.js",
+        "test_local": "karma start test/unit/karma.local.conf.js",
         "uglify": "terser kbase-extension/static/kbase-narrative.js -c --source-map --output kbase-extension/static/kbase-narrative-min.js",
         "update_browserslist": "npx browserslist@latest --update-db",
         "watch_css": "grunt watch"


### PR DESCRIPTION
# Description of PR purpose/changes

- update jasmine to v3.7.1
- fix occasional kbaseNarrativeWorkspace widget test failures due to DOM elements not appearing quickly enough.

Integration tests timed out in both runs; frontend tests are fine.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-314
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and seeing that nothing has changed.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
