### PR TITLE
fix issue with infotab not removing itself completely

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
@@ -45,6 +45,7 @@ define(['common/format', 'common/utils'], (format, utils) => {
 
     function factory(config) {
         const model = config.model;
+        let containerNode;
 
         function start(arg) {
             let appSpec = model.getItem('app.spec'); // for plain app cell
@@ -144,14 +145,17 @@ define(['common/format', 'common/utils'], (format, utils) => {
             ];
 
             // Populate info tab
-            arg.node.appendChild(description);
+            containerNode = arg.node;
+            containerNode.appendChild(description);
             const infoList = document.createElement('ul');
             appendChildren(infoList, listItems);
-            arg.node.appendChild(infoList);
-            return Promise.resolve(arg.node);
+            containerNode.appendChild(infoList);
+
+            return Promise.resolve(containerNode);
         }
 
         function stop() {
+            containerNode.innerHTML = '';
             return Promise.resolve();
         }
 

--- a/kbase-extension/static/kbase/js/common/spec.js
+++ b/kbase-extension/static/kbase/js/common/spec.js
@@ -67,7 +67,7 @@ define(['bluebird', 'common/lang', 'common/sdk', 'widgets/appWidgets2/validators
          * this spec. This returns a Promise that resolves into a map from parameter ids to
          * validations.
          * @param {object} model the object containing the data model to validate
-         * should have key-value-pairs for each parameter id.
+         * should have key-value pairs for each parameter id.
          * @returns Promise that resolves into a mapping from parameter id -> validation
          * structure
          */
@@ -77,14 +77,14 @@ define(['bluebird', 'common/lang', 'common/sdk', 'widgets/appWidgets2/validators
 
         /**
          * A trimmed version of validateModel that's specific for a few params.
-         * Given an array of parameter ids and an object with key-value-pairs from
+         * Given an array of parameter ids and an object with key-value pairs from
          * paramId -> value, validate the set. Only the given parameter ids are validated.
          * Any others are ignored.
          *
-         * This returns a Promise that resolves into the a key-value-pair of parameter id ->
+         * This returns a Promise that resolves into key-value pairs of parameter id ->
          * validation response.
          * @param {array} paramIds - the array of parameter ids to validate
-         * @param {object} values - a key-value-pair structure of values to validate. Keys should
+         * @param {object} values - a key-value pair structure of values to validate. Keys should
          *   be parameter ids.
          */
         function validateParams(paramIds, values) {

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -225,13 +225,8 @@ define([
                 spec.validateParams(otherParamIds, paramValues),
                 ...filePathValidations,
             ]).then((results) => {
-                let isValid = true;
-                results.forEach((result) => {
-                    Object.values(result).forEach((param) => {
-                        if (!param.isValid) {
-                            isValid = false;
-                        }
-                    });
+                const isValid = results.every((result) => {
+                    return Object.values(result).every((param) => param.isValid);
                 });
                 return isValid ? 'complete' : 'incomplete';
             });

--- a/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
@@ -72,9 +72,14 @@ define(['common/cellComponents/tabs/infoTab'], (InfoTab) => {
             expect(infoTabPromise instanceof Promise).toBeTrue();
         });
 
-        it('has a method "stop" which returns a Promise', () => {
+        it('has a method "stop" which returns a Promise and clears its container', () => {
+            // just expect it to have something real.
+            expect(container.innerHTML).toContain('View Full Documentation');
             const result = infoTabInstance.stop();
             expect(result instanceof Promise).toBeTrue();
+            return result.then(() => {
+                expect(container.innerHTML).toEqual('');
+            });
         });
 
         it('returns the defined description', () => {


### PR DESCRIPTION
# Description of PR purpose/changes

The infoTab wasn't removing itself from the DOM properly. This wasn't an issue in the single-app appCell, due to how it removes and replaces its widget container, but is in the bulk import cell. There's likely something that can be streamlined there, too, but we've mostly been rolling with the concept that widgets that have `stop()` called on them should remove themselves from the DOM where appropriate. So, now it does.

# Jira Ticket / Issue #
- not really a JIRA issue, just a thing I noticed.
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* toggling back and forth from the info tab in the bulk import cell should completely detach it / rebuild it now.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
