### PR TITLE
Debug issue with narrative_version

### DIFF
--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -29,5 +29,4 @@ docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
                 --build-arg NARRATIVE_GIT_HASH=$NARRATIVE_GIT_HASH \
                 -f Dockerfile2 \
                 .
-docker rmi kbase/narrative:tmp
 docker push ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR"

--- a/.github/workflows/scripts/build_prodrc_pr.sh
+++ b/.github/workflows/scripts/build_prodrc_pr.sh
@@ -6,6 +6,7 @@ export DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 export COMMIT=$(echo "$SHA" | cut -c -7)
 export NARRATIVE_VERSION_NUM=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
+export NARRATIVE_GIT_HASH=`grep '\"git_commit_hash\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g' | sed 's/,//'`
 export MY_APP2="$MY_APP"_version
 
 
@@ -18,8 +19,6 @@ docker build --build-arg BUILD_DATE="$DATE" \
              -t ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" .
 docker push ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR"
 
-docker tag ghcr.io/"$MY_ORG"/"$MY_APP":"pr-""$PR" kbase/narrative:tmp
-
 docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
                 --build-arg BUILD_DATE=$DATE \
                 --build-arg VCS_REF=$COMMIT \
@@ -27,6 +26,7 @@ docker build -t ghcr.io/"$MY_ORG"/"$MY_APP2":"pr-""$PR" \
                 --build-arg PULL_REQUEST="$PR" \
                 --label us.kbase.vcs-pull-req="$PR" \
                 --build-arg NARRATIVE_VERSION=$NARRATIVE_VERSION_NUM \
+                --build-arg NARRATIVE_GIT_HASH=$NARRATIVE_GIT_HASH \
                 -f Dockerfile2 \
                 .
 docker rmi kbase/narrative:tmp

--- a/Dockerfile2
+++ b/Dockerfile2
@@ -13,7 +13,7 @@ ARG NARRATIVE_GIT_HASH
 EXPOSE 80
 
 RUN echo >/usr/share/nginx/html/narrative_version '{"version":"'${NARRATIVE_VERSION}'","git_hash":"'${NARRATIVE_GIT_HASH}'"}' && \
-    cat /usr/share/nginx/html/narrative_version && echo
+    cat /usr/share/nginx/html/narrative_version
 
 # Replace index file with redirect to www.kbase.us
 

--- a/Dockerfile2
+++ b/Dockerfile2
@@ -15,6 +15,8 @@ COPY --from=kbase/narrative:tmp /kb/deployment/services/kbase-ui/ /usr/share/ngi
 
 # Replace index file with redirect to www.kbase.us
 
+RUN cat /usr/share/nginx/html/narrative_version && echo
+
 RUN echo >/usr/share/nginx/html/index.html '<html>\
   <head><meta http-equiv="refresh" content="0; url=http://www.kbase.us/"> \
   <script type="text/javascript">window.location.href = "http://www.kbase.us"</script> \

--- a/Dockerfile2
+++ b/Dockerfile2
@@ -12,7 +12,7 @@ ARG NARRATIVE_GIT_HASH
 
 EXPOSE 80
 
-RUN echo >/usr/share/nginx/html/narrative_version '{"version":"'${NARRATIVE_VERSION_NUM}'","git_hash":"'${NARRATIVE_GIT_HASH}'"}' && \
+RUN echo >/usr/share/nginx/html/narrative_version '{"version":"'${NARRATIVE_VERSION}'","git_hash":"'${NARRATIVE_GIT_HASH}'"}' && \
     cat /usr/share/nginx/html/narrative_version && echo
 
 # Replace index file with redirect to www.kbase.us

--- a/Dockerfile2
+++ b/Dockerfile2
@@ -8,14 +8,15 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG BRANCH=develop
 ARG NARRATIVE_VERSION
+ARG NARRATIVE_GIT_HASH
 
 EXPOSE 80
 
-COPY --from=kbase/narrative:tmp /kb/deployment/services/kbase-ui/ /usr/share/nginx/html
+RUN echo >/usr/share/nginx/html/narrative_version '{"version":"'${NARRATIVE_VERSION_NUM}'","git_hash":"'${NARRATIVE_GIT_HASH}'"}' && \
+    cat /usr/share/nginx/html/narrative_version && echo
 
 # Replace index file with redirect to www.kbase.us
 
-RUN cat /usr/share/nginx/html/narrative_version && echo
 
 RUN echo >/usr/share/nginx/html/index.html '<html>\
   <head><meta http-equiv="refresh" content="0; url=http://www.kbase.us/"> \


### PR DESCRIPTION
The narrative_version that was built and pushed by GHA has an old version number 4.2.0 for some reason, might be an issue with when the feature branch was branched off and merged back in versus when the most recent merge of develop into master occurred. Debugging it with a print during the build.

# Description of PR purpose/changes

* Please include a summary of the change and which issue is fixed.
* Please also include relevant motivation and context.
* List any dependencies that are required for this change.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
