### PR TITLE
DATAUP-312 fix configuration errors not being propagated

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -117,7 +117,7 @@ define([
                 // only propagate if its invalid
                 if (!message.isValid) {
                     bus.emit('invalid-param-value', {
-                        parameter: parameterSpec.id
+                        parameter: parameterSpec.id,
                     });
                 }
             });

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -113,6 +113,15 @@ define([
                 });
             });
 
+            fieldWidget.bus.on('validation', (message) => {
+                // only propagate if its invalid
+                if (!message.isValid) {
+                    bus.emit('invalid-param-value', {
+                        parameter: parameterSpec.id
+                    });
+                }
+            });
+
             fieldWidget.bus.on('touched', () => {
                 bus.emit('parameter-touched', {
                     parameter: parameterSpec.id,

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -472,6 +472,11 @@ define([
          */
         function updateParameterState(fileType, state) {
             model.setItem(['state', 'param', fileType], state);
+            const newFileTypeState = {};
+            for (const [ fileId, state ] of Object.entries(model.getItem(['state', 'param']))) {
+                newFileTypeState[fileId] = state === 'complete'
+            }
+            fileTypePanel.updateState({ completed: newFileTypeState });
             let cellReady = true;
             for (const state of Object.values(model.getItem('state.param'))) {
                 if (state !== 'complete') {
@@ -480,6 +485,7 @@ define([
                 }
             }
             if (cellReady) {
+                console.log('cell ready!');
             }
         }
 

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -473,8 +473,8 @@ define([
         function updateParameterState(fileType, state) {
             model.setItem(['state', 'param', fileType], state);
             const newFileTypeState = {};
-            for (const [ fileId, state ] of Object.entries(model.getItem(['state', 'param']))) {
-                newFileTypeState[fileId] = state === 'complete'
+            for (const [fileId, state] of Object.entries(model.getItem(['state', 'param']))) {
+                newFileTypeState[fileId] = state === 'complete';
             }
             fileTypePanel.updateState({ completed: newFileTypeState });
             let cellReady = true;


### PR DESCRIPTION
# Description of PR purpose/changes

This activates the "ready" checkboxes in the file type panel and fixes a couple of minor issues that were causing the state of it to be strange and not respond to errors in the parameter widgets.

There's still an ongoing issue with the advanced parameters where the insert size controls (std dev and mean size) default to `null`, which is invalid, but can be set to empty string, which is valid. I'm not sure what to do about that yet.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-312
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Fully configure all required fields in a bulk import cell, including advanced parameters. Then break them.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
