### PR TITLE
Bump chromedriver to ^90.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,9 +1534,9 @@
             }
         },
         "chromedriver": {
-            "version": "87.0.7",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-87.0.7.tgz",
-            "integrity": "sha512-7J7iN2rJuSDsKb9BUUMewJt07PuTlZYd809D10dUCT1rjMD3i2jUw7dum9RxdC1xO3aFwMd8TwZ5NR82T+S+Dg==",
+            "version": "89.0.0",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-89.0.0.tgz",
+            "integrity": "sha512-+DVYp3+m6tZUYTMl9fEgCZIDk9YBTcHws82nIV1JYwusu51zRITA0oeNzuPyFhuK7ageFnnKCDviH2BL5I4M0w==",
             "dev": true,
             "requires": {
                 "@testim/chrome-version": "^1.0.7",
@@ -3130,9 +3130,9 @@
             }
         },
         "globby": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-            "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+            "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
             "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
@@ -3795,9 +3795,9 @@
             "dev": true
         },
         "is-path-inside": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-            "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true
         },
         "is-plain-obj": {
@@ -5754,9 +5754,9 @@
             "dev": true
         },
         "queue-microtask": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
-            "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
         "quick-lru": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1534,9 +1534,9 @@
             }
         },
         "chromedriver": {
-            "version": "89.0.0",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-89.0.0.tgz",
-            "integrity": "sha512-+DVYp3+m6tZUYTMl9fEgCZIDk9YBTcHws82nIV1JYwusu51zRITA0oeNzuPyFhuK7ageFnnKCDviH2BL5I4M0w==",
+            "version": "90.0.0",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-90.0.0.tgz",
+            "integrity": "sha512-k+GMmNb7cmuCCctQvUIeNxDGSq8DJauO+UKQS2qLT8aA36CPEcv8rpFepf6lRkNaIlfwdCUt/0B5bZDw3wY2yw==",
             "dev": true,
             "requires": {
                 "@testim/chrome-version": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@wdio/spec-reporter": "^6.6.0",
         "bower": "^1.8.12",
         "chrome-launcher": "^0.13.4",
-        "chromedriver": "^87.0.0",
+        "chromedriver": "^89.0.0",
         "eslint": "7.23.0",
         "eslint-config-prettier": "^7.2.0",
         "grunt": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@wdio/spec-reporter": "^6.6.0",
         "bower": "^1.8.12",
         "chrome-launcher": "^0.13.4",
-        "chromedriver": "^89.0.0",
+        "chromedriver": "^90.0.0",
         "eslint": "7.23.0",
         "eslint-config-prettier": "^7.2.0",
         "grunt": "1.3.0",


### PR DESCRIPTION
# Description of PR purpose/changes

Integration tests are all failing hard due to an out of date chromedriver. And dependabot is only doing v 89, and those are failing, too.

