### PR TITLE
DATAUP-312 update appmanager tests, first step toward deduplication

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -33,6 +33,13 @@ __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
 
 def _app_error_wrapper(app_func: Callable) -> any:
+    """
+    This is a decorator meant to wrap any of the `run_app*` methods here.
+    It captures any raised exception, formats it into a message that can be sent
+    over the comm channel to the frontend, then prints a more friendly form of the
+    error, instead of showing an arcane traceback.
+    Otherwise it runs whatever function it decorates with its expected args and kwargs
+    """
     @functools.wraps(app_func)
     def wrapper(self, *args, **kwargs):
         try:
@@ -65,7 +72,6 @@ def _app_error_wrapper(app_func: Callable) -> any:
                 + "-----------------------------------------------------\n"
                 + e_trace
             )
-
     return wrapper
 
 

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -65,7 +65,9 @@ def _app_error_wrapper(app_func: Callable) -> any:
                 + "-----------------------------------------------------\n"
                 + e_trace
             )
+
     return wrapper
+
 
 class AppManager(object):
     """
@@ -491,7 +493,6 @@ class AppManager(object):
         # } BatchSubmission;
 
         # funcdef run_job_batch(list<RunJobParams> params, BatchParams batch_params) returns (BatchSubmission job_ids) authentication required;
-
 
     def run_local_app(
         self,

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -178,24 +178,6 @@ class MockClients:
                 infos.append(random_obj_info)
         return infos
 
-        # infos = [
-        #     [
-        #         5,
-        #         "Sbicolor2",
-        #         "KBaseGenomes.Genome-12.3",
-        #         "2017-03-31T23:42:59+0000",
-        #         1,
-        #         "wjriehl",
-        #         18836,
-        #         "wjriehl:1490995018528",
-        #         "278abf8f0dbf8ab5ce349598a8674a6e",
-        #         109180038,
-        #         None,
-        #     ]
-        # ]
-        # ret_val = infos * len(params.get("objects", [0]))
-        # return ret_val
-
     def get_object_info3(self, params):
         infos = [
             [

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -8,18 +8,17 @@ from biokbase.narrative.jobs.job import Job
 from IPython.display import HTML
 import unittest
 import mock
+from mock import MagicMock
 from .narrative_mock.mockclients import get_mock_client
 import os
 from .util import TestConfig
+from typing import List
+import sys
+import io
 
 
 def mock_agent_token(*args, **kwargs):
     return dict({"user": "testuser", "id": "12345", "token": "abcde"})
-
-
-def mock_run_job(*args, **kwargs):
-    return "new_job_id"
-
 
 class AppManagerTestCase(unittest.TestCase):
     @classmethod
@@ -45,6 +44,60 @@ class AppManagerTestCase(unittest.TestCase):
         cls.ws_id = int(config.get("app_tests", "public_ws_id"))
         cls.app_input_ref = config.get("app_tests", "test_input_ref")
         cls.batch_app_id = config.get("app_tests", "batch_app_id")
+        cls.bulk_run_good_inputs = [{
+            "app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+            "tag": "release",
+            "version": "1.0.46",
+            "params": [{
+                "fastq_fwd_staging_file_name": "",
+                "fastq_rev_staging_file_name": "",
+                "sra_staging_file_name": "",
+                "name": "asdf",
+                "import_type": "FASTQ/FASTA",
+                "insert_size_mean": 0,
+                "insert_size_std_dev": 0,
+                "interleaved": 1,
+                "read_orientation_outward": "0",
+                "sequencing_tech": "Illumina",
+                "single_genome": 1
+            }]
+        }, {
+            "app_id": "kb_uploadmethods/import_sra_as_reads_from_staging",
+            "tag": "release",
+            "version": "1.0.46",
+            "params": [{
+                "sra_staging_file_name": "",
+                "name": "asdf",
+                "insert_size_mean": 1,
+                "insert_size_std_dev": 1,
+                "read_orientation_outward": "0",
+                "sequencing_tech": "Illumina",
+                "single_genome": "1"
+            }]
+        }]
+
+    def setUp(self):
+        os.environ["KB_WORKSPACE_ID"] = self.public_ws
+
+    def tearDown(self):
+        del os.environ["KB_WORKSPACE_ID"]
+
+    def run_app_expect_error(self, comm_mock, run_func, func_name, print_error):
+        """
+        A wrapper for various versions of run_app* that'll test and verify that errors get
+        1. printed to stdout and
+        2. sent over the (mocked) comm channel as expected
+        The stdout prints and the comm channel responses are both side effects that get
+        captured by re-routing stdout, and by capturing mock calls, respectively.
+        """
+        output = io.StringIO()
+        sys.stdout = output
+        self.assertIsNone(run_func())
+        sys.stdout = sys.__stdout__
+        output_str = output.getvalue()
+        self.assertIn(f"Error while trying to start your app ({func_name})!", output_str)
+        self.assertIn(print_error, output_str)
+        self._verify_comm_error(comm_mock)
 
     def test_reload(self):
         self.am.reload()
@@ -80,14 +133,17 @@ class AppManagerTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.am.available_apps(self.bad_tag)
 
+    ############# Testing run_app #############
+
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     @mock.patch(
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_dry_run_app(self, c, auth):
-        os.environ["KB_WORKSPACE_ID"] = self.public_ws
+    def test_run_app_dry_run(self, auth, c):
+        mock_comm = MagicMock()
+        c.return_value.send_comm_message = mock_comm
         output = self.am.run_app(
             self.test_app_id, self.test_app_params, tag=self.test_tag, dry_run=True
         )
@@ -99,6 +155,7 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertIn("meta", output)
         self.assertIn("tag", output["meta"])
         self.assertIn("wsid", output)
+        self.assertEqual(mock_comm.call_count, 0)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -106,9 +163,8 @@ class AppManagerTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_run_app_good_inputs(self, c, auth):
-        c.return_value.send_comm_message.return_value = None
-        os.environ["KB_WORKSPACE_ID"] = self.public_ws
+    def test_run_app_good_inputs(self, auth, c):
+        c.return_value.send_comm_message = MagicMock()
         new_job = self.am.run_app(
             self.test_app_id, self.test_app_params, tag=self.test_tag
         )
@@ -117,6 +173,7 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertEqual(new_job.app_id, self.test_app_id)
         self.assertEqual(new_job.tag, self.test_tag)
         self.assertIsNone(new_job.cell_id)
+        self._verify_comm_success(c.return_value.send_comm_message)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -124,34 +181,55 @@ class AppManagerTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_run_app_from_gui_cell(self, c, auth):
-        c.return_value.send_comm_message.return_value = None
-        os.environ["KB_WORKSPACE_ID"] = self.public_ws
+    def test_run_app_from_gui_cell(self, auth, c):
+        cell_id = "12345"
+        c.return_value.send_comm_message = MagicMock()
         self.assertIsNone(
             self.am.run_app(
                 self.test_app_id,
                 self.test_app_params,
                 tag=self.test_tag,
-                cell_id="12345",
+                cell_id=cell_id,
             )
         )
+        self._verify_comm_success(c.return_value.send_comm_message, cell_id=cell_id)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_bad_id(self, c):
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(self.am.run_app(self.bad_app_id, None))
+        c.return_value.send_comm_message = MagicMock()
+        def run_func():
+            return self.am.run_app(self.bad_app_id, None)
+        self.run_app_expect_error(
+            c.return_value.send_comm_message,
+            run_func,
+            "run_app",
+            f'Unknown app id "{self.bad_app_id}" tagged as "release"'
+        )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_bad_tag(self, c):
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(self.am.run_app(self.good_app_id, None, tag=self.bad_tag))
+        c.return_value.send_comm_message = MagicMock()
+        def run_func():
+            return self.am.run_app(self.good_app_id, None, tag=self.bad_tag)
+        self.run_app_expect_error(
+            c.return_value.send_comm_message,
+            run_func,
+            "run_app",
+            f"Can't find tag {self.bad_tag} - allowed tags are release, beta, dev"
+        )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_bad_version_match(self, c):
         # fails because a non-release tag can't be versioned
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(
-            self.am.run_app(self.good_app_id, None, tag=self.good_tag, version=">0.0.1")
+        c.return_value.send_comm_message = MagicMock()
+        def run_func():
+            return self.am.run_app(self.good_app_id, None, tag="dev", version="0.0.1")
+
+        self.run_app_expect_error(
+            c.return_value.send_comm_message,
+            run_func,
+            "run_app",
+            f"Semantic versions only apply to released app modules."
         )
 
     # Running an app with missing inputs is now allowed. The app can
@@ -162,16 +240,14 @@ class AppManagerTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_run_app_missing_inputs(self, c, auth):
-        c.return_value.send_comm_message.return_value = None
+    def test_run_app_missing_inputs(self, auth, c):
+        c.return_value.send_comm_message = MagicMock()
         self.assertIsNotNone(self.am.run_app(self.good_app_id, None, tag=self.good_tag))
+        self._verify_comm_success(c.return_value.send_comm_message)
 
-    @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
-    def test_run_app_bad_version(self, c):
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(
-            self.am.run_app(self.good_app_id, None, tag="dev", version="1.0.0")
-        )
+    ############# End tests for run_app #############
+
+    ############# Test run_app_batch #############
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -179,9 +255,8 @@ class AppManagerTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_run_app_batch_good_inputs(self, c, auth):
-        c.return_value.send_comm_message.return_value = None
-        os.environ["KB_WORKSPACE_ID"] = self.public_ws
+    def test_run_app_batch_good_inputs(self, auth, c):
+        c.return_value.send_comm_message = MagicMock()
         new_job = self.am.run_app_batch(
             self.test_app_id,
             [self.test_app_params, self.test_app_params],
@@ -192,6 +267,7 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertEqual(new_job.app_id, self.batch_app_id)
         self.assertEqual(new_job.tag, self.test_tag)
         self.assertIsNone(new_job.cell_id)
+        self._verify_comm_success(c.return_value.send_comm_message)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -199,38 +275,54 @@ class AppManagerTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_run_app_batch_gui_cell(self, c, auth):
-        c.return_value.send_comm_message.return_value = None
-        os.environ["KB_WORKSPACE_ID"] = self.public_ws
+    def test_run_app_batch_gui_cell(self, auth, c):
+        cell_id = "12345"
+        c.return_value.send_comm_message = MagicMock()
         self.assertIsNone(
             self.am.run_app_batch(
                 self.test_app_id,
                 [self.test_app_params, self.test_app_params],
                 tag=self.test_tag,
-                cell_id="12345",
+                cell_id=cell_id,
             )
         )
+        self._verify_comm_success(c.return_value.send_comm_message, cell_id=cell_id)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_batch_bad_id(self, c):
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(self.am.run_app_batch(self.bad_app_id, None))
+        c.return_value.send_comm_message = MagicMock()
+        def run_func():
+            return self.am.run_app_batch(self.bad_app_id, None)
+        self.run_app_expect_error(
+            c.return_value.send_comm_message,
+            run_func,
+            "run_app_batch",
+            f'Unknown app id "{self.bad_app_id}" tagged as "release"'
+        )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_batch_bad_tag(self, c):
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(
-            self.am.run_app_batch(self.good_app_id, None, tag=self.bad_tag)
+        c.return_value.send_comm_message = MagicMock()
+        def run_func():
+            return self.am.run_app_batch(self.good_app_id, None, tag=self.bad_tag)
+        self.run_app_expect_error(
+            c.return_value.send_comm_message,
+            run_func,
+            "run_app_batch",
+            f"Can't find tag {self.bad_tag} - allowed tags are release, beta, dev"
         )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_batch_bad_version_match(self, c):
         # fails because a non-release tag can't be versioned
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(
-            self.am.run_app_batch(
-                self.good_app_id, None, tag=self.good_tag, version=">0.0.1"
-            )
+        c.return_value.send_comm_message = MagicMock()
+        def run_func():
+            return self.am.run_app_batch(self.good_app_id, None, tag="dev", version="0.0.1")
+        self.run_app_expect_error(
+            c.return_value.send_comm_message,
+            run_func,
+            "run_app_batch",
+            f"Semantic versions only apply to released app modules."
         )
 
     # Running an app with missing inputs is now allowed. The app can
@@ -241,18 +333,51 @@ class AppManagerTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_run_app_missing_inputs2(self, c, auth):
-        c.return_value.send_comm_message.return_value = None
+    def test_run_app_batch_missing_inputs2(self, auth, c):
+        c.return_value.send_comm_message = MagicMock()
         self.assertIsNotNone(
             self.am.run_app_batch(self.good_app_id, None, tag=self.good_tag)
         )
+        self._verify_comm_success(c.return_value.send_comm_message)
+
+    ############# End tests for run_app_batch #############
+
+    ############# Test run_app_bulk #############
+
+    @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
+    @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
+    @mock.patch(
+        "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
+        side_effect=mock_agent_token,
+    )
+    def test_run_app_bulk_good_inputs(self, auth, c):
+        c.return_value.send_comm_message = MagicMock()
+        new_job = self.am.run_app_bulk(self.bulk_run_good_inputs)
+        self.assertEqual(new_job, -1)
+        # self.assertIsInstance(new_job, Job)
+        # self.assertEqual(new_job.job_id, self.test_job_id)
+        # self.assertEqual(new_job.app_id, self.batch_app_id)
+        # self.assertEqual(new_job.tag, self.test_tag)
+        # self.assertIsNone(new_job.cell_id)
+
+    @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
+    @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
+    @mock.patch(
+        "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
+        side_effect=mock_agent_token,
+    )
+    def test_run_app_bulk_dry_run(self, auth, c):
+        c.return_value.send_comm_message = MagicMock()
+        new_job = self.am.run_app_bulk(self.bulk_run_good_inputs, dry_run=True)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
-    def test_run_app_batch_bad_version(self, c):
-        c.return_value.send_comm_message.return_value = None
-        self.assertIsNone(
-            self.am.run_app_batch(self.good_app_id, None, tag="dev", version="1.0.0")
-        )
+    def test_run_app_bulk_bad_inputs(self, c):
+        c.return_value.send_comm_message = MagicMock()
+
+        self.am.run_app_bulk(None)
+        self._verify_comm_error(c.return_value.send_comm_message)
+
+    ############# End tests for run_app_bulk #############
 
     @mock.patch(
         "biokbase.narrative.jobs.appmanager.specmanager.clients.get", get_mock_client
@@ -298,8 +423,6 @@ class AppManagerTestCase(unittest.TestCase):
         }
         app_id = "NarrativeTest/test_create_set"
         tag = "dev"
-        prev_ws_id = os.environ.get("KB_WORKSPACE_ID")
-        os.environ["KB_WORKSPACE_ID"] = self.public_ws
         sm = specmanager.SpecManager()
         spec = sm.get_spec(app_id, tag=tag)
         (params, ws_inputs) = app_util.validate_parameters(
@@ -308,10 +431,6 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertDictEqual(params, inputs)
         self.assertIn("12345/8/1", ws_inputs)
         self.assertIn("12345/7/1", ws_inputs)
-        if prev_ws_id is None:
-            del os.environ["KB_WORKSPACE_ID"]
-        else:
-            os.environ["KB_WORKSPACE_ID"] = prev_ws_id
 
     @mock.patch(
         "biokbase.narrative.jobs.appmanager.specmanager.clients.get", get_mock_client
@@ -339,8 +458,6 @@ class AppManagerTestCase(unittest.TestCase):
         app_id = "NarrativeTest/test_create_set"
         tag = "dev"
         ws_name = self.public_ws
-        prev_ws_id = os.environ.get("KB_WORKSPACE_ID", None)
-        os.environ["KB_WORKSPACE_ID"] = ws_name
         sm = specmanager.SpecManager()
         spec = sm.get_spec(app_id, tag=tag)
         spec_params = sm.app_params(spec)
@@ -377,10 +494,6 @@ class AppManagerTestCase(unittest.TestCase):
         )
         ret = app_util.transform_param_value("resolved-ref", ref_path, None)
         self.assertEqual(ret, ws_name + "/MyReadsSet;18836/5/1")
-        if prev_ws_id is None:
-            del os.environ["KB_WORKSPACE_ID"]
-        else:
-            os.environ["KB_WORKSPACE_ID"] = prev_ws_id
 
     @mock.patch(
         "biokbase.narrative.jobs.appmanager.specmanager.clients.get", get_mock_client
@@ -403,7 +516,6 @@ class AppManagerTestCase(unittest.TestCase):
 
     def test_transform_input_good(self):
         ws_name = self.public_ws
-        os.environ["KB_WORKSPACE_ID"] = ws_name
         test_data = [
             {
                 "value": "input_value",
@@ -474,11 +586,94 @@ class AppManagerTestCase(unittest.TestCase):
             spec = test.get("spec", None)
             ret = app_util.transform_param_value(test["type"], test["value"], spec)
             self.assertEqual(ret, test["expected"])
-        del os.environ["KB_WORKSPACE_ID"]
 
     def test_transform_input_bad(self):
         with self.assertRaises(ValueError):
             app_util.transform_param_value("foo", "bar", None)
+
+    def _verify_comm_mock(
+        self,
+        send_comm_mock: MagicMock,
+        num_calls: int,
+        expected_messages: List[str]=None,
+        expected_keys: List[List[str]]=None,
+        expected_values: List[List[dict]]=None) -> None:
+        """
+        Validates the usage of the MagicMock used instead of sending a comm message to the
+        front end. This is expected to mock any calls to JobComm.mock_comm_channel. Each of
+        the "expected_*" kwargs are given as a list - each element represents which time the
+        call was made, in order.
+
+        This is done through a series of asserts. If they all pass and None is returned, then
+        the mock was used as expected.
+
+        num_calls - the number of times the call was expected (>= 0)
+        expected_messages - the send message types
+        expected_keys - the list of keys used in each message (may not all be given inspected
+          values, but all should be present)
+        expected_values - the set of values used in each message (there may be more keys, but
+          these are known key-value pairs)
+        """
+        self.assertEqual(send_comm_mock.call_count, num_calls)
+        for i in range(num_calls):
+            [message_name, message_dict] = send_comm_mock.call_args_list[i][0]
+            if expected_messages is not None:
+                self.assertEqual(message_name, expected_messages[i])
+            if expected_keys is not None:
+                for key in expected_keys[i]:
+                    self.assertIn(key, message_dict)
+            if expected_values is not None:
+                for key in expected_values[i]:
+                    self.assertEqual(message_dict.get(key), expected_values[i][key])
+
+    def _verify_comm_error(self, comm_mock, cell_id=None, run_id=None) -> None:
+        """
+        a wrapper around self._verify_comm_mock that just looks for the error message, and
+        ONLY the error message, to have been sent, so we can make these tests a little more
+        DRY.
+
+        This is really for app running cases that are expected to fail before trying to start
+        the app with EE2. Other cases should run _verify_comm_mock directly.
+        """
+        expected_keys = [["event", "event_at", "error_message", "error_code", "error_source", "error_stacktrace", "error_type"]]
+        expected_values=[{
+            "run_id": run_id,
+            "cell_id": cell_id,
+            "event": "error",
+            "error_code": -1,
+            "error_source": "appmanager"
+        }]
+        self._verify_comm_mock(
+            comm_mock,
+            1,
+            expected_messages=["run_status"],
+            expected_keys=expected_keys,
+            expected_values=expected_values
+        )
+
+    def _verify_comm_success(self, comm_mock, cell_id=None, run_id=None) -> None:
+        expected_messages = ["run_status", "new_job"]
+        expected_keys = [
+            ["event", "event_at", "cell_id", "run_id", "job_id"],
+            ["job_id"]
+        ]
+        expected_values = [
+            {
+                "event": "launched_job",
+                "cell_id": cell_id,
+                "run_id": run_id,
+                "job_id": "new_job_id",
+            },
+            { "job_id": "new_job_id" }
+        ]
+        self._verify_comm_mock(
+            comm_mock,
+            2,
+            expected_messages=expected_messages,
+            expected_keys=expected_keys,
+            expected_values=expected_values
+        )
+
 
 
 if __name__ == "__main__":

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -20,6 +20,7 @@ import io
 def mock_agent_token(*args, **kwargs):
     return dict({"user": "testuser", "id": "12345", "token": "abcde"})
 
+
 class AppManagerTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -44,37 +45,44 @@ class AppManagerTestCase(unittest.TestCase):
         cls.ws_id = int(config.get("app_tests", "public_ws_id"))
         cls.app_input_ref = config.get("app_tests", "test_input_ref")
         cls.batch_app_id = config.get("app_tests", "batch_app_id")
-        cls.bulk_run_good_inputs = [{
-            "app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
-            "tag": "release",
-            "version": "1.0.46",
-            "params": [{
-                "fastq_fwd_staging_file_name": "",
-                "fastq_rev_staging_file_name": "",
-                "sra_staging_file_name": "",
-                "name": "asdf",
-                "import_type": "FASTQ/FASTA",
-                "insert_size_mean": 0,
-                "insert_size_std_dev": 0,
-                "interleaved": 1,
-                "read_orientation_outward": "0",
-                "sequencing_tech": "Illumina",
-                "single_genome": 1
-            }]
-        }, {
-            "app_id": "kb_uploadmethods/import_sra_as_reads_from_staging",
-            "tag": "release",
-            "version": "1.0.46",
-            "params": [{
-                "sra_staging_file_name": "",
-                "name": "asdf",
-                "insert_size_mean": 1,
-                "insert_size_std_dev": 1,
-                "read_orientation_outward": "0",
-                "sequencing_tech": "Illumina",
-                "single_genome": "1"
-            }]
-        }]
+        cls.bulk_run_good_inputs = [
+            {
+                "app_id": "kb_uploadmethods/import_fastq_sra_as_reads_from_staging",
+                "tag": "release",
+                "version": "1.0.46",
+                "params": [
+                    {
+                        "fastq_fwd_staging_file_name": "",
+                        "fastq_rev_staging_file_name": "",
+                        "sra_staging_file_name": "",
+                        "name": "asdf",
+                        "import_type": "FASTQ/FASTA",
+                        "insert_size_mean": 0,
+                        "insert_size_std_dev": 0,
+                        "interleaved": 1,
+                        "read_orientation_outward": "0",
+                        "sequencing_tech": "Illumina",
+                        "single_genome": 1,
+                    }
+                ],
+            },
+            {
+                "app_id": "kb_uploadmethods/import_sra_as_reads_from_staging",
+                "tag": "release",
+                "version": "1.0.46",
+                "params": [
+                    {
+                        "sra_staging_file_name": "",
+                        "name": "asdf",
+                        "insert_size_mean": 1,
+                        "insert_size_std_dev": 1,
+                        "read_orientation_outward": "0",
+                        "sequencing_tech": "Illumina",
+                        "single_genome": "1",
+                    }
+                ],
+            },
+        ]
 
     def setUp(self):
         os.environ["KB_WORKSPACE_ID"] = self.public_ws
@@ -95,7 +103,9 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertIsNone(run_func())
         sys.stdout = sys.__stdout__
         output_str = output.getvalue()
-        self.assertIn(f"Error while trying to start your app ({func_name})!", output_str)
+        self.assertIn(
+            f"Error while trying to start your app ({func_name})!", output_str
+        )
         self.assertIn(print_error, output_str)
         self._verify_comm_error(comm_mock)
 
@@ -197,31 +207,36 @@ class AppManagerTestCase(unittest.TestCase):
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_bad_id(self, c):
         c.return_value.send_comm_message = MagicMock()
+
         def run_func():
             return self.am.run_app(self.bad_app_id, None)
+
         self.run_app_expect_error(
             c.return_value.send_comm_message,
             run_func,
             "run_app",
-            f'Unknown app id "{self.bad_app_id}" tagged as "release"'
+            f'Unknown app id "{self.bad_app_id}" tagged as "release"',
         )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_bad_tag(self, c):
         c.return_value.send_comm_message = MagicMock()
+
         def run_func():
             return self.am.run_app(self.good_app_id, None, tag=self.bad_tag)
+
         self.run_app_expect_error(
             c.return_value.send_comm_message,
             run_func,
             "run_app",
-            f"Can't find tag {self.bad_tag} - allowed tags are release, beta, dev"
+            f"Can't find tag {self.bad_tag} - allowed tags are release, beta, dev",
         )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_bad_version_match(self, c):
         # fails because a non-release tag can't be versioned
         c.return_value.send_comm_message = MagicMock()
+
         def run_func():
             return self.am.run_app(self.good_app_id, None, tag="dev", version="0.0.1")
 
@@ -229,7 +244,7 @@ class AppManagerTestCase(unittest.TestCase):
             c.return_value.send_comm_message,
             run_func,
             "run_app",
-            f"Semantic versions only apply to released app modules."
+            "Semantic versions only apply to released app modules.",
         )
 
     # Running an app with missing inputs is now allowed. The app can
@@ -291,38 +306,46 @@ class AppManagerTestCase(unittest.TestCase):
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_batch_bad_id(self, c):
         c.return_value.send_comm_message = MagicMock()
+
         def run_func():
             return self.am.run_app_batch(self.bad_app_id, None)
+
         self.run_app_expect_error(
             c.return_value.send_comm_message,
             run_func,
             "run_app_batch",
-            f'Unknown app id "{self.bad_app_id}" tagged as "release"'
+            f'Unknown app id "{self.bad_app_id}" tagged as "release"',
         )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_batch_bad_tag(self, c):
         c.return_value.send_comm_message = MagicMock()
+
         def run_func():
             return self.am.run_app_batch(self.good_app_id, None, tag=self.bad_tag)
+
         self.run_app_expect_error(
             c.return_value.send_comm_message,
             run_func,
             "run_app_batch",
-            f"Can't find tag {self.bad_tag} - allowed tags are release, beta, dev"
+            f"Can't find tag {self.bad_tag} - allowed tags are release, beta, dev",
         )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_batch_bad_version_match(self, c):
         # fails because a non-release tag can't be versioned
         c.return_value.send_comm_message = MagicMock()
+
         def run_func():
-            return self.am.run_app_batch(self.good_app_id, None, tag="dev", version="0.0.1")
+            return self.am.run_app_batch(
+                self.good_app_id, None, tag="dev", version="0.0.1"
+            )
+
         self.run_app_expect_error(
             c.return_value.send_comm_message,
             run_func,
             "run_app_batch",
-            f"Semantic versions only apply to released app modules."
+            "Semantic versions only apply to released app modules.",
         )
 
     # Running an app with missing inputs is now allowed. The app can
@@ -369,6 +392,7 @@ class AppManagerTestCase(unittest.TestCase):
     def test_run_app_bulk_dry_run(self, auth, c):
         c.return_value.send_comm_message = MagicMock()
         new_job = self.am.run_app_bulk(self.bulk_run_good_inputs, dry_run=True)
+        self.assertIsNotNone(new_job)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     def test_run_app_bulk_bad_inputs(self, c):
@@ -595,9 +619,10 @@ class AppManagerTestCase(unittest.TestCase):
         self,
         send_comm_mock: MagicMock,
         num_calls: int,
-        expected_messages: List[str]=None,
-        expected_keys: List[List[str]]=None,
-        expected_values: List[List[dict]]=None) -> None:
+        expected_messages: List[str] = None,
+        expected_keys: List[List[str]] = None,
+        expected_values: List[List[dict]] = None,
+    ) -> None:
         """
         Validates the usage of the MagicMock used instead of sending a comm message to the
         front end. This is expected to mock any calls to JobComm.mock_comm_channel. Each of
@@ -635,27 +660,39 @@ class AppManagerTestCase(unittest.TestCase):
         This is really for app running cases that are expected to fail before trying to start
         the app with EE2. Other cases should run _verify_comm_mock directly.
         """
-        expected_keys = [["event", "event_at", "error_message", "error_code", "error_source", "error_stacktrace", "error_type"]]
-        expected_values=[{
-            "run_id": run_id,
-            "cell_id": cell_id,
-            "event": "error",
-            "error_code": -1,
-            "error_source": "appmanager"
-        }]
+        expected_keys = [
+            [
+                "event",
+                "event_at",
+                "error_message",
+                "error_code",
+                "error_source",
+                "error_stacktrace",
+                "error_type",
+            ]
+        ]
+        expected_values = [
+            {
+                "run_id": run_id,
+                "cell_id": cell_id,
+                "event": "error",
+                "error_code": -1,
+                "error_source": "appmanager",
+            }
+        ]
         self._verify_comm_mock(
             comm_mock,
             1,
             expected_messages=["run_status"],
             expected_keys=expected_keys,
-            expected_values=expected_values
+            expected_values=expected_values,
         )
 
     def _verify_comm_success(self, comm_mock, cell_id=None, run_id=None) -> None:
         expected_messages = ["run_status", "new_job"]
         expected_keys = [
             ["event", "event_at", "cell_id", "run_id", "job_id"],
-            ["job_id"]
+            ["job_id"],
         ]
         expected_values = [
             {
@@ -664,16 +701,15 @@ class AppManagerTestCase(unittest.TestCase):
                 "run_id": run_id,
                 "job_id": "new_job_id",
             },
-            { "job_id": "new_job_id" }
+            {"job_id": "new_job_id"},
         ]
         self._verify_comm_mock(
             comm_mock,
             2,
             expected_messages=expected_messages,
             expected_keys=expected_keys,
-            expected_values=expected_values
+            expected_values=expected_values,
         )
-
 
 
 if __name__ == "__main__":

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -356,7 +356,7 @@ class AppManagerTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
         side_effect=mock_agent_token,
     )
-    def test_run_app_batch_missing_inputs2(self, auth, c):
+    def test_run_app_batch_missing_inputs(self, auth, c):
         c.return_value.send_comm_message = MagicMock()
         self.assertIsNotNone(
             self.am.run_app_batch(self.good_app_id, None, tag=self.good_tag)


### PR DESCRIPTION
# Description of PR purpose/changes

This is PR 1 of ~3 for adding the `run_app_bulk` method to `biokbase.narrative.jobs.appmanager`.

There were some... issues with that old module. 
1. There's a fair amount of duplicated code. This takes the first step of taking the wrappers around each app running style and turning that into a decorator. Now, instead of `run_app` calling `_run_app_internal`, where `run_app` would just catch and reformat errors for Narrative consumption, this uses a single decorator that applies to each function. It still follows the idiom of sending errors as comm messages to the front end as well as printing a prettier form of error message (which would go under the cell). I applied this only to `run_app` and `run_app_batch` as there are no tests for `run_local_app` right now, and I don't want to make any changes without any regression tests in place. Next PR.
2. Many of the tests for that module just did a basic exercise of the code, and checked to see if they didn't return anything. They also used mocks in the wrong order, and incompletely. This addresses that for the existing tests for `run_app` and `run_app_batch` (none for `run_local_app` yet) by capturing both `stdout` and the mocked calls to the comm channel and verifying them. Found a couple bugs that way, too. Funny what you find when you make tests work.
3. I put in a stub for the `run_app_bulk` function and a couple stubby tests. I'm ok with removing those for now if they're a distraction from this PR and adding them to the next if that makes more sense.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-312
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Run tests with `make test-backend`.
* Should be no other changes.
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
