### PR TITLE
DATAUP-428 allow jobs to be listed more than once

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -8,6 +8,7 @@ from jinja2 import Template
 from datetime import datetime, timezone, timedelta
 from biokbase.narrative.app_util import system_variable
 from biokbase.narrative.exception_util import transform_job_exception
+import copy
 
 """
 KBase Job Manager
@@ -132,7 +133,7 @@ class JobManager(object):
         """
         try:
             all_statuses = self.lookup_all_job_states(ignore_refresh_flag=True)
-            state_list = [s["state"] for s in all_statuses.values()]
+            state_list = [copy.deepcopy(s["state"]) for s in all_statuses.values()]
 
             if not len(state_list):
                 return "No running jobs!"

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -91,11 +91,18 @@ class JobManagerTest(unittest.TestCase):
         self.assertIn("<td>Not started</td>", html)
         self.assertIn("<td>Incomplete</td>", html)
 
-    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_list_jobs_twice(self):
-        jobs_html_0 = self.jm.list_jobs()
-        jobs_html_1 = self.jm.list_jobs()
-        self.assertTrue(jobs_html_0.data == jobs_html_1.data)
+        # with no jobs
+        with mock.patch.object(self.jm, '_running_jobs', {}):
+            expected = 'No running jobs!'
+            self.assertEqual(self.jm.list_jobs(), expected)
+            self.assertEqual(self.jm.list_jobs(), expected)
+
+        # with some jobs
+        with mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client):
+            jobs_html_0 = self.jm.list_jobs()
+            jobs_html_1 = self.jm.list_jobs()
+            self.assertEqual(jobs_html_0.data, jobs_html_1.data)
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_cancel_job_good(self):

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -92,6 +92,12 @@ class JobManagerTest(unittest.TestCase):
         self.assertIn("<td>Incomplete</td>", html)
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_list_jobs_twice(self):
+        jobs_html_0 = self.jm.list_jobs()
+        jobs_html_1 = self.jm.list_jobs()
+        self.assertTrue(jobs_html_0.data == jobs_html_1.data)
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_cancel_job_good(self):
         new_job = phony_job()
         job_id = new_job.job_id


### PR DESCRIPTION
# Description of PR purpose/changes

Make copies of looked-up job states in jm.list_jobs() so that when they are modified, they don't affect the next lookup. 

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [n/a] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [?] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
