### PR TITLE
DATAUP-312 add run_local_app tests

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -40,6 +40,7 @@ def _app_error_wrapper(app_func: Callable) -> any:
     error, instead of showing an arcane traceback.
     Otherwise it runs whatever function it decorates with its expected args and kwargs
     """
+
     @functools.wraps(app_func)
     def wrapper(self, *args, **kwargs):
         try:
@@ -72,6 +73,7 @@ def _app_error_wrapper(app_func: Callable) -> any:
                 + "-----------------------------------------------------\n"
                 + e_trace
             )
+
     return wrapper
 
 
@@ -500,6 +502,7 @@ class AppManager(object):
 
         # funcdef run_job_batch(list<RunJobParams> params, BatchParams batch_params) returns (BatchSubmission job_ids) authentication required;
 
+    @_app_error_wrapper
     def run_local_app(
         self,
         app_id,
@@ -539,49 +542,6 @@ class AppManager(object):
                       version='0.0.1',
                       input_expression_matrix="MyMatrix")
         """
-        try:
-            if params is None:
-                params = dict()
-            return self._run_local_app_internal(
-                app_id, params, widget_state, tag, version, cell_id, run_id
-            )
-        except Exception as e:
-            e_type = type(e).__name__
-            e_message = str(e).replace("<", "&lt;").replace(">", "&gt;")
-            e_trace = traceback.format_exc()
-            e_trace = e_trace.replace("<", "&lt;").replace(">", "&gt;")
-            self._send_comm_message(
-                "run_status",
-                {
-                    "event": "error",
-                    "event_at": datetime.datetime.utcnow().isoformat() + "Z",
-                    "cell_id": cell_id,
-                    "run_id": run_id,
-                    "error_message": e_message,
-                    "error_type": e_type,
-                    "error_stacktrace": e_trace,
-                },
-            )
-            # raise
-            print(
-                "Error while trying to start your app (run_local_app)!\n"
-                + "-------------------------------------\n"
-                + str(e)
-            )
-
-    def _run_local_app_internal(
-        self, app_id, params, widget_state, tag, version, cell_id, run_id
-    ):
-        self._send_comm_message(
-            "run_status",
-            {
-                "event": "validating_app",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
-                "cell_id": cell_id,
-                "run_id": run_id,
-            },
-        )
-
         spec = self._get_validated_app_spec(app_id, tag, False, version=version)
 
         # Here, we just deal with two behaviors:

--- a/src/biokbase/narrative/tests/test.cfg
+++ b/src/biokbase/narrative/tests/test.cfg
@@ -51,6 +51,7 @@ test_app_tag=dev
 test_job_id=new_job_id
 test_input_ref=11635/19/4
 batch_app_id=kb_BatchApp/run_batch
+test_viewer_app_id=NarrativeViewers/view_genome
 
 [logging]
 config=logproxy.conf

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -404,6 +404,18 @@ class AppManagerTestCase(unittest.TestCase):
                 "kwargs": {"tag": "dev"}
             },
             "expected_error": "Missing required parameters"
+        }, {
+            "inputs": {
+                "args": [self.good_app_id, {}],
+                "kwargs": {"tag": self.bad_tag}
+            },
+            "expected_error": f"Can't find tag {self.bad_tag} - allowed tags are release, beta, dev"
+        }, {
+            "inputs": {
+                "args": [self.good_app_id, {}],
+                "kwargs": {"tag": "dev", "version": "1.0.0"}
+            },
+            "expected_error": "Semantic versions only apply to released app modules.",
         }]
         for test_case in cases:
             inputs = test_case["inputs"]

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -5,7 +5,7 @@ from biokbase.narrative.jobs.appmanager import AppManager
 import biokbase.narrative.jobs.specmanager as specmanager
 import biokbase.narrative.app_util as app_util
 from biokbase.narrative.jobs.job import Job
-from IPython.display import HTML
+from IPython.display import HTML, Javascript
 import unittest
 import mock
 from mock import MagicMock
@@ -31,6 +31,7 @@ class AppManagerTestCase(unittest.TestCase):
         cls.bad_app_id = config.get("app_tests", "bad_app_id")
         cls.bad_tag = config.get("app_tests", "bad_app_tag")
         cls.test_app_id = config.get("app_tests", "test_app_id")
+        cls.test_viewer_app_id = config.get("app_tests", "test_viewer_app_id")
         cls.test_app_params = {
             "read_library_names": ["rhodo.art.jgi.reads"],
             "output_contigset_name": "rhodo_contigs",
@@ -364,6 +365,59 @@ class AppManagerTestCase(unittest.TestCase):
         self._verify_comm_success(c.return_value.send_comm_message)
 
     ############# End tests for run_app_batch #############
+
+    ############# Test run_local_app #############
+    @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
+    @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
+    @mock.patch(
+        "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
+        side_effect=mock_agent_token,
+    )
+    def test_run_local_app_ok(self, auth, c):
+        c.return_value.send_comm_message = MagicMock()
+        result = self.am.run_local_app(
+            self.test_viewer_app_id,
+            {"param0": "fakegenome"},
+            tag="release",
+        )
+        self.assertIsInstance(result, Javascript)
+        self.assertIn("KBaseNarrativeOutputCell", result.data)
+
+    @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
+    @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
+    @mock.patch(
+        "biokbase.narrative.jobs.appmanager.auth.get_agent_token",
+        side_effect=mock_agent_token,
+    )
+    def test_run_local_app_fail_cases(self, auth, c):
+        comm_mock = MagicMock()
+        c.return_value.send_comm_message = comm_mock
+        cases = [{
+            "inputs": {
+                "args": [self.bad_app_id, {}],
+                "kwargs": {}
+            },
+            "expected_error": f'Unknown app id "{self.bad_app_id}" tagged as "release"',
+        }, {
+            "inputs": {
+                "args": [self.test_viewer_app_id, {}],
+                "kwargs": {"tag": "dev"}
+            },
+            "expected_error": "Missing required parameters"
+        }]
+        for test_case in cases:
+            inputs = test_case["inputs"]
+            def run_func():
+                return self.am.run_local_app(*inputs["args"], **inputs["kwargs"])
+            comm_mock.reset_mock()
+            self.run_app_expect_error(
+                comm_mock,
+                run_func,
+                "run_local_app",
+                test_case["expected_error"],
+            )
+
+    ############# End tests for run_local_app #############
 
     ############# Test run_app_bulk #############
 


### PR DESCRIPTION
# Description of PR purpose/changes

This little gap was a bit unacceptable. Should cover the appropriate test and error cases.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-312
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
