### PR TITLE
DATAUP-315: batch cancel call

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -1,12 +1,12 @@
 # Job Management Architecture
 The Narrative job manager is based on a data flow that operates between the browser, the IPython Kernel behind the Narrative, and the KBase Execution Engine (EE2) behind that. In general, each bit of data flows between those three stops.
 
-In general, there's a single point of information flow on the front end and one on the backend. 
+In general, there's a single point of information flow on the front end and one on the backend.
 
 # Comm channels
 Jupyter provides a "Comm" object that allows for custom messaging between the frontend and the kernel ([details and documentation here](https://jupyter-notebook.readthedocs.io/en/stable/comms.html)). This provides an interface for the frontend to directly request information from the kernel, and to listen to asynchronous responses. On the kernel-side, it allows one or more modules to register message handlers to process those requests out of the band of the usual kernel invocation. These are used to implement the Jupyter Notebook's ipywidgets, for example.
 
-The Narrative Interface uses one of these channels to manage job information. These are funneled through an interface on the frontend side and a matching one in the kernel. 
+The Narrative Interface uses one of these channels to manage job information. These are funneled through an interface on the frontend side and a matching one in the kernel.
 
 ## Frontend Comm Channel
 On the frontend, there's a `jobCommChannel.js` module that uses the MiniBus system to communicate. So, the following happens. Frontend modules use the bus system to send one of the following messages over the main channel, which then get interpreted and crafted into a message that gets passed through a kernel comm object. Most of these take one or more inputs. These are listed below the command, where applicable.
@@ -43,7 +43,7 @@ These messages are sent to the `JobCommChannel` on the front end, to get process
     * `first_line` - the first line (0-indexed) to request
     * `num_lines` - the number of lines to request (will get back up to that many if there aren't more)
 
-`request-latest-job-log` - request the latest several job log lines
+`request-job-log-latest` - request the latest several job log lines
   * `jobId` - a string, the job id
   * `options` - an object, with attributes:
     * `num_lines` - the number of lines to request (will get back up to that many if there aren't more)
@@ -108,7 +108,7 @@ When the kernel sends a message to the front end, the only module set up to list
 `job-logs` - sent with information about some job logs.
   * `jobId` - string, the job id
   * `logs` - the raw message data from the kernel. (see the **Data Structures** section below)
-  * `latest` - if truthy, then these are the latest logs, if falsy, then they don't have to be the latest logs. 
+  * `latest` - if truthy, then these are the latest logs, if falsy, then they don't have to be the latest logs.
 
 `job-error` - sent in response to an error that happened on job information lookup, or another error that happened while processing some other message to the JobManager.
   * `jobId` - string, the job id
@@ -207,15 +207,15 @@ These are organized by the `request_type` field, followed by the expected respon
 }
 ```
 
-`all_status` - request the status of all currently running jobs, responds with `job_status_all`  
+`all_status` - request the status of all currently running jobs, responds with `job_status_all`
 
 `job_status` - request a single job status, responds with `job_status`
 * `job_id` - string,
 * `parent_job_id` - optional string
 
-`start_update_loop` - request starting the global job status update thread, no specific response, but generally with `job_status_all`  
+`start_update_loop` - request starting the global job status update thread, no specific response, but generally with `job_status_all`
 
-`stop_update_loop` - request stopping the global job status update thread, no response  
+`stop_update_loop` - request stopping the global job status update thread, no response
 
 `start_job_update` - request updating a single job during the update thread, no specific response, but generally with `job_status`
 * `job_id` - string
@@ -376,7 +376,7 @@ All cases:
 **bus** `run-status`
 
 ### `result`
-Sent at the end of a `AppManager.run_dynamic_service` call (of which there aren't many). 
+Sent at the end of a `AppManager.run_dynamic_service` call (of which there aren't many).
 
 **content**
   * `cell_id` - the app cell id (used for routing)

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -220,12 +220,8 @@ define(['common/html', 'common/jobs', 'common/ui', 'util/string'], (html, Jobs, 
                     if (!confirmed) {
                         return false;
                     }
-                    // TODO: when ee2 adds endpoints to allow submission of multiple jobs to cancel,
-                    // this can be rewritten
-                    jobsList.forEach((jobId) => {
-                        this.bus.emit(jobCommand[action], {
-                            jobId: jobId,
-                        });
+                    this.bus.emit(jobCommand[action], {
+                        jobIdList: jobsList,
                     });
                     return true;
                 }

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -527,7 +527,7 @@ define([
             scrollToEndOnNext = true;
             awaitingLog = true;
             ui.showElement('spinner');
-            bus.emit('request-latest-job-log', {
+            bus.emit('request-job-log-latest', {
                 jobId: jobId,
                 options: {},
             });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
@@ -168,7 +168,8 @@ define([
 
                 for (const [key, value] of Object.entries(message)) {
                     if (key !== 'options') {
-                        translations[key] ? (msg[translations[key]] = value) : (msg[key] = value);
+                        const msgKey = translations[key] || key;
+                        msg[msgKey] = value;
                     }
                 }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
@@ -58,6 +58,7 @@ define([
         STOP_JOB_UPDATE = 'stop_job_update',
         START_JOB_UPDATE = 'start_job_update',
         CANCEL_JOB = 'cancel_job',
+        RETRY_JOB = 'retry_job',
         JOB_LOGS = 'job_logs',
         JOB_LOGS_LATEST = 'job_logs_latest',
         JOB_INFO = 'job_info',
@@ -102,74 +103,50 @@ define([
         handleBusMessages() {
             const bus = this.runtime.bus();
 
-            bus.on('ping-comm-channel', (message) => {
-                this.sendCommMessage('ping', null, {
-                    ping_id: message.pingId,
+            // valid messages
+            const requestTranslation = {
+                'ping-comm-channel': 'ping',
+
+                // Fetches job status from kernel.
+                'request-job-status': JOB_STATUS,
+
+                // Requests job status updates for this job via the job channel, and also
+                // ensures that job polling is running.
+                'request-job-update': START_JOB_UPDATE,
+                // Tells kernel to stop including a job in the lookup loop.
+                'request-job-completion': STOP_JOB_UPDATE,
+
+                // cancels the job
+                'request-job-cancellation': CANCEL_JOB,
+                // retries the job
+                'request-job-retry': RETRY_JOB,
+
+                // Fetches info (not state) about a job, including the app id, name, and inputs.
+                'request-job-info': JOB_INFO,
+
+                // Fetches job logs from kernel.
+                'request-job-log': JOB_LOGS,
+                // Fetches most recent job logs from kernel.
+                'request-job-log-latest': JOB_LOGS_LATEST,
+            };
+
+            for (const [key, value] of Object.entries(requestTranslation)) {
+                bus.on(key, (message) => {
+                    this.sendCommMessage(value, message);
                 });
-            });
-
-            // Cancels the job.
-            bus.on('request-job-cancellation', (message) => {
-                this.sendCommMessage(CANCEL_JOB, message.jobId);
-            });
-
-            // Fetches job status from kernel.
-            bus.on('request-job-status', (message) => {
-                // console.log('requesting job status for ' + message.jobId);
-                this.sendCommMessage(JOB_STATUS, message.jobId, {
-                    parent_job_id: message.parentJobId,
-                });
-            });
-
-            // Requests job status updates for this job via the job channel, and also
-            // ensures that job polling is running.
-            bus.on('request-job-update', (message) => {
-                // console.log('requesting job updates for ' + message.jobId);
-                this.sendCommMessage(START_JOB_UPDATE, message.jobId, {
-                    parent_job_id: message.parentJobId,
-                });
-            });
-
-            // Tells kernel to stop including a job in the lookup loop.
-            bus.on('request-job-completion', (message) => {
-                // console.log('cancelling job updates for ' + message.jobId);
-                this.sendCommMessage(STOP_JOB_UPDATE, message.jobId, {
-                    parent_job_id: message.parentJobId,
-                });
-            });
-
-            // Fetches job logs from kernel.
-            bus.on('request-job-log', (message) => {
-                this.sendCommMessage(JOB_LOGS, message.jobId, message.options);
-            });
-
-            // Fetches most recent job logs from kernel.
-            bus.on('request-latest-job-log', (message) => {
-                this.sendCommMessage(JOB_LOGS_LATEST, message.jobId, message.options);
-            });
-
-            // Fetches info (not state) about a job. Like the app id, name, and inputs.
-            bus.on('request-job-info', (message) => {
-                this.sendCommMessage(JOB_INFO, message.jobId, {
-                    parent_job_id: message.parentJobId,
-                });
-            });
+            }
         }
 
         /**
          * Sends a comm message to the JobManager in the kernel.
          * If there's no comm channel ready, tries to set one up first.
-         * @param msgType {string} - one of (prepend with this.)
-         *   ALL_STATUS,
-         *   STOP_UPDATE_LOOP,
-         *   START_UPDATE_LOOP,
-         *   STOP_JOB_UPDATE,
-         *   START_JOB_UPDATE,
-         *   JOB_LOGS
-         * @param jobId {string} - optional - a job id to send along with the
-         * message, where appropriate.
+         * @param msgType {string} - one of the values in the requestTranslation object
+         *                           (see function handleBusMessages)
+         *
+         * @param message {object} - an object containing additional parameters for the request
+         *                           such as jobId or jobIdList, or an 'options' object
          */
-        sendCommMessage(msgType, jobId, options) {
+        sendCommMessage(msgType, message) {
             return new Promise((resolve, reject) => {
                 // TODO: send specific error so that client can retry.
                 if (!this.comm) {
@@ -181,23 +158,34 @@ define([
                     target_name: COMM_NAME,
                     request_type: msgType,
                 };
-                if (jobId) {
-                    msg.job_id = jobId;
+
+                const translations = {
+                    jobId: 'job_id',
+                    jobIdList: 'job_id_list',
+                    parentJobId: 'parent_job_id',
+                    pingId: 'ping_id',
+                };
+
+                for (const [key, value] of Object.entries(message)) {
+                    if (key !== 'options') {
+                        translations[key] ? (msg[translations[key]] = value) : (msg[key] = value);
+                    }
                 }
-                if (options) {
-                    msg = $.extend({}, msg, options);
+
+                if (message.options) {
+                    msg = Object.assign({}, msg, message.options);
                 }
+
                 this.comm.send(msg);
                 resolve();
             }).catch((err) => {
-                console.error('ERROR sending comm message', err, msgType, jobId, options);
+                console.error('ERROR sending comm message', err, msgType, message);
                 throw new Error(
                     'ERROR sending comm message: ' +
                         JSON.stringify({
                             error: err,
                             msgType: msgType,
-                            jobId: jobId,
-                            options: options,
+                            message: message,
                         })
                 );
             });
@@ -227,8 +215,8 @@ define([
             let jobId = null;
             switch (msgType) {
                 case 'start':
-                    // console.log('START', msgData.time);
                     break;
+
                 case 'new_job':
                     Jupyter.notebook.save_checkpoint();
                     break;
@@ -309,6 +297,7 @@ define([
                         }
                     });
                     break;
+
                 case 'job_info':
                     jobId = msgData.job_id;
                     this.sendBusMessage(JOB, jobId, 'job-info', {
@@ -316,6 +305,7 @@ define([
                         jobInfo: msgData,
                     });
                     break;
+
                 case 'run_status':
                     // Send job status notifications on the default channel,
                     // with a key on the message type and the job id, sending
@@ -327,6 +317,7 @@ define([
                     // filtering.
                     this.sendBusMessage(CELL, msgData.cell_id, 'run-status', msgData);
                     break;
+
                 case 'job_canceled':
                     this.sendBusMessage(JOB, msgData.job_id, 'job-canceled', {
                         jobId: msgData.job_id,
@@ -348,6 +339,10 @@ define([
                         logs: msgData,
                         latest: msgData.latest,
                     });
+                    break;
+
+                case 'result':
+                    this.sendBusMessage(CELL, msgData.address.cell_id, 'result', msgData);
                     break;
 
                 case 'job_comm_error':
@@ -387,70 +382,69 @@ define([
 
                 case 'job_init_err':
                 case 'job_init_lookup_err':
-                    /*
-                 code, error, job_id (opt), message, name, source
-                 */
-                    // eslint-disable-next-line no-case-declarations
-                    const $modalBody = $(Handlebars.compile(JobInitErrorTemplate)(msgData));
-                    // eslint-disable-next-line no-case-declarations
-                    const modal = new BootstrapDialog({
-                        title: 'Job Initialization Error',
-                        body: $modalBody,
-                        buttons: [
-                            $('<a type="button" class="btn btn-default kb-job-err-dialog__button">')
-                                .append('OK')
-                                .click(() => {
-                                    modal.hide();
-                                }),
-                        ],
-                    });
-                    new kbaseAccordion($modalBody.find('div#kb-job-err-trace'), {
-                        elements: [
-                            {
-                                title: 'Detailed Error Information',
-                                body: $(
-                                    '<table class="table table-bordered"><tr><th>code:</th><td>' +
-                                        msgData.code +
-                                        '</td></tr>' +
-                                        '<tr><th>error:</th><td>' +
-                                        msgData.message +
-                                        '</td></tr>' +
-                                        (function () {
-                                            if (msgData.service) {
-                                                return (
-                                                    '<tr><th>service:</th><td>' +
-                                                    msgData.service +
-                                                    '</td></tr>'
-                                                );
-                                            }
-                                            return '';
-                                        })() +
-                                        '<tr><th>type:</th><td>' +
-                                        msgData.name +
-                                        '</td></tr>' +
-                                        '<tr><th>source:</th><td>' +
-                                        msgData.source +
-                                        '</td></tr></table>'
-                                ),
-                            },
-                        ],
-                    });
+                    this.displayJobError(msgData);
+                    console.error('Error from job comm:', msg);
+                    break;
 
-                    $modalBody.find('button#kb-job-err-report').click(() => {});
-                    modal.getElement().on('hidden.bs.modal', () => {
-                        modal.destroy();
-                    });
-                    modal.show();
-                    break;
-                case 'result':
-                    this.sendBusMessage(CELL, msgData.address.cell_id, 'result', msgData);
-                    break;
                 default:
                     console.warn(
-                        "Unhandled KBaseJobs message from kernel (type='" + msgType + "'):"
+                        `Unhandled KBaseJobs message from kernel (type='${msgType}'):`,
+                        msg
                     );
-                    console.warn(msg);
             }
+        }
+
+        displayJobError(msgData) {
+            // code, error, job_id (opt), message, name, source
+            const $modalBody = $(Handlebars.compile(JobInitErrorTemplate)(msgData));
+            const modal = new BootstrapDialog({
+                title: 'Job Initialization Error',
+                body: $modalBody,
+                buttons: [
+                    $('<a type="button" class="btn btn-default kb-job-err-dialog__button">')
+                        .append('OK')
+                        .click(() => {
+                            modal.hide();
+                        }),
+                ],
+            });
+            new kbaseAccordion($modalBody.find('div#kb-job-err-trace'), {
+                elements: [
+                    {
+                        title: 'Detailed Error Information',
+                        body: $(
+                            '<table class="table table-bordered"><tr><th>code:</th><td>' +
+                                msgData.code +
+                                '</td></tr>' +
+                                '<tr><th>error:</th><td>' +
+                                msgData.message +
+                                '</td></tr>' +
+                                (function () {
+                                    if (msgData.service) {
+                                        return (
+                                            '<tr><th>service:</th><td>' +
+                                            msgData.service +
+                                            '</td></tr>'
+                                        );
+                                    }
+                                    return '';
+                                })() +
+                                '<tr><th>type:</th><td>' +
+                                msgData.name +
+                                '</td></tr>' +
+                                '<tr><th>source:</th><td>' +
+                                msgData.source +
+                                '</td></tr></table>'
+                        ),
+                    },
+                ],
+            });
+
+            $modalBody.find('button#kb-job-err-report').click(() => {});
+            modal.getElement().on('hidden.bs.modal', () => {
+                modal.destroy();
+            });
+            modal.show();
         }
 
         /**

--- a/test/unit/spec/narrative_core/jobCommChannel-spec.js
+++ b/test/unit/spec/narrative_core/jobCommChannel-spec.js
@@ -106,37 +106,48 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
         });
 
         const busMsgCases = [
-            { channel: 'ping-comm-channel', message: { pingId: 'ping!' }, type: 'ping' },
+            {
+                channel: 'ping-comm-channel',
+                message: { pingId: 'ping!', pongId: 'pong!' },
+                expected: { request_type: 'ping', ping_id: 'ping!', pongId: 'pong!' },
+            },
             {
                 channel: 'request-job-cancellation',
                 message: { jobId: 'someJob' },
-                type: 'cancel_job',
+                expected: { request_type: 'cancel_job', job_id: 'someJob' },
             },
             {
                 channel: 'request-job-retry',
                 message: { jobId: 'someJob' },
-                type: 'retry_job',
+                expected: { request_type: 'retry_job', job_id: 'someJob' },
             },
             {
                 channel: 'request-job-status',
                 message: { jobId: 'someJob', parentJobId: 'someParent' },
-                type: 'job_status',
+                expected: {
+                    request_type: 'job_status',
+                    job_id: 'someJob',
+                    parent_job_id: 'someParent',
+                },
             },
             {
                 channel: 'request-job-update',
                 message: { jobId: 'someJob', parentJobId: 'someParent' },
-                type: 'start_job_update',
+                expected: {
+                    request_type: 'start_job_update',
+                    job_id: 'someJob',
+                    parent_job_id: 'someParent',
+                },
             },
             {
                 channel: 'request-job-completion',
                 message: { jobId: 'someJob' },
-                type: 'stop_job_update',
+                expected: { request_type: 'stop_job_update', job_id: 'someJob' },
             },
             {
                 channel: 'request-job-log',
                 message: { jobId: 'someJob', options: {} },
                 expected: {
-                    target_name: 'KBaseJobs',
                     request_type: 'job_logs',
                     job_id: 'someJob',
                 },
@@ -144,7 +155,7 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
             {
                 channel: 'request-job-log-latest',
                 message: { jobId: 'someJob', options: {} },
-                type: 'job_logs_latest',
+                expected: { request_type: 'job_logs_latest', job_id: 'someJob' },
             },
             {
                 channel: 'request-job-log-latest',
@@ -152,27 +163,33 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
                     jobId: 'someJob',
                     parentJobId: 'none',
                     options: {
-                        firstLine: 2000,
+                        first_line: 2000,
                         job_id: 'overridden!',
                     },
                 },
                 expected: {
-                    target_name: 'KBaseJobs',
                     request_type: 'job_logs_latest',
                     job_id: 'overridden!',
-                    firstLine: 2000,
                     parent_job_id: 'none',
+                    first_line: 2000,
                 },
             },
             {
                 channel: 'request-job-info',
                 message: { jobId: 'someJob', parentJobId: 'someParent' },
-                type: 'job_info',
+                expected: {
+                    request_type: 'job_info',
+                    job_id: 'someJob',
+                    parent_job_id: 'someParent',
+                },
             },
             {
                 channel: 'request-job-info',
                 message: { jobIdList: ['someJob', 'someOtherJob', 'aThirdJob'] },
-                type: 'job_info',
+                expected: {
+                    request_type: 'job_info',
+                    job_id_list: ['someJob', 'someOtherJob', 'aThirdJob'],
+                },
             },
         ];
 
@@ -193,20 +210,9 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
                     })
                     .then((args) => {
                         expect(comm.comm.send).toHaveBeenCalled();
-                        if (testCase.expected) {
-                            expect(args[0]).toEqual(testCase.expected);
-                        } else {
-                            expect(args[0].target_name).toEqual('KBaseJobs');
-                            expect(args[0].request_type).toEqual(testCase.type);
-                            // expect the message values to exist in the comm channel message
-                            // the `options` object gets merged into the message if it is not empty
-                            // since all the examples have an empty options object, we can ignore it
-                            Object.keys(testCase.message)
-                                .filter((key) => key !== 'options')
-                                .forEach((key) => {
-                                    expect(Object.values(args[0])).toContain(testCase.message[key]);
-                                });
-                        }
+                        expect(args[0]).toEqual(
+                            Object.assign(testCase.expected, { target_name: 'KBaseJobs' })
+                        );
                     });
             });
         });

--- a/test/unit/spec/util/jobLogViewerSpec.js
+++ b/test/unit/spec/util/jobLogViewerSpec.js
@@ -578,7 +578,7 @@ define([
                 });
 
                 return new Promise((resolve) => {
-                    this.runtimeBus.on('request-latest-job-log', (msg) => {
+                    this.runtimeBus.on('request-job-log-latest', (msg) => {
                         expect(msg).toEqual({ jobId: jobId, options: {} });
                         const logUpdate = logs[acc];
                         acc += 1;
@@ -621,7 +621,7 @@ define([
                 });
 
                 // this is called when the state is 'running'
-                this.runtimeBus.on('request-latest-job-log', (msg) => {
+                this.runtimeBus.on('request-job-log-latest', (msg) => {
                     expect(msg).toEqual({ jobId: jobId, options: {} });
                     this.runtimeBus.send(...formatMessage(jobId, 'log-deleted'));
                 });


### PR DESCRIPTION
# Description of PR purpose/changes

The first commit contains some sonarcloud issues from DATAUP-379 that I fixed and accidentally committed into the wrong branch.

The second commit alters the `jobCommChannel` module to accept an array of job IDs so that action can occur on multiple jobs without requiring so many messages to the server. The backend will need to be updated appropriately.

I also renamed one of the message types to make the naming more consistent.

Whilst exploring this ticket, I found there are a number of messages that get sent out by the jobCommChannel but get ignored as there are no listeners. At some point this sad state of affairs should be rectified.

Surprise, surprise, frontend integration tests are still failing.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-315
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
