### PR TITLE
DATAUP-315 batch cancel BE

### DIFF
--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -417,6 +417,34 @@ class JobCommTestCase(unittest.TestCase):
         msg = self.jc._comm.last_message
         self.assertEqual(msg["data"]["msg_type"], "job_logs")
 
+    def _check_rq_equal(self, rq0, rq1):
+        self.assertEqual(rq0.msg_id, rq1.msg_id)
+        self.assertEqual(rq0.rq_data, rq1.rq_data)
+        self.assertEqual(rq0.request, rq1.request)
+        self.assertEqual(rq0.job_id, rq1.job_id)
+
+    def test_split_by_job_id(self):
+        rq_msg = {
+            "msg_id": "some_id",
+            "content": {"data": {"request_type": "a_request", "job_id_list": ["a", "b", "c"]}},
+        }
+        rqa0 = JobRequest({
+            "msg_id": "some_id",
+            "content": {"data": {"request_type": "a_request", "job_id": "a"}},
+        })
+        rqb0 = JobRequest({
+            "msg_id": "some_id",
+            "content": {"data": {"request_type": "a_request", "job_id": "b"}},
+        })
+        rqc0 = JobRequest({
+            "msg_id": "some_id",
+            "content": {"data": {"request_type": "a_request", "job_id": "c"}},
+        })
+        rqa1, rqb1, rqc1 = self.jc._split_request_by_job_id(rq_msg)
+        self._check_rq_equal(rqa0, rqa1)
+        self._check_rq_equal(rqb0, rqb1)
+        self._check_rq_equal(rqc0, rqc1)
+
 
 class JobRequestTestCase(unittest.TestCase):
     """

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -15,9 +15,16 @@ job_info = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
 
 
 def make_comm_msg(
-    msg_type: str, job_id: str, as_job_request: bool, content: dict = None
+    msg_type: str, job_id_like, as_job_request: bool, content: dict = None
 ):
-    msg = {"content": {"data": {"request_type": msg_type, "job_id": job_id}}}
+    if type(job_id_like) is list:
+        job_id_key = "job_id_list"
+    else:
+        job_id_key = "job_id"
+    msg = {
+        "msg_id": "some_id",
+        "content": {"data": {"request_type": msg_type, job_id_key: job_id_like}}
+    }
     if content is not None:
         msg["content"]["data"].update(content)
     if as_job_request:
@@ -417,6 +424,16 @@ class JobCommTestCase(unittest.TestCase):
         msg = self.jc._comm.last_message
         self.assertEqual(msg["data"]["msg_type"], "job_logs")
 
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_handle_cancel_job_msg_with_job_id_list(self):
+        job_id_list = ["5d64935ab215ad4128de94d6"]
+        req = make_comm_msg("cancel_job", job_id_list, False)
+        self.jc._handle_comm_message(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(msg["data"]["msg_type"], "job_status")
+
     def _check_rq_equal(self, rq0, rq1):
         self.assertEqual(rq0.msg_id, rq1.msg_id)
         self.assertEqual(rq0.rq_data, rq1.rq_data)
@@ -424,22 +441,11 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(rq0.job_id, rq1.job_id)
 
     def test_split_by_job_id(self):
-        rq_msg = {
-            "msg_id": "some_id",
-            "content": {"data": {"request_type": "a_request", "job_id_list": ["a", "b", "c"]}},
-        }
-        rqa0 = JobRequest({
-            "msg_id": "some_id",
-            "content": {"data": {"request_type": "a_request", "job_id": "a"}},
-        })
-        rqb0 = JobRequest({
-            "msg_id": "some_id",
-            "content": {"data": {"request_type": "a_request", "job_id": "b"}},
-        })
-        rqc0 = JobRequest({
-            "msg_id": "some_id",
-            "content": {"data": {"request_type": "a_request", "job_id": "c"}},
-        })
+        rq_msg = make_comm_msg("a_request", ["a", "b", "c"], False)
+        rqa1, rqb1, rqc1 = self.jc._split_request_by_job_id(rq_msg)
+        rqa0 = make_comm_msg("a_request", "a", True)
+        rqb0 = make_comm_msg("a_request", "b", True)
+        rqc0 = make_comm_msg("a_request", "c", True)
         rqa1, rqb1, rqc1 = self.jc._split_request_by_job_id(rq_msg)
         self._check_rq_equal(rqa0, rqa1)
         self._check_rq_equal(rqb0, rqb1)


### PR DESCRIPTION
# Description of PR purpose/changes

The front end was modified to be able to send job comm requests to the kernel with a `job_id_list` field instead of `job_id`. This can be handled at `JobComm._handle_comm_message` by detecting whether there is a `job_id_list` field, and if so, split that request into multiple requests with a `job_id`. Similarly to before, these requests are then wrapped in a `JobRequest` class, and delegated to the appropriate method.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [n/a] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
