### PR TITLE
DATAUP-312 run-status event listener

### DIFF
--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -465,7 +465,7 @@ define([
                 description: 'parent bus for BulkImportCell',
             });
             busEventManager.add(cellBus.on('delete-cell', () => deleteCell()));
-            busEventManager.add(cellBus.on('run-status', handleRunStatus))
+            busEventManager.add(cellBus.on('run-status', handleRunStatus));
             controllerBus = runtime.bus().makeChannelBus({
                 description: 'An app cell widget',
             });
@@ -475,7 +475,7 @@ define([
         }
 
         function handleRunStatus(message) {
-            switch(message.event) {
+            switch (message.event) {
                 case 'launched_job_batch':
                     console.log('new jobs!');
                     console.log(message.parent_job_id);

--- a/nbextensions/bulkImportCell/bulkImportCellStates.js
+++ b/nbextensions/bulkImportCell/bulkImportCellStates.js
@@ -171,7 +171,7 @@ define([], () => {
                     ['viewConfigure', 'info', 'jobStatus', 'results', 'error']
                 ),
                 action: {
-                    name: 'runApp',
+                    name: 'resetApp',
                     disabled: false,
                 },
             },

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -150,22 +150,26 @@ define([
             });
         });
 
-        [{
-            msgEvent: 'error',
-            updatedState: 'appError',
-            availableButton: 'rerun',
-            initialState: 'hidden'
-        }, {
-            msgEvent: 'launched_job_batch',
-            updatedState: 'queued',
-            availableButton: 'cancel',
-            initialState: 'hidden'
-        }, {
-            msgEvent: 'some-unknown-event',
-            updatedState: 'generalError',
-            availableButton: 'reset',
-            initialState: 'hidden'
-        }].forEach((testCase) => {
+        [
+            {
+                msgEvent: 'error',
+                updatedState: 'appError',
+                availableButton: 'rerun',
+                initialState: 'hidden',
+            },
+            {
+                msgEvent: 'launched_job_batch',
+                updatedState: 'queued',
+                availableButton: 'cancel',
+                initialState: 'hidden',
+            },
+            {
+                msgEvent: 'some-unknown-event',
+                updatedState: 'generalError',
+                availableButton: 'reset',
+                initialState: 'hidden',
+            },
+        ].forEach((testCase) => {
             it(`responds to run-status bus messages with ${testCase.msgEvent} event`, () => {
                 const runtime = Runtime.make();
                 const cell = Mocks.buildMockCell('code');
@@ -175,16 +179,15 @@ define([
                     specs: fakeSpecs,
                     initialize: true,
                 });
-                const actionButton = cell.element[0].querySelector(`.kb-rcp__action-button-container .-${testCase.availableButton}`);
+                const actionButton = cell.element[0].querySelector(
+                    `.kb-rcp__action-button-container .-${testCase.availableButton}`
+                );
                 // wait for the actionButton to get initialized as hidden,
                 // then send the message to put it in rerun state, and wait for the button to show,
                 // then we can verify both the button and state in the cell metadata.
-                return TestUtil.waitForElementState(
-                    actionButton,
-                    () => {
-                        return actionButton.classList.contains(testCase.initialState);
-                    },
-                )
+                return TestUtil.waitForElementState(actionButton, () => {
+                    return actionButton.classList.contains(testCase.initialState);
+                })
                     .then(() => {
                         return TestUtil.waitForElementState(
                             actionButton,
@@ -194,7 +197,7 @@ define([
                             () => {
                                 runtime.bus().send(
                                     {
-                                        event: testCase.msgEvent
+                                        event: testCase.msgEvent,
                                     },
                                     {
                                         channel: {
@@ -206,10 +209,13 @@ define([
                                     }
                                 );
                             }
-                    )})
+                        );
+                    })
                     .then(() => {
                         expect(actionButton).not.toHaveClass('hidden');
-                        expect(cell.metadata.kbase.bulkImportCell.state.state).toBe(testCase.updatedState);
+                        expect(cell.metadata.kbase.bulkImportCell.state.state).toBe(
+                            testCase.updatedState
+                        );
                     });
             });
         });

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -3,8 +3,9 @@ define([
     'base/js/namespace',
     'common/runtime',
     'narrativeMocks',
+    'testUtil',
     'json!/test/data/NarrativeTest.test_input_params.spec.json',
-], (BulkImportCell, Jupyter, Runtime, Mocks, TestAppSpec) => {
+], (BulkImportCell, Jupyter, Runtime, Mocks, TestUtil, TestAppSpec) => {
     'use strict';
     const fakeInputs = {
         dataType: {
@@ -146,6 +147,70 @@ define([
                         },
                     }
                 );
+            });
+        });
+
+        [{
+            msgEvent: 'error',
+            updatedState: 'appError',
+            availableButton: 'rerun',
+            initialState: 'hidden'
+        }, {
+            msgEvent: 'launched_job_batch',
+            updatedState: 'queued',
+            availableButton: 'cancel',
+            initialState: 'hidden'
+        }, {
+            msgEvent: 'some-unknown-event',
+            updatedState: 'generalError',
+            availableButton: 'reset',
+            initialState: 'hidden'
+        }].forEach((testCase) => {
+            it(`responds to run-status bus messages with ${testCase.msgEvent} event`, () => {
+                const runtime = Runtime.make();
+                const cell = Mocks.buildMockCell('code');
+                BulkImportCell.make({
+                    cell,
+                    importData: fakeInputs,
+                    specs: fakeSpecs,
+                    initialize: true,
+                });
+                const actionButton = cell.element[0].querySelector(`.kb-rcp__action-button-container .-${testCase.availableButton}`);
+                // wait for the actionButton to get initialized as hidden,
+                // then send the message to put it in rerun state, and wait for the button to show,
+                // then we can verify both the button and state in the cell metadata.
+                return TestUtil.waitForElementState(
+                    actionButton,
+                    () => {
+                        return actionButton.classList.contains(testCase.initialState);
+                    },
+                )
+                    .then(() => {
+                        return TestUtil.waitForElementState(
+                            actionButton,
+                            () => {
+                                return !actionButton.classList.contains(testCase.initialState);
+                            },
+                            () => {
+                                runtime.bus().send(
+                                    {
+                                        event: testCase.msgEvent
+                                    },
+                                    {
+                                        channel: {
+                                            cell: cell.metadata.kbase.attributes.id,
+                                        },
+                                        key: {
+                                            type: 'run-status',
+                                        },
+                                    }
+                                );
+                            }
+                    )})
+                    .then(() => {
+                        expect(actionButton).not.toHaveClass('hidden');
+                        expect(cell.metadata.kbase.bulkImportCell.state.state).toBe(testCase.updatedState);
+                    });
             });
         });
 


### PR DESCRIPTION
# Description of PR purpose/changes

This is one of the final tasks for getting the jobs to start - getting the cell to know that's there's new job ids.
There's two possible events to listen for from the kernel-side app startup.
* `launched_job_batch` will have the new parent and child job ids, which will get registered with the cell's JobManager.
* `error` which happens if the job batch fails to start. What to do with the errors will get fleshed out in another PR, just to keep this one tidy.

This also fixes an issue where, on startup, the cell would only go into `editingComplete` or `editingIncomplete` as those were responses to the state of the various input widgets. Now it politely ignores those state change requests if the cell's already running.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-312
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Start the cell! It should toggle to the queued state, and the button should turn to "Cancel".
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
