### PR TITLE
Implement SCT-3038 refseq public data also search by genome_id and source_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,9 @@ karma-result.json
 # Integration test logs
 /selenium-standalone-logs/
 
+# Test tokens
+/test/*.tok
+
 # Translations
 *.mo
 *.pot

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ js-coverage
 kbase-extension/static/ext_components
 kbase-extension/static/ext_packages
 kbase-extension/static/kbase/js/patched-components
+venv
+cover

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 -   PTV-1635: fix data and app slideout button and opening behavior
 -   DEVOPS-475: Change dockerfile so that container runs as nobody, without need to setuid for initialization. Enables removing CAP_SETUID from container initialization
 - SCT-2935 - fix refseq public data search behavior to properly restrict the search with multiple terms
+- SCT-3038 - refseq public data search now includes genome_id and source_id
 ### Version 4.3.2
 
 -   SCT-2778 - convert data slideout, public tab, refseq data source to use searchapi2/rpc api rather than searchapi2/legacy.

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/publicDataSources/search2DataSource.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/publicDataSources/search2DataSource.js
@@ -85,14 +85,34 @@ define([
                 track_total_hits: true,
             };
             if (query !== null) {
-                params.query.bool.must.push({
-                    'match': {
-                        'scientific_name': {
-                            'query': query,
-                            'operator': 'AND',
+                params.query.bool.filter = {
+                    'bool': {
+                        'must': {
+                            'bool': {
+                                'should': [
+                                    {
+                                        'match': {
+                                            'scientific_name': {
+                                                'query': query,
+                                                'operator': 'AND',
+                                            },
+                                        },
+                                    },
+                                    {
+                                        'match': {
+                                            'source_id': query,
+                                        },
+                                    },
+                                    {
+                                        'match': {
+                                            'genome_id': query,
+                                        },
+                                    },
+                                ],
+                            },
                         },
                     },
-                });
+                };
             }
             return this.searchAPI2.search_objects({ params, timeout: this.timeout });
         }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/publicDataSources/search2DataSource.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/publicDataSources/search2DataSource.js
@@ -85,6 +85,10 @@ define([
                 track_total_hits: true,
             };
             if (query !== null) {
+                // Note that this rather convoluted-looking filter how one implements a required "or" filter.
+                // Having the "should" within a "must" ensures that the at least one of the "should" matches 
+                // must succeed. We want a filter here because we don't care about scoring.
+                // There may be better ways to form this query, but this one does work. 
                 params.query.bool.filter = {
                     'bool': {
                         'must': {

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -2,3 +2,4 @@ env:
   amd: true
   es6: true
   jasmine: true
+  mocha: true

--- a/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
+++ b/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
@@ -592,7 +592,7 @@ async function waitForRows(panel, count) {
         const rows = await panel.$$('[role="table"][data-test-id="result"] > div > [role="row"]');
         return rows.length >= count;
     });
-    return await panel.$$('[role="table"][data-test-id="result"] > div > [role="row"]');
+    return panel.$$('[role="table"][data-test-id="result"] > div > [role="row"]');
 }
 
 async function openPublicData() {

--- a/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
+++ b/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
@@ -17,23 +17,23 @@ const allTestCases = {
         TEST_CASE_1: {
             narrativeId: 53983,
             row: 4,
-            name: 'Acetobacter ascendens',
+            name: 'Abiotrophia defectiva ATCC 49176',
             metadata: [
                 {
                     id: 'lineage',
                     label: 'Lineage',
                     value:
-                        'Bacteria > Proteobacteria > Alphaproteobacteria > Rhodospirillales > Acetobacteraceae > Acetobacter',
+                        'Bacteria > Terrabacteria group > Firmicutes > Bacilli > Lactobacillales > Aerococcaceae > Abiotrophia > Abiotrophia defectiva',
                 },
                 {
                     id: 'kbase_id',
                     label: 'KBase ID',
-                    value: 'GCF_001766255.1',
+                    value: 'GCF_000160075.2',
                 },
                 {
                     id: 'refseq_id',
                     label: 'RefSeq ID',
-                    value: 'NZ_CP015168',
+                    value: 'NZ_KI535340',
                 },
                 {
                     id: 'contigs',
@@ -43,41 +43,41 @@ const allTestCases = {
                 {
                     id: 'features',
                     label: 'Features',
-                    value: '3,032',
+                    value: '1,848',
                 },
             ],
         },
         TEST_CASE_2: {
             narrativeId: 53983,
-            row: 10,
+            row: 1,
             scrollTo: true,
-            name: 'Acidaminococcus fermentans',
+            name: "'Chrysanthemum coronarium' phytoplasma",
             metadata: [
                 {
                     id: 'lineage',
                     label: 'Lineage',
                     value:
-                        'Bacteria > Terrabacteria group > Firmicutes > Negativicutes > Acidaminococcales > Acidaminococcaceae > Acidaminococcus',
+                        'Bacteria > Terrabacteria group > Tenericutes > Mollicutes > Acholeplasmatales > Acholeplasmataceae > Candidatus Phytoplasma > Candidatus Phytoplasma asteris',
                 },
                 {
                     id: 'kbase_id',
                     label: 'KBase ID',
-                    value: 'GCF_900107075.1',
+                    value: 'GCF_000744065.1',
                 },
                 {
                     id: 'refseq_id',
                     label: 'RefSeq ID',
-                    value: 'NZ_FNOP01000039',
+                    value: 'NZ_BBIY01000170',
                 },
                 {
                     id: 'contigs',
                     label: 'Contigs',
-                    value: '40',
+                    value: '170',
                 },
                 {
                     id: 'features',
                     label: 'Features',
-                    value: '2,067',
+                    value: '839',
                 },
             ],
         },
@@ -86,34 +86,34 @@ const allTestCases = {
             row: 1,
             scrollTo: false,
             searchFor: 'prochlorococcus',
-            foundCount: '14',
-            name: 'Prochlorococcus marinus str. GP2',
+            foundCount: '69',
+            name: 'Prochlorococcus marinus',
             metadata: [
                 {
                     id: 'lineage',
                     label: 'Lineage',
                     value:
-                        'Bacteria > Terrabacteria group > Cyanobacteria/Melainabacteria group > Cyanobacteria > Synechococcales > Prochloraceae > Prochlorococcus > Prochlorococcus marinus',
+                        'Bacteria > Terrabacteria group > Cyanobacteria/Melainabacteria group > Cyanobacteria > Synechococcales > Prochloraceae > Prochlorococcus',
                 },
                 {
                     id: 'kbase_id',
                     label: 'KBase ID',
-                    value: 'GCF_000759885.1',
+                    value: 'GCF_001180245.1',
                 },
                 {
                     id: 'refseq_id',
                     label: 'RefSeq ID',
-                    value: 'NZ_JNAH01000001',
+                    value: 'NZ_CVSV01000001',
                 },
                 {
                     id: 'contigs',
                     label: 'Contigs',
-                    value: '11',
+                    value: '136',
                 },
                 {
                     id: 'features',
                     label: 'Features',
-                    value: '1,760',
+                    value: '1,616',
                 },
             ],
         },
@@ -124,10 +124,11 @@ const allTestCases = {
         },
         TEST_CASE_5: {
             narrativeId: 53983,
+            foundCount: '3,198',
             row: 30,
             scrollTo: true,
             scrolls: [20],
-            name: 'Acinetobacter baumannii',
+            name: ' ',
             metadata: [
                 {
                     id: 'lineage',
@@ -138,22 +139,22 @@ const allTestCases = {
                 {
                     id: 'kbase_id',
                     label: 'KBase ID',
-                    value: 'GCF_000804875.1',
+                    value: 'GCF_000787335.1',
                 },
                 {
                     id: 'refseq_id',
                     label: 'RefSeq ID',
-                    value: 'NZ_JSCS01000001',
+                    value: 'NZ_JPLL01000001',
                 },
                 {
                     id: 'contigs',
                     label: 'Contigs',
-                    value: '74',
+                    value: '54',
                 },
                 {
                     id: 'features',
                     label: 'Features',
-                    value: '3,862',
+                    value: '3,822',
                 },
             ],
         },
@@ -165,41 +166,110 @@ const allTestCases = {
                 20,
             ],
             searchFor: 'coli',
-            foundCount: '2,317',
-            name: 'Escherichia coli',
+            foundCount: '13,181',
+            name: 'Campylobacter coli',
             metadata: [
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value: '	Bacteria > Proteobacteria > Gammaproteobacteria > Enterobacterales > Enterobacteriaceae > Escherichia',
+                    value: 'Bacteria > Proteobacteria > delta/epsilon subdivisions > Epsilonproteobacteria > Campylobacterales > Campylobacteraceae > Campylobacter',
                 },
                 {
                     id: 'kbase_id',
                     label: 'KBase ID',
-                    value: 'GCF_000752615.1',
+                    value: 'GCF_001233705.1',
                 },
                 {
                     id: 'refseq_id',
                     label: 'RefSeq ID',
-                    value: 'NZ_CCVR01000001',
+                    value: 'NZ_CUOB01000001',
                 },
                 {
                     id: 'contigs',
                     label: 'Contigs',
-                    value: '447',
+                    value: '27',
                 },
                 {
                     id: 'features',
                     label: 'Features',
-                    value: '5,847',
+                    value: '1,767',
                 },
             ],
         },
         TEST_CASE_7: {
             narrativeId: 53983,
             searchFor: 'Acetobacter pasteurianus',
+            foundCount: '29',
+            row: 2,
+            name: 'Acetobacter pasteurianus',
+            metadata: [
+                {
+                    id: 'lineage',
+                    label: 'Lineage',
+                    value: 'Bacteria > Proteobacteria > Alphaproteobacteria > Rhodospirillales > Acetobacteraceae > Acetobacter',
+                },
+                {
+                    id: 'kbase_id',
+                    label: 'KBase ID',
+                    value: 'GCF_001662905.1',
+                },
+                {
+                    id: 'refseq_id',
+                    label: 'RefSeq ID',
+                    value: 'NZ_LYUD01000001',
+                },
+                {
+                    id: 'contigs',
+                    label: 'Contigs',
+                    value: '184',
+                },
+                {
+                    id: 'features',
+                    label: 'Features',
+                    value: '3,093',
+                },
+            ],
+        },
+        TEST_CASE_8: {
+            narrativeId: 53983,
+            searchFor: 'GCF_001662905.1',
             foundCount: '1',
             row: 1,
+            name: 'Acetobacter pasteurianus',
+            metadata: [
+                {
+                    id: 'lineage',
+                    label: 'Lineage',
+                    value: 'Bacteria > Proteobacteria > Alphaproteobacteria > Rhodospirillales > Acetobacteraceae > Acetobacter',
+                },
+                {
+                    id: 'kbase_id',
+                    label: 'KBase ID',
+                    value: 'GCF_001662905.1',
+                },
+                {
+                    id: 'refseq_id',
+                    label: 'RefSeq ID',
+                    value: 'NZ_LYUD01000001',
+                },
+                {
+                    id: 'contigs',
+                    label: 'Contigs',
+                    value: '184',
+                },
+                {
+                    id: 'features',
+                    label: 'Features',
+                    value: '3,093',
+                },
+            ],
+        },
+        TEST_CASE_9: {
+            narrativeId: 53983,
+            searchFor: 'NZ_LYUD01000001',
+            foundCount: '1',
+            row: 1,
+            name: 'Acetobacter pasteurianus',
             metadata: [
                 {
                     id: 'lineage',
@@ -415,6 +485,75 @@ const allTestCases = {
             searchFor: 'Acetobacter pasteurianus',
             foundCount: '19',
             row: 1,
+            name: 'Acetobacter pasteurianus',
+            metadata: [
+                {
+                    id: 'lineage',
+                    label: 'Lineage',
+                    value: 'Bacteria > Proteobacteria > Alphaproteobacteria > Rhodospirillales > Acetobacteraceae > Acetobacter',
+                },
+                {
+                    id: 'kbase_id',
+                    label: 'KBase ID',
+                    value: 'GCF_001662905.1',
+                },
+                {
+                    id: 'refseq_id',
+                    label: 'RefSeq ID',
+                    value: 'NZ_LYUD01000001',
+                },
+                {
+                    id: 'contigs',
+                    label: 'Contigs',
+                    value: '184',
+                },
+                {
+                    id: 'features',
+                    label: 'Features',
+                    value: '3,093',
+                },
+            ],
+        },
+        TEST_CASE_8: {
+            narrativeId: 78050,
+            searchFor: 'GCF_001662905.1',
+            foundCount: '1',
+            row: 1,
+            name: 'Acetobacter pasteurianus',
+            metadata: [
+                {
+                    id: 'lineage',
+                    label: 'Lineage',
+                    value: 'Bacteria > Proteobacteria > Alphaproteobacteria > Rhodospirillales > Acetobacteraceae > Acetobacter',
+                },
+                {
+                    id: 'kbase_id',
+                    label: 'KBase ID',
+                    value: 'GCF_001662905.1',
+                },
+                {
+                    id: 'refseq_id',
+                    label: 'RefSeq ID',
+                    value: 'NZ_LYUD01000001',
+                },
+                {
+                    id: 'contigs',
+                    label: 'Contigs',
+                    value: '184',
+                },
+                {
+                    id: 'features',
+                    label: 'Features',
+                    value: '3,093',
+                },
+            ],
+        },
+        TEST_CASE_9: {
+            narrativeId: 78050,
+            searchFor: 'NZ_LYUD01000001',
+            foundCount: '1',
+            row: 1,
+            name: 'Acetobacter pasteurianus',
             metadata: [
                 {
                     id: 'lineage',
@@ -452,11 +591,11 @@ async function testField({ container, id, label, value }) {
     const lineageLabel = await container.$(
         `[role="row"][data-test-id="${id}"] [data-test-id="label"]`,
     );
-    expect(lineageLabel).toHaveText(label);
+    await expect(lineageLabel).toHaveText(label);
     const lineageValue = await container.$(
         `[role="row"][data-test-id="${id}"] [data-test-id="value"]`,
     );
-    expect(lineageValue).toHaveText(value);
+    await expect(lineageValue).toHaveText(value);
 }
 
 async function waitForRows(panel, count) {
@@ -464,7 +603,7 @@ async function waitForRows(panel, count) {
         const rows = await panel.$$('[role="table"][data-test-id="result"] > div > [role="row"]');
         return rows.length >= count;
     });
-    return panel.$$('[role="table"][data-test-id="result"] > div > [role="row"]');
+    return await panel.$$('[role="table"][data-test-id="result"] > div > [role="row"]');
 }
 
 async function openPublicData() {
@@ -488,7 +627,7 @@ async function openPublicData() {
     // Initially, the public data tab, if loaded with refseq data to any reasonable degree,
     // will have the initial page of 20 rows fully filled.
     const rows = await waitForRows(publicPanel, 20);
-    expect(rows.length).toEqual(20);
+    await expect(rows.length).toEqual(20);
     return publicPanel;
 }
 
@@ -499,7 +638,7 @@ async function doSearch(publicPanel, testCase) {
     await browser.keys('Enter');
 
     const foundCount = await publicPanel.$('[data-test-id="found-count"]');
-    expect(foundCount).toHaveText(testCase.foundCount);
+    await expect(foundCount).toHaveText(testCase.foundCount);
 }
 
 async function doScrolling(publicPanel, testCase) {
@@ -515,24 +654,33 @@ async function doScrolling(publicPanel, testCase) {
 
 async function validateResultRow(row, testCase) {
     const nameCell = await row.$('[role="cell"][data-test-id="name"]');
-    expect(nameCell).toHaveText(testCase.name);
+    await expect(nameCell).toHaveText(testCase.name);
 
     // Confirm the metadata fields.
-    for (const { id, label, value } of testCase.metadata) {
-        await testField({
+    // for (const { id, label, value } of testCase.metadata) {
+    //     await testField({
+    //         container: row,
+    //         id,
+    //         label,
+    //         value,
+    //     });
+    // }
+
+    await Promise.all(testCase.metadata.map(({ id, label, value }) => {
+        return testField({
             container: row,
             id,
             label,
             value,
         });
-    }
+    }));
 }
 
 async function getRow(publicPanel, testCase) {
     const rows = await waitForRows(publicPanel, testCase.row);
-    expect(rows.length).toBeGreaterThanOrEqual(testCase.row);
+    await expect(rows.length).toBeGreaterThanOrEqual(testCase.row);
     const row = rows[testCase.row - 1];
-    expect(row).toBeDefined();
+    await expect(row).toBeDefined();
     return row;
 }
 
@@ -553,10 +701,13 @@ async function validateFoundCount(publicPanel, testCase) {
         }
     });
     const foundCount = await publicPanel.$('[data-test-id="found-count"]');
-    expect(foundCount).toHaveText(testCase.foundCount);
+    await expect(foundCount).toHaveText(testCase.foundCount);
 }
 
 describe('Test kbaseNarrativeSidePublicTab', () => {
+    before(() => {
+        require('expect-webdriverio').setOptions({ wait: 5000 })
+    })
     beforeEach(async () => {
         await browser.setTimeout({ implicit: 30000 });
         await browser.reloadSession();
@@ -608,7 +759,7 @@ describe('Test kbaseNarrativeSidePublicTab', () => {
         await validateFoundCount(publicPanel, testCase);
     });
 
-    it('opens the public data search tab, search for species part of scientific  name, scroll to desired row', async () => {
+    it('opens the public data search tab, search for species part of scientific name, scroll to desired row', async () => {
         const testCase = testCases.TEST_CASE_6;
         await login();
         await openNarrative(testCase.narrativeId);
@@ -625,6 +776,30 @@ describe('Test kbaseNarrativeSidePublicTab', () => {
 
     it('opens the public data search tab, searches for a binomial scientific name', async () => {
         const testCase = testCases.TEST_CASE_7;
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        const publicPanel = await openPublicData();
+        await doSearch(publicPanel, testCase);
+        await validateFoundCount(publicPanel, testCase);
+        const row = await scrollToRow(publicPanel, testCase);
+        await validateResultRow(row, testCase);
+    });
+
+    it('opens the public data search tab, searches for a kbase_id (aka RefSeq assembly accession)', async () => {
+        const testCase = testCases.TEST_CASE_8;
+        await login();
+        await openNarrative(testCase.narrativeId);
+
+        const publicPanel = await openPublicData();
+        await doSearch(publicPanel, testCase);
+        await validateFoundCount(publicPanel, testCase);
+        const row = await scrollToRow(publicPanel, testCase);
+        await validateResultRow(row, testCase);
+    });
+
+    it('opens the public data search tab, searches for a source_id (aka NCBI project accession)', async () => {
+        const testCase = testCases.TEST_CASE_9;
         await login();
         await openNarrative(testCase.narrativeId);
 

--- a/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
+++ b/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
@@ -655,17 +655,6 @@ async function doScrolling(publicPanel, testCase) {
 async function validateResultRow(row, testCase) {
     const nameCell = await row.$('[role="cell"][data-test-id="name"]');
     await expect(nameCell).toHaveText(testCase.name);
-
-    // Confirm the metadata fields.
-    // for (const { id, label, value } of testCase.metadata) {
-    //     await testField({
-    //         container: row,
-    //         id,
-    //         label,
-    //         value,
-    //     });
-    // }
-
     await Promise.all(testCase.metadata.map(({ id, label, value }) => {
         return testField({
             container: row,

--- a/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
+++ b/test/integration/specs/kbaseNarrativeSidePublicTab_test.js
@@ -22,8 +22,7 @@ const allTestCases = {
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value:
-                        'Bacteria > Terrabacteria group > Firmicutes > Bacilli > Lactobacillales > Aerococcaceae > Abiotrophia > Abiotrophia defectiva',
+                    value: 'Bacteria > Terrabacteria group > Firmicutes > Bacilli > Lactobacillales > Aerococcaceae > Abiotrophia > Abiotrophia defectiva',
                 },
                 {
                     id: 'kbase_id',
@@ -56,8 +55,7 @@ const allTestCases = {
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value:
-                        'Bacteria > Terrabacteria group > Tenericutes > Mollicutes > Acholeplasmatales > Acholeplasmataceae > Candidatus Phytoplasma > Candidatus Phytoplasma asteris',
+                    value: 'Bacteria > Terrabacteria group > Tenericutes > Mollicutes > Acholeplasmatales > Acholeplasmataceae > Candidatus Phytoplasma > Candidatus Phytoplasma asteris',
                 },
                 {
                     id: 'kbase_id',
@@ -92,8 +90,7 @@ const allTestCases = {
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value:
-                        'Bacteria > Terrabacteria group > Cyanobacteria/Melainabacteria group > Cyanobacteria > Synechococcales > Prochloraceae > Prochlorococcus',
+                    value: 'Bacteria > Terrabacteria group > Cyanobacteria/Melainabacteria group > Cyanobacteria > Synechococcales > Prochloraceae > Prochlorococcus',
                 },
                 {
                     id: 'kbase_id',
@@ -133,8 +130,7 @@ const allTestCases = {
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value:
-                        'Bacteria > Proteobacteria > Gammaproteobacteria > Pseudomonadales > Moraxellaceae > Acinetobacter > Acinetobacter calcoaceticus/baumannii complex',
+                    value: 'Bacteria > Proteobacteria > Gammaproteobacteria > Pseudomonadales > Moraxellaceae > Acinetobacter > Acinetobacter calcoaceticus/baumannii complex',
                 },
                 {
                     id: 'kbase_id',
@@ -162,9 +158,7 @@ const allTestCases = {
             narrativeId: 53983,
             row: 30,
             scrollTo: true,
-            scrolls: [
-                20,
-            ],
+            scrolls: [20],
             searchFor: 'coli',
             foundCount: '13,181',
             name: 'Campylobacter coli',
@@ -303,7 +297,7 @@ const allTestCases = {
         TEST_CASE_1: {
             narrativeId: 78050,
             row: 3,
-            name: '\'Massilia aquatica\' Holochova et al. 2020',
+            name: "'Massilia aquatica' Holochova et al. 2020",
             metadata: [
                 {
                     id: 'lineage',
@@ -341,8 +335,7 @@ const allTestCases = {
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value:
-                        'Bacteria > Terrabacteria group > Firmicutes > Bacilli > Bacillales > Staphylococcaceae > Abyssicoccus',
+                    value: 'Bacteria > Terrabacteria group > Firmicutes > Bacilli > Bacillales > Staphylococcaceae > Abyssicoccus',
                 },
                 {
                     id: 'kbase_id',
@@ -377,8 +370,7 @@ const allTestCases = {
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value:
-                        'Bacteria > Terrabacteria group > Cyanobacteria/Melainabacteria group > Cyanobacteria > Synechococcales > Prochloraceae > Prochlorococcus',
+                    value: 'Bacteria > Terrabacteria group > Cyanobacteria/Melainabacteria group > Cyanobacteria > Synechococcales > Prochloraceae > Prochlorococcus',
                 },
                 {
                     id: 'kbase_id',
@@ -417,8 +409,7 @@ const allTestCases = {
                 {
                     id: 'lineage',
                     label: 'Lineage',
-                    value:
-                        'Bacteria > Proteobacteria > Alphaproteobacteria > Rhodospirillales > Acetobacteraceae > Acetobacter',
+                    value: 'Bacteria > Proteobacteria > Alphaproteobacteria > Rhodospirillales > Acetobacteraceae > Acetobacter',
                 },
                 {
                     id: 'kbase_id',
@@ -446,9 +437,7 @@ const allTestCases = {
             narrativeId: 78050,
             row: 30,
             scrollTo: true,
-            scrolls: [
-                20,
-            ],
+            scrolls: [20],
             searchFor: 'orientalis',
             foundCount: '',
             name: 'Francisella orientalis',
@@ -589,11 +578,11 @@ const testCases = allTestCases[browser.config.testParams.ENV];
 
 async function testField({ container, id, label, value }) {
     const lineageLabel = await container.$(
-        `[role="row"][data-test-id="${id}"] [data-test-id="label"]`,
+        `[role="row"][data-test-id="${id}"] [data-test-id="label"]`
     );
     await expect(lineageLabel).toHaveText(label);
     const lineageValue = await container.$(
-        `[role="row"][data-test-id="${id}"] [data-test-id="value"]`,
+        `[role="row"][data-test-id="${id}"] [data-test-id="value"]`
     );
     await expect(lineageValue).toHaveText(value);
 }
@@ -655,14 +644,16 @@ async function doScrolling(publicPanel, testCase) {
 async function validateResultRow(row, testCase) {
     const nameCell = await row.$('[role="cell"][data-test-id="name"]');
     await expect(nameCell).toHaveText(testCase.name);
-    await Promise.all(testCase.metadata.map(({ id, label, value }) => {
-        return testField({
-            container: row,
-            id,
-            label,
-            value,
-        });
-    }));
+    await Promise.all(
+        testCase.metadata.map(({ id, label, value }) => {
+            return testField({
+                container: row,
+                id,
+                label,
+                value,
+            });
+        })
+    );
 }
 
 async function getRow(publicPanel, testCase) {
@@ -695,8 +686,8 @@ async function validateFoundCount(publicPanel, testCase) {
 
 describe('Test kbaseNarrativeSidePublicTab', () => {
     before(() => {
-        require('expect-webdriverio').setOptions({ wait: 5000 })
-    })
+        require('expect-webdriverio').setOptions({ wait: 5000 });
+    });
     beforeEach(async () => {
         await browser.setTimeout({ implicit: 30000 });
         await browser.reloadSession();


### PR DESCRIPTION
## Description of PR purpose/changes

* Please include a summary of the change and which issue is fixed.

Modifies the query backing the refseq public data panel so that searches are conducted against the scientific_name, genome_id, and source_id fields. The match is an ES version of "or", so that a match on any one of these fields will succeed.
Previously only scientific_name was considered.
genome_id,  shown. as "KBase ID", is the refseq assembly accession number, and source_id is the ncbi project accession number.

Integration tests added for searching a value in these new fields.

* Please also include relevant motivation and context.

This request was originally from Shane, who adds:

FYI.  This search change is actually related to a message we want to send out to users that had corrupt Euk genomes.  With out this fix it is difficult to explain to users how to find the right substitute.

* List any dependencies that are required for this change.

none

## Jira Ticket / Issue #

https://kbase-jira.atlassian.net/browse/SCT-3038
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

## Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
