### PR TITLE
DATAUP-312 connect cancel button

### DIFF
--- a/kbase-extension/static/kbase/js/common/busEventManager.js
+++ b/kbase-extension/static/kbase/js/common/busEventManager.js
@@ -1,14 +1,19 @@
 define([], () => {
+    'use strict';
+
     function factory(config) {
-        let listeners = [],
-            bus = config.bus;
+        let listeners = [];
+        const bus = config.bus;
+
         function add(listenerId) {
             listeners.push(listenerId);
         }
+
         function remove(listenerId) {
             bus.removeListener(listenerId);
             delete listeners[listenerId];
         }
+
         function removeAll() {
             listeners.forEach((id) => {
                 try {
@@ -19,6 +24,7 @@ define([], () => {
             });
             listeners = [];
         }
+
         return {
             add: add,
             remove: remove,

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -215,7 +215,7 @@ define(['common/html', 'common/jobs', 'common/ui', 'util/string'], (html, Jobs, 
                 return Promise.resolve(false);
             }
 
-            await UI.showConfirmDialog(this._generateDialogArgs(action, statusList, jobsList)).then(
+            return await UI.showConfirmDialog(this._generateDialogArgs(action, statusList, jobsList)).then(
                 (confirmed) => {
                     if (!confirmed) {
                         return false;

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -215,17 +215,17 @@ define(['common/html', 'common/jobs', 'common/ui', 'util/string'], (html, Jobs, 
                 return Promise.resolve(false);
             }
 
-            return await UI.showConfirmDialog(this._generateDialogArgs(action, statusList, jobsList)).then(
-                (confirmed) => {
-                    if (!confirmed) {
-                        return false;
-                    }
-                    this.bus.emit(jobCommand[action], {
-                        jobIdList: jobsList,
-                    });
-                    return true;
+            return await UI.showConfirmDialog(
+                this._generateDialogArgs(action, statusList, jobsList)
+            ).then((confirmed) => {
+                if (!confirmed) {
+                    return false;
                 }
-            );
+                this.bus.emit(jobCommand[action], {
+                    jobIdList: jobsList,
+                });
+                return true;
+            });
         }
 
         /**

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -207,7 +207,7 @@ define(['common/html', 'common/jobs', 'common/ui', 'util/string'], (html, Jobs, 
          * if the user cancels the batch action. If the users confirms the action, the appropriate
          * message will be emitted by the bus.
          */
-        async executeActionByJobStatus(args) {
+        executeActionByJobStatus(args) {
             const { action, statusList, validStatuses } = args;
 
             const jobsList = this.getJobIDsByStatus(statusList, validStatuses);
@@ -215,7 +215,7 @@ define(['common/html', 'common/jobs', 'common/ui', 'util/string'], (html, Jobs, 
                 return Promise.resolve(false);
             }
 
-            return await UI.showConfirmDialog(
+            return UI.showConfirmDialog(
                 this._generateDialogArgs(action, statusList, jobsList)
             ).then((confirmed) => {
                 if (!confirmed) {

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -803,21 +803,18 @@ define([
                             'Any output objects already created will remain in your narrative and can be removed from the Data panel.',
                         ]),
                         p('Continue to Cancel the running job batch?'),
-                    ])
-                }
+                    ]),
+                };
 
-                await UI.showConfirmDialog(dialogArgs).then(
-                    (confirmed) => {
-                        if (!confirmed) {
-                            return false;
-                        }
-                        busEventManager.remove(runStatusListener);
-                        updateEditingState();
-                        return true;
+                await UI.showConfirmDialog(dialogArgs).then((confirmed) => {
+                    if (!confirmed) {
+                        return false;
                     }
-                );
-            }
-            else {
+                    busEventManager.remove(runStatusListener);
+                    updateEditingState();
+                    return true;
+                });
+            } else {
                 await jobManager.cancelJobsByStatus(['created', 'estimating', 'queued', 'running']);
                 updateEditingState();
             }

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -791,7 +791,6 @@ define([
          * 3. Return to the editing state, trigger updateParameterState.
          */
         async function doCancelCellAction() {
-            // if we're currently listening to the run_status event, stop.
             if (runStatusListener !== null) {
                 const dialogArgs = {
                     title: 'Cancel job batch?',
@@ -804,14 +803,12 @@ define([
                     ]),
                 };
 
-                await UI.showConfirmDialog(dialogArgs).then((confirmed) => {
-                    if (!confirmed) {
-                        return false;
-                    }
-                    busEventManager.remove(runStatusListener);
-                    updateEditingState();
-                    return true;
-                });
+                const confirmed = await UI.showConfirmDialog(dialogArgs);
+                if (!confirmed) {
+                    return;
+                }
+                busEventManager.remove(runStatusListener);
+                updateEditingState();
             } else {
                 await jobManager.cancelJobsByStatus(['created', 'estimating', 'queued', 'running']);
                 updateEditingState();

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -247,9 +247,7 @@ define([
         let state = getInitialState();
 
         for (const [appId, appSpec] of Object.entries(model.getItem('app.specs'))) {
-            specs[appId] = Spec.make({
-                appSpec: appSpec,
-            });
+            specs[appId] = Spec.make({ appSpec });
         }
 
         setupCell();

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -796,7 +796,7 @@ define([
                     title: 'Cancel job batch?',
                     body: div([
                         p([
-                            'Canceling the job will halt any currently running jobs.',
+                            'Canceling the job will halt any currently running jobs. ',
                             'Any output objects already created will remain in your narrative and can be removed from the Data panel.',
                         ]),
                         p('Continue to Cancel the running job batch?'),

--- a/test/data/testAppObj.js
+++ b/test/data/testAppObj.js
@@ -479,7 +479,7 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
             fastq_reads: {
                 appId: 'kb_uploadmethods/import_fastq_sra_as_reads_from_staging',
                 files: ['file1.txt'],
-            }
+            },
         },
         params: {
             fastq_reads: {

--- a/test/data/testAppObj.js
+++ b/test/data/testAppObj.js
@@ -20,6 +20,8 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
             },
             specs: {
                 'kb_uploadmethods/import_fastq_sra_as_reads_from_staging': {
+                    tag: 'release',
+                    version: '1.0.43',
                     gitCommitHash: '25e7a896377f5ec50bd15a27ade9f279cb16cd0b',
                     id: 'kb_uploadmethods/import_fastq_sra_as_reads_from_staging',
                     behavior: {
@@ -395,8 +397,6 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
                         output: 'no-display',
                     },
                 },
-                tag: 'release',
-                version: '1.0.43',
             },
         },
         exec: {
@@ -476,7 +476,10 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
             byJob: {},
         },
         inputs: {
-            fastq_reads: ['file1.txt'],
+            fastq_reads: {
+                appId: 'kb_uploadmethods/import_fastq_sra_as_reads_from_staging',
+                files: ['file1.txt'],
+            }
         },
         params: {
             fastq_reads: {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -242,7 +242,6 @@ define([
                         );
                     })
                     .then(() => {
-                        // expect(actionButton).not.toHaveClass('hidden');
                         expect(cell.metadata.kbase.bulkImportCell.state.state).toBe(
                             testCase.updatedState
                         );
@@ -250,24 +249,13 @@ define([
             });
         });
 
-        // [{
-        //     state: 'launching',
-        //     jobs: [],
-        // }, {
-        //     state: 'queued',
-        //     jobs: ['job1', 'job2'],
-        // }, {
-        //     state: 'running',
-        //     jobs: ['job1', 'job2']
-        // }]
         ['launching', 'queued', 'running'].forEach((testCase) => {
             it(`should cancel the ${testCase} state and return to a previous state`, () => {
                 // init cell with the test case state and jobs (they're all run-related)
-                // wait for the cancel button to appear and be ready
+                // wait for the cancel button to appear and be ready, and for the run button to disappear
                 // click it
-                // wait for it to reset to editingComplete
-                // expect the exec part of the cell metadata to be gone
-                // const runtime = Runtime.make();
+                // wait for it to reset so the run button is visible
+                // expect the state to be editingComplete
                 const cell = Mocks.buildMockCell('code');
                 cell.execute = () => {};
                 // add dummy metadata so we can make a cell that's in the ready-to-run state.
@@ -307,7 +295,6 @@ define([
                 })
                     .then(() => {
                         // click the button and wait for the dialog to pop up
-                        // const dialogOkButton = document.querySelector(
                         const okBtnSelector =
                             '[data-element="kbase"] [data-element="modal"] .modal-footer button[data-element="ok"]';
                         return TestUtil.waitForElement(document.body, okBtnSelector, () => {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -157,16 +157,16 @@ define([
                 updatedState: 'appError',
                 testSelector: '.kb-rcp__action-button-container .-rerun',
                 testState: (elem) => !elem.classList.contains('hidden'),
-                enabledTabs: ['viewConfigure', 'info', 'jobStatus', 'results', 'error']
+                enabledTabs: ['viewConfigure', 'info', 'jobStatus', 'results', 'error'],
             },
             {
                 msgEvent: 'launched_job_batch',
                 msgData: {
-                    child_job_ids: ['foo']
+                    child_job_ids: ['foo'],
                 },
                 updatedState: 'queued',
                 testSelector: '.kb-rcp__btn-toolbar button[data-button="jobStatus"]',
-                testState: (elem) => !elem.classList.contains('disabled')
+                testState: (elem) => !elem.classList.contains('disabled'),
             },
             {
                 msgEvent: 'some-unknown-event',
@@ -186,18 +186,18 @@ define([
                         selectedFileType: 'fastq_reads',
                         selectedTab: 'configure',
                         params: {
-                            fastq_reads: 'complete'
-                        }
-                    }
+                            fastq_reads: 'complete',
+                        },
+                    },
                 };
                 cell.metadata = {
                     kbase: {
                         bulkImportCell: Object.assign({}, state, TestAppObj),
                         type: 'app-bulk-import',
                         attributes: {
-                            id: 'some-fake-bulk-import-cell'
-                        }
-                    }
+                            id: 'some-fake-bulk-import-cell',
+                        },
+                    },
                 };
                 BulkImportCell.make({ cell });
                 const testElem = cell.element[0].querySelector(testCase.testSelector);
@@ -211,31 +211,33 @@ define([
                     '.kb-rcp__action-button-container .-cancel'
                 );
                 return TestUtil.waitForElementState(cancelButton, () => {
-                    return !runButton.classList.contains('disabled') &&
-                        cancelButton.classList.contains('hidden');
+                    return (
+                        !runButton.classList.contains('disabled') &&
+                        cancelButton.classList.contains('hidden')
+                    );
                 })
                     .then(() => {
                         runButton.click();
                         return TestUtil.waitForElementState(
                             testElem,
                             () => {
-                                return testCase.testState(testElem)
+                                return testCase.testState(testElem);
                             },
                             () => {
-                                const message = Object.assign({
-                                    event: testCase.msgEvent
-                                }, testCase.msgData ? testCase.msgData : {});
-                                runtime.bus().send(
-                                    message,
+                                const message = Object.assign(
                                     {
-                                        channel: {
-                                            cell: cell.metadata.kbase.attributes.id,
-                                        },
-                                        key: {
-                                            type: 'run-status',
-                                        },
-                                    }
+                                        event: testCase.msgEvent,
+                                    },
+                                    testCase.msgData ? testCase.msgData : {}
                                 );
+                                runtime.bus().send(message, {
+                                    channel: {
+                                        cell: cell.metadata.kbase.attributes.id,
+                                    },
+                                    key: {
+                                        type: 'run-status',
+                                    },
+                                });
                             }
                         );
                     })


### PR DESCRIPTION
# Description of PR purpose/changes

Makes the Cancel button actually work and do stuff. It will:
* cancel the launching job state (which, incidentally, orphans the jobs it would have otherwise started. Not sure how to fix that yet)
* cancel all running jobs that it knows about
* return the cell to the editing state.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-312
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* start a bulk import job and hit the cancel button. It should work and return to the ready-to-run state.
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
