### PR TITLE
DATAUP-438 kernel responds with job_status message type with does_not_exist status

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -298,7 +298,7 @@ These are described below. The name (`msg_type`) is given, followed by the keys 
 By design, these should only be seen by the `JobCommChannel` instance, then sent into bus messages that get sent on specific channels. That information is also given in each block.
 
 ### `job_does_not_exist`
-This is an error message triggered when trying to get info/state/logs on a job that either doesn't exist in EE2 or that the JobManager doesn't have associated with the running narrative.
+This is an error message triggered when trying to get info/logs on a job that either doesn't exist in EE2 or that the JobManager doesn't have associated with the running narrative.
 
 **content**
   * `job_id` - a string, the job id
@@ -347,7 +347,7 @@ Includes information about the running job
 The current job state. This one is probably most common.
 
 **content**
-  * `state` - see **Data Structures** below for details (it's big and shouldn't be repeated all over this document)
+  * `state` - see **Data Structures** below for details (it's big and shouldn't be repeated all over this document). Non-existent jobs have the status `does_not_exist`
   * `widget_info` - the parameters to send to output widgets, only available for a completed job
   * `owner` - string, username of user who submitted the job
 

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -223,6 +223,10 @@ class JobComm:
         except ValueError:
             # kblogging.log_event(self._log, "lookup_job_state_error", {"err": str(e)})
             self.send_error_message("job_does_not_exist", req)
+            self.send_comm_message(
+                "job_status",
+                {"state": {"job_id": req.job_id, "status": "does_not_exist"}}
+            )
             raise
 
     def _modify_job_update(self, req: JobRequest) -> None:

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -129,9 +129,9 @@ class JobCommTestCase(unittest.TestCase):
         self.assertIn(f"No job present with id {job_id}", str(e.exception))
         msg = self.jc._comm.last_message
         self.assertEqual(
-            {"job_id": job_id, "source": "job_state"}, msg["data"]["content"]
+            {"state": {"job_id": job_id, "status": "does_not_exist"}}, msg["data"]["content"]
         )
-        self.assertEqual("job_does_not_exist", msg["data"]["msg_type"])
+        self.assertEqual("job_status", msg["data"]["msg_type"])
 
     # ---------------
     # Lookup job info


### PR DESCRIPTION
# Description of PR purpose/changes

When the browser requests a `job_status` from the kernel, the kernel currently responds with `job_does_not_exist` when the `job_id` is not associated with the current narrative. This PR changes the kernel to also respond with a `job_status` with a `status` of `does_not_exist`, "also" because the front end has not been altered yet. This new response message is actually sent after the current `job_does_not_exist` response message, because the testing scheme only tests the last message sent over the job comm channel.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [X] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [n/a] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
