### PR TITLE
let dynamic dropdown inputs be clearable

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -110,7 +110,9 @@ define([
             const control = ui.getElement('input-container.input'),
                 selected = $(control).select2('data')[0];
 
-            const selection_val = selected[dd_options.selection_id] || selected.subpath;
+            const selection_val = selected
+                ? selected[dd_options.selection_id] || selected.subpath
+                : '';
             if (!selected || !selection_val) {
                 // might have just started up, and we don't have a selection value, but
                 // we might have a model value.
@@ -289,6 +291,16 @@ define([
         }
 
         /**
+         * Clears the current selection and updates the model.
+         */
+        function doClear() {
+            model.value = spec.data.nullValue;
+            channel.emit('changed', {
+                newValue: spec.data.nullValue,
+            });
+        }
+
+        /**
          * Formats the display of an object in the dropdown.
          id: "data/bulk/wjriehl/subfolder/i_am_a_file.txt"
          isFolder: false
@@ -359,6 +371,7 @@ define([
 
                 $(ui.getElement('input-container.input'))
                     .select2({
+                        allowClear: true,
                         templateResult: formatObjectDisplay,
                         templateSelection: selectionTemplate,
                         ajax: {
@@ -374,9 +387,15 @@ define([
                                     });
                             },
                         },
+                        placeholder: {
+                            id: 'select an option',
+                        },
                     })
                     .on('change', () => {
                         doChange();
+                    })
+                    .on('select2:clear', () => {
+                        doClear();
                     });
                 events.attachEvents(container);
             });


### PR DESCRIPTION
# Description of PR purpose/changes

Dynamic dropdown inputs - even optional ones - were previously unclearable. If you set a value, you'd have to make a whole new app cell to get an empty one.

This activates the `allowClear` select2 option and wires various events up.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
no ticket on this one, yet.
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
