### PR TITLE
DATAUP-312 Fix report tab

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
@@ -34,13 +34,13 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
          * @returns {Array} an array of report ids.
          */
         function getReportRefs() {
-            const jobindex = model.getItem('exec.jobs.byId');
-            const jobStates = Object.values(jobindex);
+            const jobIndex = model.getItem('exec.jobs.byId');
+            const jobStates = Object.values(jobIndex);
 
             const reportRefs = [];
             jobStates.forEach((job) => {
-                if ('result' in job && job.result.length > 0) {
-                    job.result.forEach((result) => {
+                if ('job_output' in job && 'result' in job.job_output && job.job_output.result.length > 0) {
+                    job.job_output.result.forEach((result) => {
                         if ('report_ref' in result) {
                             reportRefs.push(result.report_ref);
                         }

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
@@ -39,7 +39,11 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
 
             const reportRefs = [];
             jobStates.forEach((job) => {
-                if ('job_output' in job && 'result' in job.job_output && job.job_output.result.length > 0) {
+                if (
+                    'job_output' in job &&
+                    'result' in job.job_output &&
+                    job.job_output.result.length > 0
+                ) {
                     job.job_output.result.forEach((result) => {
                         if ('report_ref' in result) {
                             reportRefs.push(result.report_ref);

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -265,7 +265,7 @@ define(['common/format'], (format) => {
                         report_name: 'kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e',
                         report_ref: '57373/16/1',
                     },
-                ]
+                ],
             },
         },
     ];

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -259,12 +259,14 @@ define(['common/format'], (format) => {
                 },
                 appCellFsm: { mode: 'success' },
             },
-            result: [
-                {
-                    report_name: 'kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e',
-                    report_ref: '57373/16/1',
-                },
-            ],
+            job_output: {
+                result: [
+                    {
+                        report_name: 'kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e',
+                        report_ref: '57373/16/1',
+                    },
+                ]
+            },
         },
     ];
 


### PR DESCRIPTION
# Description of PR purpose/changes

As part of the BE connection, fix the report tab - it was using some job status keys that were there in the early test data, but don't exist in live data. Namely, the job status `result` key is really under `job_output.result`.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-312
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook

