### PR TITLE
DATAUP-449 add view configure mode for bulk import cells

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -29,6 +29,7 @@ define([
      *  - workspaceId - the id of the workspace we should use for searching for objects
      *  - initialParams - Array of objects. Each item represents a row of parameter values.
      *    So each item has an object with parameter id -> value
+     *  - viewOnly - boolean, if true start with the view version of input widgets
      * @returns
      */
     function factory(config) {

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -33,7 +33,8 @@ define([
      * @returns
      */
     function factory(config) {
-        const { workspaceId, initialParams, paramIds, viewOnly } = config;
+        const viewOnly = config.viewOnly || false;
+        const { workspaceId, initialParams, paramIds } = config;
         const runtime = Runtime.make(),
             // paramsBus is used to communicate from this parameter container to the parent that
             // created and owns it

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -32,13 +32,11 @@ define([
      * @returns
      */
     function factory(config) {
+        const { workspaceId, initialParams, paramIds, viewOnly } = config;
         const runtime = Runtime.make(),
             // paramsBus is used to communicate from this parameter container to the parent that
             // created and owns it
             paramsBus = config.bus,
-            workspaceId = config.workspaceId,
-            initialParams = config.initialParams,
-            paramIds = config.paramIds, // these aren't in the right order, get the right order in start()
             model = Props.make(),
             /**
              * Internal data model
@@ -154,23 +152,6 @@ define([
                         parameter: parameterSpec.id,
                     });
                 }
-            });
-
-            // The 'sync' message is a request for the current model value from the
-            // input widget.
-            fieldWidget.bus.on('sync', () => {
-                const newValue = dataModel.rows[rowId].values[parameterSpec.id];
-                fieldWidget.bus.send(
-                    {
-                        value: newValue,
-                    },
-                    {
-                        // This points the update back to a listener on this key
-                        key: {
-                            type: 'update',
-                        },
-                    }
-                );
             });
 
             fieldWidget.bus.respond({
@@ -304,35 +285,40 @@ define([
          */
         function renderLayout() {
             let formContent = [];
+            const panelBody = [
+                ol({
+                    class: `${cssBaseClass}__list`,
+                    dataElement: `${cssClassType}-fields`,
+                }),
+            ];
+            if (!viewOnly) {
+                panelBody.push(
+                    button(
+                        {
+                            class: `${cssBaseClass}__button--add_row`,
+                            type: 'button',
+                            id: events.addEvent({
+                                type: 'click',
+                                handler: function () {
+                                    addRow();
+                                },
+                            }),
+                        },
+                        [
+                            span({
+                                class: `${cssBaseClass}__button_icon--add_row fa fa-plus`,
+                            }),
+                            'Add Row',
+                        ]
+                    )
+                );
+            }
 
             formContent = formContent.concat([
                 ui.buildPanel({
                     title: span(['File Paths']),
                     name: `${cssClassType}s-area`,
-                    body: [
-                        ol({
-                            class: `${cssBaseClass}__list`,
-                            dataElement: `${cssClassType}-fields`,
-                        }),
-                        button(
-                            {
-                                class: `${cssBaseClass}__button--add_row`,
-                                type: 'button',
-                                id: events.addEvent({
-                                    type: 'click',
-                                    handler: function () {
-                                        addRow();
-                                    },
-                                }),
-                            },
-                            [
-                                span({
-                                    class: `${cssBaseClass}__button_icon--add_row fa fa-plus`,
-                                }),
-                                'Add Row',
-                            ]
-                        ),
-                    ],
+                    body: panelBody,
                     classes: ['kb-panel-light'],
                 }),
             ]);
@@ -430,8 +416,13 @@ define([
         function createFilePathWidget(rowId, appSpec, filePathParams, parameterId, parameterValue) {
             const spec = filePathParams.paramMap[parameterId];
             let widget;
-            return paramResolver
-                .loadInputControl(spec)
+            let controlPromise;
+            if (viewOnly) {
+                controlPromise = paramResolver.loadViewControl(spec);
+            } else {
+                controlPromise = paramResolver.loadInputControl(spec);
+            }
+            return controlPromise
                 .then((inputWidget) => {
                     widget = makeFieldWidget(rowId, inputWidget, appSpec, spec, parameterValue);
 
@@ -505,7 +496,7 @@ define([
                 );
             }
 
-            filePathRow.innerHTML = [
+            const fpRowHtml = (filePathRow.innerHTML = [
                 div(
                     {
                         class: `${cssBaseClass}__params`,
@@ -519,24 +510,30 @@ define([
                         ),
                     ]
                 ),
-                button(
-                    {
-                        class: `${cssBaseClass}__button--delete`,
-                        type: 'button',
-                        id: rowEvents.addEvent({
-                            type: 'click',
-                            handler: function (e) {
-                                deleteRow(e, rowId);
-                            },
-                        }),
-                    },
-                    [
-                        icon({
-                            class: 'fa fa-trash-o fa-lg',
-                        }),
-                    ]
-                ),
-            ].join('');
+            ]);
+            if (!viewOnly) {
+                fpRowHtml.push(
+                    button(
+                        {
+                            class: `${cssBaseClass}__button--delete`,
+                            type: 'button',
+                            id: rowEvents.addEvent({
+                                type: 'click',
+                                handler: function (e) {
+                                    deleteRow(e, rowId);
+                                },
+                            }),
+                        },
+                        [
+                            icon({
+                                class: 'fa fa-trash-o fa-lg',
+                            }),
+                        ]
+                    )
+                );
+            }
+
+            filePathRow.innerHTML = fpRowHtml.join('');
 
             return Promise.all(
                 filePathParams.layout.map(async (parameterId) => {

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -18,11 +18,8 @@ define([
         div = tag('div');
 
     function factory(config) {
+        const { bus, workspaceId, paramIds, initialParams, viewOnly } = config;
         const runtime = Runtime.make(),
-            bus = config.bus,
-            workspaceId = config.workspaceId,
-            paramIds = config.paramIds,
-            initialParams = config.initialParams,
             model = Props.make(),
             paramResolver = ParamResolver.make(),
             settings = {
@@ -88,138 +85,141 @@ define([
                 referenceType: 'name',
                 paramsChannelName: bus.channelName,
                 closeParameters: closeParameters,
+                viewOnly,
             });
 
-            // Forward all changed parameters to the controller. That is our main job!
-            fieldWidget.bus.on('changed', (message) => {
-                bus.send(
-                    {
-                        parameter: parameterSpec.id,
-                        newValue: message.newValue,
-                        isError: message.isError,
-                    },
-                    {
-                        key: {
-                            type: 'parameter-changed',
+            if (!viewOnly) {
+                // Forward all changed parameters to the controller. That is our main job!
+                fieldWidget.bus.on('changed', (message) => {
+                    bus.send(
+                        {
                             parameter: parameterSpec.id,
+                            newValue: message.newValue,
+                            isError: message.isError,
                         },
-                    }
-                );
-
-                bus.emit('parameter-changed', {
-                    parameter: parameterSpec.id,
-                    newValue: message.newValue,
-                    isError: message.isError,
-                });
-            });
-
-            fieldWidget.bus.on('validation', (message) => {
-                // only propagate if invalid. value changes come through
-                // the 'changed' message
-                if (!message.isValid) {
-                    bus.emit('invalid-param-value', {
-                        parameter: parameterSpec.id,
-                    });
-                }
-            });
-
-            fieldWidget.bus.on('touched', () => {
-                bus.emit('parameter-touched', {
-                    parameter: parameterSpec.id,
-                });
-            });
-
-            // An input widget may ask for the current model value at any time.
-            fieldWidget.bus.on('sync', () => {
-                bus.emit('parameter-sync', {
-                    parameter: parameterSpec.id,
-                });
-            });
-
-            fieldWidget.bus.on('sync-params', (message) => {
-                bus.emit('sync-params', {
-                    parameters: message.parameters,
-                    replyToChannel: fieldWidget.bus.channelName,
-                });
-            });
-
-            fieldWidget.bus.on('set-param-state', (message) => {
-                bus.emit('set-param-state', {
-                    id: parameterSpec.id,
-                    state: message.state,
-                });
-            });
-
-            fieldWidget.bus.respond({
-                key: {
-                    type: 'get-param-state',
-                },
-                handle: function () {
-                    return bus.request(
-                        { id: parameterSpec.id },
                         {
                             key: {
-                                type: 'get-param-state',
+                                type: 'parameter-changed',
+                                parameter: parameterSpec.id,
                             },
                         }
                     );
-                },
-            });
 
-            fieldWidget.bus.respond({
-                key: {
-                    type: 'get-parameter',
-                },
-                handle: function (message) {
-                    if (message.parameterName) {
-                        return bus.request(message, {
-                            key: {
-                                type: 'get-parameter',
-                            },
+                    bus.emit('parameter-changed', {
+                        parameter: parameterSpec.id,
+                        newValue: message.newValue,
+                        isError: message.isError,
+                    });
+                });
+
+                fieldWidget.bus.on('validation', (message) => {
+                    // only propagate if invalid. value changes come through
+                    // the 'changed' message
+                    if (!message.isValid) {
+                        bus.emit('invalid-param-value', {
+                            parameter: parameterSpec.id,
                         });
-                    } else {
-                        return null;
                     }
-                },
-            });
+                });
 
-            fieldWidget.bus.respond({
-                key: {
-                    type: 'get-parameters',
-                },
-                handle: (message) => {
-                    if (message.parameterNames) {
-                        return Promise.all(
-                            message.parameterNames.map((paramName) => {
-                                return bus
-                                    .request(
-                                        {
-                                            parameterName: paramName,
-                                        },
-                                        {
-                                            key: {
-                                                type: 'get-parameter',
-                                            },
-                                        }
-                                    )
-                                    .then((result) => {
-                                        const returnVal = {};
-                                        returnVal[paramName] = result.value;
-                                        return returnVal;
-                                    });
-                            })
-                        ).then((results) => {
-                            const combined = {};
-                            results.forEach((res) => {
-                                Object.keys(res).forEach((key) => {
-                                    combined[key] = res[key];
-                                });
+                fieldWidget.bus.on('touched', () => {
+                    bus.emit('parameter-touched', {
+                        parameter: parameterSpec.id,
+                    });
+                });
+
+                // An input widget may ask for the current model value at any time.
+                fieldWidget.bus.on('sync', () => {
+                    bus.emit('parameter-sync', {
+                        parameter: parameterSpec.id,
+                    });
+                });
+
+                fieldWidget.bus.on('sync-params', (message) => {
+                    bus.emit('sync-params', {
+                        parameters: message.parameters,
+                        replyToChannel: fieldWidget.bus.channelName,
+                    });
+                });
+
+                fieldWidget.bus.on('set-param-state', (message) => {
+                    bus.emit('set-param-state', {
+                        id: parameterSpec.id,
+                        state: message.state,
+                    });
+                });
+
+                fieldWidget.bus.respond({
+                    key: {
+                        type: 'get-param-state',
+                    },
+                    handle: function () {
+                        return bus.request(
+                            { id: parameterSpec.id },
+                            {
+                                key: {
+                                    type: 'get-param-state',
+                                },
+                            }
+                        );
+                    },
+                });
+
+                fieldWidget.bus.respond({
+                    key: {
+                        type: 'get-parameter',
+                    },
+                    handle: function (message) {
+                        if (message.parameterName) {
+                            return bus.request(message, {
+                                key: {
+                                    type: 'get-parameter',
+                                },
                             });
-                            return combined;
-                        });
-                    }
-                },
-            });
+                        } else {
+                            return null;
+                        }
+                    },
+                });
+
+                fieldWidget.bus.respond({
+                    key: {
+                        type: 'get-parameters',
+                    },
+                    handle: (message) => {
+                        if (message.parameterNames) {
+                            return Promise.all(
+                                message.parameterNames.map((paramName) => {
+                                    return bus
+                                        .request(
+                                            {
+                                                parameterName: paramName,
+                                            },
+                                            {
+                                                key: {
+                                                    type: 'get-parameter',
+                                                },
+                                            }
+                                        )
+                                        .then((result) => {
+                                            const returnVal = {};
+                                            returnVal[paramName] = result.value;
+                                            return returnVal;
+                                        });
+                                })
+                            ).then((results) => {
+                                const combined = {};
+                                results.forEach((res) => {
+                                    Object.keys(res).forEach((key) => {
+                                        combined[key] = res[key];
+                                    });
+                                });
+                                return combined;
+                            });
+                        }
+                    },
+                });
+            }
 
             // Just pass the update along to the input widget.
             bus.listen({
@@ -402,8 +402,13 @@ define([
 
         function createParameterWidget(appSpec, parameterInfo, parameterId) {
             const paramSpec = parameterInfo.paramMap[parameterId];
-            return paramResolver
-                .loadInputControl(paramSpec)
+            let controlPromise;
+            if (viewOnly) {
+                controlPromise = paramResolver.loadViewControl(paramSpec);
+            } else {
+                controlPromise = paramResolver.loadInputControl(paramSpec);
+            }
+            return controlPromise
                 .then((inputWidget) => {
                     const widget = makeFieldWidget(
                         inputWidget,

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -1,8 +1,6 @@
 define([
     'bluebird',
-    // CDN
     'common/html',
-    // LOCAL
     'common/ui',
     'common/events',
     'common/props',

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -78,12 +78,12 @@ define([
                 showHint: true,
                 useRowHighight: true,
                 initialValue: value,
-                appSpec: appSpec,
-                parameterSpec: parameterSpec,
-                workspaceId: workspaceId,
                 referenceType: 'name',
                 paramsChannelName: bus.channelName,
-                closeParameters: closeParameters,
+                appSpec,
+                parameterSpec,
+                workspaceId,
+                closeParameters,
                 viewOnly,
             });
 
@@ -393,9 +393,9 @@ define([
             return {
                 content: layout,
                 layout: orderedParams,
-                params: params,
-                view: view,
-                paramMap: paramMap,
+                params,
+                view,
+                paramMap,
             };
         }
 
@@ -517,8 +517,8 @@ define([
         }
 
         return {
-            start: start,
-            stop: stop,
+            start,
+            stop,
             bus: function () {
                 return bus;
             },

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -16,7 +16,8 @@ define([
         div = tag('div');
 
     function factory(config) {
-        const { bus, workspaceId, paramIds, initialParams, viewOnly } = config;
+        const viewOnly = config.viewOnly || false;
+        const { bus, workspaceId, paramIds, initialParams } = config;
         const runtime = Runtime.make(),
             model = Props.make(),
             paramResolver = ParamResolver.make(),

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/dynamicDropdownView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/dynamicDropdownView.js
@@ -16,7 +16,7 @@ define([
     function factory(config) {
         const spec = config.parameterSpec,
             bus = config.bus,
-            model  = Props.make({
+            model = Props.make({
                 data: {
                     value: null,
                 },

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/dynamicDropdownView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/dynamicDropdownView.js
@@ -1,13 +1,11 @@
 define([
     'bluebird',
     'kb_common/html',
-    'common/events',
     'common/ui',
     'common/props',
-
     'bootstrap',
     'css!font-awesome',
-], (Promise, html, Events, UI, Props) => {
+], (Promise, html, UI, Props) => {
     'use strict';
 
     const t = html.tag,
@@ -17,8 +15,18 @@ define([
 
     function factory(config) {
         const spec = config.parameterSpec,
-            bus = config.bus;
-        let parent, container, ui, model;
+            bus = config.bus,
+            model  = Props.make({
+                data: {
+                    value: null,
+                },
+                onUpdate: () => {},
+            });
+        let parent, container, ui;
+
+        // INIT
+
+        setModelValue(config.initialValue);
 
         // CONTROL
 
@@ -49,7 +57,7 @@ define([
 
         // DOM & RENDERING
 
-        function makeViewControl(events) {
+        function makeViewControl() {
             return select(
                 {
                     class: 'form-control',
@@ -61,12 +69,12 @@ define([
             );
         }
 
-        function render(events) {
+        function render() {
             return div(
                 {
                     dataElement: 'input-container',
                 },
-                [makeViewControl(events)]
+                [makeViewControl()]
             );
         }
 
@@ -90,10 +98,7 @@ define([
                 container = parent.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
 
-                const events = Events.make();
-                container.innerHTML = render(events);
-                events.attachEvents(container);
-                // model.setItem('value', config.initialValue);
+                container.innerHTML = render();
                 syncModelToControl();
 
                 bus.on('reset-to-defaults', () => {
@@ -102,7 +107,6 @@ define([
                 bus.on('focus', () => {
                     doFocus();
                 });
-                // bus.emit('sync');
             });
         }
 
@@ -114,20 +118,9 @@ define([
             });
         }
 
-        // INIT
-
-        model = Props.make({
-            data: {
-                value: null,
-            },
-            onUpdate: () => {},
-        });
-
-        setModelValue(config.initialValue);
-
         return {
-            start: start,
-            stop: stop,
+            start,
+            stop,
         };
     }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/dynamicDropdownView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/dynamicDropdownView.js
@@ -1,15 +1,13 @@
 define([
     'bluebird',
     'kb_common/html',
-    '../validators/text',
     'common/events',
     'common/ui',
     'common/props',
-    '../inputUtils',
 
     'bootstrap',
     'css!font-awesome',
-], (Promise, html, Validation, Events, UI, Props, inputUtils) => {
+], (Promise, html, Events, UI, Props) => {
     'use strict';
 
     const t = html.tag,
@@ -18,12 +16,9 @@ define([
         option = t('option');
 
     function factory(config) {
-        let spec = config.parameterSpec,
-            bus = config.bus,
-            parent,
-            container,
-            ui,
-            model;
+        const spec = config.parameterSpec,
+            bus = config.bus;
+        let parent, container, ui, model;
 
         // CONTROL
 
@@ -125,7 +120,7 @@ define([
             data: {
                 value: null,
             },
-            onUpdate: function () {},
+            onUpdate: () => {},
         });
 
         setModelValue(config.initialValue);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/newObjectView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/newObjectView.js
@@ -20,8 +20,7 @@ define(['bluebird', 'common/html', 'common/ui', 'bootstrap', 'css!font-awesome']
             const inputField = ui.getElement('input');
             if (value === null || value === undefined) {
                 inputField.removeAttribute('value');
-            }
-            else {
+            } else {
                 inputField.setAttribute('value', newValue);
             }
         }
@@ -37,7 +36,7 @@ define(['bluebird', 'common/html', 'common/ui', 'bootstrap', 'css!font-awesome']
                 value,
                 readonly: true,
                 disabled: true,
-            })
+            });
             ui.setContent('input-container', inputControl);
         }
 

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -146,11 +146,11 @@ define([
                 tabs: {
                     configure: {
                         label: 'Configure',
-                        widget: ConfigureWidget.ConfigureWidget,
+                        widget: ConfigureWidget.editMode,
                     },
                     viewConfigure: {
                         label: 'View Configure',
-                        widget: ConfigureWidget.ViewConfigureWidget,
+                        widget: ConfigureWidget.viewMode,
                     },
                     info: {
                         label: 'Info',

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -146,11 +146,11 @@ define([
                 tabs: {
                     configure: {
                         label: 'Configure',
-                        widget: ConfigureWidget,
+                        widget: ConfigureWidget.ConfigureWidget,
                     },
                     viewConfigure: {
                         label: 'View Configure',
-                        widget: DefaultWidget(),
+                        widget: ConfigureWidget.ViewConfigureWidget,
                     },
                     info: {
                         label: 'Info',

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -473,7 +473,7 @@ define([
                 return ConfigureWidget(Object.assign({}, options, { viewOnly: true }));
             },
         },
-        // the standard constructor, let the caller decide which mode manually
+        // the standard constructor, let the caller manually decide which mode to use
         make: ConfigureWidget,
     };
 });

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -30,10 +30,8 @@ define([
      * @returns
      */
     function ConfigureWidget(options) {
-        if (!options.viewOnly) {
-            options.viewOnly = false;
-        }
-        const { model, specs, typesToFiles, viewOnly } = options;
+        const viewOnly = options.viewOnly || false;
+        const { model, specs, typesToFiles } = options;
         const cellBus = options.bus,
             runtime = Runtime.make(),
             FILE_PATH_TYPE = 'filePaths',

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -25,11 +25,12 @@ define([
      *     bus: message bus
      *     model: cell metadata, contains such fun items as the app parameters and state
      *     specs: app specs, keyed by their app id
-     *     typesToFiles: map from object type to appId and list of input files
+     *     typesToFiles: map from object type to appId and list of input files,
+     *     viewOnly: boolean - if true, then will start child widgets in view only mode
      * @returns
      */
     function ConfigureWidget(options) {
-        const { model, specs, typesToFiles } = options;
+        const { model, specs, typesToFiles, viewOnly } = options;
         const cellBus = options.bus,
             runtime = Runtime.make(),
             FILE_PATH_TYPE = 'filePaths',
@@ -193,6 +194,7 @@ define([
                 workspaceId: runtime.workspaceId(),
                 paramIds: model.getItem(['app', 'otherParamIds', selectedFileType]),
                 initialParams: model.getItem(['params', selectedFileType, PARAM_TYPE]),
+                viewOnly,
             });
 
             return widget
@@ -246,6 +248,7 @@ define([
                 workspaceId: runtime.workspaceId(),
                 paramIds: model.getItem(['app', 'fileParamIds', selectedFileType]),
                 initialParams: model.getItem(['params', selectedFileType, FILE_PATH_TYPE]),
+                viewOnly,
             });
 
             return widget
@@ -457,6 +460,16 @@ define([
     }
 
     return {
+        ConfigureWidget: {
+            make: (options) => {
+                return ConfigureWidget(Object.assign({}, options, { viewOnly: false }));
+            },
+        },
+        ViewConfigureWidget: {
+            make: (options) => {
+                return ConfigureWidget(Object.assign({}, options, { viewOnly: true }));
+            },
+        },
         make: ConfigureWidget,
     };
 });

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -30,6 +30,9 @@ define([
      * @returns
      */
     function ConfigureWidget(options) {
+        if (!options.viewOnly) {
+            options.viewOnly = false;
+        }
         const { model, specs, typesToFiles, viewOnly } = options;
         const cellBus = options.bus,
             runtime = Runtime.make(),
@@ -460,16 +463,19 @@ define([
     }
 
     return {
-        ConfigureWidget: {
+        // wrapper to make a widget in edit mode
+        editMode: {
             make: (options) => {
                 return ConfigureWidget(Object.assign({}, options, { viewOnly: false }));
             },
         },
-        ViewConfigureWidget: {
+        // wrapper to make a widget in view mode
+        viewMode: {
             make: (options) => {
                 return ConfigureWidget(Object.assign({}, options, { viewOnly: true }));
             },
         },
+        // the standard constructor, let the caller decide which mode manually
         make: ConfigureWidget,
     };
 });

--- a/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
@@ -19,8 +19,6 @@ define([
         });
     });
 
-    describe('The file path widget can start in different view modes.', () => {});
-
     describe('The file path widget instance', () => {
         let container;
 

--- a/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
@@ -20,6 +20,14 @@ define([
 
     describe('The Parameter instance', () => {
         let container;
+
+        function makeParamsWidget(args, viewOnly) {
+            if (viewOnly !== undefined) {
+                args.viewOnly = viewOnly;
+            }
+            return ParamsWidget.make(args);
+        }
+
         beforeAll(() => {
             window.kbaseRuntime = null;
             Jupyter.narrative = {
@@ -31,111 +39,152 @@ define([
             Jupyter.narrative = null;
         });
 
-        beforeEach(async function () {
-            const bus = Runtime.make().bus();
+        beforeEach(function () {
+            this.bus = Runtime.make().bus();
 
             container = document.createElement('div');
             this.node = document.createElement('div');
             container.appendChild(this.node);
 
-            const model = Props.make({
+            this.model = Props.make({
                 data: TestAppObject,
                 onUpdate: () => {},
             });
 
-            const spec = Spec.make({
-                appSpec: model.getItem([
+            this.spec = Spec.make({
+                appSpec: this.model.getItem([
                     'app',
                     'specs',
                     'kb_uploadmethods/import_fastq_sra_as_reads_from_staging',
                 ]),
             });
 
-            const paramIds = model.getItem(['app', 'otherParamIds', 'fastq_reads']);
+            this.paramIds = this.model.getItem(['app', 'otherParamIds', 'fastq_reads']);
 
-            this.parameters = spec.getSpec().parameters;
-            const workspaceId = 54745;
-            const initialParams = model.getItem('params');
+            this.parameters = this.spec.getSpec().parameters;
+            this.workspaceId = 54745;
+            this.initialParams = this.model.getItem('params');
 
-            this.paramsWidgetInstance = ParamsWidget.make({
-                bus,
-                workspaceId,
-                initialParams,
-                paramIds,
-            });
-
-            await this.paramsWidgetInstance.start({
-                node: this.node,
-                appSpec: spec,
-                parameters: this.parameters,
-            });
+            this.defaultArgs = {
+                bus: this.bus,
+                workspaceId: this.workspaceId,
+                initialParams: this.initialParams,
+                paramIds: this.paramIds,
+            };
         });
 
-        afterEach(async function () {
-            if (this.paramsWidgetInstance) {
-                await this.paramsWidgetInstance.stop();
-            }
+        afterEach(() => {
             window.kbaseRuntime = null;
             container.remove();
         });
 
-        it('should render the correct parameters', function () {
-            //Regular (non-advanced) params
-            const paramContainers = this.node.querySelectorAll(
-                'div.kb-field-cell__param_container'
-            );
-            const titleList = Object.values(this.parameters.specs).map((item) => {
-                return item.ui.label;
-            });
-
-            paramContainers.forEach((paramNode) => {
-                //each param container should have ONE label
-                const labelArr = paramNode.querySelectorAll('label.kb-field-cell__cell_label');
-                expect(labelArr.length).toBe(1);
-                const label = labelArr[0];
-                expect(label).toBeDefined();
-                expect(titleList.includes(label.innerText)).toBeTrue();
-
-                //each label should also have a title
-                const title = label.getAttribute('title');
-                expect(title).toBeDefined();
-                expect(titleList.includes(title)).toBeTrue();
-
-                //each param container should have ONE input control
-                const inputControlArr = paramNode.querySelectorAll(
-                    'div.kb-field-cell__input_control'
-                );
-                expect(inputControlArr).toBeDefined();
-                expect(inputControlArr.length).toBe(1);
+        [
+            {
+                label: 'default',
+            },
+            {
+                label: 'edit',
+                viewOnly: false,
+            },
+            {
+                label: 'view',
+                viewOnly: true,
+            },
+        ].forEach((testCase) => {
+            it(`can run in ${testCase.label} mode`, function () {
+                const paramsWidget = makeParamsWidget(this.defaultArgs, testCase.viewOnly);
+                return paramsWidget
+                    .start({
+                        node: this.node,
+                        appSpec: this.spec,
+                        parameters: this.parameters,
+                    })
+                    .then(() => {
+                        const viewOnly = testCase.viewOnly || false;
+                        const inputField = this.node.querySelector(
+                            '[data-parameter="import_type"] select[data-element="input"]'
+                        );
+                        expect(inputField.hasAttribute('readonly')).toBe(viewOnly);
+                        return paramsWidget.stop();
+                    });
             });
         });
 
-        it('should render with advanced parameters hidden', function () {
-            //get all advanced params using the spec
-            const thisNode = this.node;
-            const advancedParams = [];
-            for (const [, entry] of Object.entries(this.parameters.specs)) {
-                if (entry.ui.advanced) {
-                    advancedParams.push(entry.id);
+        describe('The running instance', () => {
+            beforeEach(async function () {
+                this.paramsWidgetInstance = makeParamsWidget(this.defaultArgs);
+
+                await this.paramsWidgetInstance.start({
+                    node: this.node,
+                    appSpec: this.spec,
+                    parameters: this.parameters,
+                });
+            });
+
+            afterEach(async function () {
+                if (this.paramsWidgetInstance) {
+                    await this.paramsWidgetInstance.stop();
                 }
-            }
-
-            //search for these on the rendered page, make sure they are there and have the correct class
-            advancedParams.forEach((param) => {
-                const renderedAdvancedParam = thisNode.querySelector(
-                    `div[data-advanced-parameter="${param}"]`
-                );
-                expect(renderedAdvancedParam).toBeDefined();
-                expect(renderedAdvancedParam).toHaveClass(
-                    'kb-app-params__fields--parameters__hidden_field'
-                );
             });
-        });
 
-        it('should stop itself and empty the node it was in', async function () {
-            await this.paramsWidgetInstance.stop();
-            expect(this.node.innerHTML).toEqual('');
-            this.paramsWidgetInstance = null;
+            it('should render the correct parameters', function () {
+                //Regular (non-advanced) params
+                const paramContainers = this.node.querySelectorAll(
+                    'div.kb-field-cell__param_container'
+                );
+                const titleList = Object.values(this.parameters.specs).map((item) => {
+                    return item.ui.label;
+                });
+
+                paramContainers.forEach((paramNode) => {
+                    //each param container should have ONE label
+                    const labelArr = paramNode.querySelectorAll('label.kb-field-cell__cell_label');
+                    expect(labelArr.length).toBe(1);
+                    const label = labelArr[0];
+                    expect(label).toBeDefined();
+                    expect(titleList.includes(label.innerText)).toBeTrue();
+
+                    //each label should also have a title
+                    const title = label.getAttribute('title');
+                    expect(title).toBeDefined();
+                    expect(titleList.includes(title)).toBeTrue();
+
+                    //each param container should have ONE input control
+                    const inputControlArr = paramNode.querySelectorAll(
+                        'div.kb-field-cell__input_control'
+                    );
+                    expect(inputControlArr).toBeDefined();
+                    expect(inputControlArr.length).toBe(1);
+                });
+            });
+
+            it('should render with advanced parameters hidden', function () {
+                //get all advanced params using the spec
+                const thisNode = this.node;
+                const advancedParams = [];
+                for (const [, entry] of Object.entries(this.parameters.specs)) {
+                    if (entry.ui.advanced) {
+                        advancedParams.push(entry.id);
+                    }
+                }
+
+                //search for these on the rendered page, make sure they are there and have the correct class
+                advancedParams.forEach((param) => {
+                    const renderedAdvancedParam = thisNode.querySelector(
+                        `div[data-advanced-parameter="${param}"]`
+                    );
+                    expect(renderedAdvancedParam).toBeDefined();
+                    expect(renderedAdvancedParam).toHaveClass(
+                        'kb-app-params__fields--parameters__hidden_field'
+                    );
+                });
+            });
+
+            it('should stop itself and empty the node it was in', async function () {
+                await this.paramsWidgetInstance.stop();
+                expect(this.node.innerHTML).toEqual('');
+                this.paramsWidgetInstance = null;
+            });
         });
     });
 });

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -50,27 +50,50 @@ define([
             Jupyter.narrative = null;
         });
 
-        it('should start and render itself', () => {
-            const model = Props.make({
-                data: Object.assign({}, TestAppObject, { state: initialState }),
-                onUpdate: () => {},
-            });
-            const configure = ConfigureTab.make({
-                bus,
-                model,
-                specs,
-                typesToFiles,
-            });
-
-            return configure
-                .start({
-                    node: container,
-                })
-                .then(() => {
-                    // just make sure it renders the "File Paths" and "Parameters" headers
-                    expect(container.innerHTML).toContain('Parameters');
-                    expect(container.innerHTML).toContain('File Paths');
+        [
+            {
+                widget: ConfigureTab,
+                viewOnly: false,
+                label: 'default',
+            },
+            {
+                widget: ConfigureTab.editMode,
+                viewOnly: false,
+                label: 'edit',
+            },
+            {
+                widget: ConfigureTab.viewMode,
+                viewOnly: true,
+                label: 'view',
+            },
+        ].forEach((testCase) => {
+            it(`should start in ${testCase.label} mode`, () => {
+                const model = Props.make({
+                    data: Object.assign({}, TestAppObject, { state: initialState }),
+                    onUpdate: () => {},
                 });
+                const configure = testCase.widget.make({
+                    bus,
+                    model,
+                    specs,
+                    typesToFiles,
+                });
+
+                return configure
+                    .start({
+                        node: container,
+                    })
+                    .then(() => {
+                        // just make sure it renders the "File Paths" and "Parameters" headers
+                        expect(container.innerHTML).toContain('Parameters');
+                        expect(container.innerHTML).toContain('File Paths');
+                        const inputForm = container.querySelector(
+                            '[data-parameter="import_type"] select[data-element="input"]'
+                        );
+                        expect(inputForm.hasAttribute('readonly')).toBe(testCase.viewOnly);
+                        return configure.stop();
+                    });
+            });
         });
 
         it('should stop itself and empty the node it was in', () => {


### PR DESCRIPTION
# Description of PR purpose/changes

Implements the "View Configure" tab that appears while jobs are running / completed.
Really, all that happens here is this creates a mode switch for the configure, file path, and params widgets. Default is "edit" mode, with "view" mode as an option when the flag is set. The only real difference is that "view" mode uses the `view` variant of the input widgets.

There's a couple of those widgets identified here that don't really play as expected. I suspect there are others, but these fixes fill the need at the moment. I'm sure there's be a bugfix jamboree at some point...

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-449
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* get a running bulk import cell, and click on "View Configure", this should show up with read only / disabled versions of all of the input widgets.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
