### PR TITLE
DATAUP-328 Batch Retry BE Hookup

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -253,7 +253,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
-`retry_job` - retry a job or list of jobs, responds with `job_retried` and `new_job` for each job
+`retry_job` - retry a job or list of jobs, responds with `jobs_retried` and `new_job` for each job
 * `job_id` - string OR `job_id_list` - array of strings
 
 ## Messages sent from the kernel to the browser
@@ -297,7 +297,7 @@ By design, these should only be seen by the `JobCommChannel` instance, then sent
 This is an error message triggered when trying to get info/logs on a job that either doesn't exist in EE2 or that the JobManager doesn't have associated with the running narrative.
 
 **content**
-  * `job_id` - a string, the job id
+  * `job_id` - string OR `job_id_list` - array of strings, the job id(s)
   * `source` - string, the source of the error
 
 **bus** `job-does-not-exist`
@@ -307,7 +307,7 @@ A general job comm error, capturing most errors that get thrown by the kernel
 
 **content** (this varies, but usually includes the below)
   * `request_type` - the original request message that wound up in an error
-  * `job_id` - string, the job id (if present)
+  * `job_id` - string OR `job_id_list` - array of strings, the job id(s) (if present)
   * `message` - string, an error message
 
 **bus** one of `job-cancel-error`, `job-log-deleted`, `job-error`
@@ -363,15 +363,26 @@ Includes log statement information for a given job.
 
 **bus** `job-logs`
 
-### `job_retried`
-Sent when a job is retried
+### `jobs_retried`
+Sent when one or more jobs is retried
 
-**content**
+**content** An array of objects, each containing these keys, e.g.:
+```json
+{
+  [
+    { ...contents... },
+    { ...contents... }
+  ]
+}
+```
   * `job_id` - string, the job id of the retried job
   * `retry_id` - string, the job id of the job that was launched
 
 ### `new_job`
 Sent when a new job is launched and serialized. This just triggers a save/checkpoint on the frontend - no other bus message is sent
+
+**content**
+  * `job_id` - string OR `job_id_list` - array of strings
 
 ### `run_status`
 Sent during the job startup process. There are a few of these containing various startup status, including errors (if they happen).

--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -253,7 +253,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
-`retry_job` - retry a job or list of jobs, responds with `jobs_retried` and `new_job` for each job
+`retry_job` - retry a job or list of jobs, responds with `jobs_retried` and `new_job`
 * `job_id` - string OR `job_id_list` - array of strings
 
 ## Messages sent from the kernel to the browser
@@ -366,12 +366,12 @@ Includes log statement information for a given job.
 ### `jobs_retried`
 Sent when one or more jobs is retried
 
-**content** An array of objects, each containing these keys, e.g.:
+**content** An array of objects, each containing the below keys, e.g.:
 ```json
 {
   [
-    { ...contents... },
-    { ...contents... }
+    { "job_id": "0", "retry_id": "1" },
+    { "job_id": "2", "retry_id": "3" }
   ]
 }
 ```

--- a/src/biokbase/narrative/exception_util.py
+++ b/src/biokbase/narrative/exception_util.py
@@ -3,6 +3,12 @@ from biokbase.execution_engine2.baseclient import ServerError as EEServerError
 from biokbase.userandjobstate.baseclient import ServerError as UJSServerError
 
 
+class JobException(Exception):
+    def __init__(self, message, err_job_ids=None):
+        super().__init__(message)
+        self.err_job_ids = err_job_ids
+
+
 class NarrativeException(Exception):
     def __init__(self, code, message, name, source):
         self.code = code

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -69,8 +69,7 @@ class JobRequest:
         If a message comes with job_id instead of job_id_list, it may be converted
         into a JobRequest with a job_id_list
         """
-        job_id = msg["content"]["data"]["job_id"]
-        msg["content"]["data"]["job_id_list"] = [job_id]
+        msg["content"]["data"]["job_id_list"] = [msg["content"]["data"]["job_id"]]
         del msg["content"]["data"]["job_id"]
         return cls(msg)
 

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -3,7 +3,7 @@ import threading
 from typing import List
 from ipykernel.comm import Comm
 import biokbase.narrative.jobs.jobmanager as jobmanager
-from biokbase.narrative.exception_util import NarrativeException
+from biokbase.narrative.exception_util import JobException, NarrativeException
 from biokbase.narrative.common import kblogging
 
 
@@ -26,18 +26,31 @@ class JobRequest:
     2. If there's a job_id field, it makes sure that it's real (by asking the
        JobManager - avoids a bunch of duplicate validation code)
 
-    Each JobRequest has at most one job_id. If the job comm channel request data
-    is received with a job_id_list, those will be split up into multiple JobRequests
+    Each JobRequest has at most one of a job_id or job_id_list. If the job comm
+    channel request data is received with a job_id_list, it may be split up
+    into multiple JobRequests. Likewise, if the job comm channel request data
+    is received with a job_id, a JobRequest may be created with a job_id_list
+    containing that job_id
 
     Provides 4 attributes:
     msg_id: str - a unique string (within reason) for a message id.
     request: str - a string for the request sent from the front end. This isn't
         strictly controlled here, but by JobComm._handle_comm_message.
-    job_id: str - (optional) - a string for the job id, as set by EE2.
+    job_id: str or job_id_list: list - (optional) - a string or strings for
+        the job id, as set by EE2.
     rq_data: dict - the actual data of the request. Containers the request type,
         job_id (sometimes), and other information that can be specific for
         each request.
     """
+
+    # request types either require a job_id, a job_id_list, or neither
+    REQUIRE_JOB_ID = [
+        "job_info", "job_status", "start_job_update", "stop_job_update",
+        "cancel_job", "job_logs", "job_logs_latest",
+    ]
+    REQUIRE_JOB_ID_LIST = [
+        "retry_job"
+    ]
 
     def __init__(self, rq: dict):
         self.msg_id = rq.get("msg_id")  # might be useful later?
@@ -48,6 +61,52 @@ class JobRequest:
         if self.request is None:
             raise ValueError("Missing request type in job channel message!")
         self.job_id = self.rq_data.get("job_id")
+        self.job_id_list = self.rq_data.get("job_id_list")
+
+    @classmethod
+    def _convert_to_using_job_id_list(cls, msg: dict) -> "JobRequest":
+        """
+        If a message comes with job_id instead of job_id_list, it may be converted
+        into a JobRequest with a job_id_list
+        """
+        job_id = msg["content"]["data"]["job_id"]
+        msg["content"]["data"]["job_id_list"] = [job_id]
+        del msg["content"]["data"]["job_id"]
+        return cls(msg)
+
+    @classmethod
+    def _split_request_by_job_id(cls, msg: dict) -> List["JobRequest"]:
+        """
+        If a message comes with job_id_list instead of job_id, it may be converted
+        into multiple JobRequest objects each having a single job_id
+        """
+        job_id_list = msg["content"]["data"]["job_id_list"]
+        if not isinstance(job_id_list, list):
+            raise ValueError("List expected for job_id_list")
+        insts = []
+        for job_id in job_id_list:
+            msg_ = copy.deepcopy(msg)
+            msg_["content"]["data"]["job_id"] = job_id
+            del msg_["content"]["data"]["job_id_list"]
+            insts.append(cls(msg_))
+        return insts
+
+    @classmethod
+    def translate(cls, msg: dict) -> List["JobRequest"]:
+        req_type = msg.get("content", {}).get("data", {}).get("request_type")
+        job_id = msg.get("content", {}).get("data", {}).get("job_id")
+        job_id_list = msg.get("content", {}).get("data", {}).get("job_id_list")
+
+        if job_id is not None and job_id_list is not None:
+            raise ValueError("Both job_id and job_id_list present")
+
+        if job_id_list is not None and req_type in cls.REQUIRE_JOB_ID:
+            requests = cls._split_request_by_job_id(msg)
+        elif job_id is not None and req_type in cls.REQUIRE_JOB_ID_LIST:
+            requests = [cls._convert_to_using_job_id_list(msg)]
+        else:
+            requests = [cls(msg)]
+        return requests
 
 
 class JobComm:
@@ -116,15 +175,23 @@ class JobComm:
                 "start_job_update": self._modify_job_update,
                 "stop_job_update": self._modify_job_update,
                 "cancel_job": self._cancel_job,
-                "retry_job": self._retry_job,
+                "retry_job": self._retry_jobs,
                 "job_logs": self._get_job_logs,
                 "job_logs_latest": self._get_job_logs,
             }
 
     def _verify_job_id(self, req: JobRequest) -> None:
-        if req.job_id is None:
+        if not req.job_id:
             self.send_error_message("job_does_not_exist", req)
             raise ValueError(f"Job id required to process {req.request} request")
+
+    def _verify_job_id_list(self, req: JobRequest) -> None:
+        if not isinstance(req.job_id_list, list):
+            raise ValueError("List expected for job_id_list")
+        req.job_id_list[:] = [job_id for job_id in req.job_id_list if job_id]
+        if len(req.job_id_list) == 0:
+            self.send_error_message("job_does_not_exist", req)
+            raise ValueError("No valid job ids")
 
     def start_job_status_loop(self, *args, **kwargs) -> None:
         """
@@ -282,32 +349,42 @@ class JobComm:
             raise
         self._lookup_job_state(req)
 
-    def _retry_job(self, req: JobRequest) -> None:
+    def _retry_jobs(self, req: JobRequest) -> None:
         """
-        In this case, retry_results is formatted as:
-        {
-            "job_id": original_job_id,
-            "retry_id": new_job_id
-        }
+        retry_results is formatted as:
+        [
+            {
+                "job_id": original_job_id,
+                "retry_id": new_job_id
+            },
+            ...
+        ]
         """
-        self._verify_job_id(req)
+        self._verify_job_id_list(req)
         try:
-            retry_results = self._jm.retry_job(req.job_id)
-            self.send_comm_message("job_retried", retry_results)
-            self.send_comm_message("new_job", {"job_id": retry_results["retry_id"]})
-        except ValueError:
-            self.send_error_message("job_does_not_exist", req)
+            retry_results = self._jm.retry_jobs(req.job_id_list)
+            self.send_comm_message("jobs_retried", retry_results)
+            self.send_comm_message(
+                "new_job",
+                {"job_id_list": [job["retry_id"] for job in retry_results if job["retry_id"]]}
+            )
+        except JobException as e:
+            self.send_error_message(
+                "job_does_not_exist",
+                req,
+                {"job_id_list": e.err_job_ids}
+            )
             raise
         except NarrativeException as e:
             self.send_error_message(
                 "job_comm_error",
                 req,
                 {
-                    "error": "Unable to retry job",
+                    "error": "Unable to retry job(s)",
                     "message": getattr(e, "message", "Unknown reason"),
                     "code": getattr(e, "code", -1),
                     "name": getattr(e, "name", type(e).__name__),
-                },
+                }
             )
             raise
 
@@ -352,29 +429,6 @@ class JobComm:
             )
             raise
 
-    def _split_request_by_job_id(self, rq: dict) -> List[JobRequest]:
-        """
-        If request data comes with job_id_list instead of job_id, convert it into
-        JobRequest objects each having a single job_id
-        """
-        if not isinstance(rq["content"]["data"]["job_id_list"], list):
-            message = "List expected for job_id_list"
-            self.send_comm_message(
-                "job_comm_error",
-                {
-                    "message": message,
-                    "request_type": rq["content"]["data"].get("request_type")
-                }
-            )
-            raise ValueError(message)
-        insts = []
-        for job_id in rq["content"]["data"]["job_id_list"]:
-            rq_ = copy.deepcopy(rq)
-            rq_["content"]["data"]["job_id"] = job_id
-            del rq_["content"]["data"]["job_id_list"]
-            insts.append(JobRequest(rq_))
-        return insts
-
     def _handle_comm_message(self, msg: dict) -> None:
         """
         Handles comm messages that come in from the other end of the KBaseJobs channel.
@@ -386,10 +440,7 @@ class JobComm:
         Any unknown request is returned over the channel as a job_comm_error, and a
         ValueError is raised.
         """
-        if msg.get("content", {}).get("data", {}).get("job_id_list"):
-            requests = self._split_request_by_job_id(msg)
-        else:
-            requests = [JobRequest(msg)]
+        requests = JobRequest.translate(msg)
         for request in requests:
             kblogging.log_event(self._log, "handle_comm_message", {"msg": request.request})
             if request.request in self._msg_map:
@@ -419,12 +470,16 @@ class JobComm:
 
         This sends a packet that looks like:
         {
-            job_id: (string, if relevant),
+            job_id or job_id_list: (string or list of strings, if relevant),
             source: the original message that spawned the error,
             other fields about the error, dependent on the content.
         }
         """
-        error_content = {"job_id": req.job_id, "source": req.request}
+        error_content = {"source": req.request}
+        if req.job_id_list is not None:
+            error_content["job_id_list"] = req.job_id_list
+        else:
+            error_content["job_id"] = req.job_id
         if content is not None:
             error_content.update(content)
         self.send_comm_message(err_type, error_content)

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -217,6 +217,15 @@ class MockClients:
         job_id = params["job_id"]
         return {"job_id": job_id, "retry_id": job_id[::-1]}
 
+    def retry_jobs(self, params):
+        job_ids = params["job_ids"]
+        results = list()
+        for job_id in job_ids:
+            results.append({
+                "job_id": job_id, "retry_id": job_id[::-1]
+            })
+        return results
+
     def check_job_canceled(self, params):
         return {"finished": 0, "canceled": 0, "job_id": params.get("job_id")}
 
@@ -459,6 +468,9 @@ class FailingMockClient:
 
     def retry_job(self, params):
         raise ServerError("JSONRPCError", -32000, "Job retry failed")
+
+    def retry_jobs(self, params):
+        raise ServerError("JSONRPCError", -32000, "Jobs retry failed")
 
     def check_job_canceled(self, params):
         raise ServerError("JSONRPCError", 1, "Can't cancel job")

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -9,7 +9,7 @@ from .util import ConfigTests
 import os
 from IPython.display import HTML
 from .narrative_mock.mockclients import get_mock_client, get_failing_mock_client
-from biokbase.narrative.exception_util import NarrativeException
+from biokbase.narrative.exception_util import JobException, NarrativeException
 
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
@@ -118,18 +118,18 @@ class JobManagerTest(unittest.TestCase):
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_retry_job_good(self):
         job_id = "5d64935cb215ad4128de94d9"
-        retry_results = self.jm.retry_job(job_id)
+        retry_results = self.jm.retry_jobs([job_id])
         self.assertEqual(
             retry_results,
-            {"job_id": job_id, "retry_id": "9d49ed8214da512bc53946d5"}
+            [{"job_id": job_id, "retry_id": "9d49ed8214da512bc53946d5"}]
         )
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_retry_job_bad(self):
-        with self.assertRaises(ValueError):
-            self.jm.retry_job(None)
-        with self.assertRaises(ValueError):
-            self.jm.retry_job("nope")
+        with self.assertRaises(JobException):
+            self.jm.retry_jobs([None])
+        with self.assertRaises(JobException):
+            self.jm.retry_jobs(["nope"])
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_lookup_all_job_states(self):


### PR DESCRIPTION
# Description of PR purpose/changes

Backend hookup for batch retry.

Only the EE2 `retry_jobs` endpoint is used now, and `retry_job` is not used anymore. So the communication is adapted to be done in the plural. This means that requests that come in with request type `retry_job` and data `job_id` are converted to use `job_id_list`. Also, this endpoint always sends the resulting `new_job` comm message with data `job_id_list`, and the resulting `jobs_retried` message with data being a list of objects containing `job_id` and `retry_id`. In addition,  message types `job_does_not_exist` and `job_comm_error` also can use `job_id_list` now. 

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR: Run `make test-backend`. Or, spin up local narrative, import some files with the bulk import cell, cancel those jobs, then either retry individually or retry all canceled jobs.
- [ ] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
