### PR TITLE
replace missing code, remove old code

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -156,6 +156,21 @@ define([
                 }
             });
 
+            fieldWidget.bus.on('sync', () => {
+                const newValue = dataModel.rows[rowId].values[parameterSpec.id];
+                fieldWidget.bus.send(
+                    {
+                        value: newValue,
+                    },
+                    {
+                        // This points the update back to a listener on this key
+                        key: {
+                            type: 'update',
+                        },
+                    }
+                );
+            });
+
             fieldWidget.bus.respond({
                 key: {
                     type: 'get-param-state',

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -56,27 +56,6 @@ define([
         p = html.tag('p'),
         cssCellType = 'kb-bulk-import';
 
-    function DefaultWidget() {
-        function make() {
-            function start() {
-                alert('starting default widget');
-                return Promise.resolve();
-            }
-
-            function stop() {
-                return Promise.resolve();
-            }
-
-            return {
-                start: start,
-                stop: stop,
-            };
-        }
-        return {
-            make: make,
-        };
-    }
-
     /**
      * This class creates and manages the bulk import cell. This works with, and wraps around,
      * the Jupyter Cell object.


### PR DESCRIPTION
# Description of PR purpose/changes

This fixes a new bug where the object name input wasn't showing up in the file path widget. It was missing an event that should've been moved, but was just deleted.

Also deletes the `DefaultWidget` from the `bulkImportCell`. No more defaults, now we have something to fit everywhere!

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* For FASTQ uploader types, the output object name field should appear now.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
