### PR TITLE
fix a bug when searching loaded data objects

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 ### Unreleased
 
 - SCT-3602 - refseq public data tool now searches by lineage as well; for all public data tools: automatically focus the search input; fix paging bug
+- No ticket - fixed bug where searching loaded data (under the DATA panel on the left side) would fail.
 
 ### Version 4.4.0
 -   No ticket: boatloads of code cleanup and fixes to the unit and internal testing

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -2119,9 +2119,9 @@ define([
                         match = true;
                     } // match on saved_by user
 
-                    if (!match && info[10]) {
+                    if (!match && Object.prototype.toString.call(info[10]) === '[object Object]') {
                         // match on metadata values
-                        for (const [metaKey, metaValue] of info[10].entries()) {
+                        for (const [metaKey, metaValue] of Object.entries(info[10])) {
                             // Omits enumerable properties not directly on this object,
                             // which in reality simply won't occur.
                             if (!Object.prototype.hasOwnProperty.call(info[10], metaKey)) {


### PR DESCRIPTION
# Description of PR purpose/changes

There was a bug in the data list search that's used for filtering loaded data in the left-side panel. This would get hung up on trying to filter through object metadata and fail to search all together. This fix should address that bug.

# Jira Ticket / Issue #
no ticket made for this one
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
1. Open a narrative with some data in it.
2. Click on the magnifying glass button in the Data side panel
3. Search for some data in there
4. Optionally search for data by metadata keys / values (can find these by expanding the data card with the ... button).
(specific unit / integration tests still pending)
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [-] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
