### PR TITLE
split test functions in gha

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,44 @@
+name: CI-integration-testing
+
+on:
+  [push, pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2.0.0
+      with:
+        miniconda-version: 'latest'
+        activate-environment: test-environment
+        python-version: 3.6.10
+        auto-activate-base: false
+        auto-update-conda: true
+        condarc-file: test/condarc.yml
+
+    - name: Use Node JS 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - name: Install JS dependencies
+      run: |
+        npm ci
+        npm install bower
+        ./node_modules/bower/bin/bower install
+
+    - name: Install Narrative Application
+      shell: bash -l {0}
+      run: |
+          bash ./scripts/install_narrative.sh
+          npm run minify
+          sed <src/config.json.templ >src/config.json "s/{{ .Env.CONFIG_ENV }}/dev/"
+          sed -i 's/{{ if ne .Env.CONFIG_ENV "prod" }} true {{- else }} false {{- end }}/true/' src/config.json
+          jupyter notebook --version
+
+    - name: Run Narrative Frontend Integration Tests
+      shell: bash -l {0}
+      env:
+        KBASE_TEST_TOKEN: ${{ secrets.NARRATIVE_TEST_TOKEN }}
+      run: make test-integration

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,4 +1,4 @@
-name: CI-testing
+name: CI-unit-testing
 
 on:
   [push, pull_request]
@@ -45,18 +45,12 @@ jobs:
       shell: bash -l {0}
       run: make test-frontend-unit
 
-    - name: make test output available as artefact in case of failure
+    - name: make test output available as artifact in case of failure
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
         name: karma-result.json
         path: karma-result.json
-
-    - name: Run Narrative Frontend Integration Tests
-      shell: bash -l {0}
-      env:
-        KBASE_TEST_TOKEN: ${{ secrets.NARRATIVE_TEST_TOKEN }}
-      run: make test-integration
 
     - name: Send to Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
# Description of PR purpose/changes

Separates the test actions into unit test and integration test runs, so they can be more easily checked to see what passes and what fails. It maybe makes things take a little longer as the app has to get built multiple times, but I think it'll be helpful for seeing at a glance what's failing.

This came up from seeing a new batch of `dependabot` PRs which all failed miserably. This is really due to `dependabot` using a separate fork for submitting PRs - so another option might be to have the integration tests skip / fail immediately if there's no token available. Right now, they continue and just time out all over the place as they're running tokenless. The unit tests should be fine without authentication, and in fact, that's preferred.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [n/a] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
