### PR TITLE
fix ee2 endpoint

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -330,7 +330,7 @@
         "compound_img_url": "http://minedatabase.mcs.anl.gov/compound_images/ModelSEED/",
         "data_import_export": "https://narrative-refactor.kbase.us/services/data_import_export",
         "data_panel_sources": "/data_source_config.json",
-        "execution_engine2": "https://narrative-refactor.kbase.us/services/ee2",
+        "execution_engine2": "https://narrative-refactor.kbase.us/services/ee2-nr",
         "fba": "https://narrative-refactor.kbase.us/services/KBaseFBAModeling/",
         "ftp_api_root": "/data/bulk",
         "ftp_api_url": "https://narrative-refactor.kbase.us/services/kb-ftp-api/v0",

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -330,7 +330,7 @@
         "compound_img_url": "http://minedatabase.mcs.anl.gov/compound_images/ModelSEED/",
         "data_import_export": "https://narrative-refactor.kbase.us/services/data_import_export",
         "data_panel_sources": "/data_source_config.json",
-        "execution_engine2": "https://narrative-refactor.kbase.us/services/ee2",
+        "execution_engine2": "https://narrative-refactor.kbase.us/services/ee2-nr",
         "fba": "https://narrative-refactor.kbase.us/services/KBaseFBAModeling/",
         "ftp_api_root": "/data/bulk",
         "ftp_api_url": "https://narrative-refactor.kbase.us/services/kb-ftp-api/v0",


### PR DESCRIPTION
# Description of PR purpose/changes

The EE2 endpoint in the narrative-refactor config is pointing at the wrong place! 😱 

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
