### PR TITLE
DATAUP-462: get parent job

### DIFF
--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -45,12 +45,15 @@ class JobRequest:
 
     # request types either require a job_id, a job_id_list, or neither
     REQUIRE_JOB_ID = [
-        "job_info", "job_status", "start_job_update", "stop_job_update",
-        "cancel_job", "job_logs", "job_logs_latest",
+        "job_info",
+        "job_status",
+        "start_job_update",
+        "stop_job_update",
+        "cancel_job",
+        "job_logs",
+        "job_logs_latest",
     ]
-    REQUIRE_JOB_ID_LIST = [
-        "retry_job"
-    ]
+    REQUIRE_JOB_ID_LIST = ["retry_job"]
 
     def __init__(self, rq: dict):
         self.msg_id = rq.get("msg_id")  # might be useful later?
@@ -297,7 +300,7 @@ class JobComm:
             self.send_error_message("job_does_not_exist", req)
             self.send_comm_message(
                 "job_status",
-                {"state": {"job_id": req.job_id, "status": "does_not_exist"}}
+                {"state": {"job_id": req.job_id, "status": "does_not_exist"}},
             )
             raise
 
@@ -365,13 +368,15 @@ class JobComm:
             self.send_comm_message("jobs_retried", retry_results)
             self.send_comm_message(
                 "new_job",
-                {"job_id_list": [job["retry_id"] for job in retry_results if job["retry_id"]]}
+                {
+                    "job_id_list": [
+                        job["retry_id"] for job in retry_results if job["retry_id"]
+                    ]
+                },
             )
         except JobException as e:
             self.send_error_message(
-                "job_does_not_exist",
-                req,
-                {"job_id_list": e.err_job_ids}
+                "job_does_not_exist", req, {"job_id_list": e.err_job_ids}
             )
             raise
         except NarrativeException as e:
@@ -383,7 +388,7 @@ class JobComm:
                     "message": getattr(e, "message", "Unknown reason"),
                     "code": getattr(e, "code", -1),
                     "name": getattr(e, "name", type(e).__name__),
-                }
+                },
             )
             raise
 
@@ -441,7 +446,9 @@ class JobComm:
         """
         requests = JobRequest.translate(msg)
         for request in requests:
-            kblogging.log_event(self._log, "handle_comm_message", {"msg": request.request})
+            kblogging.log_event(
+                self._log, "handle_comm_message", {"msg": request.request}
+            )
             if request.request in self._msg_map:
                 self._msg_map[request.request](request)
             else:

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -205,10 +205,7 @@ class MockClients:
 
     def run_job_batch(self, batch_job_inputs, batch_params):
         child_job_ids = [self.test_job_id for i in range(len(batch_job_inputs))]
-        return {
-            "parent_job_id": self.test_job_id,
-            "child_job_ids": child_job_ids
-        }
+        return {"parent_job_id": self.test_job_id, "child_job_ids": child_job_ids}
 
     def cancel_job(self, job_id):
         return "done"
@@ -221,9 +218,7 @@ class MockClients:
         job_ids = params["job_ids"]
         results = list()
         for job_id in job_ids:
-            results.append({
-                "job_id": job_id, "retry_id": job_id[::-1]
-            })
+            results.append({"job_id": job_id, "retry_id": job_id[::-1]})
         return results
 
     def check_job_canceled(self, params):

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -26,59 +26,78 @@ test_jobs = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
 class JobTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # info = test_jobs["job_info"][0]
         info = next(iter(test_jobs.values()))
 
-        # cls.job_id = info[0]
         cls.job_id = info["job_id"]
-        # param_info = test_jobs["job_param_info"][cls.job_id]
         param_info = info["job_input"]
+
         cls.app_id = param_info["app_id"]
-        cls.app_tag = param_info.get("narrative_cell_info", {}).get("tag", "dev")
         cls.app_version = param_info.get("service_ver", "0.0.1")
         cls.cell_id = param_info.get("narrative_cell_info", {}).get("cell_id")
-        cls.run_id = param_info.get("narrative_cell_info", {}).get("run_id")
-        cls.inputs = param_info["params"]
-        cls.owner = info["user"]
-        cls.token_id = "temp_token"
         cls.inputs = None
+        cls.meta = dict()
+        cls.owner = info["user"]
+        cls.parent_job_id = "parent_job"
+        cls.run_id = param_info.get("narrative_cell_info", {}).get("run_id")
+        cls.tag = param_info.get("narrative_cell_info", {}).get("tag", "dev")
+        cls.token_id = "temp_token"
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
-    def _mocked_job(
-        self, with_version=True, with_cell_id=True, with_run_id=True, with_token_id=True
-    ):
-        kwargs = dict()
-        if with_version:
-            kwargs["app_version"] = self.app_version
-        if with_cell_id:
-            kwargs["cell_id"] = self.cell_id
-        if with_run_id:
-            kwargs["run_id"] = self.run_id
-        if with_token_id:
-            kwargs["token_id"] = self.token_id
+    def _mocked_job(self, job_attrs=[]):
+        job_kwargs = {}
 
-        job = Job(
-            self.job_id,
-            self.app_id,
-            self.inputs,
-            self.owner,
-            tag=self.app_tag,
-            **kwargs
-        )
+        for arg in [
+            "app_version",
+            "cell_id",
+            "parent_job_id",
+            "run_id",
+            "tag",
+            "token_id",
+        ]:
+            if not len(job_attrs) or "no_" + arg not in job_attrs:
+                job_kwargs[arg] = getattr(self, arg)
+
+        job = Job(self.job_id, self.app_id, self.inputs, self.owner, **job_kwargs)
 
         return job
 
     def test_job_init(self):
         job = self._mocked_job()
-        self.assertEqual(job.job_id, self.job_id)
-        self.assertEqual(job.app_id, self.app_id)
-        self.assertEqual(job.inputs, self.inputs)
-        self.assertEqual(job.owner, self.owner)
-        self.assertEqual(job.tag, self.app_tag)
-        self.assertEqual(job.app_version, self.app_version)
-        self.assertEqual(job.cell_id, self.cell_id)
-        self.assertEqual(job.run_id, self.run_id)
-        self.assertEqual(job.token_id, self.token_id)
+
+        for attr in [
+            "job_id",
+            "app_id",
+            "inputs",
+            "owner",
+            "app_version",
+            "cell_id",
+            "meta",
+            "parent_job_id",
+            "run_id",
+            "tag",
+            "token_id",
+        ]:
+            self.assertEqual(getattr(job, attr), getattr(self, attr))
+
+    def test_job_init_defaults(self):
+        job = self._mocked_job(
+            [
+                "no_app_version",
+                "no_cell_id",
+                "no_parent_job_id",
+                "no_run_id",
+                "no_tag",
+                "no_token_id",
+            ]
+        )
+
+        for attr in ["job_id", "app_id", "inputs", "owner", "meta"]:
+            self.assertEqual(getattr(job, attr), getattr(self, attr))
+
+        for attr in ["app_version", "cell_id", "parent_job_id", "run_id", "token_id"]:
+            self.assertEqual(getattr(job, attr), None)
+
+        self.assertEqual(job.tag, "release")
 
     def test_job_from_state(self):
         job_info = {"params": self.inputs, "service_ver": self.app_version}
@@ -87,20 +106,44 @@ class JobTest(unittest.TestCase):
             job_info,
             self.owner,
             self.app_id,
-            tag=self.app_tag,
+            tag=self.tag,
             cell_id=self.cell_id,
             run_id=self.run_id,
             token_id=self.token_id,
+            parent_job_id=self.parent_job_id,
         )
-        self.assertEqual(job.job_id, self.job_id)
-        self.assertEqual(job.app_id, self.app_id)
-        self.assertEqual(job.inputs, self.inputs)
-        self.assertEqual(job.owner, self.owner)
-        self.assertEqual(job.tag, self.app_tag)
-        self.assertEqual(job.app_version, self.app_version)
-        self.assertEqual(job.cell_id, self.cell_id)
-        self.assertEqual(job.run_id, self.run_id)
-        self.assertEqual(job.token_id, self.token_id)
+
+        for attr in [
+            "job_id",
+            "app_id",
+            "inputs",
+            "owner",
+            "app_version",
+            "cell_id",
+            "meta",
+            "parent_job_id",
+            "run_id",
+            "token_id",
+            "tag",
+        ]:
+            self.assertEqual(getattr(job, attr), getattr(self, attr))
+
+    def test_job_from_state_defaults(self):
+        job_info = {"params": self.inputs, "service_ver": self.app_version}
+        job = Job.from_state(
+            "another_job",
+            job_info,
+            self.owner,
+            self.app_id,
+        )
+        for attr in ["app_id", "inputs", "owner", "app_version", "meta"]:
+            self.assertEqual(getattr(job, attr), getattr(self, attr))
+
+        for attr in ["cell_id", "parent_job_id", "run_id", "token_id"]:
+            self.assertEqual(getattr(job, attr), None)
+
+        self.assertEqual(job.job_id, "another_job")
+        self.assertEqual(job.tag, "release")
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_job_info(self):
@@ -139,6 +182,8 @@ class JobTest(unittest.TestCase):
         self.assertEqual(state["job_id"], job.job_id)
         self.assertIn("status", state)
         self.assertIn("updated", state)
+        for arg in ["cell_id", "parent_job_id", "run_id", "token_id"]:
+            self.assertEqual(state[arg], getattr(self, arg))
         self.assertNotIn("job_input", state)
 
         # to do - add a test to only fetch from _last_state if it's populated and in a final state

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -23,7 +23,7 @@ def make_comm_msg(
         job_id_key = "job_id"
     msg = {
         "msg_id": "some_id",
-        "content": {"data": {"request_type": msg_type, job_id_key: job_id_like}}
+        "content": {"data": {"request_type": msg_type, job_id_key: job_id_like}},
     }
     if content is not None:
         msg["content"]["data"].update(content)
@@ -136,7 +136,8 @@ class JobCommTestCase(unittest.TestCase):
         self.assertIn(f"No job present with id {job_id}", str(e.exception))
         msg = self.jc._comm.last_message
         self.assertEqual(
-            {"state": {"job_id": job_id, "status": "does_not_exist"}}, msg["data"]["content"]
+            {"state": {"job_id": job_id, "status": "does_not_exist"}},
+            msg["data"]["content"],
         )
         self.assertEqual("job_status", msg["data"]["msg_type"])
 
@@ -271,7 +272,8 @@ class JobCommTestCase(unittest.TestCase):
         msg = self.jc._comm.last_message
         self.assertEqual("job_does_not_exist", msg["data"]["msg_type"])
         self.assertEqual(
-            {"job_id_list": job_id_list[1:], "source": "retry_job"}, msg["data"]["content"]
+            {"job_id_list": job_id_list[1:], "source": "retry_job"},
+            msg["data"]["content"],
         )
 
     @mock.patch(

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -93,13 +93,15 @@ class JobManagerTest(unittest.TestCase):
 
     def test_list_jobs_twice(self):
         # with no jobs
-        with mock.patch.object(self.jm, '_running_jobs', {}):
-            expected = 'No running jobs!'
+        with mock.patch.object(self.jm, "_running_jobs", {}):
+            expected = "No running jobs!"
             self.assertEqual(self.jm.list_jobs(), expected)
             self.assertEqual(self.jm.list_jobs(), expected)
 
         # with some jobs
-        with mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client):
+        with mock.patch(
+            "biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client
+        ):
             jobs_html_0 = self.jm.list_jobs()
             jobs_html_1 = self.jm.list_jobs()
             self.assertEqual(jobs_html_0.data, jobs_html_1.data)
@@ -120,8 +122,7 @@ class JobManagerTest(unittest.TestCase):
         job_id = "5d64935cb215ad4128de94d9"
         retry_results = self.jm.retry_jobs([job_id])
         self.assertEqual(
-            retry_results,
-            [{"job_id": job_id, "retry_id": "9d49ed8214da512bc53946d5"}]
+            retry_results, [{"job_id": job_id, "retry_id": "9d49ed8214da512bc53946d5"}]
         )
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -39,7 +39,7 @@ def skipUnlessToken():
 
 
 def str_to_ref(s):
-    """ Takes a ref string, returns a NarrativeRef object """
+    """Takes a ref string, returns a NarrativeRef object"""
     vals = s.split("/")
     ref = {"wsid": vals[0], "objid": vals[1]}
     if len(vals) == 3:

--- a/src/biokbase/narrative/tests/util.py
+++ b/src/biokbase/narrative/tests/util.py
@@ -80,6 +80,7 @@ class ConfigTests(object):
         else:
             return os.path.join(self._path_prefix, filename)
 
+
 def fetch_narrative(nar_id, auth_token, url=ci_ws, file_name=None):
     """
     Fetches a Narrative object with the given reference id (of the form ##/##).


### PR DESCRIPTION
# Description of PR purpose/changes

Makes sure that the parent job ID gets saved as part of the job object by the narrative backend

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-462
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and seeing that nothing has changed. Phew!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
