### PR TITLE
Update code promptly

### DIFF
--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -377,21 +377,18 @@ define([
                     spec
                 );
             }).then((state) => {
-                const currentState = model.getItem(['state', 'params', selectedFileType]);
-                if (currentState !== state) {
-                    model.setItem(['state', 'params', selectedFileType], state);
-                    const fileTypeState = getFileTypeState();
-                    fileTypePanel.updateState(fileTypeState);
-                    const paramsReady = Object.values(fileTypeState.completed).reduce(
-                        (prev, cur) => {
-                            return cur && prev;
-                        },
-                        true
-                    );
-                    cellBus.emit('update-param-state', {
-                        paramsReady,
-                    });
-                }
+                model.setItem(['state', 'params', selectedFileType], state);
+                const fileTypeState = getFileTypeState();
+                fileTypePanel.updateState(fileTypeState);
+                const paramsReady = Object.values(fileTypeState.completed).reduce(
+                    (prev, cur) => {
+                        return cur && prev;
+                    },
+                    true
+                );
+                cellBus.emit('update-param-state', {
+                    paramsReady,
+                });
             });
         }
 

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -380,12 +380,9 @@ define([
                 model.setItem(['state', 'params', selectedFileType], state);
                 const fileTypeState = getFileTypeState();
                 fileTypePanel.updateState(fileTypeState);
-                const paramsReady = Object.values(fileTypeState.completed).reduce(
-                    (prev, cur) => {
-                        return cur && prev;
-                    },
-                    true
-                );
+                const paramsReady = Object.values(fileTypeState.completed).reduce((prev, cur) => {
+                    return cur && prev;
+                }, true);
                 cellBus.emit('update-param-state', {
                     paramsReady,
                 });


### PR DESCRIPTION
# Description of PR purpose/changes

When a bulk import cell is in a ready to run state, and a user makes a change to some parameter, it wasn't always updating the code. This forces the message to get passed from the configure tab to the main widget every time a parameter changes, not just when it changes state from ready <-> not ready. This will trigger the code generator as appropriate.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
no ticket - this was a quick response to a finding on Slack.
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Make a new bulk import cell, open the show code area, get it in the editingComplete state (run button's active)
* This should now show the code that'll execute.
* Make a change, especially to a numerical parameter
* Watch the code change.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
