### PR TITLE
DATAUP-463: job manager job ID deduplication

### DIFF
--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -6,6 +6,8 @@ import biokbase.narrative.jobs.jobmanager as jobmanager
 from biokbase.narrative.exception_util import JobException, NarrativeException
 from biokbase.narrative.common import kblogging
 
+UNKNOWN_REASON = "Unknown reason"
+
 
 class JobRequest:
     """
@@ -211,7 +213,7 @@ class JobComm:
             except Exception as e:
                 error = {
                     "error": "Unable to get initial jobs list",
-                    "message": getattr(e, "message", "Unknown reason"),
+                    "message": getattr(e, "message", UNKNOWN_REASON),
                     "code": getattr(e, "code", -1),
                     "source": getattr(e, "source", "jobmanager"),
                     "name": getattr(e, "name", type(e).__name__),
@@ -343,7 +345,7 @@ class JobComm:
                 req,
                 {
                     "error": "Unable to cancel job",
-                    "message": getattr(e, "message", "Unknown reason"),
+                    "message": getattr(e, "message", UNKNOWN_REASON),
                     "code": getattr(e, "code", -1),
                     "name": getattr(e, "name", type(e).__name__),
                 },
@@ -385,7 +387,7 @@ class JobComm:
                 req,
                 {
                     "error": "Unable to retry job(s)",
-                    "message": getattr(e, "message", "Unknown reason"),
+                    "message": getattr(e, "message", UNKNOWN_REASON),
                     "code": getattr(e, "code", -1),
                     "name": getattr(e, "name", type(e).__name__),
                 },
@@ -426,7 +428,7 @@ class JobComm:
                 req,
                 {
                     "error": "Unable to retrieve job logs",
-                    "message": getattr(e, "message", "Unknown reason"),
+                    "message": getattr(e, "message", UNKNOWN_REASON),
                     "code": getattr(e, "code", -1),
                     "name": getattr(e, "name", type(e).__name__),
                 },

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -1,6 +1,8 @@
 from ..util import ConfigTests
 from biokbase.workspace.baseclient import ServerError
 
+RANDOM_DATE = "2018-08-10T16:47:36+0000"
+RANDOM_TYPE = "ModuleA.TypeA-1.0"
 
 class MockClients:
     """
@@ -208,7 +210,7 @@ class MockClients:
         return {"parent_job_id": self.test_job_id, "child_job_ids": child_job_ids}
 
     def cancel_job(self, job_id):
-        return "done"
+        return {}
 
     def retry_job(self, params):
         job_id = params["job_id"]
@@ -314,8 +316,8 @@ class MockClients:
                     "object_info": [
                         1,
                         "obj1",
-                        "ModuleA.TypeA-1.0",
-                        "2018-08-10T16:47:36+0000",
+                        RANDOM_TYPE,
+                        RANDOM_DATE,
                         2,
                         user_id,
                         ws_id,
@@ -329,8 +331,8 @@ class MockClients:
                     "object_info": [
                         7,
                         "obj7",
-                        "ModuleA.TypeA-1.0",
-                        "2018-08-10T16:47:36+0000",
+                        RANDOM_TYPE,
+                        RANDOM_DATE,
                         2,
                         user_id,
                         ws_id,
@@ -344,8 +346,8 @@ class MockClients:
                     "object_info": [
                         8,
                         "obj8",
-                        "ModuleA.TypeA-1.0",
-                        "2018-08-10T16:47:36+0000",
+                        RANDOM_TYPE,
+                        RANDOM_DATE,
                         2,
                         user_id,
                         ws_id,
@@ -360,7 +362,7 @@ class MockClients:
                         9,
                         "obj9",
                         "ModuleB.TypeB-1.0",
-                        "2018-08-10T16:47:36+0000",
+                        RANDOM_DATE,
                         3,
                         user_id,
                         ws_id,
@@ -375,7 +377,7 @@ class MockClients:
                         3,
                         "obj3",
                         "ModuleC.TypeC-1.0",
-                        "2018-08-10T16:47:36+0000",
+                        RANDOM_DATE,
                         4,
                         user_id,
                         ws_id,
@@ -390,7 +392,7 @@ class MockClients:
                         4,
                         "obj4",
                         "ModuleD.TypeD-1.0",
-                        "2018-08-10T16:47:36+0000",
+                        RANDOM_DATE,
                         5,
                         user_id,
                         ws_id,
@@ -406,7 +408,7 @@ class MockClients:
                         5,
                         "obj5",
                         "Module5.Type5-1.0",
-                        "2018-08-10T16:47:36+0000",
+                        RANDOM_DATE,
                         6,
                         user_id,
                         ws_id,

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -4,6 +4,7 @@ from biokbase.workspace.baseclient import ServerError
 RANDOM_DATE = "2018-08-10T16:47:36+0000"
 RANDOM_TYPE = "ModuleA.TypeA-1.0"
 
+
 class MockClients:
     """
     Mock KBase service clients as needed for Narrative backend tests.

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -12,6 +12,12 @@ from .narrative_mock.mockclients import get_mock_client, get_failing_mock_client
 
 config = ConfigTests()
 job_info = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
+# job_info contains jobs in the following states
+JOB_COMPLETED = "5d64935ab215ad4128de94d6"
+JOB_CREATED = "5d64935cb215ad4128de94d7"
+JOB_RUNNING = "5d64935cb215ad4128de94d8"
+JOB_TERMINATED = "5d64935cb215ad4128de94d9"
+JOB_NOT_FOUND = "job_not_found"
 
 
 def make_comm_msg(
@@ -107,7 +113,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_lookup_job_state_direct_ok(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("job_state", job_id, True)
         state = self.jc._lookup_job_state(req)
         msg = self.jc._comm.last_message
@@ -145,7 +151,7 @@ class JobCommTestCase(unittest.TestCase):
     # Lookup job info
     # ---------------
     def test_lookup_job_info_ok(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("job_info", job_id, True)
         job_info = self.jc._lookup_job_info(req)
         expected = {
@@ -192,7 +198,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_cancel_job_ok(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("cancel_job", job_id, True)
         self.jc._cancel_job(req)
         msg = self.jc._comm.last_message
@@ -226,7 +232,7 @@ class JobCommTestCase(unittest.TestCase):
         get_failing_mock_client,
     )
     def test_cancel_job_failure(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_CREATED
         req = make_comm_msg("cancel_job", job_id, True)
         with self.assertRaises(NarrativeException) as e:
             self.jc._cancel_job(req)
@@ -281,7 +287,7 @@ class JobCommTestCase(unittest.TestCase):
         get_failing_mock_client,
     )
     def test_retry_jobs_failure(self):
-        job_id_list = ["5d64935ab215ad4128de94d6"]
+        job_id_list = [JOB_COMPLETED]
         req = make_comm_msg("retry_job", job_id_list, True)
         with self.assertRaises(NarrativeException) as e:
             self.jc._retry_jobs(req)
@@ -298,7 +304,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_get_job_logs_ok(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         lines_available = 100  # just for convenience if the mock changes
         cases = [
             (0, 10, False),
@@ -338,7 +344,7 @@ class JobCommTestCase(unittest.TestCase):
         get_failing_mock_client,
     )
     def test_get_job_logs_failure(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("job_logs", job_id, True)
         with self.assertRaises(NarrativeException) as e:
             self.jc._get_job_logs(req)
@@ -410,7 +416,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_handle_job_status_msg(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("job_status", job_id, False)
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
@@ -418,7 +424,7 @@ class JobCommTestCase(unittest.TestCase):
         validate_job_state(msg["data"]["content"])
 
     def test_handle_job_info_msg(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("job_info", job_id, False)
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
@@ -428,7 +434,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_handle_cancel_job_msg(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("cancel_job", job_id, False)
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
@@ -438,7 +444,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_handle_start_job_update_msg(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         refresh_count = self.jm._running_jobs[job_id]["refresh"]
         req = make_comm_msg("start_job_update", job_id, False)
         self.jc._handle_comm_message(req)
@@ -449,7 +455,7 @@ class JobCommTestCase(unittest.TestCase):
         self.jc.stop_job_status_loop()
 
     def test_handle_stop_job_update_msg(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         refresh_count = self.jm._running_jobs[job_id]["refresh"]
         req = make_comm_msg("stop_job_update", job_id, False)
         self.jc._handle_comm_message(req)
@@ -463,7 +469,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_handle_latest_job_logs_msg(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg("job_logs_latest", job_id, False, content={"num_lines": 10})
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
@@ -473,7 +479,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_handle_job_logs_msg(self):
-        job_id = "5d64935ab215ad4128de94d6"
+        job_id = JOB_COMPLETED
         req = make_comm_msg(
             "job_logs", job_id, False, content={"num_lines": 10, "first_line": 0}
         )
@@ -485,7 +491,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_handle_cancel_job_msg_with_job_id_list(self):
-        job_id_list = ["5d64935ab215ad4128de94d6"]
+        job_id_list = [JOB_COMPLETED]
         req = make_comm_msg("cancel_job", job_id_list, False)
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
@@ -520,7 +526,7 @@ class JobRequestTestCase(unittest.TestCase):
         rq_msg2 = {"msg_id": "some_other_id", "content": {"data": {}}}
         for msg in [rq_msg, rq_msg2]:
             with self.assertRaises(ValueError) as e:
-                JobRequest(rq_msg)
+                JobRequest(msg)
             self.assertIn(
                 "Missing request type in job channel message!", str(e.exception)
             )


### PR DESCRIPTION
# Description of PR purpose/changes

Added a new function to deduplication job IDs in a list, removing any None or '' values first.

Also made some generic fixes, like swapping out repeated strings for constants and updating method docs

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-463
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and seeing that there are no noticeable changes

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
