### PR TITLE
DATAUP-463: Adding cancel jobs (plural) method to the job manager

### DIFF
--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -13,6 +13,7 @@ from .narrative_mock.mockclients import (
     get_mock_client,
     get_failing_mock_client,
     assert_obj_method_called,
+    MockClients,
 )
 from biokbase.narrative.exception_util import JobException, NarrativeException
 
@@ -280,7 +281,7 @@ class JobManagerTest(unittest.TestCase):
         self.assertNotIn(JOB_RUNNING, self.jm._completed_job_states)
 
         with mock.patch.object(
-            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            MockClients,
             "check_job_canceled",
             mock.Mock(return_value={"finished": 1, "canceled": 0}),
         ) as mock_check_job_canceled:
@@ -297,7 +298,7 @@ class JobManagerTest(unittest.TestCase):
             self.assertNotIn(job_id, self.jm._completed_job_states)
 
         with mock.patch.object(
-            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            MockClients,
             "check_job_canceled",
             mock.Mock(return_value={"finished": 1, "canceled": 0}),
         ) as mock_check_job_canceled:
@@ -311,9 +312,6 @@ class JobManagerTest(unittest.TestCase):
                 ],
                 any_order=True,
             )
-
-            print({"got": canceled_jobs})
-            print({"expected": self.job_states})
 
             self.assertEqual(canceled_jobs, self.job_states)
 
@@ -336,11 +334,11 @@ class JobManagerTest(unittest.TestCase):
         # patch MockClients.check_job_canceled to respond that neither job has finished or been canceled
         # patch MockClients.cancel_job so we can test the input
         with mock.patch.object(
-            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            MockClients,
             "check_job_canceled",
             mock.Mock(return_value={"finished": 0, "canceled": 0}),
         ) as mock_check_job_canceled, mock.patch.object(
-            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            MockClients,
             "cancel_job",
             mock.Mock(return_value={}, side_effect=check_state),
         ) as mock_cancel_job:
@@ -384,7 +382,7 @@ class JobManagerTest(unittest.TestCase):
         # check_job_canceled responds that JOB_RUNNING has been canceled and JOB_CREATED has not
         # patch MockClients.cancel_job so we can test the input
         with mock.patch.object(
-            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            MockClients,
             "cancel_job",
             mock.Mock(return_value={}, side_effect=check_state),
         ) as mock_cancel_job:

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -9,7 +9,11 @@ from biokbase.narrative.jobs.job import Job
 from .util import ConfigTests
 import os
 from IPython.display import HTML
-from .narrative_mock.mockclients import get_mock_client, get_failing_mock_client
+from .narrative_mock.mockclients import (
+    get_mock_client,
+    get_failing_mock_client,
+    assert_obj_method_called,
+)
 from biokbase.narrative.exception_util import JobException, NarrativeException
 
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
@@ -185,6 +189,7 @@ class JobManagerTest(unittest.TestCase):
         job_id = self.job_ids[0]
         job = self.jm.get_job(job_id)
         self.assertEqual(job_id, job.job_id)
+        self.assertIsInstance(job, Job)
 
     def test_get_job_bad(self):
         with self.assertRaisesRegex(ValueError, "No job present with id not_a_job_id"):
@@ -219,39 +224,219 @@ class JobManagerTest(unittest.TestCase):
             jobs_html_1 = self.jm.list_jobs()
             self.assertEqual(jobs_html_0.data, jobs_html_1.data)
 
+    def test_cancel_job__bad_input(self):
+        with self.assertRaisesRegex(ValueError, no_id_err_str):
+            self.jm.cancel_job(None)
+
+        with self.assertRaisesRegex(ValueError, no_id_err_str):
+            self.jm.cancel_job("")
+
+    def test_cancel_jobs__bad_inputs(self):
+        with self.assertRaisesRegex(ValueError, no_id_err_str):
+            self.jm.cancel_jobs()
+
+        with self.assertRaisesRegex(ValueError, no_id_err_str):
+            self.jm.cancel_jobs([])
+
+        with self.assertRaisesRegex(ValueError, no_id_err_str):
+            self.jm.cancel_jobs(["", "", None])
+
+    def test_cancel_job__job_already_finished(self):
+        self.assertEqual(job_info[JOB_COMPLETED]["status"], "completed")
+        self.assertEqual(job_info[JOB_TERMINATED]["status"], "terminated")
+        self.assertIn(JOB_COMPLETED, self.jm._completed_job_states)
+        self.assertIn(JOB_TERMINATED, self.jm._completed_job_states)
+
+        with mock.patch(
+            "biokbase.narrative.jobs.jobmanager.JobManager._cancel_job"
+        ) as mock_cancel_job, mock.patch(
+            "biokbase.narrative.jobs.jobmanager.JobManager._check_job_terminated"
+        ) as mock_check_term:
+            self.assertTrue(self.jm.cancel_job(JOB_COMPLETED))
+            mock_cancel_job.assert_not_called()
+            mock_check_term.assert_not_called()
+
+            self.assertTrue(self.jm.cancel_job(JOB_TERMINATED))
+            mock_cancel_job.assert_not_called()
+            mock_check_term.assert_not_called()
+
+            # multiple jobs
+            canceled_jobs = self.jm.cancel_jobs([JOB_COMPLETED, JOB_TERMINATED])
+            mock_cancel_job.assert_not_called()
+            mock_check_term.assert_not_called()
+            self.assertEqual(
+                {
+                    JOB_COMPLETED: self.jm._completed_job_states[JOB_COMPLETED],
+                    JOB_TERMINATED: self.jm._completed_job_states[JOB_TERMINATED],
+                },
+                canceled_jobs,
+            )
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.JobManager._cancel_job")
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
-    def test_cancel_job_good(self):
+    def test_cancel_job__check_job_terminated_returns_true(self, mock_cancel_job):
+        """cancel a single job where check_job_terminated returns true"""
+        self.assertEqual(job_info[JOB_RUNNING]["status"], "running")
+        self.assertNotIn(JOB_RUNNING, self.jm._completed_job_states)
+
+        with mock.patch.object(
+            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            "check_job_canceled",
+            mock.Mock(return_value={"finished": 1, "canceled": 0}),
+        ) as mock_check_job_canceled:
+            # the check_job_canceled call returns output that says the job is finished
+            self.jm.cancel_job(JOB_RUNNING)
+            mock_cancel_job.assert_not_called()
+            mock_check_job_canceled.assert_called_once()
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.JobManager._cancel_job")
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_cancel_jobs__check_job_terminated_returns_true(self, mock_cancel_job):
+        """cancel multiple jobs where all check_job_terminated calls return true"""
+        for job_id in [JOB_RUNNING, JOB_CREATED]:
+            self.assertNotIn(job_id, self.jm._completed_job_states)
+
+        with mock.patch.object(
+            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            "check_job_canceled",
+            mock.Mock(return_value={"finished": 1, "canceled": 0}),
+        ) as mock_check_job_canceled:
+            # the check_job_canceled call returns output that says the job is finished
+            canceled_jobs = self.jm.cancel_jobs([JOB_RUNNING, JOB_CREATED, None, ""])
+            mock_cancel_job.assert_not_called()
+            mock_check_job_canceled.assert_has_calls(
+                [
+                    mock.call({"job_id": JOB_RUNNING}),
+                    mock.call({"job_id": JOB_CREATED}),
+                ],
+                any_order=True,
+            )
+
+            print({"got": canceled_jobs})
+            print({"expected": self.job_states})
+
+            self.assertEqual(canceled_jobs, self.job_states)
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_cancel_job__run_ee2_cancel_job(self):
+        """cancel a job that runs cancel_job on ee2"""
         new_job = phony_job()
+        new_job.status = "running"
         job_id = new_job.job_id
         self.jm.register_new_job(new_job)
-        self.jm.cancel_job(job_id)
+        self.assertIn(job_id, self.jm._running_jobs)
+        self.assertNotIn(job_id, self.jm._completed_job_states)
+        # set the job refresh to 1
+        self.jm._running_jobs[job_id]["refresh"] = 1
 
-    def test_cancel_job_bad(self):
-        with self.assertRaises(ValueError):
-            self.jm.cancel_job(None)
+        def check_state(arg):
+            self.assertEqual(self.jm._running_jobs[arg["job_id"]]["refresh"], 0)
+            self.assertEqual(self.jm._running_jobs[arg["job_id"]]["canceling"], True)
+
+        # patch MockClients.check_job_canceled to respond that neither job has finished or been canceled
+        # patch MockClients.cancel_job so we can test the input
+        with mock.patch.object(
+            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            "check_job_canceled",
+            mock.Mock(return_value={"finished": 0, "canceled": 0}),
+        ) as mock_check_job_canceled, mock.patch.object(
+            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            "cancel_job",
+            mock.Mock(return_value={}, side_effect=check_state),
+        ) as mock_cancel_job:
+            self.jm.cancel_job(job_id)
+            mock_check_job_canceled.assert_called_once_with({"job_id": job_id})
+            mock_cancel_job.assert_called_once_with({"job_id": job_id})
+            self.assertNotIn("canceling", self.jm._running_jobs[job_id])
+            self.assertEqual(self.jm._running_jobs[job_id]["refresh"], 1)
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_cancel_jobs__run_ee2_cancel_job(self):
+        """cancel a set of jobs that run cancel_job on ee2"""
+        # jobs list:
+        jobs = [
+            None,
+            JOB_CREATED,
+            JOB_RUNNING,
+            "",
+            JOB_TERMINATED,
+            JOB_COMPLETED,
+            JOB_TERMINATED,
+            None,
+            JOB_NOT_FOUND,
+        ]
+
+        expected = {
+            JOB_CREATED: self.job_states[JOB_CREATED],
+            JOB_RUNNING: self.job_states[JOB_RUNNING],
+            JOB_COMPLETED: self.jm._completed_job_states[JOB_COMPLETED],
+            JOB_TERMINATED: self.jm._completed_job_states[JOB_TERMINATED],
+            JOB_NOT_FOUND: {
+                "job_id": JOB_NOT_FOUND,
+                "status": "does_not_exist",
+            },
+        }
+
+        def check_state(arg):
+            self.assertEqual(self.jm._running_jobs[arg["job_id"]]["refresh"], 0)
+            self.assertEqual(self.jm._running_jobs[arg["job_id"]]["canceling"], True)
+
+        # check_job_canceled responds that JOB_RUNNING has been canceled and JOB_CREATED has not
+        # patch MockClients.cancel_job so we can test the input
+        with mock.patch.object(
+            biokbase.narrative.tests.narrative_mock.mockclients.MockClients,
+            "cancel_job",
+            mock.Mock(return_value={}, side_effect=check_state),
+        ) as mock_cancel_job:
+            results = self.jm.cancel_jobs(jobs)
+            self.assertNotIn("canceling", self.jm._running_jobs[JOB_RUNNING])
+            self.assertNotIn("canceling", self.jm._running_jobs[JOB_CREATED])
+            self.assertEqual(results.keys(), expected.keys())
+            self.assertEqual(results, expected)
+            mock_cancel_job.assert_has_calls(
+                [
+                    mock.call({"job_id": JOB_CREATED}),
+                ],
+                any_order=True,
+            )
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_cancel_jobs(self):
+
+        with assert_obj_method_called(self.jm, "cancel_jobs", True):
+            self.jm.cancel_jobs([JOB_COMPLETED])
+
+        with assert_obj_method_called(self.jm, "cancel_jobs", False):
+            self.jm.cancel_job(JOB_COMPLETED)
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_retry_job_good(self):
-        job_id = "5d64935cb215ad4128de94d9"
-        retry_results = self.jm.retry_jobs([job_id])
+        retry_results = self.jm.retry_jobs([JOB_TERMINATED])
         self.assertEqual(
-            retry_results, [{"job_id": job_id, "retry_id": "9d49ed8214da512bc53946d5"}]
+            retry_results,
+            [{"job_id": JOB_TERMINATED, "retry_id": "9d49ed8214da512bc53946d5"}],
         )
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_retry_job_bad(self):
         with self.assertRaises(JobException):
             self.jm.retry_jobs([None])
+
         with self.assertRaises(JobException):
             self.jm.retry_jobs(["nope"])
+
+        with self.assertRaises(JobException):
+            self.jm.retry_jobs(["", "nope"])
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def test_lookup_all_job_states(self):
         states = self.jm.lookup_all_job_states()
         self.assertEqual(len(states), 2)
+        self.assertEqual({JOB_CREATED, JOB_RUNNING}, set(states.keys()))
 
         states = self.jm.lookup_all_job_states(ignore_refresh_flag=True)
         self.assertEqual(len(states), 4)
+        self.assertEqual(set(self.job_ids), set(states.keys()))
 
     # @mock.patch('biokbase.narrative.jobs.jobmanager.clients.get', get_mock_client)
     # def test_job_status_fetching(self):


### PR DESCRIPTION
# Description of PR purpose/changes

Adding `cancel_jobs` method to job manager and updating tests

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
