### PR TITLE
DATAUP-500 (DATAUP-452 part 1) update selectInput to use select2

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidget.js
@@ -377,8 +377,7 @@ define([
                         [
                             label(
                                 {
-                                    class:
-                                        'col-md-3 xcontrol-label kb-app-parameter-name control-label',
+                                    class: 'col-md-3 kb-app-parameter-name control-label',
                                 },
                                 [spec.label() || spec.id()]
                             ),

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetCompact.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetCompact.js
@@ -345,7 +345,7 @@ define([
                             div({ class: 'col-md-3' }, [
                                 label(
                                     {
-                                        class: 'xcontrol-label kb-app-parameter-name control-label',
+                                        class: 'kb-app-parameter-name control-label',
                                         title: infoTipText,
                                         style: { cursor: 'help' },
                                         id: events.addEvent({

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetMicro.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetMicro.js
@@ -357,8 +357,7 @@ define([
                                 return div({ class: 'col-md-3' }, [
                                     label(
                                         {
-                                            class:
-                                                'xcontrol-label kb-app-parameter-name control-label',
+                                            class: 'kb-app-parameter-name control-label',
                                             title: infoTipText,
                                             style: { cursor: 'help' },
                                             id: events.addEvent({

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
@@ -26,15 +26,9 @@ define([
             channel = busConnection.channel(config.channelName),
             model = {
                 availableValues: spec.data.constraints.options,
-                availableValuesMap: {},
                 value: config.initialValue,
             };
         let parent, ui, container;
-
-        model.availableValues.forEach((item, index) => {
-            item.index = index;
-            model.availableValuesMap[item.value] = item;
-        });
 
         function getControlValue() {
             const control = ui.getElement('input-container.input'),
@@ -126,10 +120,6 @@ define([
             );
         }
 
-        // function syncModelToControl() {
-        //     $(ui.getElement('input-container.input')).val(model.value).trigger('change');
-        // }
-
         function layout() {
             return div(
                 {
@@ -182,7 +172,6 @@ define([
                 });
 
                 autoValidate();
-                // syncModelToControl();
             });
         }
 
@@ -196,8 +185,8 @@ define([
         }
 
         return {
-            start: start,
-            stop: stop,
+            start,
+            stop,
         };
     }
 

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -6,7 +6,7 @@ define([
 ], ($, StagingAreaViewer, Jupyter) => {
     'use strict';
 
-    fdescribe('The staging area viewer widget', () => {
+    describe('The staging area viewer widget', () => {
         let stagingViewer, container, $container, $parentNode;
         const startingPath = '/',
             updatePathFn = null, //() => {},


### PR DESCRIPTION
# Description of PR purpose/changes

Change the select input dropdown to use select 2 for app cells and bulk import cells.

This is the first step to finishing DATAUP-452. Now all dropdowns should make use of the select2 widget styling and should look and behave consistently. This has a couple typo and missing style fixes as well.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-500
https://kbase-jira.atlassian.net/browse/DATAUP-452
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
Details for how to test the PR manually
1. Open a new bulk import cell with FASTQ reads (for example)
2. Scroll down to the Sequencing Technology parameter. It should use select2 styling instead of browser standards. It should also have a little x to delete on the right side.
3. Open a standard app with a dropdown input and do the same (like MEGAHIT)

- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
