### PR TITLE
DATAUP-500 Add messages to enable/disable options in select input

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -22,19 +22,8 @@ define([
         let places, parent, container, inputControl;
 
         try {
-            inputControl = inputControlFactory.make({
-                bus: bus,
-                paramsChannelName: config.paramsChannelName,
-                channelName: bus.channelName,
-                initialValue: config.initialValue,
-                appSpec: config.appSpec,
-                parameterSpec: config.parameterSpec,
-                workspaceInfo: config.workspaceInfo,
-                workspaceId: config.workspaceId,
-                fieldSpec: config.fieldSpec,
-                referenceType: config.referenceType,
-                closeParameters: config.closeParameters,
-            });
+            const controlConfig = Object.assign({}, config, {bus, channelName: bus.channelName});
+            inputControl = inputControlFactory.make(controlConfig);
         } catch (ex) {
             console.error('Error creating input control', ex);
             inputControl = ErrorControlFactory.make({

--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -22,7 +22,7 @@ define([
         let places, parent, container, inputControl;
 
         try {
-            const controlConfig = Object.assign({}, config, {bus, channelName: bus.channelName});
+            const controlConfig = Object.assign({}, config, { bus, channelName: bus.channelName });
             inputControl = inputControlFactory.make(controlConfig);
         } catch (ex) {
             console.error('Error creating input control', ex);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
@@ -46,7 +46,7 @@ define([
                 disabledValues: new Set(config.disabledValues || []),
             };
         let parent, ui, container;
-        model.availableValuesSet = new Set(model.availableValues.map(valueObj => valueObj.value));
+        model.availableValuesSet = new Set(model.availableValues.map((valueObj) => valueObj.value));
 
         function getControlValue() {
             const control = ui.getElement('input-container.input'),
@@ -124,8 +124,7 @@ define([
                 };
                 if (item.value === model.value) {
                     attribs.selected = true;
-                }
-                else if (model.disabledValues.has(item.value)) {
+                } else if (model.disabledValues.has(item.value)) {
                     attribs.disabled = true;
                 }
                 return option(attribs, item.display);
@@ -156,7 +155,7 @@ define([
                 model.value = value;
             }
             setValuesEnabled([value], true);
-            setValuesEnabled([oldValue], !model.disabledValues.has(oldValue))
+            setValuesEnabled([oldValue], !model.disabledValues.has(oldValue));
         }
 
         function resetModelValue() {
@@ -170,8 +169,7 @@ define([
                     const option = control.querySelector(`option[value="${value}"]`);
                     if (enabled) {
                         option.removeAttribute('disabled');
-                    }
-                    else {
+                    } else {
                         option.setAttribute('disabled', true);
                     }
                 }

--- a/test/unit/spec/appWidgets/input/selectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/selectInputSpec.js
@@ -187,5 +187,52 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
                 });
             });
         });
+
+        it('Should take a list of disabledValues on startup', () => {
+            const config = Object.assign({}, testConfig, {disabledValues: ['carrot']});
+            const widget = SelectInput.make(config);
+
+            return widget
+                .start({ node: container })
+                .then(() => {
+                    // verify it's there.
+                    const inputElem = container.querySelector('select[data-element="input"]');
+                    const carrotItem = inputElem.querySelector('option[value="carrot"]');
+                    expect(carrotItem.hasAttribute('disabled')).toBeTrue();
+                    const bananaItem = inputElem.querySelector('option[value="banana"]');
+                    expect(bananaItem.hasAttribute('disabled')).toBeFalse();
+                });
+        });
+
+        xit('Should obey a message to disable selection options', () => {
+
+        });
+
+        xit('Should obey a message to enable selection options', () => {
+
+        });
+
+        it('Should take a set of options that override the options from the parameter spec', () => {
+            const values = [{
+                display: 'Dirigible',
+                value: 'dirigible'
+            }, {
+                display: 'Elephant',
+                value: 'elephant'
+            }, {
+                display: 'Frittata',
+                value: 'frittata'
+            }];
+            const config = Object.assign({}, testConfig, {availableValues: values, initialValue: 'elephant'});
+            const widget = SelectInput.make(config);
+            return widget.start({ node: container }).then(() => {
+                const inputElem = container.querySelector('select[data-element="input"]');
+                expect(inputElem.value).toEqual('elephant');
+                expect(inputElem.childElementCount).toBe(3);
+                for (const child of inputElem.children) {
+                    expect(['dirigible', 'elephant', 'frittata'].includes(child.value)).toBeTrue();
+                }
+            });
+        });
     });
 });

--- a/test/unit/spec/appWidgets/input/selectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/selectInputSpec.js
@@ -189,41 +189,42 @@ define(['common/runtime', 'widgets/appWidgets2/input/selectInput'], (Runtime, Se
         });
 
         it('Should take a list of disabledValues on startup', () => {
-            const config = Object.assign({}, testConfig, {disabledValues: ['carrot']});
+            const config = Object.assign({}, testConfig, { disabledValues: ['carrot'] });
             const widget = SelectInput.make(config);
 
-            return widget
-                .start({ node: container })
-                .then(() => {
-                    // verify it's there.
-                    const inputElem = container.querySelector('select[data-element="input"]');
-                    const carrotItem = inputElem.querySelector('option[value="carrot"]');
-                    expect(carrotItem.hasAttribute('disabled')).toBeTrue();
-                    const bananaItem = inputElem.querySelector('option[value="banana"]');
-                    expect(bananaItem.hasAttribute('disabled')).toBeFalse();
-                });
+            return widget.start({ node: container }).then(() => {
+                // verify it's there.
+                const inputElem = container.querySelector('select[data-element="input"]');
+                const carrotItem = inputElem.querySelector('option[value="carrot"]');
+                expect(carrotItem.hasAttribute('disabled')).toBeTrue();
+                const bananaItem = inputElem.querySelector('option[value="banana"]');
+                expect(bananaItem.hasAttribute('disabled')).toBeFalse();
+            });
         });
 
-        xit('Should obey a message to disable selection options', () => {
+        xit('Should obey a message to disable selection options', () => {});
 
-        });
-
-        xit('Should obey a message to enable selection options', () => {
-
-        });
+        xit('Should obey a message to enable selection options', () => {});
 
         it('Should take a set of options that override the options from the parameter spec', () => {
-            const values = [{
-                display: 'Dirigible',
-                value: 'dirigible'
-            }, {
-                display: 'Elephant',
-                value: 'elephant'
-            }, {
-                display: 'Frittata',
-                value: 'frittata'
-            }];
-            const config = Object.assign({}, testConfig, {availableValues: values, initialValue: 'elephant'});
+            const values = [
+                {
+                    display: 'Dirigible',
+                    value: 'dirigible',
+                },
+                {
+                    display: 'Elephant',
+                    value: 'elephant',
+                },
+                {
+                    display: 'Frittata',
+                    value: 'frittata',
+                },
+            ];
+            const config = Object.assign({}, testConfig, {
+                availableValues: values,
+                initialValue: 'elephant',
+            });
             const widget = SelectInput.make(config);
             return widget.start({ node: container }).then(() => {
                 const inputElem = container.querySelector('select[data-element="input"]');


### PR DESCRIPTION
# Description of PR purpose/changes

This alters the selectInput widget in the following ways
1. Adds an optional `availableValues` config option, which, if present, overrides the values taken from the constant spec.
2. Adds an optional `disabledValues` config, which disables any of the set values on startup.
3. Adds the `disable-values` and `enable-values` messages, which each take an Array of value strings. If any are present in the dropdown they'll be disabled/enabled. If any of those are the currently selected value, it stays enabled until the user selects a separate option. It doesn't seem to make sense to disable the selected value.


# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-500
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Nothing really obviously user-facing yet - commands will be included in the next PR.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
