### PR TITLE
DATAUP-512: use batch_id instead of parent_job_id

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -425,21 +425,19 @@ define(['common/jobMessages', 'common/jobs'], (JobMessages, Jobs) => {
              * set up the job manager to handle a batch job
              *
              * @param {object} batchJob - with keys
-             *        {string} parent_job_id
+             *        {string} batch_id
              *        {array}  child_job_ids
              */
             initBatchJob(batchJob) {
-                const { parent_job_id, child_job_ids } = batchJob;
+                const { batch_id, child_job_ids } = batchJob;
 
                 if (
-                    !parent_job_id ||
+                    !batch_id ||
                     !child_job_ids ||
                     Object.prototype.toString.call(child_job_ids) !== '[object Array]' ||
                     !child_job_ids.length
                 ) {
-                    throw new Error(
-                        'Batch job must have a parent job ID and at least one child job ID'
-                    );
+                    throw new Error('Batch job must have a batch ID and at least one child job ID');
                 }
 
                 this.addListener('job-status', child_job_ids);
@@ -462,7 +460,7 @@ define(['common/jobMessages', 'common/jobs'], (JobMessages, Jobs) => {
 
                 // TODO: implement more complete handling for parent
                 this.model.setItem('exec.jobState', {
-                    job_id: parent_job_id,
+                    job_id: batch_id,
                     status: 'created',
                     created: 0,
                 });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
@@ -194,7 +194,6 @@ define([
                 const translations = {
                     jobId: 'job_id',
                     jobIdList: 'job_id_list',
-                    parentJobId: 'parent_job_id',
                     pingId: 'ping_id',
                 };
 
@@ -497,7 +496,9 @@ define([
                 ],
             });
 
-            $modalBody.find('button#kb-job-err-report').click(() => {});
+            $modalBody.find('button#kb-job-err-report').click(() => {
+                // no action
+            });
             modal.getElement().on('hidden.bs.modal', () => {
                 modal.destroy();
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,9 +2147,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001242",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-            "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+            "version": "1.0.30001243",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+            "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15306,9 +15306,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001242",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-            "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+            "version": "1.0.30001243",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz",
+            "integrity": "sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==",
             "dev": true
         },
         "chalk": {

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -31,7 +31,7 @@ A module for managing apps, specs, requirements, and for starting jobs.
 """
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
-BATCH_ID_KEY = "parent_job_id"
+BATCH_ID_KEY = "batch_id"
 
 BATCH_APP = {
     "APP_ID": "kb_BatchApp/run_batch",

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -745,18 +745,17 @@ define([
             const invalidInput = [
                 {},
                 { parent_job: 12345 },
-                { parent_job_id: 12345, child_jobs: [] },
-                { parent_job_id: 12345, child_job_ids: [] },
-                { parent_job_id: 12345, child_job_ids: {} },
+                { batch_job: 12345 },
+                { batch_id: 12345, child_jobs: [] },
+                { batch_id: 12345, child_job_ids: [] },
+                { batch_id: 12345, child_job_ids: {} },
             ];
 
             invalidInput.forEach((input) => {
                 it(`will not accept invalid input ${JSON.stringify(input)}`, function () {
                     expect(() => {
                         this.jobManagerInstance.initBatchJob(input);
-                    }).toThrowError(
-                        /Batch job must have a parent job ID and at least one child job ID/
-                    );
+                    }).toThrowError(/Batch job must have a batch ID and at least one child job ID/);
                 });
             });
 
@@ -772,7 +771,7 @@ define([
                         .sort()
                 );
                 this.jobManagerInstance.initBatchJob({
-                    parent_job_id: 'something',
+                    batch_id: 'something',
                     child_job_ids: childJobs,
                 });
                 expect(

--- a/test/unit/spec/narrative_core/jobCommChannel-spec.js
+++ b/test/unit/spec/narrative_core/jobCommChannel-spec.js
@@ -132,20 +132,18 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
             },
             {
                 channel: 'request-job-status',
-                message: { jobId: 'someJob', parentJobId: 'someParent' },
+                message: { jobId: 'someJob' },
                 expected: {
                     request_type: 'job_status',
                     job_id: 'someJob',
-                    parent_job_id: 'someParent',
                 },
             },
             {
                 channel: 'request-job-update',
-                message: { jobId: 'someJob', parentJobId: 'someParent' },
+                message: { jobId: 'someJob' },
                 expected: {
                     request_type: 'start_job_update',
                     job_id: 'someJob',
-                    parent_job_id: 'someParent',
                 },
             },
             {
@@ -170,7 +168,6 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
                 channel: 'request-job-log-latest',
                 message: {
                     jobId: 'someJob',
-                    parentJobId: 'none',
                     options: {
                         first_line: 2000,
                         job_id: 'overridden!',
@@ -179,17 +176,15 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
                 expected: {
                     request_type: 'job_logs_latest',
                     job_id: 'overridden!',
-                    parent_job_id: 'none',
                     first_line: 2000,
                 },
             },
             {
                 channel: 'request-job-info',
-                message: { jobId: 'someJob', parentJobId: 'someParent' },
+                message: { jobId: 'someJob' },
                 expected: {
                     request_type: 'job_info',
                     job_id: 'someJob',
-                    parent_job_id: 'someParent',
                 },
             },
             {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -6,8 +6,7 @@ define([
     'testUtil',
     '/test/data/testAppObj',
     'common/ui',
-    'json!/test/data/NarrativeTest.test_input_params.spec.json',
-], (BulkImportCell, Jupyter, Runtime, Mocks, TestUtil, TestAppObj, UI, TestAppSpec) => {
+], (BulkImportCell, Jupyter, Runtime, Mocks, TestUtil, TestAppObj, UI) => {
     'use strict';
     const fakeInputs = {
             dataType: {
@@ -183,7 +182,7 @@ define([
             {
                 msgEvent: 'launched_job_batch',
                 msgData: {
-                    parent_job_id: 'bar',
+                    batch_id: 'bar',
                     child_job_ids: ['foo'],
                 },
                 updatedState: 'inProgress',


### PR DESCRIPTION

# Description of PR purpose/changes

* Switch front and backend over to using "batch id" instead of "parent_job_id" to refer to the batch job parent

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-512
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative running against CI, and then kicking off a batch job. Prior to the update, you would get a frontend error about batch jobs requiring a parent job ID and child IDs; this should disappear after this update.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
