### PR TITLE
DATAUP-437: remove 'request-job-log-latest', use 'request-job-log' instead

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -54,12 +54,7 @@ All the `request-job-*` requests take as arguments either a single job ID string
   * `options` - an object, with attributes:
     * `first_line` - the first line (0-indexed) to request
     * `num_lines` - the number of lines to request (will get back up to that many if there aren't more)
-
-`request-job-log-latest` - request the latest several job log lines
-  * `jobId` - a string, the job id OR
-  * `jobIdList` - an array of job IDs
-  * `options` - an object, with attributes:
-    * `num_lines` - the number of lines to request (will get back up to that many if there aren't more)
+    * `latest` -  true if requesting just the latest set of logs
 
 ### Usage Example
 The comm channel is used through the main Bus object that's instantiated through the global `Runtime` object. That needs to be included in the `define` statement for all AMD modules. The bus is then used with its `emit` function (you have the bus *emit* a message to its listeners), and any inputs are passed along with it.
@@ -241,13 +236,9 @@ These are organized by the `request_type` field, followed by the expected respon
 `job_logs` - request job log information, responds with `job_logs` for each job
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
-* `first_line` - int >= 0,
+* `first_line` - int >= 0, ignored if `latest` is `true`
 * `num_lines` - int > 0
-
-`job_logs_latest` - request the latest set of lines from job logs, responds with `job_logs`
-* `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
-* `num_lines` - int > 0
+* `latest` - boolean, `true` if requesting just the latest logs
 
 `cancel_job` - cancel a job or list of jobs; responds with `job_canceled` for each job
 * `job_id` - string OR `job_id_list` - array of strings

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -527,9 +527,11 @@ define([
             scrollToEndOnNext = true;
             awaitingLog = true;
             ui.showElement('spinner');
-            bus.emit('request-job-log-latest', {
+            bus.emit('request-job-log', {
                 jobId: jobId,
-                options: {},
+                options: {
+                    latest: true,
+                },
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/jobCommChannel.js
@@ -62,7 +62,6 @@ define([
         CANCEL_JOB = 'cancel_job',
         RETRY_JOB = 'retry_job',
         JOB_LOGS = 'job_logs',
-        JOB_LOGS_LATEST = 'job_logs_latest',
         JOB_INFO = 'job_info',
         JOB = 'jobId',
         CELL = 'cell';
@@ -91,8 +90,6 @@ define([
 
         // Fetches job logs from kernel.
         'request-job-log': JOB_LOGS,
-        // Fetches most recent job logs from kernel.
-        'request-job-log-latest': JOB_LOGS_LATEST,
     };
 
     class JobCommChannel {
@@ -208,6 +205,7 @@ define([
                 if (message.options) {
                     msg = Object.assign({}, msg, message.options);
                 }
+
                 this.comm.send(msg);
                 this.debug(`sending comm message: ${COMM_NAME} ${msgType}`);
                 resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,9 +2147,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001236",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-            "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
+            "version": "1.0.30001244",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001244.tgz",
+            "integrity": "sha512-Wb4UFZPkPoJoKKVfELPWytRzpemjP/s0pe22NriANru1NoI+5bGNxzKtk7edYL8rmCWTfQO8eRiF0pn1Dqzx7Q==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15306,9 +15306,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001236",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001236.tgz",
-            "integrity": "sha512-o0PRQSrSCGJKCPZcgMzl5fUaj5xHe8qA2m4QRvnyY4e1lITqoNkr7q/Oh1NcpGSy0Th97UZ35yoKcINPoq7YOQ==",
+            "version": "1.0.30001244",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001244.tgz",
+            "integrity": "sha512-Wb4UFZPkPoJoKKVfELPWytRzpemjP/s0pe22NriANru1NoI+5bGNxzKtk7edYL8rmCWTfQO8eRiF0pn1Dqzx7Q==",
             "dev": true
         },
         "chalk": {

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -53,7 +53,6 @@ class JobRequest:
         "stop_job_update",
         "cancel_job",
         "job_logs",
-        "job_logs_latest",
     ]
     REQUIRE_JOB_ID_LIST = ["retry_job"]
 
@@ -139,8 +138,7 @@ class JobComm:
     * start_job_update - tells the update loop to include a job when updating (requires a job_id)
     * stop_job_update - has the update loop not include a job when updating (requires a job_id)
     * cancel_job - cancels a running job, if it hasn't otherwise terminated (requires a job_id)
-    * job_logs - sends job logs back over the comm channel (requires a job id and first line)
-    * job_logs_latest - sends the most recent job logs over the comm channel (requires a job_id)
+    * job_logs - sends job logs back over the comm channel (requires a job id)
     """
 
     # An instance of this class. It's meant to be a singleton, so this just gets created and
@@ -181,7 +179,6 @@ class JobComm:
                 "cancel_job": self._cancel_job,
                 "retry_job": self._retry_jobs,
                 "job_logs": self._get_job_logs,
-                "job_logs_latest": self._get_job_logs,
             }
 
     def _verify_job_id(self, req: JobRequest) -> None:
@@ -401,7 +398,7 @@ class JobComm:
         self._verify_job_id(req)
         first_line = req.rq_data.get("first_line", 0)
         num_lines = req.rq_data.get("num_lines", None)
-        latest_only = req.request == "job_logs_latest"
+        latest_only = req.rq_data.get("latest", False)
         try:
             (first_line, max_lines, logs) = self._jm.get_job_logs(
                 req.job_id,

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -578,7 +578,6 @@ class JobManager(object):
     def get_job_logs(
         self,
         job_id: str,
-        parent_job_id: str = None,
         first_line: int = 0,
         num_lines: int = None,
         latest_only: bool = False,
@@ -586,10 +585,9 @@ class JobManager(object):
         """
         Raises a Value error if the job_id doesn't exist or is not present.
         :param job_id: str - the job id from the execution engine
-        :param parent_job_id: if the job is a child job, this is its parent (optional)
         :param first_line: int - the first line to be requested by the log. 0-indexed. If < 0,
             this will be set to 0
-        :param max_lines: int - the maximum number of lines to return.
+        :param num_lines: int - the maximum number of lines to return.
             if < 0, will be reset to 0.
             if None, then will not be considered, and just return all the lines.
         :param latest_only: bool - if True, will only return the most recent max_lines
@@ -613,7 +611,9 @@ class JobManager(object):
         try:
             if latest_only:
                 (max_lines, logs) = job.log()
-                if num_lines is not None and max_lines > num_lines:
+                if num_lines is None or max_lines <= num_lines:
+                    first_line = 0
+                else:
                     first_line = max_lines - num_lines
                     logs = logs[first_line:]
             else:

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -516,10 +516,14 @@ class assert_obj_method_called(object):
         self.method_called = False
 
     def __exit__(self, exc_type, exc_value, traceback):
-        assert getattr(self.obj, self.method) == self.called, "method %s was modified during assertMethodIsCalled" % self.method
+        assert getattr(self.obj, self.method) == self.called, (
+            "method %s was modified during assertMethodIsCalled" % self.method
+        )
 
         setattr(self.obj, self.method, self.orig_method)
 
         # If an exception was thrown within the block, we've already failed.
         if traceback is None:
-            assert self.method_called is self.call_status, "method %s of %s was not %s" % (self.method, self.obj, self.call_status)
+            assert (
+                self.method_called is self.call_status
+            ), "method %s of %s was not %s" % (self.method, self.obj, self.call_status)

--- a/test/unit/run_tests.py
+++ b/test/unit/run_tests.py
@@ -37,7 +37,7 @@ nb_server = None
 
 
 def run_narrative():
-    print(f'Starting local narrative on {JUPYTER_PORT}')
+    print(f"Starting local narrative on {JUPYTER_PORT}")
     nb_command = [
         "kbase-narrative",
         "--no-browser",
@@ -50,7 +50,10 @@ def run_narrative():
         nb_command[0] = "kbase-narrative"
 
     nb_server = subprocess.Popen(
-        nb_command, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, preexec_fn=os.setsid
+        nb_command,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        preexec_fn=os.setsid,
     )
 
     # wait for notebook server to start up
@@ -104,7 +107,7 @@ try:
             resp_unit = e.returncode
     if options.integration:
         env = os.environ.copy()
-        base_url = env.get('BASE_URL', None)
+        base_url = env.get("BASE_URL", None)
         if base_url is None:
             if nb_server is None:
                 nb_server = run_narrative()
@@ -121,7 +124,7 @@ try:
         except subprocess.CalledProcessError as e:
             resp_integration = e.returncode
 except Exception as e:
-    print(f'Error! {str(e)}')
+    print(f"Error! {str(e)}")
 finally:
     print("Done running tests.")
     if nb_server is not None:

--- a/test/unit/spec/narrative_core/jobCommChannel-spec.js
+++ b/test/unit/spec/narrative_core/jobCommChannel-spec.js
@@ -162,25 +162,31 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
                 },
             },
             {
-                channel: 'request-job-log-latest',
-                message: { jobId: 'someJob', options: {} },
-                expected: { request_type: 'job_logs_latest', job_id: 'someJob' },
+                channel: 'request-job-log',
+                message: { jobId: 'someJob', options: { latest: true } },
+                expected: {
+                    request_type: 'job_logs',
+                    job_id: 'someJob',
+                    latest: true,
+                },
             },
             {
-                channel: 'request-job-log-latest',
+                channel: 'request-job-log',
                 message: {
                     jobId: 'someJob',
                     parentJobId: 'none',
                     options: {
                         first_line: 2000,
                         job_id: 'overridden!',
+                        latest: true,
                     },
                 },
                 expected: {
-                    request_type: 'job_logs_latest',
+                    request_type: 'job_logs',
                     job_id: 'overridden!',
                     parent_job_id: 'none',
                     first_line: 2000,
+                    latest: true,
                 },
             },
             {
@@ -499,10 +505,6 @@ define(['jobCommChannel', 'base/js/namespace', 'common/runtime', 'testUtil'], (
                 error: 'job-cancel-error',
             },
             job_logs: {
-                ok: 'job-logs',
-                error: 'job-log-deleted',
-            },
-            job_logs_latest: {
                 ok: 'job-logs',
                 error: 'job-log-deleted',
             },

--- a/test/unit/spec/util/jobLogViewerSpec.js
+++ b/test/unit/spec/util/jobLogViewerSpec.js
@@ -578,8 +578,8 @@ define([
                 });
 
                 return new Promise((resolve) => {
-                    this.runtimeBus.on('request-job-log-latest', (msg) => {
-                        expect(msg).toEqual({ jobId: jobId, options: {} });
+                    this.runtimeBus.on('request-job-log', (msg) => {
+                        expect(msg).toEqual({ jobId: jobId, options: { latest: true } });
                         const logUpdate = logs[acc];
                         acc += 1;
                         // set up the mutation observer to watch for UI spinner changes
@@ -621,8 +621,8 @@ define([
                 });
 
                 // this is called when the state is 'running'
-                this.runtimeBus.on('request-job-log-latest', (msg) => {
-                    expect(msg).toEqual({ jobId: jobId, options: {} });
+                this.runtimeBus.on('request-job-log', (msg) => {
+                    expect(msg).toEqual({ jobId: jobId, options: { latest: true } });
                     this.runtimeBus.send(...formatMessage(jobId, 'log-deleted'));
                 });
 


### PR DESCRIPTION
# Description of PR purpose/changes

Simplifies the frontend by removing the 'request-job-log-latest' message channel and use 'request-job-log' with an option instead.

The python parts were taken from a branch that @n1mus worked on.

Update docs and tests.

Narrative frontend unit tests are failing. 😢 

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-437
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by reinstalling the narrative and then doing the following:
* view the log of a job that has been completed
* run a job and view the logs
* stop the logs and restart them

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
