### PR TITLE
SCT-3084 fix broken search in data panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 /coverage/
+/python-coverage/
 htmlcov/
 .tox/
 .coverage

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
 ### Unreleased
 
+- SCT-3084 - Fixed broken (non-functional) search in the data panel
 - SCT-3602 - refseq public data tool now searches by lineage as well; for all public data tools: automatically focus the search input; fix paging bug.
 - No ticket - migrate from `nosetests` to `pytest` for testing the Python stack.
 - Python dependency updates

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -2115,8 +2115,8 @@ define([
                     // [9] : int size // [10] : usermeta meta
 
                     orderedObject.inFilter = (() => {
-                        const objectTypeName = info[2].split(/[.-]/)[1];
                         const info = this.dataObjects[orderedObject.objId].info;
+                        const objectTypeName = info[2].split(/[.-]/)[1];
 
                         // if type is defined, then our sort must also filter by the type
                         if (type && type !== objectTypeName) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -2095,52 +2095,62 @@ define([
                 // optimization => we filter existing matches instead of researching everything if the new
                 // term starts with the last term searched for
                 // clean the term for regex use
-                term = term.replace(/\|/g, '\\|').replace(/\\\\\|/g, '|'); // bars are common in kb ids, so escape them unless we have \\|
-                term = term.replace(/\./g, '\\.').replace(/\\\\\./g, '.'); // dots are common in names, so we escape them, but
+
+                // bars are common in kb ids, so escape them unless we have \\|
+                term = term.replace(/\|/g, '\\|').replace(/\\\\\|/g, '|');
+
+                // dots are common in names, so we escape them, but
                 // if a user writes '\\.' we assume they want the regex '.'
+                term = term.replace(/\./g, '\\.').replace(/\\\\\./g, '.');
 
                 const regex = new RegExp(term, 'i');
 
+                // TODO: n_filteredObjsRendered does not seem to be used anywhere, but needs
+                // further investigation.
                 this.n_filteredObjsRendered = 0;
                 for (const orderedObject of this.viewOrder) {
                     // [0] : obj_id objid // [1] : obj_name name // [2] : type_string type
                     // [3] : timestamp save_date // [4] : int version // [5] : username saved_by
                     // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
                     // [9] : int size // [10] : usermeta meta
-                    let match = false;
                     const info = this.dataObjects[orderedObject.objId].info;
-                    if (regex.test(info[1])) {
-                        match = true;
-                    } // match on name
-                    else if (regex.test(info[2].split('.')[1].split('-'))) {
-                        match = true;
-                    } // match on type name
-                    else if (regex.test(info[5])) {
-                        match = true;
-                    } // match on saved_by user
+                    const objectTypeName = info[2].split(/[.-]/)[1];
+                    orderedObject.inFilter = (() => {
+                        const objectTypeName = info[2].split(/[.-]/)[1];
 
-                    if (!match && info[10]) {
-                        // match on metadata values
-                        for (const [metaKey, metaValue] of Object.entries(info[10])) {
-                            // Omits enumerable properties not directly on this object,
-                            // which in reality simply won't occur.
-                            if (!Object.prototype.hasOwnProperty.call(info[10], metaKey)) {
-                                continue;
-                            }
-                            if (regex.test(metaValue) || regex.test(metaKey + '::' + metaValue)) {
-                                match = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (type) {
                         // if type is defined, then our sort must also filter by the type
-                        if (type !== info[2].split('-')[0].split('.')[1]) {
-                            match = false; // no match if we are not the selected type!
+                        if (type && type !== objectTypeName) {
+                            return false; // no match if we are not the selected type!
                         }
-                    }
-                    orderedObject.inFilter = match;
+
+                        // match on name
+                        if (regex.test(info[1])) {
+                            return true;
+                        }
+                        // match on type name
+                        if (regex.test(objectTypeName)) {
+                            return true;
+                        }
+                        // match on saved_by user
+                        if (regex.test(info[5])) {
+                            return true;
+                        }
+
+                        const metadata = info[10];
+                        if (metadata) {
+                            // match on metadata values
+                            for (const [metaKey, metaValue] of Object.entries(metadata)) {
+                                if (
+                                    regex.test(metaValue) ||
+                                    regex.test(metaKey + '::' + metaValue)
+                                ) {
+                                    return true;
+                                }
+                            }
+                        }
+
+                        return false;
+                    })();
                 }
             } else {
                 // no new search, so show all and render the list

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -2113,7 +2113,7 @@ define([
                     // [3] : timestamp save_date // [4] : int version // [5] : username saved_by
                     // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
                     // [9] : int size // [10] : usermeta meta
-                    
+
                     orderedObject.inFilter = (() => {
                         const objectTypeName = info[2].split(/[.-]/)[1];
                         const info = this.dataObjects[orderedObject.objId].info;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -1940,7 +1940,7 @@ define([
                     this.writingLock = false;
                     this.refresh();
                 });
-            this.$searchDiv = $('<div>');
+            this.$searchDiv = $('<div data-testid="search-field">');
             this.bsSearch = new BootstrapSearch(this.$searchDiv, {
                 inputFunction: () => {
                     this.search();
@@ -2121,7 +2121,7 @@ define([
 
                     if (!match && info[10]) {
                         // match on metadata values
-                        for (const [metaKey, metaValue] of info[10].entries()) {
+                        for (const [metaKey, metaValue] of Object.entries(info[10])) {
                             // Omits enumerable properties not directly on this object,
                             // which in reality simply won't occur.
                             if (!Object.prototype.hasOwnProperty.call(info[10], metaKey)) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -2113,10 +2113,10 @@ define([
                     // [3] : timestamp save_date // [4] : int version // [5] : username saved_by
                     // [6] : ws_id wsid // [7] : ws_name workspace // [8] : string chsum
                     // [9] : int size // [10] : usermeta meta
-                    const info = this.dataObjects[orderedObject.objId].info;
-                    const objectTypeName = info[2].split(/[.-]/)[1];
+                    
                     orderedObject.inFilter = (() => {
                         const objectTypeName = info[2].split(/[.-]/)[1];
+                        const info = this.dataObjects[orderedObject.objId].info;
 
                         // if type is defined, then our sort must also filter by the type
                         if (type && type !== objectTypeName) {

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
@@ -204,7 +204,6 @@ define([
         });
 
         it('Should render with data, conduct a search, and show a resulting data card', async () => {
-            const start = Date.now();
             mockNarrativeServiceListObjects(OBJDATA);
             await dataListObj.refresh();
 

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
@@ -43,11 +43,59 @@ define([
         });
     }
 
+    /**
+     * Returns a promise which will resolve when the provided function returns true,
+     * and reject if it exceeds the provided timeout or default of 5s, or if the
+     * function throws an exception.
+     */
+    function waitFor(fun, timeout=5000) {
+        const interval = 100;
+        let elapsed = 0;
+        const started = Date.now();
+        return new Promise((resolve, reject) => {
+            const tryIt = () => {
+                elapsed = Date.now() - started;
+                if (elapsed > timeout) {
+                    throw new Error(`waitFor expired without success after ${elapsed}ms`);
+                }
+                try {
+                    const result = fun();
+                    if (!result) {
+                        window.setTimeout(() => {
+                            tryIt();
+                        }, interval);
+                    } else {
+                        resolve(result);
+                        return;
+                    }
+                } catch (ex) {
+                    reject(ex);
+                }
+            }
+            tryIt();
+        })
+    }
+
     const OBJDATA = [
         {
             object_info: [
                 5,
                 'Rhodobacter_CACIA_14H1',
+                'KBaseGenomes.Genome-7.0',
+                '2020-10-03T01:15:14+0000',
+                1,
+                'testuser',
+                54640,
+                'testuser:narrative_1601675739009',
+                '53af8071b814a1db43f81eb490a35491',
+                3110399,
+                {},
+            ],
+        },
+        {
+            object_info: [
+                6,
+                'Rhodobacter_CACIA_x',
                 'KBaseGenomes.Genome-7.0',
                 '2020-10-03T01:15:14+0000',
                 1,
@@ -153,6 +201,38 @@ define([
             expect($addDataButton.length).toEqual(1);
             expect($addDataButton.is('button')).toBeTruthy();
             expect($addDataButton.css('display')).toEqual('inline-block');
+        });
+
+        it('Should render with data, conduct a search, and show a resulting data card', async () => {
+            const start = Date.now();
+            mockNarrativeServiceListObjects(OBJDATA);
+            await dataListObj.refresh();
+
+            // There should initially be as many rows as test objects
+            const $initialRows = $dataList.find('.narrative-card-row');
+            expect($initialRows.length).toEqual(OBJDATA.length);
+
+            // Click the search button to expose the search input.
+            const $searchButton = $dataList.find('#kb-data-list-searchctl');
+            $searchButton.click();
+
+            // Simulate a search for the second object.
+            const $searchInput = $dataList.find('[data-testid="search-field"] input');
+            const objectName = OBJDATA[1].object_info[1];
+            $searchInput.val(objectName);
+            $searchInput.trigger('input');
+
+            const success = await waitFor(() => {
+                const $result = $dataList.find('.narrative-card-row');
+                // Wait for there to be only one row.
+                if ($result.length !== 1) {
+                    return false;
+                }
+                // And the result should be the object we searched for.
+                const $title = $result.find('.kb-data-list-name');
+                return $title.text() === objectName;
+            });
+            expect(success).toBeTrue();
         });
     });
 });

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
@@ -48,7 +48,7 @@ define([
      * and reject if it exceeds the provided timeout or default of 5s, or if the
      * function throws an exception.
      */
-    function waitFor(fun, timeout=5000) {
+    function waitFor(fun, timeout = 5000) {
         const interval = 100;
         let elapsed = 0;
         const started = Date.now();
@@ -71,9 +71,9 @@ define([
                 } catch (ex) {
                     reject(ex);
                 }
-            }
+            };
             tryIt();
-        })
+        });
     }
 
     const OBJDATA = [


### PR DESCRIPTION
# Fixes data panel search feature

The data panel's search feature was non-functional. This was simply caused by incorrect usage of `entries()` which caused the data object list filtering attempt to fail.

This was reported in a public ticket (https://kbase-jira.atlassian.net/browse/PUBLIC-1687) with development linked to a tracking ticket (https://kbase-jira.atlassian.net/browse/SCT-3084).

This PR also includes a single test added to ensure basic filtering is operational. (More tests could be added to cover data panel filtering and sorting.)

## Jira Ticket / Issue #
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions

The test for this fix is included in `test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js` located here https://github.com/kbase/narrative/pull/2371/files#diff-cb9d9f24ad0c6a467ed27c2706878f2be2642c542281180cd8cfb5886bf572b7R206. This will be run with the frontend unit tests, `make test-frontend-unit`.

- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [-] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
