### PR TITLE
DATAUP-511: Removing the unnecessary check_job_terminated method

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -598,10 +598,7 @@ class JobManager(object):
         if job_id in self._completed_job_states:
             return True
 
-        if not self._check_job_terminated(job_id):
-            return self._cancel_job(job_id)
-
-        return True
+        return self._cancel_job(job_id)
 
     def cancel_jobs(self, job_id_list: List[str] = []):
         """
@@ -616,10 +613,7 @@ class JobManager(object):
         checked_jobs = self._check_job_list(job_id_list)
 
         for job_id in checked_jobs["job_id_list"]:
-            if (
-                job_id not in self._completed_job_states
-                and not self._check_job_terminated(job_id)
-            ):
+            if job_id not in self._completed_job_states:
                 self._cancel_job(job_id)
 
         job_states = self._construct_job_status_set(checked_jobs["job_id_list"])
@@ -628,22 +622,6 @@ class JobManager(object):
             job_states[job_id] = {"job_id": job_id, "status": "does_not_exist"}
 
         return job_states
-
-    def _check_job_terminated(self, job_id: str) -> bool:
-        try:
-            cancel_status = clients.get("execution_engine2").check_job_canceled(
-                {"job_id": job_id}
-            )
-            if (
-                cancel_status.get("finished", 0) == 1
-                or cancel_status.get("canceled", 0) == 1
-            ):
-                # It's already finished, don't try to cancel it again.
-                return True
-            return False
-
-        except Exception as e:
-            raise transform_job_exception(e)
 
     def _cancel_job(self, job_id: str) -> None:
         # Stop updating the job status while we try to cancel.

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -225,14 +225,6 @@ class MockClients:
             results.append({"job_id": job_id, "retry_id": job_id[::-1]})
         return results
 
-    def check_job_canceled(self, params):
-        job_id = params.get("job_id")
-        # JOB_RUNNING from test_jobmanager.py
-        if job_id == "5d64935cb215ad4128de94d8":
-            return {"finished": 1, "canceled": 0, "job_id": job_id}
-
-        return {"finished": 0, "canceled": 0, "job_id": job_id}
-
     def get_job_params(self, job_id):
         return self.ee2_job_info.get(job_id, {}).get("job_input", {})
 


### PR DESCRIPTION
# Description of PR purpose/changes

The `check_job_terminated` method makes a call to ee2 to check whether a job is finished or not; if it is not, `ee2.cancel_job` is then called. This first call can be avoided by calling `ee2.cancel_job` straight away, as `cancel_job` returns a 200 / success response if the job is finished, regardless of whether the job was already finished or whether executing `cancel_job` caused it to complete.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-511
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
