### PR TITLE
DATAUP-457 automatically check the import box when user selects a file type

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -570,17 +570,19 @@ define([
                                 });
                         });
 
-                    //find the element
+                    // find the element
                     const importDropdown = $('td:eq(5)', row).find('select');
 
-                    /*
-                        when a user selects a data type from the import as dropdown
-                        enable the checkbox for that row (so user can import)
-                        make sure the "select all" checkbox is also enabled
-
-                        accepts dataType: string (the identifier of what the data type is e.g. sra_reads)
-                    */
-                    function enableCheckboxes(dataType) {
+                    /**
+                     * When a data type is selected from the "Import As..." dropdown,
+                     * enable the checkbox for that row (so user can import).
+                     * Make sure the "select all" checkbox is also enabled.
+                     *
+                     * @param {string} dataType the identifier of what the data type is, e.g.: sra_reads
+                     * @param {boolean} check if true, checks the now-enabled checkbox. Should generally only
+                     *  be true if this is called from a user selection event.
+                     */
+                    function enableCheckboxes(dataType, check) {
                         $('td:eq(5)', row)
                             .find('.select2-selection')
                             .addClass(`${cssBaseClass}-body__import-type-selected`);
@@ -597,6 +599,13 @@ define([
                         $('#staging_table_select_all')
                             .prop('disabled', false)
                             .attr('aria-label', 'Select to import all files checkbox');
+
+                        if (check) {
+                            $('td:eq(0)', row)
+                                .find(`.${cssBaseClass}-body__checkbox-input`)
+                                .prop('checked', true);
+                            stagingAreaViewer.enableImportButton();
+                        }
                     }
 
                     const storedFileData = stagingAreaViewer.selectedFileTypes[rowFileName];
@@ -644,7 +653,7 @@ define([
                         rowFileData.dataType = dataType;
                         stagingAreaViewer.selectedFileTypes[rowFileName] = rowFileData;
 
-                        enableCheckboxes(dataType);
+                        enableCheckboxes(dataType, true);
                     });
 
                     $('td:eq(5)', row)

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -346,7 +346,6 @@ define([
             //check the checkbox
             $container.find('input.kb-staging-table-body__checkbox-input:enabled').click();
             expect(importButton.disabled).toBeTrue();
-
         });
 
         describe('Should initialize an import app', () => {

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -318,6 +318,8 @@ define([
             expect(headerCheckbox.attr('aria-label')).toContain(
                 'Select to import all files checkbox'
             );
+
+            expect(tableCheckbox.prop('checked')).toBeTruthy();
         });
 
         it('should render the import selected button', async () => {
@@ -338,12 +340,13 @@ define([
                 .siblings('select');
 
             selectDropdown.val('sra_reads').trigger('change').trigger('select2:select');
+            const importButton = container.querySelector('.kb-staging-table-import__button');
+            expect(importButton.disabled).toBeFalse();
 
             //check the checkbox
             $container.find('input.kb-staging-table-body__checkbox-input:enabled').click();
+            expect(importButton.disabled).toBeTrue();
 
-            const button = container.querySelector('.kb-staging-table-import__button');
-            expect(button.disabled).toBeFalse();
         });
 
         describe('Should initialize an import app', () => {
@@ -445,10 +448,8 @@ define([
                         .find(`[data-download='${testCase.filename}']`)
                         .siblings('select');
 
+                    //this auto-checks the checkbox
                     selectDropdown.val('sra_reads').trigger('change').trigger('select2:select');
-
-                    //check the checkbox
-                    $container.find('input.kb-staging-table-body__checkbox-input:enabled').click();
 
                     const button = container.querySelector('.kb-staging-table-import__button');
                     expect(button.disabled).toBeFalse();


### PR DESCRIPTION
# Description of PR purpose/changes

As the title says, this automatically checks the selection box when a user selects a file type in the staging area.
Note this only happens when a USER selects the file type. If there's only one suggested type for the file from the system, which gets auto-selected, this doesn't also auto-check the import checkbox.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-457
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
