### PR TITLE
DATAUP-487 get checked rows from other pages

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -321,7 +321,7 @@ define([
 
             stagingAreaViewer.$elem.append($fileTable);
 
-            const fullDataTable = stagingAreaViewer.$elem.find('table').dataTable({
+            stagingAreaViewer.fullDataTable = stagingAreaViewer.$elem.find('table').DataTable({
                 language: {
                     emptyTable: emptyMsg,
                 },
@@ -603,7 +603,8 @@ define([
                         if (check) {
                             $('td:eq(0)', row)
                                 .find(`.${cssBaseClass}-body__checkbox-input`)
-                                .prop('checked', true);
+                                .prop('checked', true)
+                                .attr('aria-checked', true);
                             stagingAreaViewer.enableImportButton();
                         }
                     }
@@ -957,13 +958,15 @@ define([
              */
             const bulkMapping = {};
             // get all of the selected checkbox file names and import type
-            $(
-                stagingAreaViewer.$elem[0].querySelectorAll(
-                    `input.${cssBaseClass}-body__checkbox-input:checked`
-                )
-            ).each(function () {
-                const importType = $(this).attr('data-type');
-                let importFile = $(this).attr('data-file-name');
+
+            const checkedBoxSelector = `input.${cssBaseClass}-body__checkbox-input:checked`;
+            const selectedRows = stagingAreaViewer.fullDataTable.rows((idx, data, node) => {
+                return !!node.querySelector(checkedBoxSelector);
+            });
+            selectedRows.nodes().each((rowNode) => {
+                const dataElem = rowNode.querySelector(checkedBoxSelector);
+                const importType = $(dataElem).attr('data-type');
+                let importFile = $(dataElem).attr('data-file-name');
                 if (stagingAreaViewer.bulkImportTypes.includes(importType)) {
                     if (!(importType in bulkMapping)) {
                         bulkMapping[importType] = {


### PR DESCRIPTION
# Description of PR purpose/changes

This converts the staging area to use the Datatables API when finding the set of files selected for import. This gets all files from all currently loaded pages in the datatable.

This is the first step in this ticket - it doesn't solve the problem of subfolders, which will be some additional work. Those are separate tables that get loaded and built when the user clicks into them.


# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-487
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
