### PR TITLE
DATAUP-533 remove wsid from batch submission

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -499,7 +499,6 @@ class AppManager(object):
                         version=version,
                         cell_id=cell_id,
                         run_id=run_id,
-                        ws_id=ws_id,
                     )
                 )
             log_app_info.append(
@@ -716,9 +715,10 @@ class AppManager(object):
             "service_ver": service_ver,
             "params": input_vals,
             "app_id": app_id,
-            "wsid": ws_id,
             "meta": job_meta,
         }
+        if ws_id is not None:
+            job_runner_inputs["wsid"] = ws_id
         if len(ws_input_refs) > 0:
             job_runner_inputs["source_ws_objects"] = ws_input_refs
 

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -716,8 +716,17 @@ class AppManagerTestCase(unittest.TestCase):
     def test_run_app_bulk_dry_run(self, auth, c):
         mock_comm = MagicMock()
         c.return_value.send_comm_message = mock_comm
-        new_job = self.am.run_app_bulk(self.bulk_run_good_inputs, dry_run=True)
-        self.assertIsInstance(new_job, dict)
+        dry_run_results = self.am.run_app_bulk(self.bulk_run_good_inputs, dry_run=True)
+        self.assertIsInstance(dry_run_results, dict)
+        for key in ["batch_run_params", "batch_params"]:
+            self.assertIn(key, dry_run_results)
+        expected_batch_run_keys = set(
+            ["method", "service_ver", "params", "app_id", "meta"]
+        )
+        # expect only the above keys in each batch run params (note the missing wsid key)
+        for param_set in dry_run_results["batch_run_params"]:
+            self.assertTrue(expected_batch_run_keys == set(param_set.keys()))
+        self.assertTrue(set(["wsid"]) == set(dry_run_results["batch_params"].keys()))
         self.assertEqual(mock_comm.call_count, 0)
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)


### PR DESCRIPTION
# Description of PR purpose/changes

The `EE2.run_job_batch` function was updated to propagate the workspace id in the `batch_params` parameter to each child job that gets started. This means that the individual jobs submitted don't need to have the `wsid` parameter, and, in fact, this throws an error.

This updates the appmanager to remove that parameter from jobs submitted through the `run_app_batch` function.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-533
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
It's easiest to do a `dry_run` of the function and see that the `wsid` isn't present. Or just run a bulk import cell and see that it doesn't get booted out of EE2 immediately.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook