### PR TITLE
[DATAUP-512] Job Attributes & Parent-Child Relationship

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -289,7 +289,7 @@ class AppManager(object):
             kblogging.log_event(self._log, "run_batch_app_error", log_info)
             raise transform_job_exception(e)
 
-        new_job = Job(
+        new_job = Job.from_attributes(
             app_id=BATCH_APP["APP_ID"],
             app_version=BATCH_APP["VERSION"],
             cell_id=cell_id,
@@ -300,7 +300,7 @@ class AppManager(object):
                 "batch_size": len(params),
             },
             job_id=job_id,
-            owner=system_variable("user_id"),
+            user=system_variable("user_id"),
             params=batch_params,
             run_id=run_id,
             tag=BATCH_APP["TAG"],
@@ -393,12 +393,12 @@ class AppManager(object):
             kblogging.log_event(self._log, "run_app_error", log_info)
             raise transform_job_exception(e)
 
-        new_job = Job(
+        new_job = Job.from_attributes(
             app_id=app_id,
             app_version=job_runner_inputs["service_ver"],
             cell_id=cell_id,
             job_id=job_id,
-            owner=system_variable("user_id"),
+            user=system_variable("user_id"),
             params=job_runner_inputs["params"],
             run_id=run_id,
             tag=tag,
@@ -556,13 +556,13 @@ class AppManager(object):
         for idx, child_job_id in enumerate(batch_submission["child_job_ids"]):
             job_info = batch_run_inputs[idx]
             child_jobs.append(
-                Job(
+                Job.from_attributes(
                     app_id=job_info["app_id"],
                     app_version=job_info["service_ver"],
                     batch_id=batch_submission[BATCH_ID_KEY],
                     cell_id=cell_id,
                     job_id=child_job_id,
-                    owner=user_id,
+                    user=user_id,
                     params=job_info["params"][0],
                     run_id=run_id,
                     tag=job_info["meta"].get("tag"),
@@ -585,7 +585,8 @@ class AppManager(object):
                 },
                 "status": "created",
                 "user": user_id,
-            }
+            },
+            children=child_jobs
         )
 
         # TODO make a tighter design in the job manager for submitting a family of jobs

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -133,7 +133,7 @@ class Job(object):
         user (str): the user who started the job
         run_id (str): unique run ID for the job
         tag (str): the application tag (dev/beta/release)
-
+        children (list): applies to batch parent jobs, Job instances of this Job's child jobs
         """
         # reconstruct the ee2 job state object
         ee2_state = kwargs.get("ee2_state", {})

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -46,6 +46,19 @@ class JobManager(object):
             JobManager.__instance = object.__new__(cls)
         return JobManager.__instance
 
+    def _reorder_parents_children(self, states: dict) -> dict:
+        ordering = []
+        for job_id, state in states.items():
+            if state.get("batch_job"):
+                ordering.append(job_id)
+            else:
+                ordering.insert(0, job_id)
+        states = {
+            job_id: states[job_id] for job_id in ordering
+        }
+
+        return states
+
     def initialize_jobs(self):
         """
         Initializes this JobManager.
@@ -67,15 +80,27 @@ class JobManager(object):
                     "exclude_fields": JOB_INIT_EXCLUDED_JOB_STATE_FIELDS,
                 }
             )
-            self._running_jobs = dict()
         except Exception as e:
             kblogging.log_event(self._log, "init_error", {"err": str(e)})
             new_e = transform_job_exception(e)
             raise new_e
 
+        self._running_jobs = dict()
+        job_states = self._reorder_parents_children(job_states)
+
         for job_state in job_states.values():
+            child_jobs = []
+            if job_state.get("batch_job"):
+                child_jobs = [
+                    self.get_job(child_id)
+                    for child_id in job_state.get("child_jobs", [])
+                ]
+
             self.register_new_job(
-                job=Job.from_state(job_state),
+                job=Job.from_state(
+                    job_state,
+                    children=child_jobs
+                ),
                 refresh=int(job_state.get("status") not in TERMINAL_STATUSES)
             )
 
@@ -149,7 +174,7 @@ class JobManager(object):
                     state["created"] / 1000.0
                 ).strftime("%Y-%m-%d %H:%M:%S")
                 state["run_time"] = "Not started"
-                state["owner"] = job.owner
+                state["owner"] = job.user
                 state["app_id"] = job.app_id
                 exec_start = state.get("running", None)
 
@@ -187,7 +212,7 @@ class JobManager(object):
                     <td>{{ j.job_id|e }}</td>
                     <td>{{ j.app_id|e }}</td>
                     <td>{{ j.created|e }}</td>
-                    <td>{{ j.owner|e }}</td>
+                    <td>{{ j.user|e }}</td>
                     <td>{{ j.status|e }}</td>
                     <td>{{ j.run_time|e }}</td>
                     <td>{% if j.finish_time %}{{ j.finish_time|e }}{% else %}Incomplete{% endif %}</td>
@@ -221,7 +246,7 @@ class JobManager(object):
         # These are already post-processed and ready to return.
         for job_id in job_ids:
             job = self.get_job(job_id)
-            if job.terminal_state:
+            if job.was_terminal:
                 job_states[job_id] = job.output_state()
             elif states and job_id in states:
                 state = states[job_id]
@@ -373,7 +398,7 @@ class JobManager(object):
             raise ValueError(f"No job present with id {job_id}")
 
         # otherwise, our job ID is fine
-        if self.get_job(job_id).terminal_state:
+        if self.get_job(job_id).was_terminal:
             return True
 
         return self._cancel_job(job_id)
@@ -391,7 +416,7 @@ class JobManager(object):
         checked_jobs = self._check_job_list(job_id_list)
 
         for job_id in checked_jobs["job_id_list"]:
-            if not self.get_job(job_id).terminal_state:
+            if not self.get_job(job_id).was_terminal:
                 self._cancel_job(job_id)
 
         job_states = self._construct_job_state_set(checked_jobs["job_id_list"])

--- a/src/biokbase/narrative/tests/data/ee2_job_test_data.json
+++ b/src/biokbase/narrative/tests/data/ee2_job_test_data.json
@@ -3,6 +3,9 @@
         "job_id": "5d64935ab215ad4128de94d6",
         "user": "fake_test_user",
         "authstrat": "kbaseworkspace",
+        "batch_id": null,
+        "batch_job": false,
+        "child_jobs": [],
         "wsid": 9999,
         "status": "completed",
         "updated": 1566860098000,
@@ -36,12 +39,17 @@
                 }
             ],
             "id": "5d7024304446f0da4ac7eac4"
-        }
+        },
+        "retry_ids": [],
+        "retry_parent": null
     },
     "5d64935cb215ad4128de94d7": {
         "job_id": "5d64935cb215ad4128de94d7",
         "user": "tgu2",
         "authstrat": "kbaseworkspace",
+        "batch_id": null,
+        "batch_job": false,
+        "child_jobs": [],
         "wsid": 9999,
         "status": "created",
         "updated": 1572462965487,
@@ -65,12 +73,17 @@
                 "tag": "dev",
                 "run_id": "6546971e-757a-4a26-8439-325497c6d842"
             }
-        }
+        },
+        "retry_ids": [],
+        "retry_parent": null
     },
     "5d64935cb215ad4128de94d8": {
         "job_id": "5d64935cb215ad4128de94d8",
         "user": "wjriehl",
         "authstrat": "kbaseworkspace",
+        "batch_id": null,
+        "batch_job": false,
+        "child_jobs": [],
         "wsid": 9999,
         "status": "running",
         "updated": 1572462965490,
@@ -95,12 +108,17 @@
                 "tag": "dev",
                 "run_id": "6546971e-757a-4a26-8439-325497c6d843"
             }
-        }
+        },
+        "retry_ids": [],
+        "retry_parent": null
     },
     "5d64935cb215ad4128de94d9": {
         "job_id": "5d64935cb215ad4128de94d9",
         "user": "fake_test_user",
         "authstrat": "kbaseworkspace",
+        "batch_id": null,
+        "batch_job": false,
+        "child_jobs": [],
         "wsid": 9999,
         "status": "terminated",
         "updated": 1572462965495,
@@ -125,12 +143,17 @@
                 "tag": "dev",
                 "run_id": "6546971e-757a-4a26-8439-325497c6d843"
             }
-        }
+        },
+        "retry_ids": [],
+        "retry_parent": null
     },
     "5d64935cb215ad4128de94e0": {
         "job_id": "5d64935cb215ad4128de94e0",
         "user": "fake_test_user",
         "authstrat": "kbaseworkspace",
+        "batch_id": null,
+        "batch_job": false,
+        "child_jobs": [],
         "wsid": 9999,
         "status": "error",
         "updated": 1572462965495,
@@ -157,7 +180,9 @@
                 "tag": "dev",
                 "run_id": "6546971e-757a-4a26-8439-325497c6d843"
             }
-        }
+        },
+        "retry_ids": [],
+        "retry_parent": null
     },
     "60e7112887b7e512a899c8f1": {
         "authstrat": "kbaseworkspace",

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -4,7 +4,7 @@ Tests for the app manager.
 from biokbase.narrative.jobs.appmanager import AppManager, BATCH_ID_KEY, BATCH_APP
 import biokbase.narrative.jobs.specmanager as specmanager
 import biokbase.narrative.app_util as app_util
-from biokbase.narrative.jobs.job import Job, ALL_JOB_ATTRS, JOB_DEFAULTS
+from biokbase.narrative.jobs.job import Job, JOB_ATTRS, JOB_ATTR_DEFAULTS
 from IPython.display import HTML, Javascript
 import unittest
 import mock
@@ -237,11 +237,11 @@ class AppManagerTestCase(unittest.TestCase):
             "tag": self.test_tag,
         }
 
-        for attr in ALL_JOB_ATTRS:
+        for attr in JOB_ATTRS:
             if attr in expected:
                 self.assertEqual(getattr(new_job, attr), expected[attr])
             else:
-                self.assertEqual(getattr(new_job, attr), JOB_DEFAULTS[attr])
+                self.assertEqual(getattr(new_job, attr), JOB_ATTR_DEFAULTS[attr])
 
         self._verify_comm_success(c.return_value.send_comm_message, False)
 
@@ -433,11 +433,11 @@ class AppManagerTestCase(unittest.TestCase):
             "tag": BATCH_APP["TAG"],
         }
 
-        for attr in ALL_JOB_ATTRS:
+        for attr in JOB_ATTRS:
             if attr in expected:
                 self.assertEqual(getattr(new_job, attr), expected[attr])
             else:
-                self.assertEqual(getattr(new_job, attr), JOB_DEFAULTS[attr])
+                self.assertEqual(getattr(new_job, attr), JOB_ATTR_DEFAULTS[attr])
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -633,11 +633,11 @@ class AppManagerTestCase(unittest.TestCase):
             "job_id": parent_job.job_id,
         }
 
-        for attr in ALL_JOB_ATTRS:
+        for attr in JOB_ATTRS:
             if attr in expected:
                 self.assertEqual(getattr(parent_job, attr), expected[attr])
             else:
-                self.assertEqual(getattr(parent_job, attr), JOB_DEFAULTS[attr])
+                self.assertEqual(getattr(parent_job, attr), JOB_ATTR_DEFAULTS[attr])
 
         self.assertIsInstance(new_jobs["child_jobs"], list)
         self.assertEqual(len(new_jobs["child_jobs"]), 3)
@@ -669,13 +669,13 @@ class AppManagerTestCase(unittest.TestCase):
         for child_job in new_jobs["child_jobs"]:
             ix += 1
             self.assertIsInstance(child_job, Job)
-            for attr in ALL_JOB_ATTRS:
+            for attr in JOB_ATTRS:
                 if attr in child_job_expected[ix]:
                     self.assertEqual(
                         getattr(child_job, attr), child_job_expected[ix][attr]
                     )
                 else:
-                    self.assertEqual(getattr(child_job, attr), JOB_DEFAULTS[attr])
+                    self.assertEqual(getattr(child_job, attr), JOB_ATTR_DEFAULTS[attr])
 
         self._verify_comm_success(c.return_value.send_comm_message, True, num_jobs=4)
 

--- a/src/biokbase/narrative/tests/util.py
+++ b/src/biokbase/narrative/tests/util.py
@@ -314,8 +314,8 @@ def validate_job_state(job_state: dict) -> None:
     """
     assert "state" in job_state, "state key missing"
     assert isinstance(job_state["state"], dict), "state is not a dict"
-    assert "owner" in job_state, "owner key missing"
-    assert isinstance(job_state["owner"], str), "owner is not a string"
+    assert "user" in job_state, "user key missing"
+    assert isinstance(job_state["user"], str), "user is not a string"
     state = job_state["state"]
     # list of tuples - first = key name, second = value type
     # details for other cases comes later. This is just the expected basic set of


### PR DESCRIPTION
Handling for `batch_id`, `batch_job`, `child_jobs`, `retry_count`, `retry_ids`, and `retry_parent`. With an increasing number of `Job` attributes that may or may not be changing, @ialarmedalien decided the right data storage way would be to store the [reconstructed] EE2 state and extract attributes from that using either `@property` or `__getattr__`.

Parent `Job` objects are made aware of child `Job` objects.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
