### PR TITLE
DATAUP-512: Fix ee2 call to ensure it never returns a list

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -89,6 +89,7 @@ class JobManager(object):
             {
                 "job_ids": job_ids,
                 "exclude_fields": JOB_INIT_EXCLUDED_JOB_STATE_FIELDS,
+                "return_list": 0,
             }
         )
         for job_state in job_states.values():


### PR DESCRIPTION
# Description of PR purpose/changes

Backend code expected the response from ee2 to be an object, but in fact it was an evil list!

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-512
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and retrying a job. It won't error out, hurrah!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
