### PR TITLE
DATAUP-512: In retry_results, change job_id to job and retry_id to retry

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -370,24 +370,25 @@ Sent when one or more jobs are retried
 ```json
 [
   {
-      "job_id": {"state": {"job_id": job_id, "status": status, ...} ...},
-      "retry_id": {"state": {"job_id": job_id, "status": status, ...} ...}
+      "job": {"state": {"job_id": job_id, "status": status, ...} ...},
+      "retry": {"state": {"job_id": job_id, "status": status, ...} ...}
   },
   {
-      "job_id": {"state": {"job_id": job_id, "status": status, ...} ...},
+      "job": {"state": {"job_id": job_id, "status": status, ...} ...},
       "error": "..."
   },
   ...
   {
-      "job_id": {"state": {"job_id": job_id, "status": "does_not_exist"}},
+      "job": {"state": {"job_id": job_id, "status": "does_not_exist"}},
       "error": "does_not_exist"
   }
 ]
 ```
-Where the dict values corresponding to "job_id" or "retry_id" are the same data structures as for `job_status`
+Where the dict values corresponding to "job" or "retry" are the same data structures as for `job_status`
 Outer keys:
-  * `job_id` - string, the job id of the retried job
-  * `retry_id` - string, the job id of the job that was launched
+  * `job` - string, the job id of the retried job
+  * `retry` - string, the job id of the job that was launched
+  * `error` - string, appears if there was an error when trying to retry the job
 
 ### `new_job`
 Sent when a new job is launched and serialized. This just triggers a save/checkpoint on the frontend - no other bus message is sent

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -362,7 +362,7 @@ class JobComm:
                 "new_job",
                 {
                     "job_id_list": [
-                        result["retry_id"]["state"]["job_id"] for result in retry_results if "retry_id" in result
+                        result["retry"]["state"]["job_id"] for result in retry_results if "retry" in result
                     ]
                 },
             )

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -422,16 +422,16 @@ class JobManager(object):
         Returns
         [
             {
-                "job_id": {"state": {"job_id": job_id, "status": status, ...} ...},
-                "retry_id": {"state": {"job_id": job_id, "status": status, ...} ...}
+                "job": {"state": {"job_id": job_id, "status": status, ...} ...},
+                "retry": {"state": {"job_id": job_id, "status": status, ...} ...}
             },
             {
-                "job_id": {"state": {"job_id": job_id, "status": status, ...} ...},
+                "job": {"state": {"job_id": job_id, "status": status, ...} ...},
                 "error": "..."
             }
             ...
             {
-                "job_id": {"state": {"job_id": job_id, "status": "does_not_exist"}},
+                "job": {"state": {"job_id": job_id, "status": "does_not_exist"}},
                 "error": "does_not_exist"
             }
         ]
@@ -457,13 +457,15 @@ class JobManager(object):
         job_states = {**orig_states, **retry_states}
         # fill in the job state details
         for result in retry_results:
-            result["job_id"] = job_states[result["job_id"]]
+            result["job"] = job_states[result["job_id"]]
+            del result["job_id"]
             if "retry_id" in result:
-                result["retry_id"] = job_states[result["retry_id"]]
+                result["retry"] = job_states[result["retry_id"]]
+                del result["retry_id"]
         for job_id in checked_jobs["error"]:
             retry_results.append(
                 {
-                    "job_id": {"state": {"job_id": job_id, "status": "does_not_exist"}},
+                    "job": {"state": {"job_id": job_id, "status": "does_not_exist"}},
                     "error": "does_not_exist",
                 }
             )

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -411,19 +411,19 @@ class JobManagerTest(unittest.TestCase):
         self.assertEqual(expected, retry_results)
 
         orig_ids = [
-            result["job_id"]["state"]["job_id"]
+            result["job"]["state"]["job_id"]
             for result in retry_results
             if "error" not in result
         ]
         retry_ids = [
-            result["retry_id"]["state"]["job_id"]
+            result["retry"]["state"]["job_id"]
             for result in retry_results
             if "error" not in result
         ]
         dne_ids = [
-            result["job_id"]["state"]["job_id"]
+            result["job"]["state"]["job_id"]
             for result in retry_results
-            if result["job_id"]["state"]["status"] == "does_not_exist"
+            if result["job"]["state"]["status"] == "does_not_exist"
         ]
 
         for job_id in orig_ids + retry_ids:
@@ -439,8 +439,8 @@ class JobManagerTest(unittest.TestCase):
         job_ids = [JOB_TERMINATED]
         expected = [
             {
-                "job_id": self.job_states[JOB_TERMINATED],
-                "retry_id": get_retry_job_state(JOB_TERMINATED),
+                "job": self.job_states[JOB_TERMINATED],
+                "retry": get_retry_job_state(JOB_TERMINATED),
             }
         ]
 
@@ -452,12 +452,12 @@ class JobManagerTest(unittest.TestCase):
         job_ids = [JOB_TERMINATED, JOB_ERROR]
         expected = [
             {
-                "job_id": self.job_states[JOB_TERMINATED],
-                "retry_id": get_retry_job_state(JOB_TERMINATED),
+                "job": self.job_states[JOB_TERMINATED],
+                "retry": get_retry_job_state(JOB_TERMINATED),
             },
             {
-                "job_id": self.job_states[JOB_ERROR],
-                "retry_id": get_retry_job_state(JOB_ERROR),
+                "job": self.job_states[JOB_ERROR],
+                "retry": get_retry_job_state(JOB_ERROR),
             },
         ]
 
@@ -469,15 +469,15 @@ class JobManagerTest(unittest.TestCase):
         job_ids = [JOB_NOT_FOUND, JOB_TERMINATED, JOB_COMPLETED]
         expected = [
             {
-                "job_id": self.job_states[JOB_TERMINATED],
-                "retry_id": get_retry_job_state(JOB_TERMINATED),
+                "job": self.job_states[JOB_TERMINATED],
+                "retry": get_retry_job_state(JOB_TERMINATED),
             },
             {
-                "job_id": self.job_states[JOB_COMPLETED],
+                "job": self.job_states[JOB_COMPLETED],
                 "error": ERR_STR,
             },
             {
-                "job_id": get_dne_job_state(JOB_NOT_FOUND),
+                "job": get_dne_job_state(JOB_NOT_FOUND),
                 "error": "does_not_exist",
             },
         ]
@@ -499,9 +499,9 @@ class JobManagerTest(unittest.TestCase):
     def test_retry_jobs__all_error(self):
         job_ids = [JOB_TERMINATED, JOB_CREATED, JOB_RUNNING]
         expected = [
-            {"job_id": self.job_states[JOB_TERMINATED], "error": ERR_STR},
-            {"job_id": self.job_states[JOB_CREATED], "error": ERR_STR},
-            {"job_id": self.job_states[JOB_RUNNING], "error": ERR_STR},
+            {"job": self.job_states[JOB_TERMINATED], "error": ERR_STR},
+            {"job": self.job_states[JOB_CREATED], "error": ERR_STR},
+            {"job": self.job_states[JOB_RUNNING], "error": ERR_STR},
         ]
 
         ee2_ret = [
@@ -526,8 +526,8 @@ class JobManagerTest(unittest.TestCase):
 
         expected = [
             {
-                "job_id": self.job_states[JOB_TERMINATED],
-                "retry_id": get_retry_job_state(JOB_TERMINATED, status=retry_status)
+                "job": self.job_states[JOB_TERMINATED],
+                "retry": get_retry_job_state(JOB_TERMINATED, status=retry_status)
             }
         ]
 
@@ -548,7 +548,7 @@ class JobManagerTest(unittest.TestCase):
         job_ids = ["", "", None, dne_id]
         expected = [
             {
-                "job_id": get_dne_job_state(dne_id),
+                "job": get_dne_job_state(dne_id),
                 "error": "does_not_exist",
             }
         ]


### PR DESCRIPTION
# Description of PR purpose/changes

Simple search-n-replace to make things more logical for the frontend; replacing the keys `job_id` and `retry_id` with `job` and `retry` respectively, since they are returning job objects.


# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-512
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
