### PR TITLE
DATAUP-512: Setting retried jobs to automatically refresh their state

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -586,7 +586,7 @@ class AppManager(object):
                 "status": "created",
                 "user": user_id,
             },
-            children=child_jobs
+            children=child_jobs,
         )
 
         # TODO make a tighter design in the job manager for submitting a family of jobs

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -60,9 +60,7 @@ STATE_ATTRS = list(set(JOB_ATTRS) - set(JOB_INPUT_ATTRS) - set(NARR_CELL_INFO_AT
 
 
 def _attr_to_ee2(attr):
-    mapping = {
-        "app_version": "service_ver"
-    }
+    mapping = {"app_version": "service_ver"}
     if attr in mapping:
         return mapping[attr]
     else:
@@ -88,9 +86,7 @@ class Job(object):
             state_child_ids = ee2_state.get("child_jobs", [])
             inst_child_ids = [job.job_id for job in children]
             if sorted(state_child_ids) != sorted(inst_child_ids):
-                raise ValueError(
-                    "Child job id mismatch"
-                )
+                raise ValueError("Child job id mismatch")
 
         self._const_state = ee2_state
         self._last_state = ee2_state
@@ -141,25 +137,37 @@ class Job(object):
         narr_cell_info = job_input.get("narrative_cell_info", {})
 
         narr_cell_info.update(
-            {key: kwargs[key] for key in NARR_CELL_INFO_ATTRS if key in kwargs and key not in narr_cell_info}
+            {
+                key: kwargs[key]
+                for key in NARR_CELL_INFO_ATTRS
+                if key in kwargs and key not in narr_cell_info
+            }
         )
         job_input.update(
             {
-                **{_attr_to_ee2(key): kwargs[key] for key in JOB_INPUT_ATTRS if key in kwargs and key not in job_input},
+                **{
+                    _attr_to_ee2(key): kwargs[key]
+                    for key in JOB_INPUT_ATTRS
+                    if key in kwargs and key not in job_input
+                },
                 "narrative_cell_info": narr_cell_info,
             }
         )
         ee2_state.update(
             {
-                **{key: kwargs[key] for key in STATE_ATTRS if key in kwargs and key not in ee2_state},
-                "job_input": job_input
+                **{
+                    key: kwargs[key]
+                    for key in STATE_ATTRS
+                    if key in kwargs and key not in ee2_state
+                },
+                "job_input": job_input,
             }
         )
 
         return cls(
             ee2_state=ee2_state,
             extra_data=kwargs.get("extra_data"),
-            children=kwargs.get("children")
+            children=kwargs.get("children"),
         )
 
     def __getattr__(self, name):
@@ -167,21 +175,42 @@ class Job(object):
         Map expected job attributes to paths in stored ee2 state
         """
         attr = dict(
-            app_id=lambda: self._const_state.get("job_input", {}).get("app_id", JOB_ATTR_DEFAULTS["app_id"]),
-            app_version=lambda: self._const_state.get("job_input", {}).get("service_ver", JOB_ATTR_DEFAULTS["app_version"]),
-            batch_id=lambda: (
-                self.job_id if self.batch_job else
-                self._const_state.get("batch_id", JOB_ATTR_DEFAULTS["batch_id"])
+            app_id=lambda: self._const_state.get("job_input", {}).get(
+                "app_id", JOB_ATTR_DEFAULTS["app_id"]
             ),
-            batch_job=lambda: self._const_state.get("batch_job", JOB_ATTR_DEFAULTS["batch_job"]),
-            cell_id=lambda: self._const_state.get("job_input", {}).get("narrative_cell_info", {}).get("cell_id", JOB_ATTR_DEFAULTS["cell_id"]),
-            child_jobs=lambda: self.state().get("child_jobs", JOB_ATTR_DEFAULTS["child_jobs"]),
+            app_version=lambda: self._const_state.get("job_input", {}).get(
+                "service_ver", JOB_ATTR_DEFAULTS["app_version"]
+            ),
+            batch_id=lambda: (
+                self.job_id
+                if self.batch_job
+                else self._const_state.get("batch_id", JOB_ATTR_DEFAULTS["batch_id"])
+            ),
+            batch_job=lambda: self._const_state.get(
+                "batch_job", JOB_ATTR_DEFAULTS["batch_job"]
+            ),
+            cell_id=lambda: self._const_state.get("job_input", {})
+            .get("narrative_cell_info", {})
+            .get("cell_id", JOB_ATTR_DEFAULTS["cell_id"]),
+            child_jobs=lambda: self.state().get(
+                "child_jobs", JOB_ATTR_DEFAULTS["child_jobs"]
+            ),
             job_id=lambda: self._const_state.get("job_id"),
-            params=lambda: self._const_state.get("job_input", {}).get("params", JOB_ATTR_DEFAULTS["params"]),
-            retry_ids=lambda: self.state().get("retry_ids", JOB_ATTR_DEFAULTS["retry_ids"]),
-            retry_parent=lambda: self._const_state.get("retry_parent", JOB_ATTR_DEFAULTS["retry_parent"]),
-            run_id=lambda: self._const_state.get("job_input", {}).get("narrative_cell_info", {}).get("run_id", JOB_ATTR_DEFAULTS["run_id"]),
-            tag=lambda: self._const_state.get("job_input", {}).get("narrative_cell_info", {}).get("tag", JOB_ATTR_DEFAULTS["tag"]),
+            params=lambda: self._const_state.get("job_input", {}).get(
+                "params", JOB_ATTR_DEFAULTS["params"]
+            ),
+            retry_ids=lambda: self.state().get(
+                "retry_ids", JOB_ATTR_DEFAULTS["retry_ids"]
+            ),
+            retry_parent=lambda: self._const_state.get(
+                "retry_parent", JOB_ATTR_DEFAULTS["retry_parent"]
+            ),
+            run_id=lambda: self._const_state.get("job_input", {})
+            .get("narrative_cell_info", {})
+            .get("run_id", JOB_ATTR_DEFAULTS["run_id"]),
+            tag=lambda: self._const_state.get("job_input", {})
+            .get("narrative_cell_info", {})
+            .get("tag", JOB_ATTR_DEFAULTS["tag"]),
             user=lambda: self._const_state.get("user", JOB_ATTR_DEFAULTS["user"]),
         )
 
@@ -198,7 +227,9 @@ class Job(object):
             self._const_state["job_input"][name] = value
         elif name in NARR_CELL_INFO_ATTRS:
             self._const_state["job_input"] = self._const_state.get("job_input", {})
-            self._const_state["job_input"]["narrative_cell_info"] = self._const_state["job_input"].get("narrative_cell_info", {})
+            self._const_state["job_input"]["narrative_cell_info"] = self._const_state[
+                "job_input"
+            ].get("narrative_cell_info", {})
             self._const_state["job_input"]["narrative_cell_info"] = value
         else:
             object.__setattr__(self, name, value)
@@ -213,14 +244,16 @@ class Job(object):
         # otherwise, child jobs may be retried
         if self._const_state.get("batch_job"):
             for child_job in self.children:
-                if child_job._last_state and child_job._last_state.get("status") != COMPLETED_STATUS:
+                if (
+                    child_job._last_state
+                    and child_job._last_state.get("status") != COMPLETED_STATUS
+                ):
                     return False
             return True
 
         else:
             return (
-                self._last_state
-                and self._last_state.get("status") in TERMINAL_STATUSES
+                self._last_state and self._last_state.get("status") in TERMINAL_STATUSES
             )
 
     @property
@@ -371,7 +404,7 @@ class Job(object):
             return self._create_error_state(
                 "Unable to find current job state. Please try again later, or contact KBase.",
                 "Unable to return job state",
-                -1
+                -1,
             )
 
         state = self._augment_ee2_state(state)

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -359,7 +359,9 @@ class JobComm:
                 "new_job",
                 {
                     "job_id_list": [
-                        result["retry"]["state"]["job_id"] for result in retry_results if "retry" in result
+                        result["retry"]["state"]["job_id"]
+                        for result in retry_results
+                        if "retry" in result
                     ]
                 },
             )

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -36,7 +36,7 @@ class JobManager(object):
 
     __instance = None
 
-    # keys = job_id, values = { refresh = T/F, job = Job object }
+    # keys = job_id, values = { refresh = 1/0, job = Job object }
     _running_jobs = dict()
 
     _log = kblogging.get_logger(__name__)
@@ -53,9 +53,7 @@ class JobManager(object):
                 ordering.append(job_id)
             else:
                 ordering.insert(0, job_id)
-        states = {
-            job_id: states[job_id] for job_id in ordering
-        }
+        states = {job_id: states[job_id] for job_id in ordering}
 
         return states
 
@@ -97,11 +95,8 @@ class JobManager(object):
                 ]
 
             self.register_new_job(
-                job=Job.from_state(
-                    job_state,
-                    children=child_jobs
-                ),
-                refresh=int(job_state.get("status") not in TERMINAL_STATUSES)
+                job=Job.from_state(job_state, children=child_jobs),
+                refresh=int(job_state.get("status") not in TERMINAL_STATUSES),
             )
 
     def _create_jobs(self, job_ids) -> dict:
@@ -118,14 +113,8 @@ class JobManager(object):
             }
         )
         for job_state in job_states.values():
-            # Note that when jobs for this narrative are initially loaded,
-            # they are set to not be refreshed. Rather, if a client requests
-            # updates via the start_job_update message, the refresh flag will
-            # be set to True.
-            self.register_new_job(
-                job=Job.from_state(job_state),
-                refresh=0
-            )
+            # set new jobs to be automatically refreshed
+            self.register_new_job(job=Job.from_state(job_state), refresh=1)
 
         return job_states
 

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -35,10 +35,9 @@ class MockClients:
     Will likely be removed (or modified, at least), when a minified KBase deploy becomes available.
     Then we don't need to mock as much.
     """
+
     config = ConfigTests()
-    _ee2_job_info = config.load_json_file(
-        config.get("jobs", "ee2_job_info_file")
-    )
+    _ee2_job_info = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
 
     def __init__(self, token=None):
         if token is not None:

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -698,11 +698,9 @@ class JobTest(unittest.TestCase):
         parent_state = create_state_from_ee2(BATCH_PARENT)
         with self.assertRaisesRegex(
             ValueError,
-            "Job with `batch_job=True` must be instantiated with child job instances"
+            "Job with `batch_job=True` must be instantiated with child job instances",
         ):
-            Job.from_state(
-                parent_state
-            )
+            Job.from_state(parent_state)
 
         child_jobs = [create_job_from_ee2(job_id) for job_id in BATCH_CHILDREN][1:]
         with self.assertRaisesRegex(ValueError, "Child job id mismatch"):

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -280,7 +280,8 @@ class JobCommTestCase(unittest.TestCase):
         self.jc._retry_jobs(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
-            {"job_id_list": [JOB_TERMINATED[::-1], JOB_ERROR[::-1]]}, msg["data"]["content"]
+            {"job_id_list": [JOB_TERMINATED[::-1], JOB_ERROR[::-1]]},
+            msg["data"]["content"],
         )
         self.assertEqual("new_job", msg["data"]["msg_type"])
 
@@ -317,9 +318,7 @@ class JobCommTestCase(unittest.TestCase):
         req = make_comm_msg("retry_job", job_id_list, True)
         self.jc._retry_jobs(req)
         msg = self.jc._comm.last_message
-        self.assertEqual(
-            {"job_id_list": []}, msg["data"]["content"]
-        )
+        self.assertEqual({"job_id_list": []}, msg["data"]["content"])
         self.assertEqual("new_job", msg["data"]["msg_type"])
 
     @mock.patch(

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -43,12 +43,8 @@ test_specs = config.load_json_file(config.get("specs", "app_specs_file"))
 
 JOB_NOT_FOUND = "job_not_found"
 
-TERMINAL_IDS = [
-    JOB_COMPLETED, JOB_TERMINATED, JOB_ERROR
-]
-NON_TERMINAL_IDS = [
-    JOB_CREATED, JOB_RUNNING
-]
+TERMINAL_IDS = [JOB_COMPLETED, JOB_TERMINATED, JOB_ERROR]
+NON_TERMINAL_IDS = [JOB_CREATED, JOB_RUNNING]
 
 no_id_err_str = r"No job id\(s\) supplied"
 ERR_STR = "Some error occurred"
@@ -90,7 +86,9 @@ def get_test_job_states():
         narr_cell_info = state.get("job_input", {}).get("narrative_cell_info", {})
         state.update(
             {
-                "batch_id": state.get("batch_id", job_id if state.get("batch_job", False) else None),
+                "batch_id": state.get(
+                    "batch_id", job_id if state.get("batch_job", False) else None
+                ),
                 "cell_id": narr_cell_info.get("cell_id", None),
                 "run_id": narr_cell_info.get("run_id", None),
                 "job_output": state.get("job_output", {}),
@@ -524,7 +522,7 @@ class JobManagerTest(unittest.TestCase):
         expected = [
             {
                 "job": self.job_states[JOB_TERMINATED],
-                "retry": get_retry_job_state(JOB_TERMINATED, status=retry_status)
+                "retry": get_retry_job_state(JOB_TERMINATED, status=retry_status),
             }
         ]
 
@@ -573,10 +571,7 @@ class JobManagerTest(unittest.TestCase):
     def test_lookup_all_job_states__ignore_refresh_flag(self):
         states = self.jm.lookup_all_job_states(ignore_refresh_flag=True)
         self.assertEqual(set(self.job_ids), set(states.keys()))
-        self.assertEqual(
-            states,
-            self.job_states
-        )
+        self.assertEqual(states, self.job_states)
 
     # @mock.patch('biokbase.narrative.jobs.jobmanager.clients.get', get_mock_client)
     # def test_job_status_fetching(self):


### PR DESCRIPTION
# Description of PR purpose/changes

Set newly retried jobs to automatically refresh their status.

The majority of the changes are from black; I've commented on the two code changes that I made for the PR.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-512
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see that not a sausage has changed.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
