### PR TITLE
DATAUP-485 Cancel Jobs

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -240,7 +240,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `num_lines` - int > 0
 * `latest` - boolean, `true` if requesting just the latest logs
 
-`cancel_job` - cancel a job or list of jobs; responds with `job_canceled` for each job
+`cancel_job` - cancel a job or list of jobs; responds with `job_statuses`
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
@@ -339,6 +339,20 @@ The current job state. This one is probably most common.
   * `user` - string, username of user who submitted the job
 
 **bus** - `job-status`
+
+## `job_statuses`
+The current job states for some jobs. The format is the same as for `job_status_all`.
+
+**content**
+```json
+{
+  "job_id_1": { ...contents... },
+  "job_id_2": { ...contents... }
+}
+```
+Where the inner objects' format is the BE Output State described in the Data Structures section.
+
+**bus** - TODO
 
 ### `job_logs`
 Includes log statement information for a given job.
@@ -468,6 +482,7 @@ These steps take place whenever the user loads a narrative, or when the kernel i
 
 ## Data Structures
 ### Job state
+#### EE2 State
 In kernel, as retrieved from EE2.check_job
 (described by example)
 ```json
@@ -507,10 +522,15 @@ In kernel, as retrieved from EE2.check_job
         }
     },
     "job_id": "5e67d5e395d1f00a7cf4ea21",
-    "created": 1583863267000
+    "created": 1583863267000,
+    "batch_id": null,
+    "batch_job": false,
+    "child_jobs": [],
+    "retry_ids": [],
+    "retry_parent": null
 }
 ```
-
+#### BE Output State
 As sent to browser, includes cell info and run info
 ```
 {
@@ -537,6 +557,12 @@ As sent to browser, includes cell info and run info
           error: string, (likely a stacktrace)
         },
         error_code: optional - int
+        created: 1583863267000,
+        batch_id: str,
+        batch_job: bool,
+        child_jobs: array,
+        retry_ids: array,
+        retry_parent: str
     }
 }
 ```

--- a/src/biokbase/narrative/tests/data/ee2_job_test_data.json
+++ b/src/biokbase/narrative/tests/data/ee2_job_test_data.json
@@ -56,7 +56,7 @@
         "created": 1572462971988,
         "job_input": {
             "wsid": 9999,
-            "method": "MADE_UP_APP.job_created",
+            "method": "AssemblyRAST.run_arast",
             "params": [
                 {
                     "k_list": [],
@@ -65,7 +65,7 @@
                 }
             ],
             "service_ver": "1.2.3",
-            "app_id": "MADE_UP_APP/job_created",
+            "app_id": "AssemblyRAST/run_arast",
             "source_ws_objects": ["a/b/c", "e/d"],
             "parent_job_id": "9998",
             "narrative_cell_info": {
@@ -91,7 +91,7 @@
         "running": 1572462965490,
         "job_input": {
             "wsid": 9999,
-            "method": "MADE_UP_APP.job_running",
+            "method": "AssemblyRAST.run_arast",
             "params": [
                 {
                     "k_list": [],
@@ -100,7 +100,7 @@
                 }
             ],
             "service_ver": "2.0.0",
-            "app_id": "MADE_UP_APP/job_running",
+            "app_id": "AssemblyRAST/run_arast",
             "source_ws_objects": ["a/b/c", "e/d"],
             "parent_job_id": null,
             "narrative_cell_info": {
@@ -126,7 +126,7 @@
         "finished": 1572462965495,
         "job_input": {
             "wsid": 9999,
-            "method": "MADE_UP_APP.job_terminated",
+            "method": "AssemblyRAST.run_arast",
             "params": [
                 {
                     "k_list": [],
@@ -135,7 +135,7 @@
                 }
             ],
             "service_ver": "4.0.0",
-            "app_id": "MADE_UP_APP/job_terminated",
+            "app_id": "AssemblyRAST/run_arast",
             "source_ws_objects": ["a/b/c", "e/d"],
             "parent_job_id": null,
             "narrative_cell_info": {
@@ -160,7 +160,7 @@
         "created": 1572462971995,
         "job_input": {
             "wsid": 9999,
-            "method": "MADE_UP_APP.job_errored",
+            "method": "AssemblyRAST.run_arast",
             "params": [
                 {
                     "k_list": [],
@@ -169,7 +169,7 @@
                 }
             ],
             "service_ver": "3.6.9",
-            "app_id": "MADE_UP_APP/job_errored",
+            "app_id": "AssemblyRAST/run_arast",
             "source_ws_objects": [
                 "a/b/c",
                 "e/d"

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -31,6 +31,7 @@ class AppManagerTestCase(unittest.TestCase):
         config = ConfigTests()
         cls.maxDiff = None
         cls.am = AppManager()
+        cls.am.reload()  # class uses non-mocked data
         cls.good_app_id = config.get("app_tests", "good_app_id")
         cls.good_tag = config.get("app_tests", "good_app_tag")
         cls.bad_app_id = config.get("app_tests", "bad_app_id")


### PR DESCRIPTION
# Description of PR purpose/changes

Use `jc._cancel_jobs` and `jm.cancel_jobs` as the cancel job(s) narrative BE endpoints. Take out `jc._cancel_job` and `jm.cancel_job`

So, narrative BE expects a `cancel_job` message with either a `job_id` or `job_id_list` data. BE will filter out falsey job IDs and partition off any job IDs not registered. BE sends to FE `job_statuses` with the job states.

Carefully eliminated tests for `jc._cancel_job` and `jm.cancel_job` and added new tests, but could always add more.


# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
