### PR TITLE
DATAUP-532: backend tweaks

### DIFF
--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -387,22 +387,14 @@ class JobComm:
         num_lines = req.rq_data.get("num_lines", None)
         latest_only = req.rq_data.get("latest", False)
         try:
-            (first_line, max_lines, logs) = self._jm.get_job_logs(
+            log_output = self._jm.get_job_logs(
                 req.job_id,
                 num_lines=num_lines,
                 first_line=first_line,
                 latest_only=latest_only,
             )
-            self.send_comm_message(
-                "job_logs",
-                {
-                    "job_id": req.job_id,
-                    "first": first_line,
-                    "max_lines": max_lines,
-                    "lines": logs,
-                    "latest": latest_only,
-                },
-            )
+            log_output["latest"] = latest_only
+            self.send_comm_message("job_logs", log_output)
         except ValueError:
             self.send_error_message("job_does_not_exist", req)
             raise


### PR DESCRIPTION
# Description of PR purpose/changes

A couple of minor tweaks to the narrative backend to include the batch ID with job data

- added batch ID to the data returned in the job info request
- added batch ID to the job logs request plus returned a dict instead of a tuple

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-532

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and taking a look at the messages from the backend, as seen in jobCommChannel.js

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
