### PR TITLE
DATAUP-487 Staging Area Viewer reworking to allow uploading of all checked files

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
@@ -106,7 +106,7 @@ define([
             // this does the staging area re-render, then tracks the time
             // it was last done.
             const renderStagingArea = () => {
-                this.stagingAreaViewer.updateDataList();
+                this.stagingAreaViewer.updateView();
                 this.lastRefresh = new Date().getTime();
             };
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
@@ -87,8 +87,9 @@ define([
                     userInfo: userInfo,
                 });
                 this.stagingAreaViewer = new StagingAreaViewer(this.$myFiles, stagingAreaArgs);
+                this.stagingAreaViewer.render();
 
-                this.updateView();
+                // this.updateView();
             });
         },
 
@@ -105,7 +106,7 @@ define([
             // this does the staging area re-render, then tracks the time
             // it was last done.
             const renderStagingArea = () => {
-                this.stagingAreaViewer.render();
+                this.stagingAreaViewer.updateDataList();
                 this.lastRefresh = new Date().getTime();
             };
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeStagingDataTab.js
@@ -88,8 +88,6 @@ define([
                 });
                 this.stagingAreaViewer = new StagingAreaViewer(this.$myFiles, stagingAreaArgs);
                 this.stagingAreaViewer.render();
-
-                // this.updateView();
             });
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -712,7 +712,7 @@ define([
                 const selectAllChecked = event.target.checked;
 
                 //get all of the rows in the data table
-                const nodes = fullDataTable.fnGetNodes();
+                const nodes = stagingAreaViewer.fullDataTable.fnGetNodes();
 
                 $(`input.${cssBaseClass}-body__checkbox-input:enabled`, nodes)
                     .prop('checked', selectAllChecked)

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -343,7 +343,7 @@ define([
                 input = html.tag('input');
             files = files || [];
             const emptyMsg = 'No files found.',
-                filterMsg = 'in directory (_MAX_ total files)',
+                filterMsg = 'in directory',
                 infoMsg = 'Showing _START_ to _END_ of _TOTAL_ files',
                 infoEmptyMsg = 'No files';
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -746,26 +746,22 @@ define([
                     .trigger('change');
                 //enable the checkboxes
                 enableCheckboxes(storedFileData.dataType);
-            }
-
-            //otherwise we set the dropdowns with a placeholder
-            else {
+            } else if (suggestedType) {
+                // otherwise we set the dropdowns with a placeholder
                 // And if we have a suggested type, select it and enable the checkboxes
-                if (suggestedType) {
-                    importDropdown
-                        .select2({
-                            containerCssClass: `${cssBaseClass}-body__import-dropdown ${cssBaseClass}-body__import-type-selected`,
-                            placeholder: 'make the empty option disappear',
-                        })
-                        .val(suggestedType.id)
-                        .trigger('change');
-                    enableCheckboxes(suggestedType.id);
-                } else {
-                    importDropdown.select2({
-                        placeholder: 'Select a type',
-                        containerCssClass: `${cssBaseClass}-body__import-dropdown`,
-                    });
-                }
+                importDropdown
+                    .select2({
+                        containerCssClass: `${cssBaseClass}-body__import-dropdown ${cssBaseClass}-body__import-type-selected`,
+                        placeholder: 'make the empty option disappear',
+                    })
+                    .val(suggestedType.id)
+                    .trigger('change');
+                enableCheckboxes(suggestedType.id);
+            } else {
+                importDropdown.select2({
+                    placeholder: 'Select a type',
+                    containerCssClass: `${cssBaseClass}-body__import-dropdown`,
+                });
             }
 
             // set the behavior on the import dropdown when a user selects a type

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -6,6 +6,7 @@ define([
     'kbwidget',
     'narrativeConfig',
     'common/runtime',
+    'common/html',
     'base/js/namespace',
     'handlebars',
     'util/string',
@@ -27,6 +28,7 @@ define([
     KBWidget,
     Config,
     Runtime,
+    html,
     Jupyter,
     Handlebars,
     StringUtil,
@@ -41,14 +43,15 @@ define([
 ) => {
     'use strict';
     const cssBaseClass = 'kb-staging-table',
-        fileMetadataCssBaseClass = `${cssBaseClass}-file-metadata`;
+        fileMetadataCssBaseClass = `${cssBaseClass}-file-metadata`,
+        tableBodyCssBaseClass = `${cssBaseClass}-body`;
 
     return new KBWidget({
         name: 'StagingAreaViewer',
 
         options: {
             refreshIntervalDuration: 30000,
-            path: '/',
+            path: '',
         },
 
         init: function (options) {
@@ -72,12 +75,12 @@ define([
             this.bulkImportTypes = this.uploaders.bulk_import_types;
             this.userInfo = options.userInfo;
 
-            // Get this party started.
-            //setting first load so setPath doesn't call updateView() as that will happen via narrativeStagingDataTab
+            // setting first load so setPath doesn't call updateView() as that will happen via narrativeStagingDataTab
             this.firstLoad = true;
             this.setPath(options.path);
             this.openFileInfo = {};
             this.selectedFileTypes = {};
+            this.loadedFilesByPath = {};
 
             return this;
         },
@@ -107,27 +110,18 @@ define([
 
         updateView: function () {
             return Promise.resolve(
-                this.stagingServiceClient.list({
-                    path: this.subpath,
-                })
+                this.stagingServiceClient.list()
             )
                 .then((data) => {
-                    //list is recursive, so it'd show all files in all subdirectories. This filters 'em out.
-                    const files = JSON.parse(data).filter((f) => {
-                        // this is less complicated than you think. The path is the username,
-                        // subpath, and name concatenated. The subpath may be empty so we
-                        // filter it out and only join defined things. If that's the same as
-                        // the file's path, we're at the right level. If not, we're not.
-                        return (
-                            [this.userInfo.user, this.subpath, f.name]
-                                .filter((p) => p.length > 0)
-                                .join('/') === f.path
-                        );
+                    const files = JSON.parse(data).map((f) => {
+                        f.subdir = f.path.substring(f.path.indexOf('/'), f.path.lastIndexOf('/')) || '/';
+                        return f;
                     });
                     files.forEach((f) => {
                         if (!f.isFolder) {
                             f.imported = {};
                         }
+                        this.loadedFilesByPath[f.path] = f;
                     });
                     return this.identifyImporterMappings(files);
                 })
@@ -153,7 +147,6 @@ define([
                     );
                 })
                 .finally(() => {
-                    this.renderPath();
                     this.renderImportButton();
                 });
         },
@@ -172,12 +165,7 @@ define([
             }
             this.subpath = subpath.slice(subpath.length - subpathTokens).join('/');
 
-            //we don't need to call to update the view if it's the first time as narrative staging data tab will do the rendering for us
-            if (this.firstLoad) {
-                this.firstLoad = false;
-            } else {
-                return this.updateView();
-            }
+            this.updateTableDrawPath();
         },
 
         renderFileHeader: function () {
@@ -220,9 +208,7 @@ define([
             if (splitPath.startsWith('/')) {
                 splitPath = splitPath.substring(1);
             }
-            // the staging service doesn't want the username as part of the path, but we still want to display it to the user for navigation purposes
             splitPath = splitPath.split('/').filter((p) => p.length);
-            splitPath.unshift(this.userInfo.user);
             const pathTerms = [];
             for (let i = 0; i < splitPath.length; i++) {
                 let prevPath = '';
@@ -234,9 +220,10 @@ define([
                     subpath: prevPath + '/' + splitPath[i],
                 };
             }
-            pathTerms[0].subpath = '/';
+            // we don't store the username as part of the path, but we still want to display it to the user for navigation purposes
+            pathTerms.unshift({term: this.userInfo.user, subpath: '/'});
 
-            this.$elem.find('div.file-path').append(
+            this.$elem.find('div.file-path').empty().append(
                 this.filePathTmpl({
                     path: pathTerms,
                 })
@@ -284,7 +271,7 @@ define([
                 })
             )
                 .then((data) => {
-                    //Extract mappings, sort by weight, assign mappings to staging files
+                    // Extract mappings, sort by weight, assign mappings to staging files
                     mappings = JSON.parse(data)['mappings'];
                     mappings.forEach((mapping) => {
                         if (mapping) {
@@ -301,6 +288,10 @@ define([
                 });
         },
 
+        updateDataList: function () {
+            alert('fetching updated data files and rendering');
+        },
+
         /**
          * This renders the files datatable. If there's no data, it gives a message
          * about no files being present. If there's an error, that gets put in the table instead.
@@ -309,15 +300,17 @@ define([
          */
         renderFiles: function (files) {
             const stagingAreaViewer = this;
+            const option = html.tag('option'),
+                button = html.tag('button'),
+                span = html.tag('span'),
+                select = html.tag('select'),
+                div = html.tag('div'),
+                optgroup = html.tag('optgroup');
             files = files || [];
             const emptyMsg = 'No files found.';
+            const uploaders = stagingAreaViewer.uploaders.dropdown_order;
 
-            const $fileTable = $(
-                stagingAreaViewer.ftpFileTableTmpl({
-                    files: files,
-                    uploaders: stagingAreaViewer.uploaders.dropdown_order,
-                })
-            );
+            const $fileTable = $(stagingAreaViewer.ftpFileTableTmpl());
 
             stagingAreaViewer.$elem.append($fileTable);
 
@@ -325,32 +318,38 @@ define([
                 language: {
                     emptyTable: emptyMsg,
                 },
+                data: files,
                 dom: '<"file-path pull-left">frtip',
                 autoWidth: false,
                 order: [[4, 'desc']],
+                drawCallback: () => stagingAreaViewer.renderPath(),
                 headerCallback: function (thead) {
                     $(thead)
                         .find('th')
                         .eq(0)
                         .on('click keyPress', (e) => {
-                            selectAllOrNone(e);
+                            stagingAreaViewer.selectAllOrNone(e);
                         });
                 },
                 columnDefs: [
                     {
+                        // checkboxes
                         targets: 0,
+                        data: null,
                         orderable: false,
                         searchable: false,
                         render: function (data) {
-                            const fileId = new UUID(4).format();
+                            const fileId = data.path;
+                            const fileName = data.path.substring(stagingAreaViewer.userInfo.user.length + 1);
+
                             //render checkboxes disabled until the user selects a type
                             return (
-                                `<input class="${cssBaseClass}-body__checkbox-input"` +
+                                `<input class="${tableBodyCssBaseClass}__checkbox-input"` +
                                 'type="checkbox" role="checkbox" disabled=true ' +
                                 'aria-checked="false" tabindex="0"' +
                                 'aria-label="Select to import file checkbox: disabled until at least one data type is selected"' +
                                 'data-file-name="' +
-                                data +
+                                fileName +
                                 '"' +
                                 'id="' +
                                 fileId +
@@ -359,17 +358,23 @@ define([
                         },
                     },
                     {
+                        // file or folder icon
+                        // if file icon, includes caret to toggle subrow
                         targets: 1,
+                        data: 'isFolder',
+                        createdCell: function(td) {
+                            $(td).addClass(`${tableBodyCssBaseClass}__cell--expander`);
+                        },
                         render: function (data, type, full) {
                             if (type === 'display') {
-                                const isFolder = data === 'true' ? true : false;
+                                const isFolder = data;
                                 const icon = isFolder ? 'folder' : 'file-o';
                                 const disp = '<span class="fa fa-' + icon + '"></span>';
                                 if (isFolder) {
                                     return (
                                         '<button data-name="' +
                                         full[0] +
-                                        `" class="${cssBaseClass}-body__button--${icon}">` +
+                                        `" class="${tableBodyCssBaseClass}__button--${icon}">` +
                                         disp +
                                         '</button>'
                                     );
@@ -387,6 +392,7 @@ define([
                     },
                     {
                         targets: 2,
+                        data: 'name',
                         render: function (data, type, full) {
                             if (type === 'display') {
                                 let decompressButton = '';
@@ -395,14 +401,14 @@ define([
                                     data.match(/\.(zip|tar\.gz|tgz|tar\.bz|tar\.bz2|tar|gz|bz2)$/)
                                 ) {
                                     decompressButton =
-                                        `<button class="${cssBaseClass}-body__button--decompress" data-decompress="` +
+                                        `<button class="${tableBodyCssBaseClass}__button--decompress" data-decompress="` +
                                         data +
                                         '"><span class="fa fa-expand"></span></button>';
                                 }
 
                                 if (full[1] === 'true') {
                                     data =
-                                        `<span class="${cssBaseClass}-body__folder" data-name="` +
+                                        `<span class="${tableBodyCssBaseClass}__folder" data-name="` +
                                         data +
                                         '">' +
                                         data +
@@ -410,7 +416,7 @@ define([
                                 }
 
                                 return (
-                                    `<div class="${cssBaseClass}-body__name">` +
+                                    `<div class="${tableBodyCssBaseClass}__name">` +
                                     decompressButton +
                                     data +
                                     '</div>'
@@ -421,6 +427,7 @@ define([
                     },
                     {
                         targets: 3,
+                        data: 'size',
                         type: 'num',
                         render: function (data, type) {
                             if (type === 'display') {
@@ -431,6 +438,7 @@ define([
                     },
                     {
                         targets: 4,
+                        data: 'mtime',
                         type: 'num',
                         render: function (data, type) {
                             if (type === 'display') {
@@ -439,294 +447,390 @@ define([
                             return data;
                         },
                     },
-                ],
-                rowCallback: function (row, data) {
-                    const getFileFromName = function (fileData) {
-                        return files.filter((file) => {
-                            return file.name === fileData;
-                        })[0];
-                    };
+                    {
+                        targets: 5,
+                        createdCell: function(td) {
+                            $(td).addClass(`${tableBodyCssBaseClass}__cell--import`)
+                                .attr('role', 'option');
+                        },
+                        data: function(rowData, type, set, meta) {
+                            return rowData.imported ? rowData.mappings : null;
+                        },
+                        render: function (data, type, rowData) {
+                            const fileOrFolder = rowData.imported ? 'file' : 'folder';
+                            const deleteBtn = button({
+                                dataDelete: rowData.path,
+                                class: `${tableBodyCssBaseClass}__button--delete`,
+                                role: 'button',
+                                ariaLabel: `Delete ${fileOrFolder}`,
+                                title: `Delete ${fileOrFolder}`
+                            },
+                            span({class: 'fa fa-trash'}));
 
-                    //get the file (or folder) name for this row
-                    const rowFileName = data[2];
-                    //use the name to look up all the data we have
-                    const rowFileData = getFileFromName(rowFileName);
-
-                    //find the initial singly mapped datatype from the staging service
-                    const suggestedTypes = $(data[5]).find('optgroup[label="Suggested Types"]');
-                    let suggestedType = null;
-                    if (suggestedTypes.children().length == 1) {
-                        const option = suggestedTypes.find('option');
-                        suggestedType = { id: option.val(), title: option.html() };
-                    }
-
-                    //Get selected
-                    function changeImportButton(event) {
-                        const checked = event.currentTarget.checked;
-                        if (checked) {
-                            stagingAreaViewer.enableImportButton();
-                        } else {
-                            /*
-                            check state of all checkboxes
-                            if any are checked we leave import button enabled
-                            */
-                            const anyCheckedBoxes = $(
-                                `input.${cssBaseClass}-body__checkbox-input:checked`
-                            );
-
-                            if (!anyCheckedBoxes.length) {
-                                stagingAreaViewer.disableImportButton();
+                            if (!rowData.imported) {
+                                return deleteBtn;
                             }
+                            let uploaderOptions = uploaders.map((uploader) => {
+                                return option({
+                                    value: uploader.id
+                                }, uploader.name);
+                            });
+                            let mappedOptions = '';
+                            if (data) {
+                                mappedOptions = optgroup({
+                                    label: 'Suggested Types'
+                                }, data.map((uploader) => {
+                                    return option({
+                                        value: uploader.id
+                                    }, uploader.title);
+                                }));
+                                uploaderOptions = optgroup({
+                                    label: 'Other Types'
+                                }, uploaderOptions);
+                            }
+
+                            const selectUploader = select({},
+                                [option(), mappedOptions, uploaderOptions]);
+                            const downloadBtn = button({
+                                dataDownload: rowData.path,
+                                class: `${tableBodyCssBaseClass}__button--download`,
+                                role: 'button',
+                                ariaLabel: 'Download Data',
+                                title: 'Download data'
+                            }, span({class: 'fa fa-download'}));
+                            return div({
+                                class: `${tableBodyCssBaseClass}__select_container`
+                            }, [
+                                selectUploader,
+                                downloadBtn,
+                                deleteBtn
+                            ]);
                         }
                     }
-
+                ],
+                createdRow: function(row, data) {
+                    $(row).addClass('kb-staging-table__row')
+                        .attr('data-file-path', data.path)
+                        .attr('data-subdir', data.subdir);
+                },
+                rowCallback: function (row, data) {
+                    stagingAreaViewer.attachFileIconEvents($('td:eq(1)', row), data);
+                    stagingAreaViewer.attachImportSelectionEvents(
+                        $('td:eq(5)', row),
+                        $('td:eq(0)', row).find(`.${cssBaseClass}-body__checkbox-input`),
+                        data
+                    );
+                    stagingAreaViewer.attachFileNameEvents($('td:eq(2)', row), data);
                     $('td:eq(0)', row)
                         .find(`input.${cssBaseClass}-body__checkbox-input`)
                         .off('click')
                         .on('click keyPress', (e) => {
-                            changeImportButton(e);
+                            stagingAreaViewer.changeImportButton(e);
                         });
-
-                    $('td:eq(1)', row)
-                        .find('button[data-name]')
-                        .off('click')
-                        .on('click', (e) => {
-                            $(e.currentTarget).off('click');
-                            stagingAreaViewer.updatePathFn((this.path += '/' + rowFileName));
-                        });
-
-                    //First, we find the expansion caret in the first cell.
-                    const $caret = $('td:eq(1)', row).find('[data-caret]');
-
-                    $caret.off('click');
-
-                    //now, if there's openFileInfo on it, that means that the user had the detailed view open during a refresh.
-                    if ($caret.length && stagingAreaViewer.openFileInfo[rowFileName]) {
-                        //so we note that we've already loaded the info.
-                        rowFileData.loaded = stagingAreaViewer.openFileInfo[rowFileName].loaded;
-                        //toggle the caret
-                        $caret.toggleClass('fa-caret-down fa-caret-right');
-                        //and append the detailed view, which we do in a timeout in the next pass through to ensure that everything is properly here.
-                        setTimeout(() => {
-                            $caret
-                                .parent()
-                                .parent()
-                                .after(stagingAreaViewer.renderMoreFileInfo(rowFileData));
-                        }, 0);
-                    }
-
-                    $caret.on('click', (e) => {
-                        const fileExpander = $(e.currentTarget);
-                        fileExpander.toggleClass('fa-caret-down fa-caret-right');
-                        const $tr = fileExpander.parent().parent();
-
-                        if (fileExpander.hasClass('fa-caret-down')) {
-                            $('.kb-dropzone').css('min-height', '75px');
-                            stagingAreaViewer.openFileInfo[rowFileName] = rowFileData;
-                            $tr.after(this.renderMoreFileInfo(rowFileData));
-                        } else {
-                            $('.kb-dropzone').css('min-height', '200px');
-                            $tr.next().detach();
-                            delete stagingAreaViewer.openFileInfo[rowFileName];
-                        }
-                    });
-
-                    $('td:eq(2)', row)
-                        .find(`.${cssBaseClass}-body__name`)
-                        .tooltip({
-                            title: rowFileName,
-                            placement: 'top',
-                            delay: {
-                                show: Config.get('tooltip').showDelay,
-                                hide: Config.get('tooltip').hideDelay,
-                            },
-                        });
-
-                    $('td:eq(2)', row)
-                        .find(`span.${cssBaseClass}-body__folder`)
-                        .off('click')
-                        .on('click', (e) => {
-                            $(e.currentTarget).off('click');
-                            this.updatePathFn((this.path += '/' + rowFileName));
-                        });
-
-                    $('td:eq(2)', row)
-                        .find('button[data-decompress]')
-                        .off('click')
-                        .on('click', (e) => {
-                            const decompressButton = $(e.currentTarget);
-                            decompressButton.replaceWith(
-                                $.jqElem('i').addClass('fa fa-spinner fa-spin')
-                            );
-
-                            stagingAreaViewer.stagingServiceClient
-                                .decompress({
-                                    path: rowFileName,
-                                })
-                                .then(() => stagingAreaViewer.updateView())
-                                .fail((xhr) => {
-                                    console.error('FAILED', xhr);
-                                    alert('Error ' + xhr.status + '\r' + xhr.responseText);
-                                });
-                        });
-
-                    // find the element
-                    const importDropdown = $('td:eq(5)', row).find('select');
-
-                    /**
-                     * When a data type is selected from the "Import As..." dropdown,
-                     * enable the checkbox for that row (so user can import).
-                     * Make sure the "select all" checkbox is also enabled.
-                     *
-                     * @param {string} dataType the identifier of what the data type is, e.g.: sra_reads
-                     * @param {boolean} check if true, checks the now-enabled checkbox. Should generally only
-                     *  be true if this is called from a user selection event.
-                     */
-                    function enableCheckboxes(dataType, check) {
-                        $('td:eq(5)', row)
-                            .find('.select2-selection')
-                            .addClass(`${cssBaseClass}-body__import-type-selected`);
-
-                        //make checkbox for that row enabled
-                        //also set the data type so that we have the reference later when importing
-                        $('td:eq(0)', row)
-                            .find(`.${cssBaseClass}-body__checkbox-input`)
-                            .prop('disabled', false)
-                            .attr('aria-label', 'Select to import file checkbox')
-                            .attr('data-type', dataType);
-
-                        //make sure select all checkbox is enabled
-                        $('#staging_table_select_all')
-                            .prop('disabled', false)
-                            .attr('aria-label', 'Select to import all files checkbox');
-
-                        if (check) {
-                            $('td:eq(0)', row)
-                                .find(`.${cssBaseClass}-body__checkbox-input`)
-                                .prop('checked', true)
-                                .attr('aria-checked', true);
-                            stagingAreaViewer.enableImportButton();
-                        }
-                    }
-
-                    const storedFileData = stagingAreaViewer.selectedFileTypes[rowFileName];
-                    //where we have data type set, render those dropdowns correctly
-                    if (storedFileData) {
-                        //tell select2 which option to set
-                        importDropdown
-                            .select2({
-                                containerCssClass: `${cssBaseClass}-body__import-dropdown`,
-                            })
-                            .val(storedFileData.dataType)
-                            .trigger('change');
-                        //enable the checkboxes
-                        enableCheckboxes(storedFileData.dataType);
-                    }
-
-                    //otherwise we set the dropdowns with a placeholder
-                    else {
-                        // And if we have a suggested type, select it and enable the checkboxes
-                        if (suggestedType) {
-                            importDropdown
-                                .select2({
-                                    containerCssClass: `${cssBaseClass}-body__import-dropdown ${cssBaseClass}-body__import-type-selected`,
-                                    placeholder: 'make the empty option disappear',
-                                })
-                                .val(suggestedType.id)
-                                .trigger('change')
-                                .trigger({
-                                    type: 'select2:select',
-                                });
-                            enableCheckboxes(suggestedType.id);
-                        } else {
-                            importDropdown.select2({
-                                placeholder: 'Select a type',
-                                containerCssClass: `${cssBaseClass}-body__import-dropdown`,
-                            });
-                        }
-                    }
-
-                    //set the behavior on the import dropdown when a user selects a type
-                    importDropdown.on('select2:select', (e) => {
-                        const dataType = e.currentTarget.value;
-
-                        //store the type we selected along with file data so we can persist on a view update
-                        rowFileData.dataType = dataType;
-                        stagingAreaViewer.selectedFileTypes[rowFileName] = rowFileData;
-
-                        enableCheckboxes(dataType, true);
-                    });
-
-                    $('td:eq(5)', row)
-                        .find('button[data-import]')
-                        .off('click')
-                        .on('click', (e) => {
-                            const dataImportButton = $(e.currentTarget);
-                            const importType = dataImportButton.prevAll('select').val();
-                            stagingAreaViewer.initImportApp(importType, rowFileName);
-                            stagingAreaViewer.updateView();
-                        });
-
-                    $('td:eq(5)', row)
-                        .find('button[data-download]')
-                        .off('click')
-                        .on('click', () => {
-                            let filePath = rowFileName;
-
-                            if (stagingAreaViewer.subpath) {
-                                filePath = stagingAreaViewer.subpath + '/' + rowFileName;
-                            }
-
-                            const url = Config.url('staging_api_url') + '/download/' + filePath;
-                            stagingAreaViewer.downloadFile(url);
-                        });
-
-                    $('td:eq(5)', row)
-                        .find('button[data-delete]')
-                        .off('click')
-                        .on('click', () => {
-                            if (window.confirm('Really delete ' + rowFileName + '?')) {
-                                stagingAreaViewer.stagingServiceClient
-                                    .delete({
-                                        path: stagingAreaViewer.subpath + '/' + rowFileName,
-                                    })
-                                    .then(() => {
-                                        stagingAreaViewer.updateView();
-                                    })
-                                    .fail((xhr) => {
-                                        alert('Error ' + xhr.status + '\r' + xhr.responseText);
-                                    });
-                            }
-                        });
-                }.bind(stagingAreaViewer),
+                },
             });
 
-            /*
-                Used to manage the select all checkbox in the header
-                has to be outside of the main DataTable call
-                so that we can get entire table data
-                not just what is drawn in the current dom
-                aka dealing with pagination
-            */
-            function selectAllOrNone(event) {
-                const selectAllChecked = event.target.checked;
+            stagingAreaViewer.updateTableDrawPath();
 
-                //get all of the rows in the data table
-                const nodes = stagingAreaViewer.fullDataTable.fnGetNodes();
+        },
 
-                $(`input.${cssBaseClass}-body__checkbox-input:enabled`, nodes)
-                    .prop('checked', selectAllChecked)
-                    .attr('aria-checked', selectAllChecked);
+        /*
+            Used to manage the select all checkbox in the header
+            has to be outside of the main DataTable call
+            so that we can get entire table data
+            not just what is drawn in the current dom
+            aka dealing with pagination
+        */
+        selectAllOrNone: function(event) {
+            const selectAllChecked = event.target.checked;
 
-                //enable or disable import appropriately
-                if (selectAllChecked) {
-                    stagingAreaViewer.enableImportButton();
-                } else {
-                    stagingAreaViewer.disableImportButton();
+            //get all of the rows in the data table
+            const nodes = this.fullDataTable.column(0).nodes();
+
+            $(`input.${cssBaseClass}-body__checkbox-input:enabled`, nodes)
+                .prop('checked', selectAllChecked)
+                .attr('aria-checked', selectAllChecked);
+
+            //enable or disable import appropriately
+            if (selectAllChecked) {
+                this.enableImportButton();
+            } else {
+                this.disableImportButton();
+            }
+        },
+
+
+        changeImportButton: function(event) {
+            const checked = event.currentTarget.checked;
+            if (checked) {
+                this.enableImportButton();
+            } else {
+                /*
+                check state of all checkboxes
+                if any are checked we leave import button enabled
+                */
+                const anyCheckedBoxes = this.$elem.find(
+                    `input.${cssBaseClass}-body__checkbox-input:checked`
+                );
+
+                if (!anyCheckedBoxes.length) {
+                    this.disableImportButton();
                 }
             }
         },
 
+        attachFileNameEvents: function ($td, data) {
+            $td.find(`.${cssBaseClass}-body__name`)
+                .tooltip({
+                    title: data.name,
+                    placement: 'top',
+                    delay: {
+                        show: Config.get('tooltip').showDelay,
+                        hide: Config.get('tooltip').hideDelay,
+                    },
+                });
+
+            $td.find(`span.${cssBaseClass}-body__folder`)
+                .off('click')
+                .on('click', (e) => {
+                    $(e.currentTarget).off('click');
+                    this.updatePathFn((this.path += '/' + data.name));
+                });
+
+            $td.find('button[data-decompress]')
+                .off('click')
+                .on('click', (e) => {
+                    const decompressButton = $(e.currentTarget);
+                    decompressButton.replaceWith(
+                        $.jqElem('i').addClass('fa fa-spinner fa-spin')
+                    );
+
+                    this.stagingServiceClient
+                        .decompress({
+                            path: data.path,
+                        })
+                        .then(() => this.updateView())
+                        .fail((xhr) => {
+                            console.error('FAILED', xhr);
+                            alert('Error ' + xhr.status + '\r' + xhr.responseText);
+                        });
+                });
+        },
+
+        /**
+         *
+         * @param {jquery element} $td the DOM element with the select box, download, and delete buttons
+         * @param {object} data the file data for that row
+         */
+        attachImportSelectionEvents: function($td, $checkboxElem, data) {
+            // find the initial singly mapped datatype from the staging service
+            const stagingAreaViewer = this;
+            let suggestedType = null;
+            if (data.mappings && data.mappings.length === 1) {
+                suggestedType = data.mappings[0];
+            }
+
+            // find the element
+            const importDropdown = $td.find('select');
+
+            /**
+             * When a data type is selected from the "Import As..." dropdown,
+             * enable the checkbox for that row (so user can import).
+             * Make sure the "select all" checkbox is also enabled.
+             *
+             * @param {string} dataType the identifier of what the data type is, e.g.: sra_reads
+             * @param {boolean} check if true, checks the now-enabled checkbox. Should generally only
+             *  be true if this is called from a user selection event.
+             */
+            function enableCheckboxes(dataType, check) {
+                $td.find('.select2-selection')
+                    .addClass(`${cssBaseClass}-body__import-type-selected`);
+
+                //make checkbox for that row enabled
+                //also set the data type so that we have the reference later when importing
+                $checkboxElem
+                    .prop('disabled', false)
+                    .attr('aria-label', 'Select to import file checkbox')
+                    .attr('data-type', dataType);
+
+                //make sure select all checkbox is enabled
+                $('#staging_table_select_all')
+                    .prop('disabled', false)
+                    .attr('aria-label', 'Select to import all files checkbox');
+
+                if (check) {
+                    $checkboxElem
+                        .prop('checked', true)
+                        .attr('aria-checked', true);
+                    stagingAreaViewer.enableImportButton();
+                }
+            }
+
+            const storedFileData = this.selectedFileTypes[data.path];
+            // where we have data type set, render those dropdowns correctly
+            if (storedFileData) {
+                // tell select2 which option to set
+                importDropdown
+                    .select2({
+                        containerCssClass: `${cssBaseClass}-body__import-dropdown`,
+                    })
+                    .val(storedFileData.dataType)
+                    .trigger('change');
+                //enable the checkboxes
+                enableCheckboxes(storedFileData.dataType);
+            }
+
+            //otherwise we set the dropdowns with a placeholder
+            else {
+                // And if we have a suggested type, select it and enable the checkboxes
+                if (suggestedType) {
+                    importDropdown
+                        .select2({
+                            containerCssClass: `${cssBaseClass}-body__import-dropdown ${cssBaseClass}-body__import-type-selected`,
+                            placeholder: 'make the empty option disappear',
+                        })
+                        .val(suggestedType.id)
+                        .trigger('change')
+                        .trigger({
+                            type: 'select2:select',
+                        });
+                    enableCheckboxes(suggestedType.id);
+                } else {
+                    importDropdown.select2({
+                        placeholder: 'Select a type',
+                        containerCssClass: `${cssBaseClass}-body__import-dropdown`,
+                    });
+                }
+            }
+
+            //set the behavior on the import dropdown when a user selects a type
+            importDropdown.on('select2:select', (e) => {
+                const dataType = e.currentTarget.value;
+
+                // store the type we selected along with file data so we can persist on a view update
+                data.dataType = dataType;
+                this.selectedFileTypes[data.path] = data;
+
+                enableCheckboxes(dataType, true);
+            });
+
+            $td
+                .find('button[data-import]')
+                .off('click')
+                .on('click', (e) => {
+                    const dataImportButton = $(e.currentTarget);
+                    const importType = dataImportButton.prevAll('select').val();
+                    this.initImportApp(importType, data.path);
+                    this.updateView();
+                });
+
+            $td
+                .find('button[data-download]')
+                .off('click')
+                .on('click', () => {
+                    const url = Config.url('staging_api_url') + '/download' + data.path;
+                    this.downloadFile(url);
+                });
+
+            $td
+                .find('button[data-delete]')
+                .off('click')
+                .on('click', () => {
+                    if (window.confirm('Really delete ' + data.name + '?')) {
+                        this.stagingServiceClient
+                            .delete({
+                                path: data.path,
+                            })
+                            .then(() => {
+                                this.updateView();
+                            })
+                            .fail((xhr) => {
+                                alert('Error ' + xhr.status + '\r' + xhr.responseText);
+                            });
+                    }
+                });
+        },
+
+        /**
+         *
+         * @param {jquery element} $td the dom element with the file or folder icon
+         * @param {object} data the file data for that row
+         */
+        attachFileIconEvents: function($td, data) {
+            if (data.isFolder) {
+                $td.find('button[data-name]')
+                .off('click')
+                .on('click', (e) => {
+                    $(e.currentTarget).off('click');
+                    const separator = this.path.slice(-1) !== '/' ? '/' : '';
+                    this.updatePathFn(this.path + separator + data.name);
+                });
+                return;
+            }
+
+            // First, we find the expansion caret in the first cell.
+            const $caret = $td.find('[data-caret]');
+
+            $caret.off('click');
+
+            // now, if there's openFileInfo on it, that means that the user had the detailed view open during a refresh.
+            if ($caret.length && this.openFileInfo[data.path]) {
+                //so we note that we've already loaded the info.
+                data.loaded = this.openFileInfo[data.path].loaded;
+                //toggle the caret
+                $caret.toggleClass('fa-caret-down fa-caret-right');
+                //and append the detailed view, which we do in a timeout in the next pass through to ensure that everything is properly here.
+                setTimeout(() => {
+                    $caret
+                        .parent()
+                        .parent()
+                        .after(this.renderMoreFileInfo(data));
+                }, 0);
+            }
+
+            $caret.on('click', (e) => {
+                const fileExpander = $(e.currentTarget);
+                fileExpander.toggleClass('fa-caret-down fa-caret-right');
+                const $tr = fileExpander.parent().parent();
+
+                if (fileExpander.hasClass('fa-caret-down')) {
+                    $('.kb-dropzone').css('min-height', '75px');
+                    this.openFileInfo[data.path] = data;
+                    $tr.after(this.renderMoreFileInfo(data));
+                } else {
+                    $('.kb-dropzone').css('min-height', '200px');
+                    $tr.next().detach();
+                    delete this.openFileInfo[data.path];
+                }
+            });
+        },
+
+        updateTableDrawPath: function () {
+            if (!this.fullDataTable) {
+                return;
+            }
+            const table = this.fullDataTable;
+            $.fn.DataTable.ext.search.pop();
+
+            $.fn.DataTable.ext.search.push(
+                (settings, data, dataIndex) => {
+                    const row = table.row(dataIndex);
+                    const subdir = row.node().getAttribute('data-subdir');
+                    return subdir === this.path;
+                }
+            );
+            this.fullDataTable.draw();
+        },
+
+        /**
+         *
+         * @param {Object} fileData - file data object with attributes:
+         *  - loaded: boolean
+         *  - subpath: string
+         *  - name: string
+         *  -
+         * @returns
+         */
         renderMoreFileInfo: function (fileData) {
             const self = this;
 
@@ -738,18 +842,12 @@ define([
                 '<span class="fa fa-spinner fa-spin"></span> Loading file info...please wait'
             );
 
-            let filePath = this.subpath;
-            if (filePath.length) {
-                filePath += '/';
-            }
-
-            filePath += fileData.name;
-
             // define our tabs externally. This is so we can do our metadata call and our jgi_metadata call (in serial) and then update
             // the UI after they're completed. It's a smidgen slower this way (maybe 0.25 seconds) - we could load the metadata and display
             // it to the user immediately, then add the JGI tab if it exists. But that causes a brief blink where the JGI tab isn't there and
             // pops into being later. This way, it all shows up fully built. It seemed like the lesser of the evils.
             let $tabs;
+            const filePath = fileData.subdir + '/' + fileData.name;
 
             this.stagingServiceClient
                 .metadata({
@@ -796,6 +894,9 @@ define([
                                 $upaField.empty();
                                 $upaField.addClass('alert alert-danger');
                                 $upaField.append(xhr.error.message);
+                            })
+                            .finally(() => {
+                                $upaField.removeClass('fa fa-spinner fa-spin');
                             });
                         fileMetadata['Imported as'] = $upaField;
                     }

--- a/kbase-extension/static/kbase/templates/data_staging/ftp_file_table.html
+++ b/kbase-extension/static/kbase/templates/data_staging/ftp_file_table.html
@@ -13,50 +13,6 @@
         </tr>
     </thead>
     <tbody class="kb-staging-table-body">
-    {{#each files}}
-        <tr class="kb-staging-table__row" scope="row">
-            <td>{{name}}</td>
-            <td class="kb-staging-table-body__cell--expander">{{isFolder}}</td>
-            <td>{{name}}</td>
-            <td>{{size}}</td>
-            <td>{{mtime}}</td>
-            <td role="option" class="kb-staging-table-body__cell--import">
-                {{#if imported }}
-                <div class="kb-staging-table-body__select_container">
-                    <select>
-                        <option></option>
-                        {{#if mappings}}
-                        <optgroup label="Suggested Types">
-                            {{#each mappings as |mapping|}} -->
-                                <option value="{{id}}">{{title}}</option>
-                            {{/each}}
-                        </optgroup>
-                        <optgroup label="Other Types">
-                            {{#each ../uploaders}}
-                            <option value="{{id}}">{{name}}</option>
-                            {{/each}}
-                        {{ else }}
-                            {{#each ../uploaders}}
-                                <option value="{{id}}">{{name}}</option>
-                            {{/each}}
-                        {{/if}}
-                        </optgroup>
-                    </select>
-                    <button data-download="{{name}}" class="kb-staging-table-body__button--download" role="button" aria-label="Download Data" title="Download data">
-                        <span class="fa fa-download"></span>
-                    </button>
-                    <button data-delete="{{name}}" class="kb-staging-table-body__button--delete" role="button" aria-label="Delete File" title="Delete file">
-                        <span class="fa fa-trash"></span>
-                    </button>
-                </div>
-            {{ else }}
-                <button data-delete="{{name}}" class="kb-staging-table-body__button--delete" role="button" aria-label="Delete Folder" title="Delete folder">
-                    <span class="fa fa-trash"></span>
-                </button>
-                {{/if}}
-            </td>
-        </tr>
-    {{/each}}
     </tbody>
 </table>
 <div class='kb-staging-table__notice'>
@@ -64,3 +20,4 @@
 </div>
 <div class='kb-staging-table-import'>
 </div>
+

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -9,7 +9,8 @@ define([
     describe('The staging area viewer widget', () => {
         let stagingViewer, container, $container, $parentNode;
         const startingPath = '/',
-            updatePathFn = null, //() => {},
+            updatePathFn = null,
+
             fakeUser = 'notAUser';
 
         beforeEach(() => {


### PR DESCRIPTION
# Description of PR purpose/changes

This has a number of changes to the staging area viewer code to support some bug fixes. There's a few other changes that this included.

Sorry for the size, there was really no way to do this piecemeal, as it needed an overhaul of how the datatable gets created and maintained. I couldn't really see a way to do that in parts without introducing strange and unusual behavior.

Bugs addressed:
* Navigating back from a two-deep-nested directory used to go from, for example `user/dir1/dir2` to `user/user/dir1`. Now it goes to `user/dir1` as expected.
* Selected files from multiple pages now all get added to the import cell.
* Select all / select none button works again.
* Selected files from nested directories all get added to the import cell.
  * For example, selecting a file from root, a file from one subdirectory, and files from a deeper directory, will all get added to the bulk import cell
* File checked state persists through refreshes.

Structural / architecture changes:
* The `render` function should now only get run once. This builds the DataTable, which should also only be done once.
* Previously, we used data built into the DOM with a template file and applied the DataTable to that. Now, we just feed the data rows into it.
* The DataTable now knows how to render the data from each file object. On refresh, this fetches the data again from the server, and just feeds it into the DataTable.
* This now fetches all the files from the Staging Area and just feeds them to the table, which filters based on what's the current directory. This really isn't that much of a change, as the `StagingArea.list()` function worked recursively. So running `list()` on the root directory returned all files anyway. We now just take advantage of that instead of throwing things away.
* Each file is now treated as unique based on its path, not its file name. If there are files with the same name in multiple directories, this should now be ok - before it led to Strange Behavior.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-487
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Throw some files in your staging area, enough to show multiple pages / directories
* Toggle through pages and select files
* Do the import step, and watch them all appear!
* Also, try a refresh, deletion, download, or other function to make sure nothing was lost
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
