### PR TITLE
DATAUP-485 Batch Statuses/Infos

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -217,7 +217,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
-`job_status_batch` request job statuses, responds with `job_statuses`
+`job_status_batch` request job statuses, responds with `job_status_batch`
 * `job_id` - string - job_id of batch container job
 
 `start_update_loop` - request starting the global job status update thread, no specific response, but generally with `job_status_all`
@@ -236,7 +236,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
-`job_info_batch` - request general information about jobs, responds with `job_infos`
+`job_info_batch` - request general information about jobs, responds with `job_info_batch`
 * `job_id` - string - job_id of batch container job
 
 `job_logs` - request job log information, responds with `job_logs` for each job
@@ -246,7 +246,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `num_lines` - int > 0
 * `latest` - boolean, `true` if requesting just the latest logs
 
-`cancel_job` - cancel a job or list of jobs; responds with `job_statuses`
+`cancel_job` - cancel a job or list of jobs; responds with `job_status_batch`
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
@@ -309,22 +309,6 @@ A general job comm error, capturing most errors that get thrown by the kernel
 
 **bus** one of `job-cancel-error`, `job-log-deleted`, `job-error`
 
-### `job_status_all`
-The set of all job states for all running jobs, or at least the set that should be updated (those that are complete and not requested by the front end are not included - if a job is sitting in an error or finished state, it doesn't need ot have its app cell updated)
-
-**content** - all of the below are included, but the top-level keys are all job id strings, e.g.:
-```json
-{
-  "job_id_1": { ...contents... },
-  "job_id_2": { ...contents... }
-}
-```
-  * `state` - the job state (see the **Data Structures** section below for details
-  * `widget_info` - the parameters to send to output widgets, only available for a completed job
-  * `user` - string, username of user who submitted the job
-
-**bus** - a series of `job-status` or `job-deleted` messages
-
 ### `job_info`
 Includes information about the running job
 
@@ -337,7 +321,7 @@ Includes information about the running job
 
 **bus** - `job-info`
 
-### `job_infos`
+### `job_info_batch`
 Includes information about the jobs
 
 **content**
@@ -364,7 +348,7 @@ The current job state. This one is probably most common.
 
 **bus** - `job-status`
 
-## `job_statuses`
+## `job_status_batch`
 The current job states for some jobs. The format is the same as for `job_status_all`.
 
 **content**
@@ -376,7 +360,23 @@ The current job states for some jobs. The format is the same as for `job_status_
 ```
 Where the inner objects' format is the BE Output State described in the Data Structures section.
 
-**bus** - TODO
+**bus** - a series of `job-status` messages
+
+### `job_status_all`
+The set of all job states for all running jobs, or at least the set that should be updated (those that are complete and not requested by the front end are not included - if a job is sitting in an error or finished state, it doesn't need ot have its app cell updated)
+
+**content** - all of the below are included, but the top-level keys are all job id strings, e.g.:
+```json
+{
+  "job_id_1": { ...contents... },
+  "job_id_2": { ...contents... }
+}
+```
+  * `state` - the job state (see the **Data Structures** section below for details
+  * `widget_info` - the parameters to send to output widgets, only available for a completed job
+  * `user` - string, username of user who submitted the job
+
+**bus** - a series of `job-status` messages
 
 ### `job_logs`
 Includes log statement information for a given job.

--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -217,6 +217,9 @@ These are organized by the `request_type` field, followed by the expected respon
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
+`job_status_batch` request job statuses, responds with `job_statuses`
+* `job_id` - string - job_id of batch container job
+
 `start_update_loop` - request starting the global job status update thread, no specific response, but generally with `job_status_all`
 
 `stop_update_loop` - request stopping the global job status update thread, no response
@@ -232,6 +235,9 @@ These are organized by the `request_type` field, followed by the expected respon
 `job_info` - request general information about job(s), responds with `job_info` for each job
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
+
+`job_info_batch` - request general information about jobs, responds with `job_infos`
+* `job_id` - string - job_id of batch container job
 
 `job_logs` - request job log information, responds with `job_logs` for each job
 * `job_id` - string OR `job_id_list` - array of strings
@@ -327,8 +333,26 @@ Includes information about the running job
   * `app_name` - string, the human-readable app name
   * `job_id` - string, the job id
   * `job_params` - the unstructured set of parameters sent to the execution engine
+  * `batch_id` - id of batch container job
 
 **bus** - `job-info`
+
+### `job_infos`
+Includes information about the jobs
+
+**content**
+```json
+{
+  "job_id_1": { ...contents... },
+  "job_id_2": { ...contents... }
+}
+```
+Where the inner objects' format is the same as for `job_info`, i.e., they have the keys
+  * `app_id` - string, the app id (format = `module_name/app_name`)
+  * `app_name` - string, the human-readable app name
+  * `job_id` - string, the job id
+  * `job_params` - the unstructured set of parameters sent to the execution engine
+  * `batch_id` - id of batch container job
 
 ### `job_status`
 The current job state. This one is probably most common.

--- a/src/biokbase/narrative/exception_util.py
+++ b/src/biokbase/narrative/exception_util.py
@@ -3,6 +3,22 @@ from biokbase.execution_engine2.baseclient import ServerError as EEServerError
 from biokbase.userandjobstate.baseclient import ServerError as UJSServerError
 
 
+class NoJobException(ValueError):
+    """
+    Raised when a job ID is invalid (e.g., None, "", ...)
+    or not registered in JobManager._running_jobs
+    Subclasses ValueError for except-clause backwards compatibility
+    """
+    pass
+
+
+class NotBatchException(Exception):
+    """
+    Raised when expecting a batch container job
+    """
+    pass
+
+
 class NarrativeException(Exception):
     def __init__(self, code, message, name, source):
         self.code = code

--- a/src/biokbase/narrative/exception_util.py
+++ b/src/biokbase/narrative/exception_util.py
@@ -9,6 +9,7 @@ class NoJobException(ValueError):
     or not registered in JobManager._running_jobs
     Subclasses ValueError for except-clause backwards compatibility
     """
+
     pass
 
 
@@ -16,6 +17,7 @@ class NotBatchException(Exception):
     """
     Raised when expecting a batch container job
     """
+
     pass
 
 

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -3,7 +3,7 @@ import threading
 from typing import List
 from ipykernel.comm import Comm
 import biokbase.narrative.jobs.jobmanager as jobmanager
-from biokbase.narrative.exception_util import NarrativeException
+from biokbase.narrative.exception_util import NarrativeException, NoJobException
 from biokbase.narrative.common import kblogging
 
 UNKNOWN_REASON = "Unknown reason"
@@ -47,10 +47,13 @@ class JobRequest:
         each request.
     """
 
-    # request types either require a job_id, a job_id_list, or neither
+    # each kind of request handling requires a job_id, a job_id_list,
+    # or none of those
     REQUIRE_JOB_ID = [
         "job_info",
+        "job_info_batch",
         "job_status",
+        "job_status_batch",
         "start_job_update",
         "stop_job_update",
         "job_logs",
@@ -180,20 +183,22 @@ class JobComm:
                 "cancel_job": self._cancel_jobs,
                 "retry_job": self._retry_jobs,
                 "job_logs": self._get_job_logs,
+                "job_status_batch": self._lookup_job_state_batch,
+                "job_info_batch": self._lookup_job_info_batch,
             }
 
     def _verify_job_id(self, req: JobRequest) -> None:
         if not req.job_id:
             self.send_error_message("job_does_not_exist", req)
-            raise ValueError(f"Job id required to process {req.request} request")
+            raise NoJobException(f"Job id required to process {req.request} request")
 
     def _verify_job_id_list(self, req: JobRequest) -> None:
         if not isinstance(req.job_id_list, list):
-            raise ValueError("List expected for job_id_list")
+            raise TypeError("List expected for job_id_list")
         req.job_id_list[:] = [job_id for job_id in req.job_id_list if job_id]
         if len(req.job_id_list) == 0:
             self.send_error_message("job_does_not_exist", req)
-            raise ValueError("No valid job ids")
+            raise NoJobException("No valid job ids")
 
     def start_job_status_loop(self, *args, **kwargs) -> None:
         """
@@ -272,6 +277,20 @@ class JobComm:
             self.send_error_message("job_does_not_exist", req)
             raise
 
+    def _lookup_job_info_batch(self, req: JobRequest) -> dict:
+        self._verify_job_id(req)
+        try:
+            job_ids = self._jm.update_batch_job(req.job_id)
+            job_infos = dict()
+            for job_id in job_ids[1:]:
+                job_infos[job_id] = self._jm.lookup_job_info(job_id)
+        except NoJobException:
+            self.send_error_message("job_does_not_exist", req)
+            raise
+
+        self.send_comm_message("job_infos", job_infos)
+        return job_infos
+
     def lookup_job_state(self, job_id: str) -> dict:
         """
         This differs from the _lookup_job_state (underscored version) in that
@@ -303,6 +322,23 @@ class JobComm:
                 {"state": {"job_id": req.job_id, "status": "does_not_exist"}},
             )
             raise
+
+    def _lookup_job_state_batch(self, req: JobRequest) -> dict:
+        self._verify_job_id(req)
+
+        try:
+            job_ids = self._jm.update_batch_job(req.job_id)
+            output_states = self._jm.get_job_states(job_ids)
+        except NoJobException:
+            self.send_error_message("job_does_not_exist", req)
+            self.send_comm_message(
+                "job_status",
+                {"state": {"job_id": req.job_id, "status": "does_not_exist"}},
+            )
+            raise
+
+        self.send_comm_message("job_statuses", output_states)
+        return output_states
 
     def _modify_job_update(self, req: JobRequest) -> None:
         """

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -1,11 +1,11 @@
 import biokbase.narrative.clients as clients
-from .job import Job, TERMINAL_STATUSES, EXCLUDED_JOB_STATE_FIELDS
+from .job import Job, TERMINAL_STATUSES, EXCLUDED_JOB_STATE_FIELDS, get_dne_job_state
 from biokbase.narrative.common import kblogging
 from IPython.display import HTML
 from jinja2 import Template
 from datetime import datetime, timezone, timedelta
 from biokbase.narrative.app_util import system_variable
-from biokbase.narrative.exception_util import transform_job_exception
+from biokbase.narrative.exception_util import transform_job_exception, NoJobException, NotBatchException
 import copy
 from typing import List
 
@@ -142,7 +142,7 @@ class JobManager(object):
                     results["error"].append(job_id)
 
         if not len(results["job_id_list"]) and not len(results["error"]):
-            raise ValueError("No job id(s) supplied")
+            raise NoJobException("No job id(s) supplied")
 
         return results
 
@@ -266,7 +266,7 @@ class JobManager(object):
 
     def lookup_job_info(self, job_id):
         """
-        Will raise a ValueError if job_id doesn't exist.
+        Will raise a NoJobException if job_id doesn't exist.
         Sends the info over the comm channel as this packet:
         {
             app_id: module/name,
@@ -327,7 +327,7 @@ class JobManager(object):
         if job_id in self._running_jobs:
             return self._running_jobs[job_id]["job"]
         else:
-            raise ValueError(f"No job present with id {job_id}")
+            raise NoJobException(f"No job present with id {job_id}")
 
     def get_job_logs(
         self,
@@ -487,6 +487,13 @@ class JobManager(object):
         state = self._running_jobs[job_id]["job"].output_state()
         return state
 
+    def get_job_states(self, job_ids: List[str]) -> dict:
+        checked_jobs = self._check_job_list(job_ids)
+        output_states = self._construct_job_state_set(checked_jobs["job_id_list"])
+        for error_id in checked_jobs["error"]:
+            output_states[error_id] = get_dne_job_state(error_id)
+        return output_states
+
     def modify_job_refresh(self, job_id: str, update_adjust: int) -> None:
         """
         Modifies how many things want to get the job updated.
@@ -498,3 +505,41 @@ class JobManager(object):
         self._running_jobs[job_id]["refresh"] += update_adjust
         if self._running_jobs[job_id]["refresh"] < 0:
             self._running_jobs[job_id]["refresh"] = 0
+
+    def update_batch_job(self, batch_id: int) -> List[str]:
+        """
+        Update a batch job and create child jobs if necessary
+        """
+        if batch_id not in self._running_jobs:
+            raise NoJobException(f"{batch_id} not registered")
+
+        parent_job = self._running_jobs[batch_id]["job"]
+
+        if not parent_job.batch_job:
+            raise NotBatchException("Not a batch job")
+
+        old_child_ids = parent_job.child_jobs
+        parent_job.state(force_refresh=True)
+        child_ids = parent_job.child_jobs
+
+        if sorted(child_ids) != sorted(old_child_ids):
+
+            child_jobs = []
+            for child_id in child_ids:
+                if child_id in self._running_jobs:
+                    child_jobs.append(
+                        self._running_jobs[child_id]["job"]
+                    )
+                else:
+                    job = Job.from_attributes(
+                        job_id=child_id
+                    )
+                    self.register_new_job(
+                        job=job,
+                        refresh=int(job.state().get("status") not in TERMINAL_STATUSES)
+                    )
+                    child_jobs.append(job)
+
+            parent_job.update_children(child_jobs)
+
+        return [batch_id] + child_ids

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -5,7 +5,11 @@ from IPython.display import HTML
 from jinja2 import Template
 from datetime import datetime, timezone, timedelta
 from biokbase.narrative.app_util import system_variable
-from biokbase.narrative.exception_util import transform_job_exception, NoJobException, NotBatchException
+from biokbase.narrative.exception_util import (
+    transform_job_exception,
+    NoJobException,
+    NotBatchException,
+)
 import copy
 from typing import List
 
@@ -407,7 +411,9 @@ class JobManager(object):
         job_states = self._construct_job_state_set(checked_jobs["job_id_list"])
 
         for job_id in checked_jobs["error"]:
-            job_states[job_id] = {"state": {"job_id": job_id, "status": "does_not_exist"}}
+            job_states[job_id] = {
+                "state": {"job_id": job_id, "status": "does_not_exist"}
+            }
 
         return job_states
 
@@ -526,12 +532,12 @@ class JobManager(object):
                 if child_id in self._running_jobs:
                     child_job = self._running_jobs[child_id]["job"]
                 else:
-                    child_job = Job.from_attributes(
-                        job_id=child_id
-                    )
+                    child_job = Job.from_attributes(job_id=child_id)
                     self.register_new_job(
                         job=child_job,
-                        refresh=int(child_job.state().get("status") not in TERMINAL_STATUSES)
+                        refresh=int(
+                            child_job.state().get("status") not in TERMINAL_STATUSES
+                        ),
                     )
                 child_jobs.append(child_job)
 

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -707,7 +707,9 @@ class JobTest(unittest.TestCase):
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_parent_children__ok(self):
-        child_jobs = [create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN]
+        child_jobs = [
+            create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN
+        ]
         parent_job = Job.from_state(
             create_state_from_ee2(BATCH_PARENT, mode="state"),
             children=child_jobs,
@@ -729,12 +731,13 @@ class JobTest(unittest.TestCase):
     def test_parent_children__fail(self):
         parent_state = create_state_from_ee2(BATCH_PARENT, mode="state")
         with self.assertRaisesRegex(
-            ValueError,
-            "Must supply children when setting children of batch job parent"
+            ValueError, "Must supply children when setting children of batch job parent"
         ):
             Job.from_state(parent_state)
 
-        child_jobs = [create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN][1:]
+        child_jobs = [
+            create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN
+        ][1:]
         with self.assertRaisesRegex(ValueError, "Child job id mismatch"):
             Job.from_state(
                 parent_state,
@@ -755,10 +758,7 @@ class JobTest(unittest.TestCase):
             job = create_job_from_ee2(job_id, mode="attributes")
             state = create_state_from_ee2(job_id, mode="state")
             out = job.get_viewer_params(state)
-            self.assertEqual(
-                get_widget_info(job_id),
-                out
-            )
+            self.assertEqual(get_widget_info(job_id), out)
 
     def test_get_viewer_params__batch_parent(self):
         """
@@ -767,10 +767,11 @@ class JobTest(unittest.TestCase):
         """
         state = create_state_from_ee2(BATCH_PARENT, mode="state")
         batch_children = [
-            create_job_from_ee2(job_id, mode="state")
-            for job_id in BATCH_CHILDREN
+            create_job_from_ee2(job_id, mode="state") for job_id in BATCH_CHILDREN
         ]
 
-        job = create_job_from_ee2(BATCH_PARENT, mode="attributes", children=batch_children)
+        job = create_job_from_ee2(
+            BATCH_PARENT, mode="attributes", children=batch_children
+        )
         out = job.get_viewer_params(state)
         self.assertIsNone(out)

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -8,6 +8,8 @@ from biokbase.narrative.jobs.job import (
     JOB_ATTRS,
     JOB_ATTR_DEFAULTS,
 )
+from biokbase.narrative.jobs.jobmanager import JOB_INIT_EXCLUDED_JOB_STATE_FIELDS
+from biokbase.narrative.jobs.specmanager import SpecManager
 from .util import ConfigTests
 from .narrative_mock.mockclients import (
     get_mock_client,
@@ -33,12 +35,24 @@ def capture_stdout():
 
 def mock_job_state(self, force_refresh=False):
     """Mock job.state() to avoid ee2 calls"""
-    return self._augment_ee2_state(self._last_state)
+    return self._augment_ee2_state(self._acc_state)
 
 
 config = ConfigTests()
-test_jobs = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
-test_specs = config.load_json_file(config.get("specs", "app_specs_file"))
+TEST_JOBS = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
+with mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client):
+    sm = SpecManager()
+    sm.reload()
+    TEST_SPECS = copy.deepcopy(sm.app_specs)
+
+
+def get_test_spec(tag, app_id):
+    return copy.deepcopy(TEST_SPECS[tag][app_id])
+
+
+def get_test_job(job_id):
+    return copy.deepcopy(TEST_JOBS[job_id])
+
 
 # test_jobs contains jobs in the following states
 JOB_COMPLETED = "5d64935ab215ad4128de94d6"
@@ -54,6 +68,7 @@ BATCH_ERROR_RETRIED = "60e7112887b7e512a899c8f5"
 BATCH_RETRY_COMPLETED = "60e71159fce9347f2adeaac6"
 BATCH_RETRY_RUNNING = "60e7165f3e91121969554d82"
 BATCH_RETRY_ERROR = "60e717d78ac80701062efe63"
+JOB_NOT_FOUND = "job_not_found"
 
 BATCH_CHILDREN = [
     BATCH_COMPLETED,
@@ -102,14 +117,6 @@ JOB_KWARGS = [
 ]
 
 
-def get_app_data(*args):
-    return test_specs[1]
-
-
-def get_test_job(job_id):
-    return copy.deepcopy(test_jobs[job_id])
-
-
 def state_2_kwargs(state, transform_list=JOB_ATTRS):
     """
     transform job data into suitable input for creating a job object
@@ -147,33 +154,39 @@ def state_2_kwargs(state, transform_list=JOB_ATTRS):
     return kwargs
 
 
-def create_job_from_ee2(job_id):
+def create_job_from_ee2(job_id, mode, children=None):
     """
     create a job object from raw job data
     """
     state = get_test_job(job_id)
-    kwargs = state_2_kwargs(state)
 
-    return Job.from_attributes(**kwargs, ee2_state=get_test_job(job_id))
+    if mode == "attributes":
+        kwargs = state_2_kwargs(state)
+        job = Job.from_attributes(**kwargs, children=children)
+    elif mode == "state":
+        job = Job.from_state(state, children=children)
+
+    return job
 
 
-def create_state_from_ee2(job_id, with_job_input=False, with_job_output=False):
+def create_state_from_ee2(job_id, mode):
     """
     create the output of job.state() from raw job data
     """
     state = get_test_job(job_id)
-    omitted_fields = EXCLUDED_JOB_STATE_FIELDS.copy()
 
-    if not with_job_output:
-        omitted_fields.append("job_output")
+    for attr in JOB_INIT_EXCLUDED_JOB_STATE_FIELDS:
+        if attr in state:
+            del state[attr]
 
-    if with_job_input:
-        omitted_fields.remove("job_input")
-
-    # remove unnecessary fields
-    for field in omitted_fields:
-        if field in state:
-            del state[field]
+    # Depending on if the job was initialized with kwargs
+    # or has been populated with actual ee2 state info,
+    # the tested state() may come out with limited fields.
+    # Restrict to JOB_ATTR fields here if needed
+    if mode == "attributes":
+        for k, v in state.copy().items():
+            if k not in JOB_ATTRS:
+                del state[k]
 
     return state
 
@@ -199,6 +212,10 @@ class JobTest(unittest.TestCase):
         cls.retry_parent = job_state.get("retry_parent")
         cls.run_id = job_input.get("narrative_cell_info", {}).get("run_id")
         cls.tag = job_input.get("narrative_cell_info", {}).get("tag", "dev")
+
+        # load mock specs
+        with mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client):
+            SpecManager().reload()
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def _mocked_job(self, job_attrs=[]):
@@ -245,7 +262,7 @@ class JobTest(unittest.TestCase):
 
     def test_job_init__error_no_job_id(self):
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "Cannot create a job without a job ID!"
         ):
             Job.from_attributes(params={}, app_id="this/that")
@@ -346,7 +363,7 @@ class JobTest(unittest.TestCase):
         """
         test that a completed job is correctly initialised
         """
-        test_job = test_jobs[JOB_COMPLETED]
+        test_job = get_test_job(JOB_COMPLETED)
         expected = {
             "job_id": JOB_COMPLETED,
             "app_id": test_job.get("job_input", {}).get(
@@ -357,7 +374,7 @@ class JobTest(unittest.TestCase):
             "cell_id": test_job.get("job_input", {})
             .get("narrative_cell_info", {})
             .get("cell_id", None),
-            "_last_state": test_job,
+            "_acc_state": test_job,
             "extra_data": None,
             "user": test_job.get("user", None),
             "params": test_job.get("job_input", {}).get("params", {}),
@@ -369,7 +386,7 @@ class JobTest(unittest.TestCase):
             .get("tag", "release"),
         }
 
-        job = Job.from_state(test_jobs[JOB_COMPLETED])
+        job = Job.from_state(get_test_job(JOB_COMPLETED))
         self.check_job_attrs(job, expected)
 
     def test_job_from_state_defaults(self):
@@ -405,38 +422,12 @@ class JobTest(unittest.TestCase):
         self.check_job_attrs(job, expected)
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
-    def test_state__no_final_state__terminal(self):
-        """
-        test that a job outputs the correct state and that the update is cached
-        """
-        # ee2_state is fully populated
-        job = create_job_from_ee2(JOB_TERMINATED)
-        # when the field is first populated, it will have all the ee2 data
-        self.assertEqual(
-            job.final_state, create_state_from_ee2(JOB_TERMINATED, True, True)
-        )
-
-        # get rid of the cached job state
-        job.clear_state()
-        self.assertFalse(job.was_terminal)
-        self.assertIsNone(job.final_state)
-
-        # when the field is repopulated, the EXCLUDED_JOB_STATE_FIELDS filter
-        # will be on, so there will be no job_input
-        state = job.state()
-        self.assertEqual(state["status"], "terminated")
-        self.assertTrue(job.was_terminal)
-        expected_state = create_state_from_ee2(JOB_TERMINATED, False, True)
-        self.assertEqual(state, expected_state)
-        self.assertEqual(job.final_state, expected_state)
-
-    @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_state__no_final_state__non_terminal(self):
         """
         test that a job outputs the correct state and that the update is not cached
         """
         # ee2_state is fully populated (includes job_input, no job_output)
-        job = create_job_from_ee2(JOB_CREATED)
+        job = create_job_from_ee2(JOB_CREATED, mode="state")
         self.assertFalse(job.was_terminal)
         self.assertIsNone(job.final_state)
         state = job.state()
@@ -444,17 +435,17 @@ class JobTest(unittest.TestCase):
         self.assertIsNone(job.final_state)
         self.assertEqual(state["status"], "created")
 
-        expected_state = create_state_from_ee2(JOB_CREATED, True)
+        expected_state = create_state_from_ee2(JOB_CREATED, mode="state")
         self.assertEqual(state, expected_state)
 
     def test_state__final_state_exists__terminal(self):
         """
         test that a completed job emits its state without calling check_job
         """
-        job = create_job_from_ee2(JOB_COMPLETED)
+        job = create_job_from_ee2(JOB_COMPLETED, mode="state")
         self.assertTrue(job.was_terminal)
         self.assertIsNotNone(job.final_state)
-        expected = create_state_from_ee2(JOB_COMPLETED, True, True)
+        expected = create_state_from_ee2(JOB_COMPLETED, mode="state")
         self.assertEqual(job.final_state, expected)
 
         with assert_obj_method_called(MockClients, "check_job", call_status=False):
@@ -467,7 +458,7 @@ class JobTest(unittest.TestCase):
         """
         test that the correct exception is thrown if check_job cannot be called
         """
-        job = create_job_from_ee2(JOB_CREATED)
+        job = create_job_from_ee2(JOB_CREATED, mode="attributes")
         self.assertFalse(job.was_terminal)
         self.assertIsNone(job.final_state)
         with self.assertRaisesRegex(Exception, "Unable to fetch info for job"):
@@ -477,7 +468,7 @@ class JobTest(unittest.TestCase):
         def mock_state(self, state=None):
             return None
 
-        job = create_job_from_ee2(JOB_CREATED)
+        job = create_job_from_ee2(JOB_CREATED, mode="attributes")
         expected = {
             "status": "error",
             "error": {
@@ -503,32 +494,24 @@ class JobTest(unittest.TestCase):
         """
         test that without a state object supplied, the job state is unchanged
         """
-        job = create_job_from_ee2(JOB_CREATED)
-        job.clear_state()
+        job = create_job_from_ee2(JOB_CREATED, mode="attributes")
         self.assertFalse(job.was_terminal)
-        self.assertIsNone(job._last_state)
         job.update_state(None)
         self.assertFalse(job.was_terminal)
-        self.assertIsNone(job._last_state)
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_job_update__invalid_job_id(self):
         """
         ensure that an ee2 state with a different job ID cannot be used to update a job
         """
-        job = create_job_from_ee2(JOB_RUNNING)
-        expected = create_state_from_ee2(
-            JOB_RUNNING, with_job_input=True, with_job_output=False
-        )
+        job = create_job_from_ee2(JOB_RUNNING, mode="state")
+        expected = create_state_from_ee2(JOB_RUNNING, mode="state")
         self.assertEqual(job.state(), expected)
 
         # try to update it with the job state from a different job
-        with self.assertRaisesRegexp(ValueError, "Job ID mismatch in update_state"):
+        with self.assertRaisesRegex(ValueError, "Job ID mismatch in update_state"):
             job.update_state(get_test_job(JOB_COMPLETED))
 
-    @mock.patch(
-        "biokbase.narrative.jobs.specmanager.SpecManager.get_spec", get_app_data
-    )
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_job_info(self):
         job = self._mocked_job()
@@ -542,9 +525,6 @@ class JobTest(unittest.TestCase):
         job_str = job.__repr__()
         self.assertRegex("KBase Narrative Job - " + job.job_id, job_str)
 
-    @mock.patch(
-        "biokbase.narrative.jobs.specmanager.SpecManager.get_spec", get_app_data
-    )
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_repr_js(self):
         job = self._mocked_job()
@@ -567,12 +547,9 @@ class JobTest(unittest.TestCase):
         }
 
         for job_id in is_finished.keys():
-            job = create_job_from_ee2(job_id)
+            job = create_job_from_ee2(job_id, mode="attributes")
             self.assertEqual(job.is_finished(), is_finished[job_id])
 
-    @mock.patch(
-        "biokbase.narrative.jobs.specmanager.SpecManager.get_spec", get_app_data
-    )
     @mock.patch("biokbase.narrative.widgetmanager.WidgetManager.show_output_widget")
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_show_output_widget(self, mock_method):
@@ -584,7 +561,7 @@ class JobTest(unittest.TestCase):
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_show_output_widget__incomplete_state(self):
         job = Job.from_state(get_test_job(JOB_CREATED))
-        self.assertRegexpMatches(
+        self.assertRegex(
             job.show_output_widget(), "Job is incomplete! It has status 'created'"
         )
 
@@ -670,14 +647,14 @@ class JobTest(unittest.TestCase):
         job = Job.from_state(job_state)
         self.assertEqual(job.params, JOB_ATTR_DEFAULTS["params"])
 
-        with self.assertRaisesRegexp(Exception, "Unable to fetch parameters for job"):
+        with self.assertRaisesRegex(Exception, "Unable to fetch parameters for job"):
             job.parameters()
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_parent_children__ok(self):
-        child_jobs = [create_job_from_ee2(job_id) for job_id in BATCH_CHILDREN]
+        child_jobs = [create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN]
         parent_job = Job.from_state(
-            create_state_from_ee2(BATCH_PARENT),
+            create_state_from_ee2(BATCH_PARENT, mode="state"),
             children=child_jobs,
         )
 
@@ -695,16 +672,43 @@ class JobTest(unittest.TestCase):
         self.assertTrue(parent_job.was_terminal)
 
     def test_parent_children__fail(self):
-        parent_state = create_state_from_ee2(BATCH_PARENT)
+        parent_state = create_state_from_ee2(BATCH_PARENT, mode="state")
         with self.assertRaisesRegex(
             ValueError,
-            "Job with `batch_job=True` must be instantiated with child job instances",
+            "Must supply children when setting children of batch job parent"
         ):
             Job.from_state(parent_state)
 
-        child_jobs = [create_job_from_ee2(job_id) for job_id in BATCH_CHILDREN][1:]
+        child_jobs = [create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN][1:]
         with self.assertRaisesRegex(ValueError, "Child job id mismatch"):
             Job.from_state(
                 parent_state,
                 children=child_jobs,
             )
+
+    def test_get_viewer_params(self):
+        for job_id in ALL_JOBS:
+            if job_id == BATCH_PARENT:
+                continue
+
+            state = create_state_from_ee2(job_id, mode="state")
+
+            job = create_job_from_ee2(job_id, mode="state")
+            job.get_viewer_params(state)
+
+            job = create_job_from_ee2(job_id, mode="attributes")
+            job.get_viewer_params(state)
+
+        # do batch parent separately
+        # since it requires passing in child jobs
+        state = create_state_from_ee2(BATCH_PARENT, mode="state")
+        batch_children = [
+            create_job_from_ee2(job_id, mode="state")
+            for job_id in BATCH_CHILDREN
+        ]
+
+        job = create_job_from_ee2(BATCH_PARENT, mode="state", children=batch_children)
+        job.get_viewer_params(state)
+
+        job = create_job_from_ee2(BATCH_PARENT, mode="attributes", children=batch_children)
+        job.get_viewer_params(state)

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -6,7 +6,11 @@ from biokbase.narrative.jobs.job import get_dne_job_state, JOB_ATTR_DEFAULTS
 import biokbase.narrative.jobs.jobcomm
 import biokbase.narrative.jobs.jobmanager
 from biokbase.narrative.jobs.jobcomm import JobRequest
-from biokbase.narrative.exception_util import NarrativeException, NoJobException, NotBatchException
+from biokbase.narrative.exception_util import (
+    NarrativeException,
+    NoJobException,
+    NotBatchException,
+)
 from .util import ConfigTests, validate_job_state
 from .narrative_mock.mockcomm import MockComm
 from .narrative_mock.mockclients import get_mock_client, get_failing_mock_client
@@ -44,7 +48,11 @@ APP_NAME = "The Best App in the World"
 def get_test_job_info(job_id):
     test_job = get_test_job(job_id)
     app_id = test_job.get("job_input", {}).get("app_id", None)
-    tag = test_job.get("job_input", {}).get("narrative_cell_info", {}).get("tag", "release")
+    tag = (
+        test_job.get("job_input", {})
+        .get("narrative_cell_info", {})
+        .get("tag", "release")
+    )
     test_spec = get_test_spec(tag, app_id)
     params = test_job.get("job_input", {}).get("params", {})
     batch_id = test_job.get("batch_id", JOB_ATTR_DEFAULTS["batch_id"])
@@ -205,13 +213,13 @@ class JobCommTestCase(unittest.TestCase):
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": "job_statuses",
+                "msg_type": "job_status_batch",
                 "content": {
                     job_id: self.job_states[job_id]
                     for job_id in [BATCH_PARENT] + BATCH_CHILDREN
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_lookup_job_state_batch__dne(self):
@@ -222,10 +230,10 @@ class JobCommTestCase(unittest.TestCase):
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": "job_status",
-                "content": get_dne_job_state(JOB_NOT_FOUND)
+                "msg_type": "job_status_batch",
+                "content": get_dne_job_state(JOB_NOT_FOUND),
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_lookup_job_state_batch__no_job(self):
@@ -237,12 +245,9 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": "job_does_not_exist",
-                "content": {
-                    "source": "job_status_batch",
-                    "job_id": job_id
-                }
+                "content": {"source": "job_status_batch", "job_id": job_id},
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_lookup_job_state_batch__not_batch(self):
@@ -343,19 +348,20 @@ class JobCommTestCase(unittest.TestCase):
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": "job_infos",
+                "msg_type": "job_info_batch",
                 "content": {
-                    job_id: get_test_job_info(job_id)
-                    for job_id in BATCH_CHILDREN
-                }
+                    job_id: get_test_job_info(job_id) for job_id in BATCH_CHILDREN
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_lookup_job_info_batch__no_job(self):
         job_id = None
         req = make_comm_msg("job_info_batch", job_id, True)
-        with self.assertRaisesRegex(NoJobException, "Job id required to process job_info_batch request"):
+        with self.assertRaisesRegex(
+            NoJobException, "Job id required to process job_info_batch request"
+        ):
             self.jc._lookup_job_info_batch(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -364,9 +370,9 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     "source": "job_info_batch",
                     "job_id": job_id,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_lookup_job_info_batch__dne(self):
@@ -381,9 +387,9 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     "source": "job_info_batch",
                     "job_id": job_id,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_lookup_job_info_batch__not_batch(self):
@@ -408,9 +414,9 @@ class JobCommTestCase(unittest.TestCase):
                 "msg_type": "job_statuses",
                 "content": {
                     JOB_RUNNING: self.job_states[JOB_RUNNING],
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     @mock.patch(
@@ -428,7 +434,7 @@ class JobCommTestCase(unittest.TestCase):
                     JOB_RUNNING: self.job_states[JOB_RUNNING],
                 },
             },
-            msg["data"]
+            msg["data"],
         )
 
     @mock.patch(
@@ -447,7 +453,7 @@ class JobCommTestCase(unittest.TestCase):
                     JOB_RUNNING: self.job_states[JOB_RUNNING],
                 },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_cancel_jobs__no_job(self):
@@ -467,9 +473,9 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     "source": "cancel_job",
                     "job_id_list": [],
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     @mock.patch(
@@ -478,7 +484,13 @@ class JobCommTestCase(unittest.TestCase):
     def test_cancel_jobs__some_bad_jobs(self):
         FAKE_JOB = "fake_job_id"
         job_id_list = [
-            None, JOB_NOT_FOUND, JOB_NOT_FOUND, "", JOB_RUNNING, JOB_CREATED, FAKE_JOB
+            None,
+            JOB_NOT_FOUND,
+            JOB_NOT_FOUND,
+            "",
+            JOB_RUNNING,
+            JOB_CREATED,
+            FAKE_JOB,
         ]
         req = make_comm_msg("cancel_job", job_id_list, True)
         self.jc._cancel_jobs(req)
@@ -493,14 +505,12 @@ class JobCommTestCase(unittest.TestCase):
                     FAKE_JOB: get_dne_job_state(FAKE_JOB),
                 },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_cancel_jobs__all_bad_jobs(self):
         FAKE_JOB = "fake_job_id"
-        job_id_list = [
-            None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, FAKE_JOB
-        ]
+        job_id_list = [None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, FAKE_JOB]
         req = make_comm_msg("cancel_job", job_id_list, True)
         self.jc._cancel_jobs(req)
         msg = self.jc._comm.last_message
@@ -510,13 +520,14 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     JOB_NOT_FOUND: get_dne_job_state(JOB_NOT_FOUND),
                     FAKE_JOB: get_dne_job_state(FAKE_JOB),
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     @mock.patch(
-        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_failing_mock_client
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get",
+        get_failing_mock_client,
     )
     def test_cancel_jobs__failure(self):
         job_id_list = [JOB_RUNNING]

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -217,7 +217,7 @@ class JobCommTestCase(unittest.TestCase):
     def test_lookup_job_state_batch__dne(self):
         job_id = JOB_NOT_FOUND
         req = make_comm_msg("job_status_batch", job_id, True)
-        with self.assertRaises(NoJobException):
+        with self.assertRaisesRegex(NoJobException, f"No job present with id {job_id}"):
             self.jc._lookup_job_state_batch(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -322,9 +322,8 @@ class JobCommTestCase(unittest.TestCase):
     def test_lookup_job_info_bad_job(self):
         job_id = "nope"
         req = make_comm_msg("job_info", job_id, True)
-        with self.assertRaises(NoJobException) as e:
+        with self.assertRaisesRegex(NoJobException, f"No job present with id {job_id}"):
             self.jc._lookup_job_info(req)
-        self.assertIn(f"No job present with id {job_id}", str(e.exception))
         msg = self.jc._comm.last_message
         self.assertEqual(
             {"job_id": job_id, "source": "job_info"}, msg["data"]["content"]
@@ -373,7 +372,7 @@ class JobCommTestCase(unittest.TestCase):
     def test_lookup_job_info_batch__dne(self):
         job_id = JOB_NOT_FOUND
         req = make_comm_msg("job_info_batch", job_id, True)
-        with self.assertRaisesRegex(NoJobException, f"{job_id} not registered"):
+        with self.assertRaisesRegex(NoJobException, f"No job present with id {job_id}"):
             self.jc._lookup_job_info_batch(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -688,9 +687,8 @@ class JobCommTestCase(unittest.TestCase):
     def test_get_job_logs_bad_job(self):
         job_id = "bad_job"
         req = make_comm_msg("job_logs", job_id, True)
-        with self.assertRaises(NoJobException) as e:
+        with self.assertRaisesRegex(NoJobException, f"No job present with id {job_id}"):
             self.jc._get_job_logs(req)
-        self.assertIn(f"No job present with id {job_id}", str(e.exception))
         msg = self.jc._comm.last_message
         self.assertEqual(
             {"job_id": job_id, "source": "job_logs"}, msg["data"]["content"]

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -46,7 +46,11 @@ from .narrative_mock.mockclients import (
     assert_obj_method_called,
     MockClients,
 )
-from biokbase.narrative.exception_util import NarrativeException, NoJobException, NotBatchException
+from biokbase.narrative.exception_util import (
+    NarrativeException,
+    NoJobException,
+    NotBatchException,
+)
 
 
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
@@ -211,7 +215,9 @@ class JobManagerTest(unittest.TestCase):
         self.assertIsInstance(job, Job)
 
     def test_get_job_bad(self):
-        with self.assertRaisesRegex(NoJobException, "No job present with id not_a_job_id"):
+        with self.assertRaisesRegex(
+            NoJobException, "No job present with id not_a_job_id"
+        ):
             self.jm.get_job("not_a_job_id")
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
@@ -254,12 +260,7 @@ class JobManagerTest(unittest.TestCase):
             self.jm.cancel_jobs(["", "", None])
 
         job_states = self.jm.cancel_jobs([JOB_NOT_FOUND])
-        self.assertEqual(
-            {
-                JOB_NOT_FOUND: get_dne_job_state(JOB_NOT_FOUND)
-            },
-            job_states
-        )
+        self.assertEqual({JOB_NOT_FOUND: get_dne_job_state(JOB_NOT_FOUND)}, job_states)
 
     def test_cancel_jobs__job_already_finished(self):
         self.assertEqual(get_test_job(JOB_COMPLETED)["status"], "completed")
@@ -588,9 +589,15 @@ class JobManagerTest(unittest.TestCase):
         exp = {
             **{
                 job_id: self.job_states[job_id]
-                for job_id in [JOB_CREATED, JOB_RUNNING, JOB_TERMINATED, JOB_COMPLETED, BATCH_PARENT]
+                for job_id in [
+                    JOB_CREATED,
+                    JOB_RUNNING,
+                    JOB_TERMINATED,
+                    JOB_COMPLETED,
+                    BATCH_PARENT,
+                ]
             },
-            JOB_NOT_FOUND: get_dne_job_state(JOB_NOT_FOUND)
+            JOB_NOT_FOUND: get_dne_job_state(JOB_NOT_FOUND),
         }
 
         res = self.jm.get_job_states(job_ids)
@@ -601,7 +608,9 @@ class JobManagerTest(unittest.TestCase):
             self.jm.get_job_states([])
 
     def test_update_batch_job__dne(self):
-        with self.assertRaisesRegex(NoJobException, f"No job present with id {JOB_NOT_FOUND}"):
+        with self.assertRaisesRegex(
+            NoJobException, f"No job present with id {JOB_NOT_FOUND}"
+        ):
             self.jm.update_batch_job(JOB_NOT_FOUND)
 
     def test_update_batch_job__not_batch(self):
@@ -635,29 +644,32 @@ class JobManagerTest(unittest.TestCase):
                 raise Exception()
 
         with mock.patch.object(
-            MockClients,
-            "check_job",
-            side_effect=mock_check_job
+            MockClients, "check_job", side_effect=mock_check_job
         ) as m:
             job_ids = self.jm.update_batch_job(BATCH_PARENT)
 
         m.assert_has_calls(
             [
-                mock.call({"job_id": BATCH_PARENT, "exclude_fields": EXCLUDED_JOB_STATE_FIELDS}),
-                mock.call({"job_id": JOB_NOT_FOUND, "exclude_fields": EXCLUDED_JOB_STATE_FIELDS})
+                mock.call(
+                    {
+                        "job_id": BATCH_PARENT,
+                        "exclude_fields": EXCLUDED_JOB_STATE_FIELDS,
+                    }
+                ),
+                mock.call(
+                    {
+                        "job_id": JOB_NOT_FOUND,
+                        "exclude_fields": EXCLUDED_JOB_STATE_FIELDS,
+                    }
+                ),
             ]
         )
 
         self.assertEqual(BATCH_PARENT, job_ids[0])
-        self.assertCountEqual(
-            new_child_ids, job_ids[1:]
-        )
+        self.assertCountEqual(new_child_ids, job_ids[1:])
 
         batch_job = self.jm.get_job(BATCH_PARENT)
-        reg_child_jobs = [
-            self.jm.get_job(job_id)
-            for job_id in batch_job.child_jobs
-        ]
+        reg_child_jobs = [self.jm.get_job(job_id) for job_id in batch_job.child_jobs]
 
         self.assertCountEqual(batch_job.child_jobs, new_child_ids)
         self.assertCountEqual(batch_job.children, reg_child_jobs)

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -1,7 +1,12 @@
 """
 Tests for job management
 """
-from src.biokbase.narrative.jobs.job import COMPLETED_STATUS, JOB_ATTR_DEFAULTS
+from src.biokbase.narrative.jobs.job import (
+    COMPLETED_STATUS,
+    EXCLUDED_JOB_STATE_FIELDS,
+    JOB_ATTR_DEFAULTS,
+    get_dne_job_state,
+)
 import unittest
 import copy
 from unittest import mock
@@ -23,9 +28,14 @@ from .test_job import (
     BATCH_RETRY_COMPLETED,
     BATCH_RETRY_RUNNING,
     BATCH_RETRY_ERROR,
+    JOB_NOT_FOUND,
     ALL_JOBS,
     FINISHED_JOBS,
     ACTIVE_JOBS,
+    BATCH_CHILDREN,
+    get_test_job,
+    get_test_spec,
+    TEST_JOBS,
 )
 import os
 from IPython.display import HTML
@@ -35,20 +45,13 @@ from .narrative_mock.mockclients import (
     assert_obj_method_called,
     MockClients,
 )
-from biokbase.narrative.exception_util import NarrativeException
+from biokbase.narrative.exception_util import NarrativeException, NoJobException, NotBatchException
 from biokbase.narrative.app_util import map_inputs_from_job, map_outputs_from_state
 
 
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
-config = ConfigTests()
-test_jobs = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
-with mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client):
-    sm = SpecManager()
-    sm.reload()
-    test_specs = copy.deepcopy(sm.app_specs)
 
-JOB_NOT_FOUND = "job_not_found"
 TERMINAL_IDS = [JOB_COMPLETED, JOB_TERMINATED, JOB_ERROR]
 NON_TERMINAL_IDS = [JOB_CREATED, JOB_RUNNING]
 
@@ -80,15 +83,11 @@ def get_retry_job_state(orig_id, status="unmocked"):
     }
 
 
-def get_dne_job_state(job_id):
-    return {"state": {"job_id": job_id, "status": "does_not_exist"}}
-
-
 def get_test_job_states():
     # generate full job state objects
     job_states = {}
-    for job_id in test_jobs.keys():
-        state = copy.deepcopy(test_jobs[job_id])
+    for job_id in TEST_JOBS.keys():
+        state = get_test_job(job_id)
         job_input = state.get("job_input", {})
         narr_cell_info = job_input.get("narrative_cell_info", {})
 
@@ -109,7 +108,7 @@ def get_test_job_states():
             params = job_input.get("params", JOB_ATTR_DEFAULTS["params"])
             tag = narr_cell_info.get("tag", JOB_ATTR_DEFAULTS["tag"])
             app_id = job_input.get("app_id", JOB_ATTR_DEFAULTS["app_id"])
-            spec = test_specs[tag][app_id]
+            spec = get_test_spec(tag, app_id)
             output_widget, widget_params = map_outputs_from_state(
                 state,
                 map_inputs_from_job(params, spec),
@@ -139,7 +138,8 @@ class JobManagerTest(unittest.TestCase):
     @classmethod
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
     def setUpClass(cls):
-        cls.job_ids = list(test_jobs.keys())
+        cls.job_ids = list(TEST_JOBS.keys())
+        config = ConfigTests()
         os.environ["KB_WORKSPACE_ID"] = config.get("jobs", "job_test_wsname")
         cls.maxDiff = None
 
@@ -262,7 +262,7 @@ class JobManagerTest(unittest.TestCase):
         self.assertIsInstance(job, Job)
 
     def test_get_job_bad(self):
-        with self.assertRaisesRegex(ValueError, "No job present with id not_a_job_id"):
+        with self.assertRaisesRegex(NoJobException, "No job present with id not_a_job_id"):
             self.jm.get_job("not_a_job_id")
 
     @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
@@ -313,8 +313,8 @@ class JobManagerTest(unittest.TestCase):
         )
 
     def test_cancel_jobs__job_already_finished(self):
-        self.assertEqual(test_jobs[JOB_COMPLETED]["status"], "completed")
-        self.assertEqual(test_jobs[JOB_TERMINATED]["status"], "terminated")
+        self.assertEqual(get_test_job(JOB_COMPLETED)["status"], "completed")
+        self.assertEqual(get_test_job(JOB_TERMINATED)["status"], "terminated")
         self.assertTrue(self.jm.get_job(JOB_COMPLETED).was_terminal)
         self.assertTrue(self.jm.get_job(JOB_TERMINATED).was_terminal)
 
@@ -419,7 +419,7 @@ class JobManagerTest(unittest.TestCase):
         for job_id in orig_ids + retry_ids:
             job = self.jm.get_job(job_id)
             self.assertIn(job_id, self.jm._running_jobs)
-            self.assertIsNotNone(job._last_state)
+            self.assertIsNotNone(job._acc_state)
 
         for job_id in dne_ids:
             self.assertNotIn(job_id, self.jm._running_jobs)
@@ -521,7 +521,7 @@ class JobManagerTest(unittest.TestCase):
             }
         ]
 
-        test_jobs_ = copy.deepcopy(test_jobs)
+        test_jobs_ = copy.deepcopy(TEST_JOBS)
         test_jobs_[retry_id] = {"job_id": retry_id, "status": retry_status}
         with mock.patch.object(
             MockClients,
@@ -619,6 +619,97 @@ class JobManagerTest(unittest.TestCase):
     #     msg = self.jm._comm.last_message
     #     self.assertTrue(self.jm._running_jobs[phony_id]['refresh'] == 0)
     #     self.assertIsNone(msg)
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_get_job_states(self):
+        job_ids = [
+            None,
+            None,
+            JOB_CREATED,
+            JOB_NOT_FOUND,
+            JOB_CREATED,
+            JOB_RUNNING,
+            JOB_TERMINATED,
+            JOB_COMPLETED,
+            BATCH_PARENT,
+            "",
+            JOB_NOT_FOUND,
+        ]
+
+        exp = {
+            **{
+                job_id: self.job_states[job_id]
+                for job_id in [JOB_CREATED, JOB_RUNNING, JOB_TERMINATED, JOB_COMPLETED, BATCH_PARENT]
+            },
+            JOB_NOT_FOUND: get_dne_job_state(JOB_NOT_FOUND)
+        }
+
+        res = self.jm.get_job_states(job_ids)
+        self.assertEqual(exp, res)
+
+    def test_get_job_states__empty(self):
+        with self.assertRaisesRegex(NoJobException, r"No job id\(s\) supplied"):
+            self.jm.get_job_states([])
+
+    def test_update_batch_job__dne(self):
+        with self.assertRaisesRegex(NoJobException, f"{JOB_NOT_FOUND} not registered"):
+            self.jm.update_batch_job(JOB_NOT_FOUND)
+
+    def test_update_batch_job__not_batch(self):
+        with self.assertRaisesRegex(NotBatchException, "Not a batch job"):
+            self.jm.update_batch_job(JOB_CREATED)
+
+        with self.assertRaisesRegex(NotBatchException, "Not a batch job"):
+            self.jm.update_batch_job(BATCH_TERMINATED)
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_update_batch_job__no_change(self):
+        job_ids = self.jm.update_batch_job(BATCH_PARENT)
+        self.assertEqual(BATCH_PARENT, job_ids[0])
+        self.assertCountEqual(BATCH_CHILDREN, job_ids[1:])
+
+    @mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client)
+    def test_update_batch_job__change(self):
+        """test child ids having changed"""
+        exp_child_ids = BATCH_CHILDREN[1:] + [JOB_CREATED, JOB_NOT_FOUND]
+
+        def mock_check_job(params):
+            """Called from job.state()"""
+            job_id = params["job_id"]
+            if job_id == BATCH_PARENT:
+                return {"child_jobs": exp_child_ids}
+            elif job_id in TEST_JOBS:
+                return get_test_job(job_id)
+            else:
+                return {"job_id": job_id, "status": "does_not_exist"}
+
+        with mock.patch.object(
+            MockClients,
+            "check_job",
+            side_effect=mock_check_job
+        ) as m:
+            job_ids = self.jm.update_batch_job(BATCH_PARENT)
+
+        m.assert_has_calls(
+            [
+                mock.call({"job_id": BATCH_PARENT, "exclude_fields": EXCLUDED_JOB_STATE_FIELDS}),
+                mock.call({"job_id": JOB_NOT_FOUND, "exclude_fields": EXCLUDED_JOB_STATE_FIELDS})
+            ]
+        )
+
+        self.assertEqual(BATCH_PARENT, job_ids[0])
+        self.assertCountEqual(
+            exp_child_ids, job_ids[1:]
+        )
+
+        batch_job = self.jm.get_job(BATCH_PARENT)
+        reg_child_jobs = [
+            self.jm.get_job(job_id)
+            for job_id in batch_job.child_jobs
+        ]
+
+        self.assertCountEqual(batch_job.child_jobs, exp_child_ids)
+        self.assertCountEqual(batch_job.children, reg_child_jobs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description of PR purpose/changes

BE support for incoming messages from FE for `job_status_batch` and `job_status_info`.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/x] [Version has been bumped](https://semver.org/) for each release
- [n/x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
