### PR TITLE
DATAUP-532: Updating job manager to correctly calculate the jobs to be retried

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobActionDropdown.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobActionDropdown.js
@@ -98,16 +98,24 @@ define([
                 return Promise.resolve(false);
             }
 
-            const jobIdList = jobManager.getJobIDsByStatus(
+            const jobList = jobManager.getCurrentJobsByStatus(
                 statusList,
                 Jobs.validStatusesForAction[action]
             );
-            if (!jobIdList || !jobIdList.length) {
+            if (!jobList || !jobList.length) {
                 return Promise.resolve(false);
             }
 
-            return JobMessages.showDialog({ action, statusList, jobIdList }).then((confirmed) => {
+            return JobMessages.showDialog({ action, statusList, jobList }).then((confirmed) => {
                 if (confirmed) {
+                    const jobIdList =
+                        action === 'retry'
+                            ? jobList.map((job) => {
+                                  return job.retry_parent || job.job_id;
+                              })
+                            : jobList.map((job) => {
+                                  return job.job_id;
+                              });
                     jobManager.doJobAction(action, jobIdList);
                 }
                 return Promise.resolve(confirmed);
@@ -172,10 +180,13 @@ define([
         }
 
         function updateState() {
-            const jobsByStatus = jobManager.model.getItem(`exec.jobs.byStatus`);
+            const jobCountsByStatus = Jobs.getCurrentJobCounts(
+                jobManager.model.getItem('exec.jobs')
+            );
+
             actionArr.forEach((action) => {
                 const result = action.target.some((status) => {
-                    return jobsByStatus[status];
+                    return jobCountsByStatus[status];
                 });
                 // if the status exists, enable the button; otherwise, set it to disabled
                 container.querySelector(

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTab.js
@@ -46,8 +46,8 @@ define(['bluebird', 'common/html', './jobStatusTable'], (Promise, html, JobStatu
         }
 
         return {
-            start: start,
-            stop: stop,
+            start,
+            stop,
         };
     }
 

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -368,9 +368,10 @@ define(['common/jobMessages', 'common/jobs'], (JobMessages, Jobs) => {
             executeActionOnJobId(args) {
                 const { action, jobId } = args;
                 const jobState = this.model.getItem(`exec.jobs.byId.${jobId}`);
-
                 if (jobState && Jobs.canDo(action, jobState)) {
-                    this.doJobAction(action, [jobId]);
+                    const actionJobId =
+                        action === 'retry' && jobState.retry_parent ? jobState.retry_parent : jobId;
+                    this.doJobAction(action, [actionJobId]);
                     return true;
                 }
                 return false;

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -523,7 +523,7 @@ define(['common/jobMessages', 'common/jobs'], (JobMessages, Jobs) => {
                 });
 
                 // populate the model
-                Jobs.populateModelFromJobArray(childJobs, this.model);
+                Jobs.populateModelFromJobArray(this.model, childJobs);
 
                 // request job updates
                 this.bus.emit('request-job-updates-start', {

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -247,25 +247,9 @@ define(['common/jobMessages', 'common/jobs'], (JobMessages, Jobs) => {
             const batchId = this.model.getItem('exec.jobState.job_id');
             let batchJob;
             jobArray.forEach((jobState) => {
-                const status = jobState.status,
-                    jobId = jobState.job_id,
-                    oldJob = jobIndex.byId[jobId];
-
                 // update the job object
-                jobIndex.byId[jobId] = jobState;
-                if (!jobIndex.byStatus[status]) {
-                    jobIndex.byStatus[status] = {};
-                }
-                jobIndex.byStatus[status][jobId] = true;
-
-                if (oldJob && status !== oldJob.status) {
-                    const oldStatus = oldJob.status;
-                    delete jobIndex.byStatus[oldStatus][jobId];
-                    if (!Object.keys(jobIndex.byStatus[oldStatus]).length) {
-                        delete jobIndex.byStatus[oldStatus];
-                    }
-                }
-                if (jobId === batchId) {
+                jobIndex.byId[jobState.job_id] = jobState;
+                if (jobState.job_id === batchId) {
                     batchJob = jobState;
                 }
             });
@@ -556,7 +540,7 @@ define(['common/jobMessages', 'common/jobs'], (JobMessages, Jobs) => {
              * @returns {string} bulk import cell FSM state
              */
             getFsmStateFromJobs() {
-                return Jobs.getFsmStateFromJobs(this.model.getItem('exec.jobs.byStatus'));
+                return Jobs.getFsmStateFromJobs(this.model.getItem('exec.jobs'));
             }
         };
 

--- a/kbase-extension/static/kbase/js/common/jobMessages.js
+++ b/kbase-extension/static/kbase/js/common/jobMessages.js
@@ -11,12 +11,12 @@ define(['common/html', 'common/jobs', 'common/ui', 'util/string'], (html, Jobs, 
      * @param {object} args with keys
      *      {string} action - what action is to occur (cancel or retry)
      *      {array} statusList - array of statuses that the action applies to
-     *      {array} jobIdList - array of job IDs
+     *      {array} jobList - array of job objects
      * @returns {object} arguments to create a modal to confirm or cancel the action
      */
 
     function generateDialogArgs(args) {
-        const { action, statusList, jobIdList } = args;
+        const { action, statusList, jobList } = args;
         const statusSet = new Set(statusList);
 
         // for presentation, created and estimating jobs are listed as 'queued'
@@ -32,7 +32,7 @@ define(['common/html', 'common/jobs', 'common/ui', 'util/string'], (html, Jobs, 
                 .sort()
                 .map((status) => Jobs.jobLabel({ status: status }))
         );
-        const jobString = jobIdList.length === 1 ? '1 job' : jobIdList.length + ' jobs';
+        const jobString = jobList.length === 1 ? '1 job' : jobList.length + ' jobs';
         const ucfirstAction = String.capitalize(action);
         return {
             title: `${ucfirstAction} ${jobLabelString} jobs`,

--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -386,43 +386,20 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/ui'], (
     }
 
     /**
-     * Given an array of jobState objects, create an object with jobs indexed by ID and by status
+     * Given an array of jobState objects, create an object with jobs indexed by ID
      *
      * @param {array} jobArray array of jobState objects
      * @returns {object} with indexed job data:
      *      byId        key: job_id, value: jobState object
-     *      byStatus    key: status, value: object whose keys are the job IDs
-     *                      of jobs with that status
      */
 
     function jobArrayToIndexedObject(jobArray = []) {
         const jobIx = {
             byId: {},
-            byStatus: {},
-            jobsWithRetries: {},
-            batchId: null,
         };
 
         jobArray.forEach((job) => {
-            const jobId = job.job_id,
-                status = job.status;
-            jobIx.byId[jobId] = job;
-            if (!jobIx.byStatus[status]) {
-                jobIx.byStatus[status] = {};
-            }
-            jobIx.byStatus[status][jobId] = true;
-
-            // any job with one or more retries
-            if (job.retry_ids && job.retry_ids.length) {
-                jobIx.jobsWithRetries[jobId] = true;
-            }
-
-            if (job.batch_job) {
-                if (jobIx.batchId && jobId !== jobIx.batchId) {
-                    console.error(`Error: two batch IDs present: ${jobIx.batchId} and ${jobId}`);
-                }
-                jobIx.batchId = job.batch_id;
-            }
+            jobIx.byId[job.job_id] = job;
         });
         return jobIx;
     }
@@ -803,7 +780,7 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/ui'], (
     /**
      * Get the FSM state for a bulk cell from the jobs
      *
-     * @param {object} jobsByStatus job IDs indexed by status
+     * @param {object} jobsIndex jobs index
      * @returns {string} FSM state
      */
     function getFsmStateFromJobs(jobsIndex) {

--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -345,10 +345,10 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/ui'], (
     /**
      * Add an array of jobs to a model
      *
-     * @param {array} jobArray - array of job state objects
      * @param {object} model - the model to add the jobs to
+     * @param {array} jobArray - array of job state objects
      */
-    function populateModelFromJobArray(jobArray = [], model) {
+    function populateModelFromJobArray(model, jobArray = []) {
         if (!model) {
             throw new Error('Missing a model to populate');
         }

--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -1,14 +1,24 @@
-define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', 'common/ui'], (
+define(['common/errorDisplay', 'common/format', 'common/html', 'common/ui'], (
     ErrorDisplay,
     Format,
     html,
-    Props,
     UI
 ) => {
     'use strict';
 
     const t = html.tag,
         span = t('span');
+
+    const JOB = {
+        created: 'created',
+        estimating: 'estimating',
+        queued: 'queued',
+        running: 'running',
+        completed: 'completed',
+        error: 'error',
+        terminated: 'terminated',
+        does_not_exist: 'does_not_exist',
+    };
 
     const cssBaseClass = 'kb-job-status',
         jobNotFound = [
@@ -18,17 +28,17 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
         jobStatusUnknown = ['Determining job state...'],
         // valid job states from ee2, plus 'does_not_exist'
         validJobStatuses = [
-            'created',
-            'estimating',
-            'queued',
-            'running',
-            'completed',
-            'error',
-            'terminated',
-            'does_not_exist',
+            JOB.created,
+            JOB.estimating,
+            JOB.queued,
+            JOB.running,
+            JOB.completed,
+            JOB.error,
+            JOB.terminated,
+            JOB.does_not_exist,
         ],
         // job states where there will be no more updates
-        terminalStates = ['completed', 'error', 'terminated', 'does_not_exist'];
+        terminalStates = [JOB.completed, JOB.error, JOB.terminated, JOB.does_not_exist];
 
     const jobStrings = {
         does_not_exist: {
@@ -93,7 +103,7 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
         const status =
             jobState.status && isValidJobStatus(jobState.status)
                 ? jobState.status
-                : 'does_not_exist';
+                : JOB.does_not_exist;
 
         return jobStrings[status][stringType];
     }
@@ -123,9 +133,9 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
             requiredProperties.every((prop) => prop in jobState) &&
             validJobStatuses.includes(jobState.status) &&
             // require the 'created' key if the status is not 'does_not_exist'
-            (jobState.status === 'does_not_exist'
+            (jobState.status === JOB.does_not_exist
                 ? true
-                : Object.prototype.hasOwnProperty.call(jobState, 'created'))
+                : Object.prototype.hasOwnProperty.call(jobState, JOB.created))
         );
     }
 
@@ -184,8 +194,8 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
     }
 
     const validStatusesForAction = {
-        cancel: ['created', 'estimating', 'queued', 'running'],
-        retry: ['created', 'estimating', 'queued', 'running', 'error', 'terminated'],
+        cancel: [JOB.created, JOB.estimating, JOB.queued, JOB.running],
+        retry: [JOB.created, JOB.estimating, JOB.queued, JOB.running, JOB.error, JOB.terminated],
     };
 
     /**
@@ -198,7 +208,8 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
     function canDo(action, jobState) {
         return (
             isValidJobStateObject(jobState) &&
-            validStatusesForAction[action].includes(jobState.status)
+            validStatusesForAction[action].includes(jobState.status) &&
+            !(action === 'retry' && jobState.batch_job)
         );
     }
 
@@ -237,7 +248,7 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
 
     function jobLabel(jobState, includeError = false) {
         const jobString = getJobString(jobState, 'status');
-        if (includeError && jobState.status && jobState.status === 'error') {
+        if (includeError && jobState.status && jobState.status === JOB.error) {
             return (
                 `${jobString}: ` + ErrorDisplay.normaliseErrorObject({ jobState: jobState }).type
             );
@@ -263,15 +274,15 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
         let label = jobStatus,
             cssClass = `--${jobStatus}`;
         switch (jobStatus) {
-            case 'does_not_exist':
+            case JOB.does_not_exist:
                 label = 'does not exist';
                 break;
-            case 'completed':
+            case JOB.completed:
                 label = 'success';
                 break;
-            case 'error':
+            case JOB.error:
                 break;
-            case 'terminated':
+            case JOB.terminated:
                 label = 'cancellation';
                 break;
             default:
@@ -329,6 +340,49 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
             },
             label
         );
+    }
+
+    /**
+     * Add an array of jobs to a model
+     *
+     * @param {array} jobArray - array of job state objects
+     * @param {object} model - the model to add the jobs to
+     */
+    function populateModelFromJobArray(jobArray = [], model) {
+        if (!model) {
+            throw new Error('Missing a model to populate');
+        }
+        const batchIds = new Set(),
+            batchJobs = new Set();
+
+        if (!jobArray.length) {
+            model.deleteItem('exec.jobs');
+            model.deleteItem('exec.jobState');
+            return;
+        }
+
+        jobArray.forEach((job) => {
+            if (job.batch_id) {
+                batchIds.add(job.batch_id);
+            }
+            if (job.batch_job) {
+                batchJobs.add(job);
+            }
+        });
+
+        if (batchIds.size > 1) {
+            // more than one batch present
+            throw new Error('More than one batch ID found');
+        }
+        if (batchJobs.size > 1) {
+            // more than one batch parent present
+            throw new Error('More than one batch parent found');
+        }
+
+        model.setItem('exec.jobs', jobArrayToIndexedObject(jobArray));
+
+        model.setItem('exec.jobState', Array.from(batchJobs)[0]);
+        return model;
     }
 
     /**
@@ -427,7 +481,7 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
             return jobStatusUnknown;
         }
 
-        if (jobState.status === 'does_not_exist') {
+        if (jobState.status === JOB.does_not_exist) {
             return jobNotFound;
         }
 
@@ -592,7 +646,7 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
 
         if (Object.keys(jobLabelFreq).length === 1) {
             const status = Object.keys(jobLabelFreq)[0];
-            if (status === 'does_not_exist') {
+            if (status === JOB.does_not_exist) {
                 return `${batch} finished with error`;
             }
             return `${batch} ${_finishString(status).toLowerCase()}`;
@@ -612,8 +666,8 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
         Object.keys(jobsByStatus).forEach((status) => {
             const nJobs = jobsByStatus[status].size;
             // reduce down the queued states
-            if (status === 'estimating' || status === 'created') {
-                status = 'queued';
+            if (status === JOB.estimating || status === JOB.created) {
+                status = JOB.queued;
             }
             if (statuses[status]) {
                 statuses[status] += nJobs;
@@ -703,12 +757,12 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
 
         const textStatusSummary = _createBatchSummaryState(statuses);
         const orderedStatuses = [
-            'queued',
-            'running',
-            'completed',
-            'error',
-            'terminated',
-            'does_not_exist',
+            JOB.queued,
+            JOB.running,
+            JOB.completed,
+            JOB.error,
+            JOB.terminated,
+            JOB.does_not_exist,
         ];
         let summaryHtml =
             `${textStatusSummary}: ` +
@@ -791,6 +845,7 @@ define(['common/errorDisplay', 'common/format', 'common/html', 'common/props', '
         jobStatusUnknown,
         jobStrings,
         niceState,
+        populateModelFromJobArray,
         updateJobModel,
         validJobStatuses,
         validStatusesForAction,

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -603,13 +603,13 @@ define([
                             // Update the execMessage panel with details of the active jobs
                             controlPanel.setExecMessage(
                                 Jobs.createCombinedJobState(
-                                    jobManagerContext.model.getItem('exec.jobs.byStatus')
+                                    jobManagerContext.model.getItem('exec.jobs')
                                 )
                             );
                         },
                         fsmState: (jobManagerContext) => {
                             const fsmState = Jobs.getFsmStateFromJobs(
-                                jobManagerContext.model.getItem('exec.jobs.byStatus')
+                                jobManagerContext.model.getItem('exec.jobs')
                             );
                             if (fsmState) {
                                 updateState(fsmState);

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -270,13 +270,6 @@ define(['common/format'], (format) => {
         },
     ];
 
-    // add in the retryTarget
-    validJobs.forEach((job) => {
-        if (job.meta.canRetry) {
-            job.meta.retryTarget = job.job_id;
-        }
-    });
-
     const unknownJob = {
         job_id: 'unknown-job',
         status: 'does_not_exist',
@@ -298,7 +291,43 @@ define(['common/format'], (format) => {
         },
     };
 
-    const allJobs = [...validJobs, unknownJob];
+    const batchParentJob = {
+        job_id: 'batch-parent-job',
+        batch_id: 'batch-parent-job',
+        batch_job: true,
+        child_jobs: ['unknown-job'].concat(
+            validJobs.map((job) => {
+                return job.job_id;
+            })
+        ),
+        created: t.created,
+        meta: {
+            canCancel: true,
+            canRetry: false,
+            jobAction: jobStrings.action.cancel,
+            // may want to reinstate these in the future
+            // createJobStatusLines: {
+            //     line: null,
+            //     history: null,
+            // },
+            // jobLabel: null,
+            // niceState: null,
+        },
+        status: 'created',
+        updated: t.finished,
+    };
+
+    // add in the retryTarget
+    validJobs.forEach((job) => {
+        if (job.meta.canRetry) {
+            job.meta.retryTarget = job.job_id;
+        }
+        job.batch_id = 'batch-parent-job';
+        job.batch_job = false;
+    });
+
+    const allJobs = JSON.parse(JSON.stringify([...validJobs, unknownJob]));
+    const allJobsWithBatchParent = JSON.parse(JSON.stringify([batchParentJob].concat(allJobs)));
 
     const invalidJobs = [
         1,
@@ -335,10 +364,12 @@ define(['common/format'], (format) => {
             job_id: 'job_with_single_param',
             app_id: 'NarrativeTest/app_sleep',
             app_name: 'App Sleep',
+            batch_id: 'batch-parent-job',
         },
         {
             job_params: [{ tag_two: 'value two', tag_three: 'value three' }],
             job_id: 'job_with_multiple_params',
+            batch_id: 'batch-parent-job',
         },
     ];
 
@@ -409,18 +440,18 @@ define(['common/format'], (format) => {
      * 'job-cancelled-whilst-in-the-queue'
      * 'job-cancelled-during-run'
      * 'job-died-whilst-queueing'
-     * 'job-in-the-queue'
+     * 'job-in-the-queue' --> can cancel, can retry
      *
      * job retries:
      * 'job-cancelled-whilst-in-the-queue'
-     *  - retry 1: 'job-running'
+     *  - retry 1: 'job-running' --> can cancel, can retry
      *
      * 'job-cancelled-during-run'
-     *  - retry 1: 'job-finished-with-success'
+     *  - retry 1: 'job-finished-with-success' --> cannot cancel or retry
      *
      * 'job-died-whilst-queueing'
      *  - retry 1: 'job-died-with-error'
-     *  - retry 2: 'job-estimating' (most recent retry)
+     *  - retry 2: 'job-estimating' (most recent retry) --> can cancel, can retry
      *
      * Extra metadata for batch jobs:
      * meta.currentJob: true/false -- this is the most recent job (including retries)
@@ -428,10 +459,6 @@ define(['common/format'], (format) => {
      */
 
     function createBatchJob() {
-        // extra metadata:
-        //
-        //
-
         const BATCH_ID = 'job-created';
         const jobsWithRetries = JSON.parse(JSON.stringify(validJobs));
         const jobIdIndex = {};
@@ -515,6 +542,10 @@ define(['common/format'], (format) => {
                 return acc;
             }, {}),
             batchId: BATCH_ID,
+            expectedButtonState: [
+                ['.dropdown [data-action="cancel"]', false],
+                ['.dropdown [data-action="retry"]', true],
+            ],
         };
     }
 
@@ -522,7 +553,9 @@ define(['common/format'], (format) => {
         validJobs,
         invalidJobs,
         unknownJob,
+        batchParentJob,
         allJobs,
+        allJobsWithBatchParent,
         batchJob: createBatchJob(),
         jobsByStatus,
         jobsById,

--- a/test/data/testAppObj.js
+++ b/test/data/testAppObj.js
@@ -1,7 +1,28 @@
 define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
     'use strict';
 
-    const jobData = JobsData.validJobs;
+    const batchParentJob = Object.assign({}, JobsData.batchParentJob, {
+        job_output: {
+            id: JobsData.batchParentJob.job_id,
+            result: [
+                {
+                    // object with jobIds as keys and
+                    // { final_job_state: jobState } as values
+                    batch_results: JobsData.allJobs.reduce(
+                        (acc, curr) => ({
+                            ...acc,
+                            [curr.job_id]: { final_job_state: curr },
+                        }),
+                        {}
+                    ),
+                    report_name: 'batch_report_1607109609490',
+                    report_ref: '57373/19/1',
+                },
+            ],
+            version: '1.1',
+        },
+    });
+
     return {
         app: {
             fileParamIds: {
@@ -400,44 +421,8 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
             },
         },
         exec: {
-            jobState: {
-                authstrat: 'kbaseworkspace',
-                batch_size: jobData.length,
-                cell_id: '13395335-1f3d-4e0c-80f7-44b634968da0',
-                child_jobs: jobData,
-                created: 1607109147000,
-                finished: 1607109627617,
-                job_id: '5fca8a1bd257f9f38c9862a0',
-                job_output: {
-                    id: '5fca8a1bd257f9f38c9862a0',
-                    result: [
-                        {
-                            // object with jobIds as keys and
-                            // { final_job_state: jobState } as values
-                            batch_results: jobData.reduce(
-                                (acc, curr) => ({
-                                    ...acc,
-                                    [curr.job_id]: { final_job_state: curr },
-                                }),
-                                {}
-                            ),
-                            report_name: 'batch_report_1607109609490',
-                            report_ref: '57373/19/1',
-                        },
-                    ],
-                    version: '1.1',
-                },
-                queued: 1607109147274,
-                run_id: '13395335-1f3d-4e0c-80f7-44b634968da0',
-                running: 1607109162603,
-                scheduler_id: '23203',
-                scheduler_type: 'condor',
-                status: 'completed',
-                updated: 1607109627760,
-                user: 'ialarmedalien',
-                wsid: 57373,
-            },
-            jobs: Jobs.jobArrayToIndexedObject(jobData),
+            jobState: batchParentJob,
+            jobs: Jobs.jobArrayToIndexedObject(JobsData.allJobsWithBatchParent),
             jobStateUpdated: 1607109635241,
             launchState: {
                 cell_id: '13395335-1f3d-4e0c-80f7-44b634968da0',

--- a/test/unit/spec/common/cellComponents/tabs/jobActionDropdown-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobActionDropdown-Spec.js
@@ -13,7 +13,7 @@ define([
     const batchJobModel = Props.make({
         data: {},
     });
-    Jobs.populateModelFromJobArray(JobsData.allJobsWithBatchParent, batchJobModel);
+    Jobs.populateModelFromJobArray(batchJobModel, JobsData.allJobsWithBatchParent);
 
     function createInstance(config) {
         return JobActionDropdown.make(
@@ -428,7 +428,7 @@ define([
 
             tests.forEach((test) => {
                 it(test.desc, function () {
-                    Jobs.populateModelFromJobArray(test.input, this.jobManager.model);
+                    Jobs.populateModelFromJobArray(this.jobManager.model, test.input);
                     test.expect ? expectButtonState(test.expect) : expectButtonState();
                 });
             });

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -17,11 +17,11 @@ define([
     const bus = Runtime.make().bus();
 
     function makeModel(jobs) {
-        const model = Props.make({
+        const tempModel = Props.make({
             data: {},
         });
-        Jobs.populateModelFromJobArray(jobs, model);
-        return model;
+        Jobs.populateModelFromJobArray(tempModel, jobs);
+        return tempModel;
     }
 
     function createInstance(config = {}) {

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -69,7 +69,7 @@ define([
             .concat(retryParentJobs)
             .concat(allOriginalJobs);
 
-        Jobs.populateModelFromJobArray(allJobs, model);
+        Jobs.populateModelFromJobArray(model, allJobs);
         return { model, allJobs };
     }
 
@@ -137,7 +137,7 @@ define([
             this.model = Props.make({
                 data: {},
             });
-            Jobs.populateModelFromJobArray(JobsData.allJobsWithBatchParent, this.model);
+            Jobs.populateModelFromJobArray(this.model, JobsData.allJobsWithBatchParent);
 
             this.bus = {
                 emit: () => {

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -170,13 +170,6 @@ define([
                             byId: {
                                 jobToUpdate: this.starterJob,
                             },
-                            byStatus: {
-                                queued: {
-                                    jobToUpdate: true,
-                                },
-                            },
-                            batchId: null,
-                            jobsWithRetries: {},
                         },
                     },
                 };
@@ -202,13 +195,6 @@ define([
                             byId: {
                                 jobToUpdate: jobState,
                             },
-                            byStatus: {
-                                running: {
-                                    jobToUpdate: true,
-                                },
-                            },
-                            batchId: null,
-                            jobsWithRetries: {},
                         },
                     },
                 };
@@ -246,16 +232,6 @@ define([
                                 jobToUpdate: this.starterJob,
                                 'a brave new job': jobState,
                             },
-                            byStatus: {
-                                queued: {
-                                    jobToUpdate: true,
-                                },
-                                does_not_exist: {
-                                    'a brave new job': true,
-                                },
-                            },
-                            batchId: null,
-                            jobsWithRetries: {},
                         },
                     },
                 };

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -556,42 +556,15 @@ define(['common/jobs', '/test/data/jobsData', 'common/props', 'testUtil'], (Jobs
             TestUtil.clearRuntime();
         });
 
-        it('creates a model with jobs indexed by ID and by status', () => {
+        it('creates a model with jobs indexed by ID', () => {
             const model = Jobs.jobArrayToIndexedObject(JobsData.allJobsWithBatchParent);
-            const idIndex = model.byId,
-                statusIndex = model.byStatus;
-
-            const jobStatuses = {};
+            const idIndex = model.byId;
             expect(Object.keys(idIndex).sort()).toEqual(
                 JobsData.allJobsWithBatchParent
                     .map((jobState) => {
-                        jobStatuses[jobState.status] = 1;
                         return jobState.job_id;
                     })
                     .sort()
-            );
-            expect(Object.keys(statusIndex).sort()).toEqual(Object.keys(jobStatuses).sort());
-        });
-
-        it('collects retried jobs', () => {
-            const model = Jobs.jobArrayToIndexedObject(JobsData.batchJob.jobArray);
-            const idIndex = model.byId,
-                statusIndex = model.byStatus;
-
-            const jobStatuses = {};
-            expect(Object.keys(idIndex).sort()).toEqual(
-                JobsData.batchJob.jobArray
-                    .map((jobState) => {
-                        jobStatuses[jobState.status] = 1;
-                        return jobState.job_id;
-                    })
-                    .sort()
-            );
-
-            expect(Object.keys(statusIndex).sort()).toEqual(Object.keys(jobStatuses).sort());
-            expect(model.batchId).toEqual('job-created');
-            expect(Object.keys(model.jobsWithRetries).sort()).toEqual(
-                JobsData.batchJob.jobsWithRetries.sort()
             );
         });
 
@@ -599,13 +572,8 @@ define(['common/jobs', '/test/data/jobsData', 'common/props', 'testUtil'], (Jobs
             const model = Jobs.jobArrayToIndexedObject([]);
             expect(model).toEqual({
                 byId: {},
-                byStatus: {},
-                // jobsWithRetries: new Set(),
-                jobsWithRetries: {},
-                batchId: null,
             });
             expect(model.byId).toEqual({});
-            expect(model.byStatus).toEqual({});
         });
     });
 });

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -521,7 +521,7 @@ define(['common/jobs', '/test/data/jobsData', 'common/props', 'testUtil'], (Jobs
     describe('populateModelFromJobArray', () => {
         it('dies without a model', () => {
             expect(() => {
-                Jobs.populateModelFromJobArray([]);
+                Jobs.populateModelFromJobArray();
             }).toThrowError(/Missing a model to populate/);
         });
         it('create removes existing jobs and jobState data with an empty jobs array', () => {
@@ -535,7 +535,7 @@ define(['common/jobs', '/test/data/jobsData', 'common/props', 'testUtil'], (Jobs
                 },
             });
             expect(model.getItem('exec')).toEqual({ jobs: {}, jobState: {}, limo: 'Rolls Royce' });
-            Jobs.populateModelFromJobArray([], model);
+            Jobs.populateModelFromJobArray(model, []);
             expect(model.getItem('exec')).toEqual({ limo: 'Rolls Royce' });
         });
 
@@ -545,7 +545,7 @@ define(['common/jobs', '/test/data/jobsData', 'common/props', 'testUtil'], (Jobs
                 }),
                 batchData = JobsData.batchJob;
             expect(model.getItem('exec')).toBeUndefined();
-            Jobs.populateModelFromJobArray(batchData.jobArray, model);
+            Jobs.populateModelFromJobArray(model, batchData.jobArray);
             expect(model.getItem('exec.jobState')).toEqual(batchData.jobsById[batchData.batchId]);
             expect(model.getItem('exec.jobs.byId')).toEqual(batchData.jobsById);
         });

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -1,4 +1,4 @@
-define(['common/jobs', '/test/data/jobsData', 'testUtil'], (Jobs, JobsData, TestUtil) => {
+define(['common/jobs', '/test/data/jobsData', 'common/props', 'testUtil'], (Jobs, JobsData, Props, TestUtil) => {
     'use strict';
 
     function arrayToHTML(array) {
@@ -28,12 +28,6 @@ define(['common/jobs', '/test/data/jobsData', 'testUtil'], (Jobs, JobsData, Test
         'validJobStatuses',
         'validStatusesForAction',
     ];
-
-    const jobsByStatus = {};
-    // N.b. only one job of each status is saved here
-    JobsData.allJobs.forEach((job) => {
-        jobsByStatus[job.status] = job;
-    });
 
     describe('Test Jobs module', () => {
         afterEach(() => {
@@ -78,7 +72,7 @@ define(['common/jobs', '/test/data/jobsData', 'testUtil'], (Jobs, JobsData, Test
         });
 
         it('Should know how to tell good job states', () => {
-            JobsData.allJobs
+            JobsData.allJobsWithBatchParent
                 .concat([
                     {
                         job_id: 'zero_created',
@@ -126,7 +120,7 @@ define(['common/jobs', '/test/data/jobsData', 'testUtil'], (Jobs, JobsData, Test
             canRetry: 'retry',
         };
         describe(`the ${fn} function`, () => {
-            JobsData.allJobs.forEach((jobState) => {
+            JobsData.allJobsWithBatchParent.forEach((jobState) => {
                 it(`should respond ${jobState.meta[fn]} for ${jobState.job_id}`, () => {
                     expect(Jobs[fn](jobState)).toBe(jobState.meta[fn]);
                     expect(Jobs.canDo(actions[fn], jobState)).toBe(jobState.meta[fn]);
@@ -206,7 +200,7 @@ define(['common/jobs', '/test/data/jobsData', 'testUtil'], (Jobs, JobsData, Test
                 expect(Jobs.jobAction({ status: item })).toEqual(null);
             });
         });
-        JobsData.allJobs.forEach((state) => {
+        JobsData.allJobsWithBatchParent.forEach((state) => {
             it(`should generate a job action with the job state ${state.status}`, () => {
                 expect(Jobs.jobAction(state)).toEqual(state.meta.jobAction);
             });
@@ -524,26 +518,58 @@ define(['common/jobs', '/test/data/jobsData', 'testUtil'], (Jobs, JobsData, Test
         });
     });
 
+    describe('populateModelFromJobArray', () => {
+        it('dies without a model', () => {
+            expect(() => {
+                Jobs.populateModelFromJobArray([]);
+            }).toThrowError(/Missing a model to populate/);
+        });
+        it('create removes existing jobs and jobState data with an empty jobs array', () => {
+            const model = Props.make({
+                data: {
+                    exec: {
+                        jobs: {},
+                        jobState: {},
+                        limo: 'Rolls Royce',
+                    },
+                },
+            });
+            expect(model.getItem('exec')).toEqual({ jobs: {}, jobState: {}, limo: 'Rolls Royce' });
+            Jobs.populateModelFromJobArray([], model);
+            expect(model.getItem('exec')).toEqual({ limo: 'Rolls Royce' });
+        });
+
+        it('adds the expected structures to jobs and jobState, batch job', () => {
+            const model = Props.make({
+                    data: {},
+                }),
+                batchData = JobsData.batchJob;
+            expect(model.getItem('exec')).toBeUndefined();
+            Jobs.populateModelFromJobArray(batchData.jobArray, model);
+            expect(model.getItem('exec.jobState')).toEqual(batchData.jobsById[batchData.batchId]);
+            expect(model.getItem('exec.jobs.byId')).toEqual(batchData.jobsById);
+        });
+    });
+
     describe('jobArrayToIndexedObject', () => {
         afterEach(() => {
             TestUtil.clearRuntime();
         });
 
         it('creates a model with jobs indexed by ID and by status', () => {
-            const model = Jobs.jobArrayToIndexedObject(JobsData.allJobs);
+            const model = Jobs.jobArrayToIndexedObject(JobsData.allJobsWithBatchParent);
             const idIndex = model.byId,
                 statusIndex = model.byStatus;
 
             const jobStatuses = {};
             expect(Object.keys(idIndex).sort()).toEqual(
-                JobsData.allJobs
+                JobsData.allJobsWithBatchParent
                     .map((jobState) => {
                         jobStatuses[jobState.status] = 1;
                         return jobState.job_id;
                     })
                     .sort()
             );
-
             expect(Object.keys(statusIndex).sort()).toEqual(Object.keys(jobStatuses).sort());
         });
 

--- a/test/unit/spec/util/jobLogViewerSpec.js
+++ b/test/unit/spec/util/jobLogViewerSpec.js
@@ -10,11 +10,7 @@ define([
 
     const cssBaseClass = JobLogViewer.cssBaseClass;
 
-    const jobsByStatus = {};
-    // N.b. this only saves one job of each type
-    JobsData.allJobs.forEach((job) => {
-        jobsByStatus[job.status] = job;
-    });
+    const jobsByStatus = JobsData.jobsByStatus;
 
     const endStates = ['completed', 'error', 'terminated'];
     const queueStates = ['created', 'estimating', 'queued'];
@@ -275,7 +271,7 @@ define([
                 itHasJobStatus();
             });
 
-            JobsData.validJobs.forEach((jobState) => {
+            JobsData.allJobs.forEach((jobState) => {
                 describe(`should create a string for status ${jobState.status}`, () => {
                     beforeEach(async function () {
                         this.jobState = jobState;
@@ -321,7 +317,7 @@ define([
                 itHasJobStatusHistory();
             });
 
-            JobsData.validJobs.forEach((jobState) => {
+            JobsData.allJobs.forEach((jobState) => {
                 describe(`should create an array in history mode for status ${jobState.status}`, () => {
                     beforeEach(async function () {
                         this.jobState = jobState;
@@ -456,7 +452,7 @@ define([
                             firstCall = false;
                             this.runtimeBus.send(
                                 ...formatMessage(jobId, 'status', {
-                                    jobState: jobsByStatus['running'],
+                                    jobState: jobsByStatus['running'][0],
                                 })
                             );
                         } else {
@@ -484,8 +480,8 @@ define([
                         expect(Jobs.isValidJobStateObject.calls.count()).toEqual(2);
                         const allCallArgs = Jobs.isValidJobStateObject.calls.allArgs();
                         expect(allCallArgs[0][0]).toEqual(state);
-                        expect(allCallArgs[1][0]).toEqual(jobsByStatus['running']);
-                        this.jobState = jobsByStatus['running'];
+                        expect(allCallArgs[1][0]).toEqual(jobsByStatus['running'][0]);
+                        this.jobState = jobsByStatus['running'][0];
                         testJobStatus(this);
                     });
                 });
@@ -500,7 +496,7 @@ define([
 
             // job not found: logs container is removed
             it('should not render logs if the job is not found', async function () {
-                const jobState = jobsByStatus['does_not_exist'];
+                const jobState = jobsByStatus['does_not_exist'][0];
                 const jobId = jobState.job_id;
 
                 this.runtimeBus.on('request-job-status', (msg) => {
@@ -525,7 +521,7 @@ define([
             // queued jobs: message to say that the logs will be available when job runs
             queueStates.forEach((queueState) => {
                 it(`should render a queued message for "${queueState}" jobs`, async function () {
-                    const jobState = jobsByStatus[queueState];
+                    const jobState = jobsByStatus[queueState][0];
                     const jobId = jobState.job_id;
 
                     this.runtimeBus.on('request-job-status', (msg) => {
@@ -552,7 +548,7 @@ define([
 
             // running job: job logs are updated as they are received
             it('Should render job logs whilst job is running', async function () {
-                const jobState = jobsByStatus['running'];
+                const jobState = jobsByStatus['running'][0];
                 const jobId = jobState.job_id;
 
                 // lines to return each time there is a request for the latest logs
@@ -605,7 +601,7 @@ define([
 
             // job running, job logs have been deleted
             it(`should render a message when logs are deleted, state running`, async function () {
-                const jobState = jobsByStatus['running'];
+                const jobState = jobsByStatus['running'][0];
                 const jobId = jobState.job_id;
 
                 this.runtimeBus.on('request-job-status', (msg) => {
@@ -645,7 +641,7 @@ define([
             endStates.forEach((endState) => {
                 // completed statuses - should be one request for logs
                 it(`Should render all job logs if the job status is ${endState}`, async function () {
-                    const jobState = jobsByStatus[endState];
+                    const jobState = jobsByStatus[endState][0];
                     const jobId = jobState.job_id;
 
                     this.runtimeBus.on('request-job-status', (msg) => {
@@ -674,7 +670,7 @@ define([
                 // create a mutation observer to watch for changes to the log-panel node; when those changes
                 // occur, `callback` will be run to test that the changes are as expected
                 it(`should render a message when logs are deleted, state ${endState}`, async function () {
-                    const jobState = jobsByStatus[endState];
+                    const jobState = jobsByStatus[endState][0];
                     const jobId = jobState.job_id;
 
                     this.runtimeBus.on('request-job-status', (msg) => {


### PR DESCRIPTION
# Description of PR purpose/changes

- added the batch parent to the set of jobs in `exec.jobs`
- implementing proper batch handling in the job cancel and retry functions
- added a batch job cancel function to be hooked up to the cell 'Cancel' button
- test updates
 
The bus creation tests seem to be broken... I will take a look at them and fix them either in this PR or the next one.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-532
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see that the job status table now has an extra line representing the batch parent job. It will be removed in an upcoming pull request.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
