### PR TITLE
DATAUP-532: enable batch queries in the frontend

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -21,28 +21,27 @@ All the `request-job-*` requests take as arguments either a single job ID string
 
 `request-job-status` - gets the status for a job or an array of jobs.
   * `jobId` - a string, the job id OR
-  * `jobIdList` - an array of job IDs
-  * `parentJobId` - (optional) a string, the id of the requested job's "parent" job
+  * `jobIdList` - an array of job IDs OR
+  * `batchId` - a batch parent (make the request for all jobs in the batch)
 
 `request-job-updates-start` - request the status for a job or jobs, but start an update cycle so that it's continually requested.
   * `jobId` - a string, the job id OR
-  * `jobIdList` - an array of job IDs
-  * `parentJobId` - (optional) a string, the id of the requested job's "parent" job
+  * `jobIdList` - an array of job IDs OR
+  * `batchId` - a batch parent (make the request for all jobs in the batch)
 
 `request-job-updates-stop` - signal that the front end doesn't need any more updates for the specified job(s), so stop sending them for each loop cycle. Doesn't actually end the job, only requests for updates.
   * `jobId` - a string, the job id OR
-  * `jobIdList` - an array of job IDs
-  * `parentJobId` - (optional) a string, the id of the requested job's "parent" job
+  * `jobIdList` - an array of job IDs OR
+  * `batchId` - a batch parent (make the request for all jobs in the batch)
 
 `request-job-info` - request information about the job(s), specifically app id, spec, input parameters and (if finished) outputs
   * `jobId` - a string, the job id OR
-  * `jobIdList` - an array of job IDs
-  * `parentJobId` - (optional) a string, the id of the requested job's "parent" job
+  * `jobIdList` - an array of job IDs OR
+  * `batchId` - a batch parent (make the request for all jobs in the batch)
 
-`request-job-cancellation` - request that the server cancel the running job(s)
+`request-job-cancel` - request that the server cancel the running job(s)
   * `jobId` - a string, the job id OR
   * `jobIdList` - an array of job IDs
-  * `parentJobId` - (optional) a string, the id of the requested job's "parent" job
 
 `request-job-retry` - request that the server rerun a job or set of jobs
   * `jobId` - a string, the job id OR
@@ -214,35 +213,29 @@ These are organized by the `request_type` field, followed by the expected respon
 `all_status` - request the status of all currently running jobs, responds with `job_status_all`
 
 `job_status` - request job status, responds with `job_status` for each job
-* `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
+* `job_id` - string OR `job_id_list` - array of strings OR `batch_id` - string
 
 `start_update_loop` - request starting the global job status update thread, no specific response, but generally with `job_status_all`
 
 `stop_update_loop` - request stopping the global job status update thread, no response
 
 `start_job_update` - request updating job(s) during the update thread, no specific response, but generally with `job_status`
-* `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
+* `job_id` - string OR `job_id_list` - array of strings OR `batch_id` - string
 
 `stop_job_update` - request halting update for job(s) during the update thread, no response
-* `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
+* `job_id` - string OR `job_id_list` - array of strings OR `batch_id` - string
 
 `job_info` - request general information about job(s), responds with `job_info` for each job
-* `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
+* `job_id` - string OR `job_id_list` - array of strings OR `batch_id` - string
 
 `job_logs` - request job log information, responds with `job_logs` for each job
 * `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
 * `first_line` - int >= 0, ignored if `latest` is `true`
 * `num_lines` - int > 0
 * `latest` - boolean, `true` if requesting just the latest logs
 
 `cancel_job` - cancel a job or list of jobs; responds with `job_statuses`
 * `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
 
 `retry_job` - retry a job or list of jobs, responds with `jobs_retried` and `new_job`
 * `job_id` - string OR `job_id_list` - array of strings

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -380,11 +380,11 @@ define([
                             {
                                 job: {
                                     jobState: jobRetried.job.state,
-                                    widgetParameters: jobRetried.job.widget_info,
+                                    outputWidgetInfo: jobRetried.job.widget_info,
                                 },
                                 retry: {
                                     jobState: jobRetried.retry.state,
-                                    widgetParameters: jobRetried.retry.widget_info,
+                                    outputWidgetInfo: jobRetried.retry.widget_info,
                                 },
                             }
                         );

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -17,7 +17,7 @@ define(['common/jobMessages', 'common/jobs'], (JobMessages, Jobs) => {
 
     const jobCommand = {
         cancel: {
-            command: 'request-job-cancellation',
+            command: 'request-job-cancel',
             listener: 'job-canceled',
         },
         retry: {

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1234,7 +1234,7 @@ define([
          * narrative metadata.
          */
         function cancelJob(jobId) {
-            runtime.bus().emit('request-job-cancellation', {
+            runtime.bus().emit('request-job-cancel', {
                 jobId: jobId,
             });
         }

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -564,7 +564,7 @@ define([
                 cancel: {
                     valid: Jobs.validStatusesForAction.cancel,
                     invalid: [],
-                    request: 'cancellation',
+                    request: 'cancel',
                 },
                 retry: {
                     valid: Jobs.validStatusesForAction.retry,


### PR DESCRIPTION
# Description of PR purpose/changes

The backend will soon be able to accept info/status/start updates/stop updates requests for all jobs in a batch, so this PR puts the frontend machinery in the `jobCommChannel.js` module in place.

I also made the FE job request naming conventions more uniform.

- Adding new batch queries into the job comm channel
- Converting "request-job-cancellation" => "request-job-cancel" for a more uniform API experience
- Updating job management docs

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-532
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
