### PR TITLE
Ensure that narrative deals with empty results

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -109,6 +109,9 @@ class JobManager(object):
         Given a list of job IDs, creates job objects for them and populates the _running_jobs dictionary
         """
         job_ids = [job_id for job_id in job_ids if job_id not in self._running_jobs]
+        if not len(job_ids):
+            return {}
+
         job_states = clients.get("execution_engine2").check_jobs(
             {
                 "job_ids": job_ids,
@@ -232,6 +235,9 @@ class JobManager(object):
         # return all.
         if not isinstance(job_ids, list):
             raise ValueError("job_ids must be a list")
+
+        if not len(job_ids):
+            return {}
 
         job_states = dict()
         jobs_to_lookup = list()

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -208,6 +208,25 @@ class JobManagerTest(unittest.TestCase):
             },
         )
 
+    def test__construct_job_state_set__empty_list(self):
+        self.assertEqual(
+            self.jm._construct_job_state_set([]),
+            {}
+        )
+
+    def test__create_jobs__empty_list(self):
+        self.assertEqual(
+            self.jm._create_jobs([]),
+            {}
+        )
+
+    def test__create_jobs__jobs_already_exist(self):
+        job_list = self.jm._running_jobs.keys()
+        self.assertEqual(
+            self.jm._create_jobs(job_list),
+            {}
+        )
+
     def test_get_job_good(self):
         job_id = self.job_ids[0]
         job = self.jm.get_job(job_id)


### PR DESCRIPTION
# Description of PR purpose/changes

Ensures that `_create_jobs` and `_construct_job_state_set` return early if there are no jobs to create or construct a job state set for.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-532
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see that nothing has changed

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
