### PR TITLE
DATAUP-532: simplify BE messages to FE

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -205,7 +205,6 @@ These are organized by the `request_type` field, followed by the expected respon
     "data": {
       "request_type": "job_status",
       "job_id": "a_job_id",
-      "parent_job_id": "another_job_id"
     }
   }
 }
@@ -217,7 +216,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
-`job_status_batch` request job statuses, responds with `job_status_batch`
+`job_status_batch` request job statuses, responds with `job_status`
 * `job_id` - string - job_id of batch container job
 
 `start_update_loop` - request starting the global job status update thread, no specific response, but generally with `job_status_all`
@@ -236,7 +235,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
-`job_info_batch` - request general information about jobs, responds with `job_info_batch`
+`job_info_batch` - request general information about jobs, responds with `job_info`
 * `job_id` - string - job_id of batch container job
 
 `job_logs` - request job log information, responds with `job_logs` for each job
@@ -246,7 +245,7 @@ These are organized by the `request_type` field, followed by the expected respon
 * `num_lines` - int > 0
 * `latest` - boolean, `true` if requesting just the latest logs
 
-`cancel_job` - cancel a job or list of jobs; responds with `job_status_batch`
+`cancel_job` - cancel a job or list of jobs; responds with `job_status`
 * `job_id` - string OR `job_id_list` - array of strings
 * `parent_job_id` - optional string
 
@@ -275,12 +274,14 @@ a specific example:
   "data": {
     "msg_type": "job_status",
     "content": {
-      "state": {
-        "status": "running",
-        ... other state keys ...
-      },
-      "spec": {},
-      "widget_info": {}
+      "example_job_id": {
+        "state": {
+          "job_id": "example_job_id",
+          "status": "running",
+          ... other state keys ...
+        },
+        "widget_info": {}
+      }
     }
   }
 }
@@ -313,54 +314,54 @@ A general job comm error, capturing most errors that get thrown by the kernel
 Includes information about the running job
 
 **content**
+Dictionary with key(s) job ID and value dictionaries with the following structure:
   * `app_id` - string, the app id (format = `module_name/app_name`)
   * `app_name` - string, the human-readable app name
   * `job_id` - string, the job id
   * `job_params` - the unstructured set of parameters sent to the execution engine
   * `batch_id` - id of batch container job
 
-**bus** - `job-info`
-
-### `job_info_batch`
-Includes information about the jobs
-
-**content**
+i.e.
 ```json
 {
-  "job_id_1": { ...contents... },
+  "job_id_1": {
+    "app_id": ...,
+    "app_name": ...,
+    "job_id": "job_id_1",
+    "job_params": ...,
+    "batch_id": "some_batch_id",
+  },
   "job_id_2": { ...contents... }
 }
 ```
-Where the inner objects' format is the same as for `job_info`, i.e., they have the keys
-  * `app_id` - string, the app id (format = `module_name/app_name`)
-  * `app_name` - string, the human-readable app name
-  * `job_id` - string, the job id
-  * `job_params` - the unstructured set of parameters sent to the execution engine
-  * `batch_id` - id of batch container job
+
+**bus** - `job-info`
 
 ### `job_status`
 The current job state. This one is probably most common.
 
 **content**
+Dictionary with key(s) job ID and value dictionaries with the following structure:
   * `state` - see **Data Structures** below for details (it's big and shouldn't be repeated all over this document). Non-existent jobs have the status `does_not_exist`
   * `widget_info` - the parameters to send to output widgets, only available for a completed job
   * `user` - string, username of user who submitted the job
 
-**bus** - `job-status`
-
-## `job_status_batch`
-The current job states for some jobs. The format is the same as for `job_status_all`.
-
-**content**
+Sample response JSON:
 ```json
 {
-  "job_id_1": { ...contents... },
+  "job_id_1": {
+    "state": {
+      "job_id": "job_id_1",
+      "status": "running",
+      ...
+    },
+    "widget_info": null, // only available for completed jobs
+  },
   "job_id_2": { ...contents... }
 }
 ```
-Where the inner objects' format is the BE Output State described in the Data Structures section.
 
-**bus** - a series of `job-status` messages
+**bus** - `job-status`
 
 ### `job_status_all`
 The set of all job states for all running jobs, or at least the set that should be updated (those that are complete and not requested by the front end are not included - if a job is sitting in an error or finished state, it doesn't need ot have its app cell updated)

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -760,9 +760,6 @@ class JobCommTestCase(unittest.TestCase):
         req = make_comm_msg("job_info", job_id, False)
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
-        import json
-
-        print(json.dumps(msg, indent=2, sort_keys=True))
         self.assertEqual(msg["data"]["msg_type"], "job_info")
         self.assertEqual(
             msg["data"]["content"],

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -209,23 +209,14 @@ class JobManagerTest(unittest.TestCase):
         )
 
     def test__construct_job_state_set__empty_list(self):
-        self.assertEqual(
-            self.jm._construct_job_state_set([]),
-            {}
-        )
+        self.assertEqual(self.jm._construct_job_state_set([]), {})
 
     def test__create_jobs__empty_list(self):
-        self.assertEqual(
-            self.jm._create_jobs([]),
-            {}
-        )
+        self.assertEqual(self.jm._create_jobs([]), {})
 
     def test__create_jobs__jobs_already_exist(self):
         job_list = self.jm._running_jobs.keys()
-        self.assertEqual(
-            self.jm._create_jobs(job_list),
-            {}
-        )
+        self.assertEqual(self.jm._create_jobs(job_list), {})
 
     def test_get_job_good(self):
         job_id = self.job_ids[0]


### PR DESCRIPTION

# Description of PR purpose/changes

Updating backend to send results of job info and job status queries as a dictionary keyed by job ID with status or info as the value.
Switch all messages to respond with either `job-info` or `job-status` for simplicity.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-532
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
