### PR TITLE
DATAUP-532: change backend response types

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -99,14 +99,6 @@ When the kernel sends a message to the front end, the only module set up to list
 
 ### Job-related
 
-`job-canceled` - sent when a job has been canceled in the kernel, as a response to other messages
-  * `jobId` - string, the job id
-  * `via` - string, generally "job_canceled"
-
-`job-cancel-error` - a cancel request has thrown an error
-  * `jobId` - string, the job id
-  * `message` - string, a reason for the error
-
 `job-does-not-exist` - sent in response to a request for information about a job that doesn't exist. Jobs might not exist if (1) they have been previously canceled, or (2) a malformed request was sent.
   * `jobId` - string, the job id
   * `source` - string, the source of the message in the kernel (what service, or module, was invoked. Usually "JobManager" or "ExecutionEngine2")

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -189,7 +189,9 @@ class JobComm:
 
     def _verify_job_id(self, req: JobRequest) -> None:
         if not req.job_id:
-            self.send_error_message("job_does_not_exist", req)
+            self.send_error_message(
+                "job_comm_error", req, {"message": "No job ID supplied"}
+            )
             raise NoJobException(f"Job id required to process {req.request} request")
 
     def _verify_job_id_list(self, req: JobRequest) -> None:
@@ -197,7 +199,9 @@ class JobComm:
             raise TypeError("List expected for job_id_list")
         req.job_id_list[:] = [job_id for job_id in req.job_id_list if job_id]
         if len(req.job_id_list) == 0:
-            self.send_error_message("job_does_not_exist", req)
+            self.send_error_message(
+                "job_comm_error", req, {"message": "No job IDs supplied"}
+            )
             raise NoJobException("No valid job ids")
 
     def start_job_status_loop(self, *args, **kwargs) -> None:

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -313,8 +313,7 @@ class JobManager(object):
                 jobs_to_lookup.append(job_id)
         if len(jobs_to_lookup) > 0:
             return self._construct_job_state_set(jobs_to_lookup)
-        else:
-            return dict()
+        return dict()
 
     def register_new_job(self, job: Job, refresh: int = 0) -> None:
         """
@@ -332,12 +331,11 @@ class JobManager(object):
     def get_job(self, job_id):
         """
         Returns a Job with the given job_id.
-        Raises a ValueError if not found.
+        Raises a NoJobException if not found.
         """
         if job_id in self._running_jobs:
             return self._running_jobs[job_id]["job"]
-        else:
-            raise NoJobException(f"No job present with id {job_id}")
+        raise NoJobException(f"No job present with id {job_id}")
 
     def get_job_logs(
         self,


### PR DESCRIPTION
# Description of PR purpose/changes

If there is no input, use the `job_comm_error` message instead of `job_does_not_exist`

# Jira Ticket / Issue 
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-532
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
