### PR TITLE
DATAUP-556 Instantiate Job with EE2 State

### DIFF
--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -324,7 +324,7 @@ class Job(object):
                     JOB_INIT_EXCLUDED_JOB_STATE_FIELDS
                     if init else
                     EXCLUDED_JOB_STATE_FIELDS
-                )
+                ),
             }
         )
 
@@ -340,7 +340,8 @@ class Job(object):
                     JOB_INIT_EXCLUDED_JOB_STATE_FIELDS
                     if init else
                     EXCLUDED_JOB_STATE_FIELDS
-                )
+                ),
+                "return_list": 0,
             }
         )
 

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -526,32 +526,30 @@ class JobManager(object):
         Update a batch job and create child jobs if necessary
         """
         parent_job = self.get_job(batch_id)
-
         if not parent_job.batch_job:
             raise NotBatchException("Not a batch job")
 
         old_child_ids = parent_job.child_jobs
         parent_job.state(force_refresh=True)
-        child_ids = parent_job.child_jobs
+        cur_child_ids = parent_job.child_jobs
 
-        if sorted(child_ids) != sorted(old_child_ids):
+        if sorted(old_child_ids) != sorted(cur_child_ids):
+            reg_cur_child_ids = [job_id for job_id in cur_child_ids if job_id in self._running_jobs]
+            unreg_cur_child_ids = [job_id for job_id in cur_child_ids if job_id not in self._running_jobs]
 
-            child_jobs = []
-            for child_id in child_ids:
-                if child_id in self._running_jobs:
-                    child_job = self._running_jobs[child_id]["job"]
-                else:
-                    child_job = Job.from_job_id(
-                        job_id=child_id
-                    )
-                    self.register_new_job(
-                        job=child_job,
-                        refresh=int(
-                            child_job.state().get("status") not in TERMINAL_STATUSES
-                        ),
-                    )
-                child_jobs.append(child_job)
+            reg_cur_child_jobs = [self.get_job(job_id) for job_id in reg_cur_child_ids]
+            unreg_cur_child_jobs = Job.from_job_ids(unreg_cur_child_ids)
 
-            parent_job.update_children(child_jobs)
+            cur_child_jobs = reg_cur_child_jobs + unreg_cur_child_jobs
 
-        return [batch_id] + child_ids
+            for job in unreg_cur_child_jobs:
+                self.register_new_job(
+                    job=job,
+                    refresh=int(
+                        job.state().get("status") not in TERMINAL_STATUSES
+                    ),
+                )
+
+            parent_job.update_children(cur_child_jobs)
+
+        return [batch_id] + cur_child_ids

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -1,5 +1,11 @@
 import biokbase.narrative.clients as clients
-from .job import Job, TERMINAL_STATUSES, EXCLUDED_JOB_STATE_FIELDS, get_dne_job_state
+from .job import (
+    Job,
+    TERMINAL_STATUSES,
+    EXCLUDED_JOB_STATE_FIELDS,
+    JOB_INIT_EXCLUDED_JOB_STATE_FIELDS,
+    get_dne_job_state,
+)
 from biokbase.narrative.common import kblogging
 from IPython.display import HTML
 from jinja2 import Template
@@ -26,10 +32,6 @@ instance in its current state.
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 __version__ = "0.0.1"
 
-JOB_INIT_EXCLUDED_JOB_STATE_FIELDS = [
-    f for f in EXCLUDED_JOB_STATE_FIELDS if f != "job_input"
-]
-
 
 class JobManager(object):
     """
@@ -50,7 +52,8 @@ class JobManager(object):
             JobManager.__instance = object.__new__(cls)
         return JobManager.__instance
 
-    def _reorder_parents_children(self, states: dict) -> dict:
+    @staticmethod
+    def _reorder_parents_children(states: dict) -> dict:
         ordering = []
         for job_id, state in states.items():
             if state.get("batch_job"):
@@ -99,7 +102,7 @@ class JobManager(object):
                 ]
 
             self.register_new_job(
-                job=Job.from_state(job_state, children=child_jobs),
+                job=Job(job_state, children=child_jobs),
                 refresh=int(job_state.get("status") not in TERMINAL_STATUSES),
             )
 
@@ -121,7 +124,7 @@ class JobManager(object):
         )
         for job_state in job_states.values():
             # set new jobs to be automatically refreshed
-            self.register_new_job(job=Job.from_state(job_state), refresh=1)
+            self.register_new_job(job=Job(job_state), refresh=1)
 
         return job_states
 
@@ -538,7 +541,9 @@ class JobManager(object):
                 if child_id in self._running_jobs:
                     child_job = self._running_jobs[child_id]["job"]
                 else:
-                    child_job = Job.from_attributes(job_id=child_id)
+                    child_job = Job.from_job_id(
+                        job_id=child_id
+                    )
                     self.register_new_job(
                         job=child_job,
                         refresh=int(

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -6,6 +6,8 @@ import copy
 RANDOM_DATE = "2018-08-10T16:47:36+0000"
 RANDOM_TYPE = "ModuleA.TypeA-1.0"
 
+WSID_STANDARD = 12345
+
 
 class MockClients:
     """
@@ -81,13 +83,13 @@ class MockClients:
     def get_workspace_info(self, params):
         """
         Some magic workspace ids.
-        12345 - the standard one.
+        12345 (WSID_STANDARD) - the standard one.
         678 - doesn't have useful narrative info in its metadata
         789 - raises a permissions error
         890 - raises a deleted workspace error
         otherwise, returns workspace info with narrative = 1, and narrative name = 'Fake'
         """
-        wsid = params.get("id", 12345)
+        wsid = params.get("id", WSID_STANDARD)
         name = params.get("workspace", "some_workspace")
         if wsid == 678:
             return [
@@ -159,7 +161,7 @@ class MockClients:
                         "2018-06-26T19:31:41+0000",
                         1,
                         "wjriehl",
-                        12345,
+                        WSID_STANDARD,
                         "random_workspace",
                         "a20f2df66f973de41b84164f2c2bedd3",
                         765,
@@ -175,7 +177,7 @@ class MockClients:
                         "2018-08-13T23:13:09+0000",
                         1,
                         "wjriehl",
-                        12345,
+                        WSID_STANDARD,
                         "random_workspace",
                         "9f014a3c08368537a40fa2e4b90f9cab",
                         757,
@@ -311,7 +313,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ]
                 },
@@ -326,7 +328,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ]
                 },
@@ -341,7 +343,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ]
                 },
@@ -356,7 +358,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ]
                 },
@@ -371,7 +373,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ]
                 },
@@ -386,7 +388,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ]
                 },
@@ -401,7 +403,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ],
                     "dp_info": {"ref": dp_ref, "refs": [dp_ref]},
@@ -417,7 +419,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        12345,
+                        WSID_STANDARD,
                         None,
                     ],
                     "dp_info": {"ref": dp_ref, "refs": [dp_ref]},

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -212,7 +212,7 @@ class MockClients:
         return self.test_job_id
 
     def run_job_batch(self, batch_job_inputs, batch_params):
-        child_job_ids = [self.test_job_id for i in range(len(batch_job_inputs))]
+        child_job_ids = [self.test_job_id + f"_child_{i}" for i in range(len(batch_job_inputs))]
         return {BATCH_ID_KEY: self.test_job_id, "child_job_ids": child_job_ids}
 
     def cancel_job(self, job_id):
@@ -462,6 +462,9 @@ class FailingMockClient:
 
     def check_workspace_jobs(self, params):
         raise ServerError("JSONRPCError", -32000, "Job lookup failed.")
+
+    def check_job(self, params):
+        raise ServerError("JSONRPCError", -32000, "Check job failed")
 
     def cancel_job(self, params):
         raise ServerError("JSONRPCError", -32000, "Can't cancel job")

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -313,7 +313,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ]
                 },
@@ -328,7 +328,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ]
                 },
@@ -343,7 +343,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ]
                 },
@@ -358,7 +358,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ]
                 },
@@ -373,7 +373,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ]
                 },
@@ -388,7 +388,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ]
                 },
@@ -403,7 +403,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ],
                     "dp_info": {"ref": dp_ref, "refs": [dp_ref]},
@@ -419,7 +419,7 @@ class MockClients:
                         ws_id,
                         ws_name,
                         "checksum",
-                        WSID_STANDARD,
+                        12345,
                         None,
                     ],
                     "dp_info": {"ref": dp_ref, "refs": [dp_ref]},

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -715,7 +715,7 @@ class JobTest(unittest.TestCase):
             got = Job.query_ee2_state(job_id, init=False)
             self.assertEqual(exp, got)
 
-    @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client) 
+    @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_query_job_states(self):
         states = Job.query_ee2_states(ALL_JOBS, init=True)
         for job_id, got in states.items():

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -36,15 +36,18 @@ def capture_stdout():
 
 
 config = ConfigTests()
+sm = SpecManager()
 TEST_JOBS = config.load_json_file(config.get("jobs", "ee2_job_info_file"))
 with mock.patch("biokbase.narrative.jobs.jobmanager.clients.get", get_mock_client):
-    sm = SpecManager()
     sm.reload()
     TEST_SPECS = copy.deepcopy(sm.app_specs)
+sm.reload()  # get live data
+LIVE_SPECS = copy.deepcopy(sm.app_specs)
 
 
-def get_test_spec(tag, app_id):
-    return copy.deepcopy(TEST_SPECS[tag][app_id])
+def get_test_spec(tag, app_id, live=False):
+    specs = LIVE_SPECS if live else TEST_SPECS
+    return copy.deepcopy(specs[tag][app_id])
 
 
 def get_test_job(job_id):

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -1,6 +1,7 @@
 import unittest
 import mock
 import copy
+from biokbase.workspace.baseclient import ServerError
 from biokbase.narrative.app_util import map_inputs_from_job, map_outputs_from_state
 from biokbase.narrative.jobs.job import (
     Job,
@@ -32,11 +33,6 @@ def capture_stdout():
         yield sys.stdout, sys.stderr
     finally:
         sys.stdout, sys.stderr = old_out, old_err
-
-
-def mock_job_state(self, force_refresh=False):
-    """Mock job.state() to avoid ee2 calls"""
-    return self._augment_ee2_state(self._acc_state)
 
 
 config = ConfigTests()
@@ -98,7 +94,7 @@ saved_jobs = {
     BATCH_RETRY_ERROR: True,
 }
 
-ALL_JOBS = saved_jobs.keys()
+ALL_JOBS = list(saved_jobs.keys())
 FINISHED_JOBS = []
 ACTIVE_JOBS = []
 for key, value in saved_jobs.items():
@@ -108,89 +104,50 @@ for key, value in saved_jobs.items():
         ACTIVE_JOBS.append(key)
 
 
-JOB_KWARGS = [
-    "app_version",
-    "batch_id",
-    "batch_job",
-    "child_jobs",
-    "cell_id",
-    "run_id",
-    "tag",
-]
-
-
-def state_2_kwargs(state, transform_list=JOB_ATTRS):
-    """
-    transform job data into suitable input for creating a job object
-
-    params:
-
-    state           - raw job data, as emitted by ee2's check_job function
-    transform_list  - attributes to generate from the raw data.
-                        defaults to using JOB_ATTRS
-
-    """
-
-    job_input = state.get("job_input")
-    mapping = {
-        "app_id": job_input.get("app_id"),
-        "app_version": job_input.get("service_ver", None),
-        "batch_id": state.get("batch_id", None),
-        "batch_job": state.get("batch_job", False),
-        "cell_id": job_input.get("narrative_cell_info", {}).get("cell_id", None),
-        "child_jobs": state.get("child_jobs", []),
-        "extra_data": None,
-        "job_id": state.get("job_id"),
-        "params": job_input.get("params", {}),
-        "retry_ids": state.get("retry_ids", []),
-        "retry_parent": state.get("retry_parent", None),
-        "run_id": job_input.get("narrative_cell_info", {}).get("run_id", None),
-        "tag": job_input.get("narrative_cell_info", {}).get("tag", "release"),
-        "user": state["user"],
-    }
-
-    kwargs = {}
-    for key in transform_list:
-        kwargs[key] = mapping[key]
-
-    return kwargs
-
-
-def create_job_from_ee2(job_id, mode, children=None):
-    """
-    create a job object from raw job data
-    """
+def create_job_from_ee2(job_id, extra_data=None, children=None):
     state = get_test_job(job_id)
-
-    if mode == "attributes":
-        kwargs = state_2_kwargs(state)
-        job = Job.from_attributes(**kwargs, children=children)
-    elif mode == "state":
-        job = Job.from_state(state, children=children)
-
+    job = Job(state, extra_data=extra_data, children=children)
     return job
 
 
-def create_state_from_ee2(job_id, mode):
+def create_state_from_ee2(job_id, exclude_fields=JOB_INIT_EXCLUDED_JOB_STATE_FIELDS):
     """
     create the output of job.state() from raw job data
     """
     state = get_test_job(job_id)
 
-    for attr in JOB_INIT_EXCLUDED_JOB_STATE_FIELDS:
+    for attr in exclude_fields:
         if attr in state:
             del state[attr]
 
-    # Depending on if the job was initialized with kwargs
-    # or has been populated with actual ee2 state info,
-    # the tested state() may come out with limited fields.
-    # Restrict to JOB_ATTR fields here if needed
-    if mode == "attributes":
-        for k, v in state.copy().items():
-            if k not in JOB_ATTRS:
-                del state[k]
-
     return state
+
+
+def create_attrs_from_ee2(job_id):
+    state = get_test_job(job_id)
+
+    job_input = state.get("job_input", {})
+    narr_cell_info = job_input.get("narrative_cell_info", {})
+    attrs = dict(
+        app_id=job_input.get("app_id", JOB_ATTR_DEFAULTS["app_id"]),
+        app_version=job_input.get("service_ver", JOB_ATTR_DEFAULTS["app_version"]),
+        batch_id=(
+            state.get("job_id")
+            if state.get("batch_job", JOB_ATTR_DEFAULTS["batch_job"])
+            else state.get("batch_id", JOB_ATTR_DEFAULTS["batch_id"])
+        ),
+        batch_job=state.get("batch_job", JOB_ATTR_DEFAULTS["batch_job"]),
+        cell_id=narr_cell_info.get("cell_id", JOB_ATTR_DEFAULTS["cell_id"]),
+        child_jobs=state.get("child_jobs", JOB_ATTR_DEFAULTS["child_jobs"]),
+        job_id=state.get("job_id"),
+        params=job_input.get("params", JOB_ATTR_DEFAULTS["params"]),
+        retry_ids=state.get("retry_ids", JOB_ATTR_DEFAULTS["retry_ids"]),
+        retry_parent=state.get("retry_parent", JOB_ATTR_DEFAULTS["retry_parent"]),
+        run_id=narr_cell_info.get("run_id", JOB_ATTR_DEFAULTS["run_id"]),
+        tag=narr_cell_info.get("tag", JOB_ATTR_DEFAULTS["tag"]),
+        user=state.get("user", JOB_ATTR_DEFAULTS["user"]),
+    )
+    return attrs
 
 
 def get_widget_info(job_id):
@@ -273,180 +230,139 @@ class JobTest(unittest.TestCase):
             SpecManager().reload()
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
-    def _mocked_job(self, job_attrs=[]):
+    def _get_batch_family_jobs(self, return_list=False):
         """
-        create a mock job; any fields included in job_attrs will be omitted from the job params
+        As invoked in appmanager's run_app_bulk, i.e.,
+        with from_job_id(s)
         """
-        job_args = {
-            "job_id": self.job_id,
-            "app_id": self.app_id,
-            "params": self.params,
-            "user": self.user,
-        }
+        child_jobs = Job.from_job_ids(BATCH_CHILDREN, return_list=True)
+        batch_job = Job.from_job_id(
+            BATCH_PARENT,
+            children=child_jobs
+        )
 
-        for arg in JOB_KWARGS:
-            if not len(job_attrs) or arg not in job_attrs:
-                job_args[arg] = getattr(self, arg)
+        if return_list:
+            return [batch_job] + child_jobs
+        else:
+            return {
+                BATCH_PARENT: batch_job,
+                **{
+                    child_id: child_job
+                    for child_id, child_job in zip(BATCH_CHILDREN, child_jobs)
+                }
+            }
 
-        job = Job.from_attributes(**job_args)
+    def check_jobs_equal(self, jobl, jobr):
+        self.assertEqual(
+            jobl._acc_state,
+            jobr._acc_state
+        )
 
-        return job
+        with mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client):
+            self.assertEqual(
+                jobl.state(),
+                jobr.state()
+            )
 
-    def check_job_attrs(self, job, expected={}):
-        """
-        Check the attributes of a job against a dictionary of expected attributes
-        If the expected attribute is not supplied, the defaults set on this test object are used
-        """
-        with mock.patch.object(Job, "state", autospec=True) as m:
-            m.side_effect = mock_job_state
-            for attr in JOB_ATTRS:
-                if attr in expected:
-                    self.assertEqual(getattr(job, attr), expected[attr])
-                else:
-                    self.assertEqual(getattr(job, attr), getattr(self, attr))
+        for attr in JOB_ATTRS:
+            self.assertEqual(
+                getattr(jobl, attr),
+                getattr(jobr, attr)
+            )
 
-    def test_job_init__id_only(self):
-        job = Job.from_attributes(job_id=JOB_COMPLETED)
-        with mock.patch.object(Job, "state", autospec=True) as m:
-            m.side_effect = mock_job_state
-            for attr in JOB_ATTRS:
-                if attr == "job_id":
-                    self.assertEqual(job.job_id, JOB_COMPLETED)
-                else:
-                    self.assertEqual(getattr(job, attr), JOB_ATTR_DEFAULTS[attr])
+    def check_job_attrs_custom(self, job, exp_attr={}):
+        attr = dict(JOB_ATTR_DEFAULTS)
+        attr.update(exp_attr)
+        for name, value in attr.items():
+            self.assertEqual(value, getattr(job, name))
+
+    def check_job_attrs(self, job, job_id, exp_attrs={}):
+        # TODO check _acc_state full vs pruned, extra_data
+        state = create_state_from_ee2(job_id)
+        with mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client):
+            self.assertEqual(
+                state,
+                job.state()
+            )
+
+        attrs = create_attrs_from_ee2(job_id)
+        attrs.update(exp_attrs)
+
+        for name, value in attrs.items():
+            self.assertEqual(
+                value,
+                getattr(job, name)
+            )
 
     def test_job_init__error_no_job_id(self):
 
         with self.assertRaisesRegex(
             ValueError, "Cannot create a job without a job ID!"
         ):
-            Job.from_attributes(params={}, app_id="this/that")
+            Job({"params": {}, "app_id": "this/that"})
 
-    def test_job_init(self):
+    def test_job_init__from_job_id(self):
         """
-        test job initialisation, no defaults used
+        test job initialisation, as is done by run_app
         """
-        job = self._mocked_job()
-        self.check_job_attrs(job)
+        for job_id in ALL_JOBS:
+            if job_id == BATCH_PARENT:
+                continue
 
-    def test_job_init_defaults(self):
-        """
-        test job initialisation using defaults
-        """
-        job = self._mocked_job(JOB_KWARGS)
-        expected = {
-            "app_version": None,
-            "batch_id": None,
-            "cell_id": None,
-            "run_id": None,
-            "tag": "release",
-        }
+            with mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client):
+                job = Job.from_job_id(job_id)
+            self.check_job_attrs(job, job_id)
 
-        self.check_job_attrs(job, expected)
+    def test_job_init__from_job_ids(self):
+        job_ids = ALL_JOBS.copy()
+        job_ids.remove(BATCH_PARENT)
 
-    def test_job_init__run_app_batch__input(self):
+        with mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client):
+            jobs = Job.from_job_ids(job_ids, return_list=False)
+
+        for job_id, job in jobs.items():
+            self.check_job_attrs(job, job_id)
+
+    def test_job_init__extra_state(self):
         """
         test job initialisation as is done by run_app_batch
         """
 
         app_id = "kb_BatchApp/run_batch"
-        batch_method_tag = "tag"
-        batch_method_ver = "ver"
         extra_data = {
             "batch_app": app_id,
             "batch_tag": None,
             "batch_size": 300,
         }
-        job_meta = {
-            **extra_data,
-            "cell_id": self.cell_id,
-            "run_id": self.run_id,
-            "tag": batch_method_tag,
-        }
 
-        batch_params = [
-            {"service_ver": batch_method_ver, "meta": job_meta, "batch_params": []}
-        ]
+        for job_id in ALL_JOBS:
+            if job_id == BATCH_PARENT:
+                continue
 
-        batch_job = Job.from_attributes(
-            app_id=app_id,
-            app_version=batch_method_ver,
-            cell_id=self.cell_id,
-            job_id=self.job_id,
-            extra_data=extra_data,
-            user=self.user,
-            params=batch_params,
-            run_id=self.run_id,
-            tag=batch_method_tag,
-        )
+            with mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client):
+                batch_job = Job.from_job_id(
+                    job_id,
+                    extra_data=extra_data,
+                )
 
-        expected = {
-            "app_id": app_id,
-            "app_version": batch_method_ver,
-            "batch_id": None,
-            "extra_data": extra_data,
-            "params": batch_params,
-            "tag": batch_method_tag,
-        }
+            self.check_job_attrs(batch_job, job_id, {"extra_data": extra_data})
 
-        self.check_job_attrs(batch_job, expected)
-
-    def test_job_init__run_app(self):
+    def test_job_init__batch_family(self):
         """
-        test job initialisation as is done by run_app
+        test job initialization, as is done by run_app_bulk
         """
-        job_runner_inputs = {"params": {}, "service_ver": "the best ever"}
+        batch_jobs = self._get_batch_family_jobs(return_list=False)
 
-        job = Job.from_attributes(
-            app_id=self.app_id,
-            app_version=job_runner_inputs["service_ver"],
-            cell_id=self.cell_id,
-            job_id=self.job_id,
-            user=self.user,
-            params=job_runner_inputs["params"],
-            run_id=self.run_id,
-            tag=self.tag,
-        )
-        expected = {
-            "app_version": job_runner_inputs["service_ver"],
-            "params": job_runner_inputs["params"],
-        }
+        for job_id, job in batch_jobs.items():
+            self.check_job_attrs(job, job_id)
 
-        self.check_job_attrs(job, expected)
+        batch_job = batch_jobs[BATCH_PARENT]
+        self.assertEqual(batch_job.job_id, batch_job.batch_id)
 
-    def test_job_from_state(self):
-        """
-        test that a completed job is correctly initialised
-        """
-        test_job = get_test_job(JOB_COMPLETED)
-        expected = {
-            "job_id": JOB_COMPLETED,
-            "app_id": test_job.get("job_input", {}).get(
-                "app_id", test_job.get("job_input", {}).get("method")
-            ),
-            "app_version": test_job.get("job_input", {}).get("service_ver", None),
-            "batch_id": test_job.get("batch_id", None),
-            "cell_id": test_job.get("job_input", {})
-            .get("narrative_cell_info", {})
-            .get("cell_id", None),
-            "_acc_state": test_job,
-            "extra_data": None,
-            "user": test_job.get("user", None),
-            "params": test_job.get("job_input", {}).get("params", {}),
-            "run_id": test_job.get("job_input", {})
-            .get("narrative_cell_info", {})
-            .get("run_id", None),
-            "tag": test_job.get("job_input", {})
-            .get("narrative_cell_info", {})
-            .get("tag", "release"),
-        }
-
-        job = Job.from_state(get_test_job(JOB_COMPLETED))
-        self.check_job_attrs(job, expected)
-
-    def test_job_from_state_defaults(self):
+    def test_job_from_state__custom(self):
         """
         test job initialisation with defaults being filled in
+        TODO do a non-default?
         """
         params = [
             {
@@ -455,34 +371,38 @@ class JobTest(unittest.TestCase):
             }
         ]
         test_job = {
-            "user": self.user,
+            "user": "the_user",
             "job_input": {
                 "params": params,
-                "service_ver": self.app_version,
-                "app_id": self.app_id,
+                "service_ver": "42",
+                "app_id": "This/app",
             },
-            "job_id": self.job_id,
+            "job_id": "0123456789abcdef",
         }
 
         expected = {
+            "app_id": "This/app",
+            "app_version": "42",
             "batch_id": JOB_ATTR_DEFAULTS["batch_id"],
             "cell_id": JOB_ATTR_DEFAULTS["cell_id"],
             "extra_data": None,
+            "job_id": "0123456789abcdef",
             "params": params,
             "run_id": JOB_ATTR_DEFAULTS["run_id"],
             "tag": JOB_ATTR_DEFAULTS["tag"],
+            "user": "the_user",
         }
 
-        job = Job.from_state(test_job)
-        self.check_job_attrs(job, expected)
+        job = Job(test_job)
+        self.check_job_attrs_custom(job, expected)
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_state__no_final_state__non_terminal(self):
         """
-        test that a job outputs the correct state and that the update is not cached
+        test that a job outputs the correct state
         """
         # ee2_state is fully populated (includes job_input, no job_output)
-        job = create_job_from_ee2(JOB_CREATED, mode="state")
+        job = create_job_from_ee2(JOB_CREATED)
         self.assertFalse(job.was_terminal)
         self.assertIsNone(job.final_state)
         state = job.state()
@@ -490,17 +410,17 @@ class JobTest(unittest.TestCase):
         self.assertIsNone(job.final_state)
         self.assertEqual(state["status"], "created")
 
-        expected_state = create_state_from_ee2(JOB_CREATED, mode="state")
+        expected_state = create_state_from_ee2(JOB_CREATED)
         self.assertEqual(state, expected_state)
 
     def test_state__final_state_exists__terminal(self):
         """
         test that a completed job emits its state without calling check_job
         """
-        job = create_job_from_ee2(JOB_COMPLETED, mode="state")
+        job = create_job_from_ee2(JOB_COMPLETED)
         self.assertTrue(job.was_terminal)
         self.assertIsNotNone(job.final_state)
-        expected = create_state_from_ee2(JOB_COMPLETED, mode="state")
+        expected = create_state_from_ee2(JOB_COMPLETED)
         self.assertEqual(job.final_state, expected)
 
         with assert_obj_method_called(MockClients, "check_job", call_status=False):
@@ -513,17 +433,17 @@ class JobTest(unittest.TestCase):
         """
         test that the correct exception is thrown if check_job cannot be called
         """
-        job = create_job_from_ee2(JOB_CREATED, mode="attributes")
+        job = create_job_from_ee2(JOB_CREATED)
         self.assertFalse(job.was_terminal)
         self.assertIsNone(job.final_state)
-        with self.assertRaisesRegex(Exception, "Unable to fetch info for job"):
+        with self.assertRaisesRegex(ServerError, "Check job failed"):
             job.state()
 
     def test_state__returns_none(self):
         def mock_state(self, state=None):
             return None
 
-        job = create_job_from_ee2(JOB_CREATED, mode="attributes")
+        job = create_job_from_ee2(JOB_CREATED)
         expected = {
             "status": "error",
             "error": {
@@ -549,7 +469,7 @@ class JobTest(unittest.TestCase):
         """
         test that without a state object supplied, the job state is unchanged
         """
-        job = create_job_from_ee2(JOB_CREATED, mode="attributes")
+        job = create_job_from_ee2(JOB_CREATED)
         self.assertFalse(job.was_terminal)
         job.update_state(None)
         self.assertFalse(job.was_terminal)
@@ -559,8 +479,8 @@ class JobTest(unittest.TestCase):
         """
         ensure that an ee2 state with a different job ID cannot be used to update a job
         """
-        job = create_job_from_ee2(JOB_RUNNING, mode="state")
-        expected = create_state_from_ee2(JOB_RUNNING, mode="state")
+        job = create_job_from_ee2(JOB_RUNNING)
+        expected = create_state_from_ee2(JOB_RUNNING)
         self.assertEqual(job.state(), expected)
 
         # try to update it with the job state from a different job
@@ -569,20 +489,20 @@ class JobTest(unittest.TestCase):
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_job_info(self):
-        job = self._mocked_job()
+        job = create_job_from_ee2(JOB_COMPLETED)
         info_str = "App name (id): Test Editor (NarrativeTest/test_editor)\nVersion: 0.0.1\nStatus: completed\nInputs:\n------\n"
         with capture_stdout() as (out, err):
             job.info()
             self.assertIn(info_str, out.getvalue().strip())
 
     def test_repr(self):
-        job = self._mocked_job()
+        job = create_job_from_ee2(JOB_COMPLETED)
         job_str = job.__repr__()
         self.assertRegex("KBase Narrative Job - " + job.job_id, job_str)
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_repr_js(self):
-        job = self._mocked_job()
+        job = create_job_from_ee2(JOB_COMPLETED)
         js_out = job._repr_javascript_()
         self.assertIsInstance(js_out, str)
         # spot check to make sure the core pieces are present. needs the
@@ -602,20 +522,20 @@ class JobTest(unittest.TestCase):
         }
 
         for job_id in is_finished.keys():
-            job = create_job_from_ee2(job_id, mode="attributes")
+            job = create_job_from_ee2(job_id)
             self.assertEqual(job.is_finished(), is_finished[job_id])
 
     @mock.patch("biokbase.narrative.widgetmanager.WidgetManager.show_output_widget")
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_show_output_widget(self, mock_method):
         mock_method.return_value = True
-        job = Job.from_state(get_test_job(JOB_COMPLETED))
+        job = Job(get_test_job(JOB_COMPLETED))
         self.assertTrue(job.show_output_widget())
         mock_method.assert_called_once()
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_show_output_widget__incomplete_state(self):
-        job = Job.from_state(get_test_job(JOB_CREATED))
+        job = Job(get_test_job(JOB_CREATED))
         self.assertRegex(
             job.show_output_widget(), "Job is incomplete! It has status 'created'"
         )
@@ -626,7 +546,7 @@ class JobTest(unittest.TestCase):
         # 1. There's 100 total log lines
         # 2. Each line has its line number embedded in it
         total_lines = 100
-        job = self._mocked_job()
+        job = create_job_from_ee2(JOB_COMPLETED)
         logs = job.log()
         # we know there's 100 lines total, so roll with it that way.
         self.assertEqual(logs[0], total_lines)
@@ -666,7 +586,7 @@ class JobTest(unittest.TestCase):
         job_state = get_test_job(JOB_COMPLETED)
         job_params = job_state.get("job_input", {}).get("params", None)
         self.assertIsNotNone(job_params)
-        job = Job.from_state(job_state)
+        job = Job(job_state)
         self.assertIsNotNone(job.params)
 
         with assert_obj_method_called(MockClients, "get_job_params", call_status=False):
@@ -686,7 +606,7 @@ class JobTest(unittest.TestCase):
 
         # delete the job params from the input
         del job_state["job_input"]["params"]
-        job = Job.from_state(job_state)
+        job = Job(job_state)
         self.assertEqual(job.params, JOB_ATTR_DEFAULTS["params"])
 
         params = job.parameters()
@@ -699,7 +619,7 @@ class JobTest(unittest.TestCase):
         """
         job_state = get_test_job(JOB_TERMINATED)
         del job_state["job_input"]["params"]
-        job = Job.from_state(job_state)
+        job = Job(job_state)
         self.assertEqual(job.params, JOB_ATTR_DEFAULTS["params"])
 
         with self.assertRaisesRegex(Exception, "Unable to fetch parameters for job"):
@@ -707,11 +627,9 @@ class JobTest(unittest.TestCase):
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_parent_children__ok(self):
-        child_jobs = [
-            create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN
-        ]
-        parent_job = Job.from_state(
-            create_state_from_ee2(BATCH_PARENT, mode="state"),
+        child_jobs = [Job.from_job_id(job_id) for job_id in BATCH_CHILDREN]
+        parent_job = Job(
+            create_state_from_ee2(BATCH_PARENT),
             children=child_jobs,
         )
 
@@ -729,34 +647,45 @@ class JobTest(unittest.TestCase):
         self.assertTrue(parent_job.was_terminal)
 
     def test_parent_children__fail(self):
-        parent_state = create_state_from_ee2(BATCH_PARENT, mode="state")
+        parent_state = create_state_from_ee2(BATCH_PARENT)
+        child_states = [create_state_from_ee2(job_id) for job_id in BATCH_CHILDREN]
         with self.assertRaisesRegex(
             ValueError, "Must supply children when setting children of batch job parent"
         ):
-            Job.from_state(parent_state)
+            Job(parent_state)
 
-        child_jobs = [
-            create_job_from_ee2(job_id, mode="attributes") for job_id in BATCH_CHILDREN
-        ][1:]
+        child_jobs = [Job(child_state) for child_state in child_states]
         with self.assertRaisesRegex(ValueError, "Child job id mismatch"):
-            Job.from_state(
+            Job(
                 parent_state,
-                children=child_jobs,
+                children=child_jobs[1:],
+            )
+
+        with self.assertRaisesRegex(ValueError, "Child job id mismatch"):
+            Job(
+                parent_state,
+                children=child_jobs * 2,
+            )
+
+        with self.assertRaisesRegex(ValueError, "Child job id mismatch"):
+            Job(
+                parent_state,
+                children=child_jobs + [create_job_from_ee2(JOB_COMPLETED)],
             )
 
     def test_get_viewer_params__active(self):
         for job_id in ACTIVE_JOBS:
             if job_id == BATCH_PARENT:
                 continue
-            job = create_job_from_ee2(job_id, mode="attributes")
-            state = create_state_from_ee2(job_id, mode="state")
+            job = create_job_from_ee2(job_id)
+            state = create_state_from_ee2(job_id)
             out = job.get_viewer_params(state)
             self.assertIsNone(out)
 
     def test_get_viewer_params__finished(self):
         for job_id in FINISHED_JOBS:
-            job = create_job_from_ee2(job_id, mode="attributes")
-            state = create_state_from_ee2(job_id, mode="state")
+            job = create_job_from_ee2(job_id)
+            state = create_state_from_ee2(job_id)
             out = job.get_viewer_params(state)
             self.assertEqual(get_widget_info(job_id), out)
 
@@ -765,13 +694,35 @@ class JobTest(unittest.TestCase):
         do batch parent separately
         since it requires passing in child jobs
         """
-        state = create_state_from_ee2(BATCH_PARENT, mode="state")
+        state = create_state_from_ee2(BATCH_PARENT)
         batch_children = [
-            create_job_from_ee2(job_id, mode="state") for job_id in BATCH_CHILDREN
+            create_job_from_ee2(job_id)
+            for job_id in BATCH_CHILDREN
         ]
 
-        job = create_job_from_ee2(
-            BATCH_PARENT, mode="attributes", children=batch_children
-        )
+        job = create_job_from_ee2(BATCH_PARENT, children=batch_children)
         out = job.get_viewer_params(state)
         self.assertIsNone(out)
+
+    @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
+    def test_query_job_state(self):
+        for job_id in ALL_JOBS:
+            exp = create_state_from_ee2(job_id, exclude_fields=JOB_INIT_EXCLUDED_JOB_STATE_FIELDS)
+            got = Job.query_ee2_state(job_id, init=True)
+            self.assertEqual(exp, got)
+
+            exp = create_state_from_ee2(job_id, exclude_fields=EXCLUDED_JOB_STATE_FIELDS)
+            got = Job.query_ee2_state(job_id, init=False)
+            self.assertEqual(exp, got)
+
+    @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client) 
+    def test_query_job_states(self):
+        states = Job.query_ee2_states(ALL_JOBS, init=True)
+        for job_id, got in states.items():
+            exp = create_state_from_ee2(job_id, exclude_fields=JOB_INIT_EXCLUDED_JOB_STATE_FIELDS)
+            self.assertEqual(exp, got)
+
+        states = Job.query_ee2_states(ALL_JOBS, init=False)
+        for job_id, got in states.items():
+            exp = create_state_from_ee2(job_id, exclude_fields=EXCLUDED_JOB_STATE_FIELDS)
+            self.assertEqual(exp, got)

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -4,6 +4,7 @@ Tests for job management
 from src.biokbase.narrative.jobs.job import (
     COMPLETED_STATUS,
     EXCLUDED_JOB_STATE_FIELDS,
+    JOB_INIT_EXCLUDED_JOB_STATE_FIELDS,
     JOB_ATTR_DEFAULTS,
     get_dne_job_state,
 )
@@ -660,18 +661,9 @@ class JobManagerTest(unittest.TestCase):
 
         m.assert_has_calls(
             [
-                mock.call(
-                    {
-                        "job_id": BATCH_PARENT,
-                        "exclude_fields": EXCLUDED_JOB_STATE_FIELDS,
-                    }
-                ),
-                mock.call(
-                    {
-                        "job_id": JOB_NOT_FOUND,
-                        "exclude_fields": EXCLUDED_JOB_STATE_FIELDS,
-                    }
-                ),
+                mock.call({"job_id": BATCH_PARENT, "exclude_fields": EXCLUDED_JOB_STATE_FIELDS}),
+                mock.call({"job_id": JOB_NOT_FOUND, "exclude_fields": JOB_INIT_EXCLUDED_JOB_STATE_FIELDS}),
+                mock.call({"job_id": JOB_NOT_FOUND, "exclude_fields": EXCLUDED_JOB_STATE_FIELDS})
             ]
         )
 


### PR DESCRIPTION
# Description of PR purpose/changes

Always instantiate a `Job` object with the ee2 state, i.e., no longer with partial state information. This cuts down on the uncertainty of the `Job` object particulars at any given moment in the narrative backend. Use `Job.from_job_id` or `Job.from_job_ids`.

Switching the tests over was a bit of a challenge because there was either a lot of testing of the instantiation with partial information (since it is a bit un-simple) or the attributes of the `Job` objects instantiated with partial information were heavily used to test the correctness of the rest of the method in question.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
