### PR TITLE
version bump to 4.5.0, webdriverio -> 7.9.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,7 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
-### Unreleased
-
+### Version 4.5.0
 - PTV-1561 - SampleSet viewer fixes to allow AMA features; not complete support for AMA features as GenomeSearchUtil does not yet support AMA.
 - SCT-3100 - Improve SampleSet viewer; add improved JSON-RPC 1.1 client and associatedKBase service client; add msw (Mock Service Worker) support;
 - SCT-3084 - Fixed broken (non-functional) search in the data panel
@@ -36,7 +35,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
   - selenium-standalone 6.23.0 -> 7.1.0
   - terser 5.7.0 -> 5.7.1
   - wdio-chromedriver-service 7.1.0 -> 7.1.1
-  - webdriverio 7.7.3 -> 7.9.0
+  - webdriverio 7.7.3 -> 7.9.1
 
 ### Version 4.4.0
 -   No ticket: boatloads of code cleanup and fixes to the unit and internal testing

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase-narrative",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "homepage": "https://kbase.us",
   "dependencies": {
     "bluebird": "3.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "kbase-narrative-core",
-    "version": "4.4.0",
+    "version": "4.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "kbase-narrative-core",
-            "version": "4.4.0",
+            "version": "4.5.0",
             "hasInstallScript": true,
             "devDependencies": {
                 "@types/puppeteer": "5.4.4",
@@ -55,7 +55,7 @@
                 "string.prototype.startswith": "1.0.0",
                 "terser": "5.7.1",
                 "wdio-chromedriver-service": "7.2.0",
-                "webdriverio": "7.9.0"
+                "webdriverio": "7.9.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -940,33 +940,6 @@
                 "@wdio/cli": "^7.0.0"
             }
         },
-        "node_modules/@wdio/browserstack-service/node_modules/@wdio/config": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.8.0.tgz",
-            "integrity": "sha512-f/9z+aPYAYGxNpdoe78pVtgpMXXcqvuZsvy3IajO5qH0+kva5XbWAAS89QH5fZFMI+/fEiwHv8ki60t229N/fQ==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.8.0",
-                "deepmerge": "^4.0.0",
-                "glob": "^7.1.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/browserstack-service/node_modules/@wdio/repl": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-            "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/utils": "7.9.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/browserstack-service/node_modules/@wdio/types": {
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -975,109 +948,6 @@
             "dependencies": {
                 "@types/node": "^15.12.5",
                 "got": "^11.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/browserstack-service/node_modules/@wdio/utils": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-            "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.8.0",
-                "p-iteration": "^1.1.8"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/browserstack-service/node_modules/devtools": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
-            "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "chrome-launcher": "^0.14.0",
-                "edge-paths": "^2.1.0",
-                "puppeteer-core": "^10.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "ua-parser-js": "^0.7.21",
-                "uuid": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/browserstack-service/node_modules/devtools-protocol": {
-            "version": "0.0.906795",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
-            "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
-            "dev": true
-        },
-        "node_modules/@wdio/browserstack-service/node_modules/webdriver": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
-            "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "got": "^11.0.2",
-                "ky": "^0.28.5",
-                "lodash.merge": "^4.6.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/browserstack-service/node_modules/webdriverio": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
-            "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
-            "dev": true,
-            "dependencies": {
-                "@types/aria-query": "^4.2.1",
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/repl": "7.9.1",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "archiver": "^5.0.0",
-                "aria-query": "^4.2.2",
-                "atob": "^2.1.2",
-                "css-shorthand-properties": "^1.1.1",
-                "css-value": "^0.0.1",
-                "devtools": "7.9.1",
-                "devtools-protocol": "^0.0.906795",
-                "fs-extra": "^10.0.0",
-                "get-port": "^5.1.1",
-                "grapheme-splitter": "^1.0.2",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isobject": "^3.0.2",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.zip": "^4.2.0",
-                "minimatch": "^3.0.4",
-                "puppeteer-core": "^10.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "resq": "^1.9.1",
-                "rgb2hex": "0.2.5",
-                "serialize-error": "^8.0.0",
-                "webdriver": "7.9.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -1139,18 +1009,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@wdio/cli/node_modules/@wdio/repl": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-            "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/utils": "7.9.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/cli/node_modules/@wdio/types": {
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -1159,109 +1017,6 @@
             "dependencies": {
                 "@types/node": "^15.12.5",
                 "got": "^11.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/cli/node_modules/@wdio/utils": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-            "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.8.0",
-                "p-iteration": "^1.1.8"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/cli/node_modules/devtools": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
-            "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "chrome-launcher": "^0.14.0",
-                "edge-paths": "^2.1.0",
-                "puppeteer-core": "^10.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "ua-parser-js": "^0.7.21",
-                "uuid": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/cli/node_modules/devtools-protocol": {
-            "version": "0.0.906795",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
-            "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
-            "dev": true
-        },
-        "node_modules/@wdio/cli/node_modules/webdriver": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
-            "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "got": "^11.0.2",
-                "ky": "^0.28.5",
-                "lodash.merge": "^4.6.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/cli/node_modules/webdriverio": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
-            "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
-            "dev": true,
-            "dependencies": {
-                "@types/aria-query": "^4.2.1",
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/repl": "7.9.1",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "archiver": "^5.0.0",
-                "aria-query": "^4.2.2",
-                "atob": "^2.1.2",
-                "css-shorthand-properties": "^1.1.1",
-                "css-value": "^0.0.1",
-                "devtools": "7.9.1",
-                "devtools-protocol": "^0.0.906795",
-                "fs-extra": "^10.0.0",
-                "get-port": "^5.1.1",
-                "grapheme-splitter": "^1.0.2",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isobject": "^3.0.2",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.zip": "^4.2.0",
-                "minimatch": "^3.0.4",
-                "puppeteer-core": "^10.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "resq": "^1.9.1",
-                "rgb2hex": "0.2.5",
-                "serialize-error": "^8.0.0",
-                "webdriver": "7.9.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -1304,18 +1059,6 @@
                 "@wdio/cli": "^7.0.0"
             }
         },
-        "node_modules/@wdio/local-runner/node_modules/@wdio/repl": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-            "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/utils": "7.9.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -1324,20 +1067,6 @@
             "dependencies": {
                 "@types/node": "^15.12.5",
                 "got": "^11.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/local-runner/node_modules/@wdio/utils": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-            "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.8.0",
-                "p-iteration": "^1.1.8"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -1388,20 +1117,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@wdio/mocha-framework/node_modules/@wdio/utils": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-            "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.8.0",
-                "p-iteration": "^1.1.8"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/protocols": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.7.4.tgz",
@@ -1412,12 +1127,12 @@
             }
         },
         "node_modules/@wdio/repl": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.0.tgz",
-            "integrity": "sha512-IrOXdZH4ogm9bS+HBxBPGrRVvl5qLEVGK7JPdTRaoGLvrWqpJnXtvc3gOKrpRDNmn2XkX/1xU24/W1CRMzjiEA==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
+            "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
             "dev": true,
             "dependencies": {
-                "@wdio/utils": "7.9.0"
+                "@wdio/utils": "7.9.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -1505,18 +1220,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@wdio/runner/node_modules/@wdio/repl": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-            "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/utils": "7.9.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/@wdio/runner/node_modules/@wdio/types": {
             "version": "7.8.0",
             "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -1525,109 +1228,6 @@
             "dependencies": {
                 "@types/node": "^15.12.5",
                 "got": "^11.8.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/runner/node_modules/@wdio/utils": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-            "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-            "dev": true,
-            "dependencies": {
-                "@wdio/logger": "7.7.0",
-                "@wdio/types": "7.8.0",
-                "p-iteration": "^1.1.8"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/runner/node_modules/devtools": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
-            "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "chrome-launcher": "^0.14.0",
-                "edge-paths": "^2.1.0",
-                "puppeteer-core": "^10.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "ua-parser-js": "^0.7.21",
-                "uuid": "^8.0.0"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/runner/node_modules/devtools-protocol": {
-            "version": "0.0.906795",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
-            "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
-            "dev": true
-        },
-        "node_modules/@wdio/runner/node_modules/webdriver": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
-            "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "got": "^11.0.2",
-                "ky": "^0.28.5",
-                "lodash.merge": "^4.6.1"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@wdio/runner/node_modules/webdriverio": {
-            "version": "7.9.1",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
-            "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
-            "dev": true,
-            "dependencies": {
-                "@types/aria-query": "^4.2.1",
-                "@types/node": "^15.12.5",
-                "@wdio/config": "7.8.0",
-                "@wdio/logger": "7.7.0",
-                "@wdio/protocols": "7.7.4",
-                "@wdio/repl": "7.9.1",
-                "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.1",
-                "archiver": "^5.0.0",
-                "aria-query": "^4.2.2",
-                "atob": "^2.1.2",
-                "css-shorthand-properties": "^1.1.1",
-                "css-value": "^0.0.1",
-                "devtools": "7.9.1",
-                "devtools-protocol": "^0.0.906795",
-                "fs-extra": "^10.0.0",
-                "get-port": "^5.1.1",
-                "grapheme-splitter": "^1.0.2",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isobject": "^3.0.2",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.zip": "^4.2.0",
-                "minimatch": "^3.0.4",
-                "puppeteer-core": "^10.1.0",
-                "query-selector-shadow-dom": "^1.0.0",
-                "resq": "^1.9.1",
-                "rgb2hex": "0.2.5",
-                "serialize-error": "^8.0.0",
-                "webdriver": "7.9.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -1702,9 +1302,9 @@
             }
         },
         "node_modules/@wdio/utils": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.0.tgz",
-            "integrity": "sha512-Wf65vTIOkg9fpX/VVXt16U9IidT8aPh/z4+nGD00/QZwCyexo4lsLV/zMms1xQ0qDsroNU1nJY1Nvi2Y8wnbYQ==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
+            "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
             "dev": true,
             "dependencies": {
                 "@wdio/logger": "7.7.0",
@@ -3114,9 +2714,9 @@
             }
         },
         "node_modules/devtools": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.0.tgz",
-            "integrity": "sha512-icgmZt2NejayJ5x/QjPUSzXq/7LsNBi54NGn5DeVKMfoFwCAVQEo941Se64e8TxQKCOK+VYkMawUholWyI8W7Q==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
+            "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
             "dev": true,
             "dependencies": {
                 "@types/node": "^15.12.5",
@@ -3124,7 +2724,7 @@
                 "@wdio/logger": "7.7.0",
                 "@wdio/protocols": "7.7.4",
                 "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.0",
+                "@wdio/utils": "7.9.1",
                 "chrome-launcher": "^0.14.0",
                 "edge-paths": "^2.1.0",
                 "puppeteer-core": "^10.1.0",
@@ -9684,9 +9284,9 @@
             }
         },
         "node_modules/webdriver": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.0.tgz",
-            "integrity": "sha512-xIOJ3nE3YCYPPYkgOcM03G35wDfCqR9YhOotr9408pY48GCseyWVQhZM9UnQG3oxc+eoJiYY2FKy9V3h2zJ4rA==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
+            "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "^15.12.5",
@@ -9694,7 +9294,7 @@
                 "@wdio/logger": "7.7.0",
                 "@wdio/protocols": "7.7.4",
                 "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.0",
+                "@wdio/utils": "7.9.1",
                 "got": "^11.0.2",
                 "ky": "^0.28.5",
                 "lodash.merge": "^4.6.1"
@@ -9732,9 +9332,9 @@
             }
         },
         "node_modules/webdriverio": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.0.tgz",
-            "integrity": "sha512-Px6H+feFrUFJLSQXMHCCWEMs9aLuxo8id/cA+h0PuvnzhiaEMQophL+KubV6GKeHqKVhrQo1f3NLFdwXrIBV3w==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
+            "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
             "dev": true,
             "dependencies": {
                 "@types/aria-query": "^4.2.1",
@@ -9742,16 +9342,16 @@
                 "@wdio/config": "7.8.0",
                 "@wdio/logger": "7.7.0",
                 "@wdio/protocols": "7.7.4",
-                "@wdio/repl": "7.9.0",
+                "@wdio/repl": "7.9.1",
                 "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.0",
+                "@wdio/utils": "7.9.1",
                 "archiver": "^5.0.0",
                 "aria-query": "^4.2.2",
                 "atob": "^2.1.2",
                 "css-shorthand-properties": "^1.1.1",
                 "css-value": "^0.0.1",
-                "devtools": "7.9.0",
-                "devtools-protocol": "^0.0.905680",
+                "devtools": "7.9.1",
+                "devtools-protocol": "^0.0.906795",
                 "fs-extra": "^10.0.0",
                 "get-port": "^5.1.1",
                 "grapheme-splitter": "^1.0.2",
@@ -9765,7 +9365,7 @@
                 "resq": "^1.9.1",
                 "rgb2hex": "0.2.5",
                 "serialize-error": "^8.0.0",
-                "webdriver": "7.9.0"
+                "webdriver": "7.9.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -9800,9 +9400,9 @@
             }
         },
         "node_modules/webdriverio/node_modules/devtools-protocol": {
-            "version": "0.0.905680",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.905680.tgz",
-            "integrity": "sha512-3lyBZWrgqPljzIUlM3CqoD1ghRrhJsdS9nbqxS2P/p+rdzek7aLdsyU2XNH8TEW2YXIFXtf3DcMCK1XWwmU+3w==",
+            "version": "0.0.906795",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
+            "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
             "dev": true
         },
         "node_modules/which": {
@@ -10999,27 +10599,6 @@
                 "webdriverio": "7.9.1"
             },
             "dependencies": {
-                "@wdio/config": {
-                    "version": "7.8.0",
-                    "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.8.0.tgz",
-                    "integrity": "sha512-f/9z+aPYAYGxNpdoe78pVtgpMXXcqvuZsvy3IajO5qH0+kva5XbWAAS89QH5fZFMI+/fEiwHv8ki60t229N/fQ==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/types": "7.8.0",
-                        "deepmerge": "^4.0.0",
-                        "glob": "^7.1.2"
-                    }
-                },
-                "@wdio/repl": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-                    "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/utils": "7.9.1"
-                    }
-                },
                 "@wdio/types": {
                     "version": "7.8.0",
                     "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -11028,97 +10607,6 @@
                     "requires": {
                         "@types/node": "^15.12.5",
                         "got": "^11.8.1"
-                    }
-                },
-                "@wdio/utils": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-                    "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/types": "7.8.0",
-                        "p-iteration": "^1.1.8"
-                    }
-                },
-                "devtools": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
-                    "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "chrome-launcher": "^0.14.0",
-                        "edge-paths": "^2.1.0",
-                        "puppeteer-core": "^10.1.0",
-                        "query-selector-shadow-dom": "^1.0.0",
-                        "ua-parser-js": "^0.7.21",
-                        "uuid": "^8.0.0"
-                    }
-                },
-                "devtools-protocol": {
-                    "version": "0.0.906795",
-                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
-                    "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
-                    "dev": true
-                },
-                "webdriver": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
-                    "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
-                    "dev": true,
-                    "requires": {
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "got": "^11.0.2",
-                        "ky": "^0.28.5",
-                        "lodash.merge": "^4.6.1"
-                    }
-                },
-                "webdriverio": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
-                    "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
-                    "dev": true,
-                    "requires": {
-                        "@types/aria-query": "^4.2.1",
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/repl": "7.9.1",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "archiver": "^5.0.0",
-                        "aria-query": "^4.2.2",
-                        "atob": "^2.1.2",
-                        "css-shorthand-properties": "^1.1.1",
-                        "css-value": "^0.0.1",
-                        "devtools": "7.9.1",
-                        "devtools-protocol": "^0.0.906795",
-                        "fs-extra": "^10.0.0",
-                        "get-port": "^5.1.1",
-                        "grapheme-splitter": "^1.0.2",
-                        "lodash.clonedeep": "^4.5.0",
-                        "lodash.isobject": "^3.0.2",
-                        "lodash.isplainobject": "^4.0.6",
-                        "lodash.zip": "^4.2.0",
-                        "minimatch": "^3.0.4",
-                        "puppeteer-core": "^10.1.0",
-                        "query-selector-shadow-dom": "^1.0.0",
-                        "resq": "^1.9.1",
-                        "rgb2hex": "0.2.5",
-                        "serialize-error": "^8.0.0",
-                        "webdriver": "7.9.1"
                     }
                 }
             }
@@ -11170,15 +10658,6 @@
                         "glob": "^7.1.2"
                     }
                 },
-                "@wdio/repl": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-                    "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/utils": "7.9.1"
-                    }
-                },
                 "@wdio/types": {
                     "version": "7.8.0",
                     "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -11187,97 +10666,6 @@
                     "requires": {
                         "@types/node": "^15.12.5",
                         "got": "^11.8.1"
-                    }
-                },
-                "@wdio/utils": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-                    "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/types": "7.8.0",
-                        "p-iteration": "^1.1.8"
-                    }
-                },
-                "devtools": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
-                    "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "chrome-launcher": "^0.14.0",
-                        "edge-paths": "^2.1.0",
-                        "puppeteer-core": "^10.1.0",
-                        "query-selector-shadow-dom": "^1.0.0",
-                        "ua-parser-js": "^0.7.21",
-                        "uuid": "^8.0.0"
-                    }
-                },
-                "devtools-protocol": {
-                    "version": "0.0.906795",
-                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
-                    "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
-                    "dev": true
-                },
-                "webdriver": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
-                    "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
-                    "dev": true,
-                    "requires": {
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "got": "^11.0.2",
-                        "ky": "^0.28.5",
-                        "lodash.merge": "^4.6.1"
-                    }
-                },
-                "webdriverio": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
-                    "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
-                    "dev": true,
-                    "requires": {
-                        "@types/aria-query": "^4.2.1",
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/repl": "7.9.1",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "archiver": "^5.0.0",
-                        "aria-query": "^4.2.2",
-                        "atob": "^2.1.2",
-                        "css-shorthand-properties": "^1.1.1",
-                        "css-value": "^0.0.1",
-                        "devtools": "7.9.1",
-                        "devtools-protocol": "^0.0.906795",
-                        "fs-extra": "^10.0.0",
-                        "get-port": "^5.1.1",
-                        "grapheme-splitter": "^1.0.2",
-                        "lodash.clonedeep": "^4.5.0",
-                        "lodash.isobject": "^3.0.2",
-                        "lodash.isplainobject": "^4.0.6",
-                        "lodash.zip": "^4.2.0",
-                        "minimatch": "^3.0.4",
-                        "puppeteer-core": "^10.1.0",
-                        "query-selector-shadow-dom": "^1.0.0",
-                        "resq": "^1.9.1",
-                        "rgb2hex": "0.2.5",
-                        "serialize-error": "^8.0.0",
-                        "webdriver": "7.9.1"
                     }
                 }
             }
@@ -11310,15 +10698,6 @@
                 "stream-buffers": "^3.0.2"
             },
             "dependencies": {
-                "@wdio/repl": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-                    "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/utils": "7.9.1"
-                    }
-                },
                 "@wdio/types": {
                     "version": "7.8.0",
                     "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -11327,17 +10706,6 @@
                     "requires": {
                         "@types/node": "^15.12.5",
                         "got": "^11.8.1"
-                    }
-                },
-                "@wdio/utils": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-                    "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/types": "7.8.0",
-                        "p-iteration": "^1.1.8"
                     }
                 }
             }
@@ -11377,17 +10745,6 @@
                         "@types/node": "^15.12.5",
                         "got": "^11.8.1"
                     }
-                },
-                "@wdio/utils": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-                    "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/types": "7.8.0",
-                        "p-iteration": "^1.1.8"
-                    }
                 }
             }
         },
@@ -11398,12 +10755,12 @@
             "dev": true
         },
         "@wdio/repl": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.0.tgz",
-            "integrity": "sha512-IrOXdZH4ogm9bS+HBxBPGrRVvl5qLEVGK7JPdTRaoGLvrWqpJnXtvc3gOKrpRDNmn2XkX/1xU24/W1CRMzjiEA==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
+            "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
             "dev": true,
             "requires": {
-                "@wdio/utils": "7.9.0"
+                "@wdio/utils": "7.9.1"
             }
         },
         "@wdio/reporter": {
@@ -11472,15 +10829,6 @@
                         "glob": "^7.1.2"
                     }
                 },
-                "@wdio/repl": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.9.1.tgz",
-                    "integrity": "sha512-XUx7d1uIH5kfpCFbdiwMbchcf8zI2a3BGoFBUBGD0r9qaEIpYTgdu2cMhuyrbYP2ufIWuwEr1NCP5OX/hynGKw==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/utils": "7.9.1"
-                    }
-                },
                 "@wdio/types": {
                     "version": "7.8.0",
                     "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.8.0.tgz",
@@ -11489,97 +10837,6 @@
                     "requires": {
                         "@types/node": "^15.12.5",
                         "got": "^11.8.1"
-                    }
-                },
-                "@wdio/utils": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
-                    "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
-                    "dev": true,
-                    "requires": {
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/types": "7.8.0",
-                        "p-iteration": "^1.1.8"
-                    }
-                },
-                "devtools": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
-                    "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "chrome-launcher": "^0.14.0",
-                        "edge-paths": "^2.1.0",
-                        "puppeteer-core": "^10.1.0",
-                        "query-selector-shadow-dom": "^1.0.0",
-                        "ua-parser-js": "^0.7.21",
-                        "uuid": "^8.0.0"
-                    }
-                },
-                "devtools-protocol": {
-                    "version": "0.0.906795",
-                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
-                    "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
-                    "dev": true
-                },
-                "webdriver": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
-                    "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
-                    "dev": true,
-                    "requires": {
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "got": "^11.0.2",
-                        "ky": "^0.28.5",
-                        "lodash.merge": "^4.6.1"
-                    }
-                },
-                "webdriverio": {
-                    "version": "7.9.1",
-                    "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
-                    "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
-                    "dev": true,
-                    "requires": {
-                        "@types/aria-query": "^4.2.1",
-                        "@types/node": "^15.12.5",
-                        "@wdio/config": "7.8.0",
-                        "@wdio/logger": "7.7.0",
-                        "@wdio/protocols": "7.7.4",
-                        "@wdio/repl": "7.9.1",
-                        "@wdio/types": "7.8.0",
-                        "@wdio/utils": "7.9.1",
-                        "archiver": "^5.0.0",
-                        "aria-query": "^4.2.2",
-                        "atob": "^2.1.2",
-                        "css-shorthand-properties": "^1.1.1",
-                        "css-value": "^0.0.1",
-                        "devtools": "7.9.1",
-                        "devtools-protocol": "^0.0.906795",
-                        "fs-extra": "^10.0.0",
-                        "get-port": "^5.1.1",
-                        "grapheme-splitter": "^1.0.2",
-                        "lodash.clonedeep": "^4.5.0",
-                        "lodash.isobject": "^3.0.2",
-                        "lodash.isplainobject": "^4.0.6",
-                        "lodash.zip": "^4.2.0",
-                        "minimatch": "^3.0.4",
-                        "puppeteer-core": "^10.1.0",
-                        "query-selector-shadow-dom": "^1.0.0",
-                        "resq": "^1.9.1",
-                        "rgb2hex": "0.2.5",
-                        "serialize-error": "^8.0.0",
-                        "webdriver": "7.9.1"
                     }
                 }
             }
@@ -11637,9 +10894,9 @@
             }
         },
         "@wdio/utils": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.0.tgz",
-            "integrity": "sha512-Wf65vTIOkg9fpX/VVXt16U9IidT8aPh/z4+nGD00/QZwCyexo4lsLV/zMms1xQ0qDsroNU1nJY1Nvi2Y8wnbYQ==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.9.1.tgz",
+            "integrity": "sha512-iLxZceh8fq9hgCINdmNbgES9LvcE0JCoHKX9YOcjusvm8fd185EOrQF+lc1V3ndGaBFVVgR1LgmVTqwa58Li2w==",
             "dev": true,
             "requires": {
                 "@wdio/logger": "7.7.0",
@@ -12709,9 +11966,9 @@
             "dev": true
         },
         "devtools": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.0.tgz",
-            "integrity": "sha512-icgmZt2NejayJ5x/QjPUSzXq/7LsNBi54NGn5DeVKMfoFwCAVQEo941Se64e8TxQKCOK+VYkMawUholWyI8W7Q==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.9.1.tgz",
+            "integrity": "sha512-hz/FxCmluVIWEq2afcUAZHnewjiSsc44okktbwbqGBnHhsnrU52Ujc/Ett7bu6l6SAlRTaiIxgH1N8tc9bkhkA==",
             "dev": true,
             "requires": {
                 "@types/node": "^15.12.5",
@@ -12719,7 +11976,7 @@
                 "@wdio/logger": "7.7.0",
                 "@wdio/protocols": "7.7.4",
                 "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.0",
+                "@wdio/utils": "7.9.1",
                 "chrome-launcher": "^0.14.0",
                 "edge-paths": "^2.1.0",
                 "puppeteer-core": "^10.1.0",
@@ -17830,9 +17087,9 @@
             }
         },
         "webdriver": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.0.tgz",
-            "integrity": "sha512-xIOJ3nE3YCYPPYkgOcM03G35wDfCqR9YhOotr9408pY48GCseyWVQhZM9UnQG3oxc+eoJiYY2FKy9V3h2zJ4rA==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.9.1.tgz",
+            "integrity": "sha512-gBQX2I4DVGe6/jzI17Xq0wfX8g/lCMbtkGMgl3WUjuJOyseLziJ0rilWvu2wbPz1gklcUmYmIw+QM8M3cLl2xw==",
             "dev": true,
             "requires": {
                 "@types/node": "^15.12.5",
@@ -17840,7 +17097,7 @@
                 "@wdio/logger": "7.7.0",
                 "@wdio/protocols": "7.7.4",
                 "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.0",
+                "@wdio/utils": "7.9.1",
                 "got": "^11.0.2",
                 "ky": "^0.28.5",
                 "lodash.merge": "^4.6.1"
@@ -17871,9 +17128,9 @@
             }
         },
         "webdriverio": {
-            "version": "7.9.0",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.0.tgz",
-            "integrity": "sha512-Px6H+feFrUFJLSQXMHCCWEMs9aLuxo8id/cA+h0PuvnzhiaEMQophL+KubV6GKeHqKVhrQo1f3NLFdwXrIBV3w==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.9.1.tgz",
+            "integrity": "sha512-6MCfxtV7QcAZo55WrBe4qc/tGATUPbJP0fww5TwZH2RN2oouOLTKTUCBba653+GRuaqVKvF9RnX0OrkxmGa5+w==",
             "dev": true,
             "requires": {
                 "@types/aria-query": "^4.2.1",
@@ -17881,16 +17138,16 @@
                 "@wdio/config": "7.8.0",
                 "@wdio/logger": "7.7.0",
                 "@wdio/protocols": "7.7.4",
-                "@wdio/repl": "7.9.0",
+                "@wdio/repl": "7.9.1",
                 "@wdio/types": "7.8.0",
-                "@wdio/utils": "7.9.0",
+                "@wdio/utils": "7.9.1",
                 "archiver": "^5.0.0",
                 "aria-query": "^4.2.2",
                 "atob": "^2.1.2",
                 "css-shorthand-properties": "^1.1.1",
                 "css-value": "^0.0.1",
-                "devtools": "7.9.0",
-                "devtools-protocol": "^0.0.905680",
+                "devtools": "7.9.1",
+                "devtools-protocol": "^0.0.906795",
                 "fs-extra": "^10.0.0",
                 "get-port": "^5.1.1",
                 "grapheme-splitter": "^1.0.2",
@@ -17904,7 +17161,7 @@
                 "resq": "^1.9.1",
                 "rgb2hex": "0.2.5",
                 "serialize-error": "^8.0.0",
-                "webdriver": "7.9.0"
+                "webdriver": "7.9.1"
             },
             "dependencies": {
                 "@wdio/config": {
@@ -17930,9 +17187,9 @@
                     }
                 },
                 "devtools-protocol": {
-                    "version": "0.0.905680",
-                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.905680.tgz",
-                    "integrity": "sha512-3lyBZWrgqPljzIUlM3CqoD1ghRrhJsdS9nbqxS2P/p+rdzek7aLdsyU2XNH8TEW2YXIFXtf3DcMCK1XWwmU+3w==",
+                    "version": "0.0.906795",
+                    "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.906795.tgz",
+                    "integrity": "sha512-K3kXWGyYGqcrvAR2Wj3dfS9LctO/fML05pBjWIQYgvAk+vE5DCYxD+zNPxKHHzXu6d9iP8/W9/63b9MeoNItYA==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kbase-narrative-core",
     "description": "Core components for the KBase Narrative Interface",
-    "version": "4.4.0",
+    "version": "4.5.0",
     "private": true,
     "repository": "github.com/kbase/narrative",
     "devDependencies": {
@@ -51,7 +51,7 @@
         "string.prototype.startswith": "1.0.0",
         "terser": "5.7.1",
         "wdio-chromedriver-service": "7.2.0",
-        "webdriverio": "7.9.0"
+        "webdriverio": "7.9.1"
     },
     "browserslist": [
         "defaults"

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -2,7 +2,7 @@ __all__ = ["magics", "common", "handlers", "contents", "services", "widgetmanage
 
 from semantic_version import Version
 
-__version__ = Version("4.4.0")
+__version__ = Version("4.5.0")
 
 
 def version():

--- a/src/config.json
+++ b/src/config.json
@@ -384,5 +384,5 @@
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,
-    "version": "4.4.0"
+    "version": "4.5.0"
 }

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -391,5 +391,5 @@
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,
-    "version": "4.4.0"
+    "version": "4.5.0"
 }


### PR DESCRIPTION
# Description of PR purpose/changes

Version bump to 4.5.0, and updated webdriverio in `package.json` to 7.9.1 to be in line with its side-dependencies.

The rest of the usual checklist is kinda redundant so was removed.
