### PR TITLE
DATAUP-551 duplicate outputs

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -192,20 +192,39 @@ define([
             }
         }
 
+        /**
+         *
+         * @param {object} rows
+         */
         function setDuplicateValue(rows) {
             state.isDuplicate = true;
             let message = 'duplicate value';
             let rowMessage = '';
+            let tabMessage = '';
+            let tabPrefix = ' on tab';
 
-            if (rows) {
+            if (rows && rows.thisTab && rows.thisTab.length) {
                 rowMessage = ' on row';
-                if (rows.length > 1) {
-                    message += 's';
+                if (rows.thisTab.length > 1) {
                     rowMessage += 's';
                 }
-                rowMessage += ' ' + StringUtil.arrayToEnglish(rows);
+                rowMessage += ' ' + StringUtil.arrayToEnglish(rows.thisTab);
+            }
+
+            if (rows && rows.otherTabs) {
+                const tabs = Object.keys(rows.otherTabs); // don't use rows for now, as there's something funny about the reporting
+                tabMessage = StringUtil.arrayToEnglish(tabs.map((x) => `"${x}"`));
+                if (tabs.length > 1) {
+                    tabPrefix += 's';
+                }
             }
             message += ' found' + rowMessage;
+            if (rowMessage.length && tabMessage.length) {
+                message += ', and ';
+            }
+            if (tabMessage.length) {
+                message += tabPrefix + ' ' + tabMessage;
+            }
             renderMessage(MESSAGE.error, message, `.${messageBaseClass}__duplicate`);
         }
 

--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -225,7 +225,7 @@ define([
             }
 
             if (rowMessage.length && tabMessage.length) {
-                rowTabSeparator = ', and ';
+                rowTabSeparator = ', and';
                 plural = true;
             }
             message += (plural ? 's' : '') + ' found' + rowMessage + rowTabSeparator;

--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -202,26 +202,33 @@ define([
             let rowMessage = '';
             let tabMessage = '';
             let tabPrefix = ' on tab';
+            let rowTabSeparator = '';
+            let plural = false;
 
             if (rows && rows.thisTab && rows.thisTab.length) {
                 rowMessage = ' on row';
                 if (rows.thisTab.length > 1) {
                     rowMessage += 's';
+                    plural = true;
                 }
                 rowMessage += ' ' + StringUtil.arrayToEnglish(rows.thisTab);
             }
 
             if (rows && rows.otherTabs) {
-                const tabs = Object.keys(rows.otherTabs); // don't use rows for now, as there's something funny about the reporting
+                const tabs = Object.keys(rows.otherTabs);
+                // don't use rows for now, as there's something funny about the reporting
                 tabMessage = StringUtil.arrayToEnglish(tabs.map((x) => `"${x}"`));
                 if (tabs.length > 1) {
                     tabPrefix += 's';
+                    plural = true;
                 }
             }
-            message += ' found' + rowMessage;
+
             if (rowMessage.length && tabMessage.length) {
-                message += ', and ';
+                rowTabSeparator = ', and ';
+                plural = true;
             }
+            message += (plural ? 's' : '') + ' found' + rowMessage + rowTabSeparator;
             if (tabMessage.length) {
                 message += tabPrefix + ' ' + tabMessage;
             }

--- a/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/fieldTableCellWidget.js
@@ -235,9 +235,11 @@ define([
             // get text for other tab rows
             if (rows && rows.otherTabs) {
                 const tabs = Object.keys(rows.otherTabs);
-                tabMessage = StringUtil.arrayToEnglish(tabs.map((tab) => {
-                    return `"${tab}" ${buildRowsText(rows.otherTabs[tab])}`;
-                }));
+                tabMessage = StringUtil.arrayToEnglish(
+                    tabs.map((tab) => {
+                        return `"${tab}" ${buildRowsText(rows.otherTabs[tab])}`;
+                    })
+                );
                 if (tabs.length > 1) {
                     tabPrefix += 's';
                     plural = true;

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -762,7 +762,7 @@ define([
              *      paramId1: {
              *        widget: Object
              *        duplicateRows: {
-             *          thisTab: [rowId, rowId],
+             *          thisTab: [rowIdx, rowIdx],
              *          otherTabs: {
              *              tabId1: [rowIdx, rowIdx]
              *          }

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -667,7 +667,7 @@ define([
                     // bulkImportWidget.js and configure.js.
                     updateDisabledFileValues();
                     const dups = updateDuplicateOutputValues();
-                    // if there's any duplicates, we need to send a message that this is an
+                    // if there are any duplicates, we need to send a message that this is an
                     // invalid setup
                     if (dups.length) {
                         paramsBus.emit('invalid-param-value');

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -42,6 +42,7 @@ define([
             paramsBus = config.bus,
             model = Props.make(),
             availableFiles = config.availableFiles,
+            otherTabOutputValues = config.unselectedOutputValues,
             /**
              * Internal data model
              * The data model / view model is a structure that maintains the overall internal
@@ -695,7 +696,7 @@ define([
          * 4. Up to widgets to act accordingly
          * 5. Return the row ids that are duplicates
          */
-        async function updateDuplicateOutputValues() {
+        function updateDuplicateOutputValues() {
             /* otherTabValues = all output values from other tabs, what tab they're in, and which row.
              *
              * looks like this:
@@ -705,10 +706,6 @@ define([
              *   }
              * }
              */
-            const otherTabValues = await paramsBus.request(
-                {},
-                { key: { type: 'get-unselected-outputs' } }
-            );
 
             /* First, set up the output value counts for this tab.
              * outputValueCounts will look like this:
@@ -748,11 +745,11 @@ define([
              */
             const values = Object.keys(outputValueCounts).reduce((duplicateValues, value) => {
                 const dup = {};
-                if (outputValueCounts[value].length > 1 || value in otherTabValues) {
+                if (outputValueCounts[value].length > 1 || value in otherTabOutputValues) {
                     dup.thisTab = outputValueCounts[value];
                 }
-                if (value in otherTabValues) {
-                    dup.otherTabs = otherTabValues[value];
+                if (value in otherTabOutputValues) {
+                    dup.otherTabs = otherTabOutputValues[value];
                 }
                 if (Object.keys(dup).length) {
                     duplicateValues[value] = dup;

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -78,8 +78,9 @@ define([
         }
 
         /**
-         * Makes a cache of the output parameter values from the unselected file type,
-         * which will make it easier to look for duplicate values.
+         * Returns the output parameter values from the unselected file types,
+         * which will make it easier to look for duplicate values against the active file
+         * type.
          *
          * Since this is focused on being used for duplicate values, with a row to point
          * to, it gets structured like this:
@@ -93,7 +94,11 @@ define([
          *   }
          * }
          *
-         * nulls / undefineds are ignored.
+         * The `fileType` fields above are the display name, just to make writing the alerts
+         * easier. This does come with the assumption that those names are all unique,
+         * but they really should be unless we want to be extra confusing to our users.
+         *
+         * Nulls, undefineds, and empty strings are ignored.
          */
         function getUnselectedOutputValues() {
             const unselectedTypes = new Set(Object.keys(typesToFiles));
@@ -110,7 +115,7 @@ define([
                 for (let i = 0; i < allParams[type].filePaths.length; i++) {
                     outputParamIds.forEach((paramId) => {
                         const value = allParams[type].filePaths[i][paramId];
-                        if (value === null || value === undefined) {
+                        if (!value) {
                             return;
                         }
                         if (!(value in unselectedOutputValues)) {

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -122,7 +122,7 @@ define([
                             unselectedOutputValues[value] = {};
                         }
                         const displayType = fileTypesDisplay[type].label;
-                        if (!(type in unselectedOutputValues[value])) {
+                        if (!(displayType in unselectedOutputValues[value])) {
                             unselectedOutputValues[value][displayType] = [];
                         }
                         unselectedOutputValues[value][displayType].push(i + 1);

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -43,7 +43,6 @@ define([
             paramsWidget,
             fileTypePanel,
             selectedFileType = model.getItem('state.selectedFileType'),
-            unselectedOutputValues,
             ui;
 
         const fileTypesDisplay = {},
@@ -96,13 +95,13 @@ define([
          *
          * nulls / undefineds are ignored.
          */
-        function cacheUnselectedOutputValues() {
-            unselectedOutputValues = {};
+        function getUnselectedOutputValues() {
             const unselectedTypes = new Set(Object.keys(typesToFiles));
             if (unselectedTypes.size === 1) {
-                return; // skip everything if there's only one file type
+                return {}; // skip everything if there's only one file type
             }
 
+            const unselectedOutputValues = {};
             unselectedTypes.delete(selectedFileType);
             const allParams = model.getItem('params');
             const allOutputParamIds = model.getItem('app.outputParamIds');
@@ -125,10 +124,10 @@ define([
                     });
                 }
             });
+            return unselectedOutputValues;
         }
 
         function startInputWidgets() {
-            cacheUnselectedOutputValues();
             const appSpec = specs[typesToFiles[selectedFileType].appId];
             const filePathNode = ui.getElement('input-container.file-paths');
             const paramNode = ui.getElement('input-container.params');
@@ -179,17 +178,6 @@ define([
          * @param {DOMElement} node - the node that should be used for the left column
          */
         function buildFileTypePanel(node) {
-            // const fileTypesDisplay = {},
-            //     fileTypeMapping = {},
-            //     uploaders = Config.get('uploaders');
-            // for (const uploader of uploaders.dropdown_order) {
-            //     fileTypeMapping[uploader.id] = uploader.name;
-            // }
-            // for (const fileType of Object.keys(typesToFiles)) {
-            //     fileTypesDisplay[fileType] = {
-            //         label: fileTypeMapping[fileType] || `Unknown type "${fileType}"`,
-            //     };
-            // }
             fileTypePanel = FileTypePanel.make({
                 bus: cellBus,
                 header: {
@@ -314,17 +302,6 @@ define([
                 }
             });
 
-            // Responds with the cached set of output parameters from all not-currently-selected
-            // file types.
-            paramBus.respond({
-                key: {
-                    type: 'get-unselected-outputs',
-                },
-                handle: () => {
-                    return unselectedOutputValues;
-                },
-            });
-
             /* Here, we need to
              * 1. Get the list of file path params.
              * 2. Get the initial parameters (this will be an array that's serialized in the model right now)
@@ -338,6 +315,7 @@ define([
                 initialParams: model.getItem(['params', selectedFileType, FILE_PATH_TYPE]),
                 availableFiles: model.getItem(['inputs', selectedFileType, 'files']),
                 viewOnly,
+                unselectedOutputValues: getUnselectedOutputValues(),
             });
 
             return widget

--- a/test/data/testAppObj.js
+++ b/test/data/testAppObj.js
@@ -18,6 +18,9 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
                     'insert_size_mean',
                 ],
             },
+            outputParamIds: {
+                fastq_reads: ['name'],
+            },
             specs: {
                 'kb_uploadmethods/import_fastq_sra_as_reads_from_staging': {
                     tag: 'release',

--- a/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
@@ -173,17 +173,23 @@ define([
                 label: 'without rows',
             },
             {
-                rows: [1],
+                rows: {
+                    thisTab: [1],
+                },
                 text: 'duplicate value found on row 1',
                 label: 'on one row',
             },
             {
-                rows: [1, 2],
+                rows: {
+                    thisTab: [1, 2],
+                },
                 text: 'duplicate values found on rows 1 and 2',
                 label: 'on two rows',
             },
             {
-                rows: [1, 2, 3],
+                rows: {
+                    thisTab: [1, 2, 3],
+                },
                 text: 'duplicate values found on rows 1, 2, and 3',
                 label: 'on more than two rows',
             },

--- a/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
@@ -200,7 +200,7 @@ define([
                         foobar: [1],
                     },
                 },
-                text: 'duplicate values found on row 1, and on tab "foobar"',
+                text: 'duplicate values found on row 1, and on tab "foobar" row 1',
                 label: 'on a row and a tab',
             },
             {
@@ -209,7 +209,7 @@ define([
                         foobar: [1],
                     },
                 },
-                text: 'duplicate value found on tab "foobar"',
+                text: 'duplicate value found on tab "foobar" row 1',
                 label: 'on a tab',
             },
             {
@@ -219,7 +219,7 @@ define([
                         baz: [1],
                     },
                 },
-                text: 'duplicate values found on tabs "foobar" and "baz"',
+                text: 'duplicate values found on tabs "foobar" row 1 and "baz" row 1',
                 label: 'on two tabs',
             },
             {
@@ -230,7 +230,7 @@ define([
                         c: [3],
                     },
                 },
-                text: 'duplicate values found on tabs "a", "b", and "c"',
+                text: 'duplicate values found on tabs "a" row 1, "b" row 2, and "c" row 3',
                 label: 'on more than two tabs',
             },
         ].forEach((testCase) => {

--- a/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/fieldTableCellWidget-Spec.js
@@ -193,6 +193,46 @@ define([
                 text: 'duplicate values found on rows 1, 2, and 3',
                 label: 'on more than two rows',
             },
+            {
+                rows: {
+                    thisTab: [1],
+                    otherTabs: {
+                        foobar: [1],
+                    },
+                },
+                text: 'duplicate values found on row 1, and on tab "foobar"',
+                label: 'on a row and a tab',
+            },
+            {
+                rows: {
+                    otherTabs: {
+                        foobar: [1],
+                    },
+                },
+                text: 'duplicate value found on tab "foobar"',
+                label: 'on a tab',
+            },
+            {
+                rows: {
+                    otherTabs: {
+                        foobar: [1],
+                        baz: [1],
+                    },
+                },
+                text: 'duplicate values found on tabs "foobar" and "baz"',
+                label: 'on two tabs',
+            },
+            {
+                rows: {
+                    otherTabs: {
+                        a: [1],
+                        b: [2],
+                        c: [3],
+                    },
+                },
+                text: 'duplicate values found on tabs "a", "b", and "c"',
+                label: 'on more than two tabs',
+            },
         ].forEach((testCase) => {
             it(`can set its state to display an error for duplicate values ${testCase.label}`, async function () {
                 await this.fieldCellWidgetInstance.start({

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -250,7 +250,9 @@ define([
                 const outputNode = container.querySelector('div[data-parameter="name"]');
                 const rowCell = outputNode.querySelector('.kb-field-cell__rowCell');
                 expect(rowCell.classList).toContain('kb-field-cell__error_message');
-                const dupMessage = rowCell.querySelector('.kb-field-cell__message_panel__duplicate');
+                const dupMessage = rowCell.querySelector(
+                    '.kb-field-cell__message_panel__duplicate'
+                );
                 expect(dupMessage.classList).not.toContain('hidden');
                 expect(dupMessage.innerHTML).toContain('duplicate value found');
                 await configure.stop();


### PR DESCRIPTION
# Description of PR purpose/changes

Check for duplicate outputs across tabs.

![Screen Shot 2021-08-18 at 10 53 00 PM](https://user-images.githubusercontent.com/2152243/130007435-1e488016-1cae-45d7-83e2-0d35a3006e6a.png)

This has a few fairly major changes, and **will require making a new bulk import cell.**
1. Track the output parameter ids in the bulkImportCell metadata now (just list and store them along side the fileParamIds and otherParamIds so we don't have to scrounge for them).
2. The configure tab now fetches and sends the output parameter for all of the unselected tabs to the filePathWidget of the selected tab.
3. Modifies the filePathWidget and fieldTableCellWidget to deal with the cross-tab changes.

There's some code in there to try to track the exact rows in each tab where there are duplicates, but that doesn't exactly work right because when multiple duplicates are made, they don't really get stored or flagged as such. So that code's in there, but will need some fine tuning at the level of the configuration validator to work right. I don't think we necessarily need to say what rows the duplicates are in, though, but that should get confirmed with user testing.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-551
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook