### PR TITLE
DATAUP-557 `job_id_list` for `job_status` and `job_info` etc.

### DIFF
--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -161,8 +161,11 @@ class Job(object):
             .get("narrative_cell_info", {})
             .get("cell_id", JOB_ATTR_DEFAULTS["cell_id"]),
             child_jobs=lambda: copy.deepcopy(
+                # TODO
                 # Only batch container jobs have a child_jobs field
-                # and need the state refresh
+                # and need the state refresh.
+                # But KBParallel/KB Batch App jobs may not have the
+                # batch_job field
                 self.state(force_refresh=True)
                 .get("child_jobs", JOB_ATTR_DEFAULTS["child_jobs"])
                 if self.batch_job else

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -161,6 +161,11 @@ class Job(object):
             .get("narrative_cell_info", {})
             .get("cell_id", JOB_ATTR_DEFAULTS["cell_id"]),
             child_jobs=lambda: copy.deepcopy(
+                # Only batch container jobs have a child_jobs field
+                # and need the state refresh
+                self.state(force_refresh=True)
+                .get("child_jobs", JOB_ATTR_DEFAULTS["child_jobs"])
+                if self.batch_job else
                 self._acc_state.get("child_jobs", JOB_ATTR_DEFAULTS["child_jobs"])
             ),
             job_id=lambda: self._acc_state.get("job_id"),
@@ -169,8 +174,13 @@ class Job(object):
                     "params", JOB_ATTR_DEFAULTS["params"]
                 )
             ),
-            retry_ids=lambda: self._acc_state.get(
-                "retry_ids", JOB_ATTR_DEFAULTS["retry_ids"]
+            retry_ids=lambda: copy.deepcopy(
+                # Batch container and retry parent jobs don't have a
+                # retry_ids field so skip the state refresh
+                self._acc_state.get("retry_ids", JOB_ATTR_DEFAULTS["retry_ids"])
+                if self.batch_job or self.retry_parent else
+                self.state(force_refresh=True)
+                .get("retry_ids", JOB_ATTR_DEFAULTS["retry_ids"])
             ),
             retry_parent=lambda: self._acc_state.get(
                 "retry_parent", JOB_ATTR_DEFAULTS["retry_parent"]
@@ -225,7 +235,6 @@ class Job(object):
     def final_state(self):
         if self.was_terminal is True:
             return self.state()
-        # refresh?
         return None
 
     def info(self):
@@ -300,14 +309,14 @@ class Job(object):
         Queries the job service to see the state of the current job.
         """
 
-        if self.was_terminal and not force_refresh:
+        if not force_refresh and self.was_terminal:
             state = copy.deepcopy(self._acc_state)
         else:
-            state = self.query_ee2_state(self.job_id, False)
+            state = self.query_ee2_state(self.job_id, init=False)
             state = self.update_state(state)
 
-        for field in EXCLUDED_JOB_STATE_FIELDS:
-            if field in state and field != "job_input":
+        for field in JOB_INIT_EXCLUDED_JOB_STATE_FIELDS:
+            if field in state:
                 del state[field]
 
         return state
@@ -596,7 +605,7 @@ class Job(object):
             )
 
         inst_child_ids = [job.job_id for job in children]
-        if sorted(inst_child_ids) != sorted(self.child_jobs):
+        if sorted(inst_child_ids) != sorted(self._acc_state.get("child_jobs")):
             raise ValueError("Child job id mismatch")
 
     def update_children(self, children: List["Job"]) -> None:

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -7,6 +7,7 @@ from biokbase.narrative.exception_util import NarrativeException, NoJobException
 from biokbase.narrative.common import kblogging
 
 UNKNOWN_REASON = "Unknown reason"
+NO_JOB_ERR = "No valid job ids"
 
 
 class JobRequest:
@@ -205,7 +206,7 @@ class JobComm:
         req.job_id_list[:] = [job_id for job_id in req.job_id_list if job_id]
         if len(req.job_id_list) == 0:
             self.send_error_message("job_does_not_exist", req)
-            raise NoJobException("No valid job ids")
+            raise NoJobException(NO_JOB_ERR)
 
     def start_job_status_loop(self, *args, **kwargs) -> None:
         """

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -17,7 +17,7 @@ from biokbase.narrative.exception_util import (
     NotBatchException,
 )
 import copy
-from typing import List
+from typing import List, Tuple
 
 """
 KBase Job Manager
@@ -128,7 +128,7 @@ class JobManager(object):
 
         return job_states
 
-    def _check_job_list(self, input_ids: List[str] = []):
+    def _check_job_list(self, input_ids: List[str] = []) -> Tuple[List[str], List[str]]:
         """
         Deduplicates the input job list, maintaining insertion order
         Any jobs not present in self._running_jobs are added to an error list
@@ -526,11 +526,16 @@ class JobManager(object):
             raise NotBatchException("Not a batch job")
 
         child_ids = batch_job.child_jobs
-        reg_child_jobs = [self.get_job(job_id) for job_id in child_ids if job_id in self._running_jobs]
 
-        unreg_child_ids = [job_id for job_id in child_ids if job_id not in self._running_jobs]
+        reg_child_jobs = []
+        unreg_child_ids = []
+        for job_id in child_ids:
+            if job_id in self._running_jobs:
+                reg_child_jobs.append(self.get_job(job_id))
+            else:
+                unreg_child_ids.append(job_id)
+
         unreg_child_jobs = []
-
         if unreg_child_ids:
             unreg_child_jobs = Job.from_job_ids(unreg_child_ids)
             for job in unreg_child_jobs:

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -128,33 +128,29 @@ class JobManager(object):
 
         return job_states
 
-    def _check_job_list(self, job_id_list: List[str] = []):
+    def _check_job_list(self, input_ids: List[str] = []):
         """
         Deduplicates the input job list, maintaining insertion order
         Any jobs not present in self._running_jobs are added to an error list
 
-        :param job_id_list: a list of job IDs
-        :return results: dict with keys "job_id_list", containing valid IDs,
-        and "error" for jobs that the narrative backend does not know about
+        :param input_ids: a list of putative job IDs
+        :return results: tuple with items "job_ids", containing valid IDs;
+        and "error_ids", for jobs that the narrative backend does not know about
         """
-        seen = {}
-        results = {
-            "error": [],
-            "job_id_list": [],
-        }
+        job_ids = []
+        for job_id in input_ids:
+            if job_id and job_id not in job_ids:
+                job_ids.append(job_id)
 
-        for job_id in job_id_list:
-            if job_id is not None and job_id != "" and job_id not in seen:
-                seen[job_id] = True
-                if job_id in self._running_jobs:
-                    results["job_id_list"].append(job_id)
-                else:
-                    results["error"].append(job_id)
+        error_ids = []
+        for i, job_id in list(enumerate(job_ids))[::-1]:
+            if job_id not in self._running_jobs:
+                error_ids.insert(0, job_ids.pop(i))
 
-        if not len(results["job_id_list"]) and not len(results["error"]):
+        if not len(job_ids) + len(error_ids):
             raise NoJobException("No job id(s) supplied")
 
-        return results
+        return job_ids, error_ids
 
     def list_jobs(self):
         """
@@ -277,10 +273,10 @@ class JobManager(object):
             job_states[job_id] = self.get_job(job_id).output_state(state)
         return job_states
 
-    def lookup_job_info(self, job_id):
+    def lookup_job_info(self, job_ids: List[str]) -> dict:
         """
         Will raise a NoJobException if job_id doesn't exist.
-        Sends the info over the comm channel as this packet:
+        Sends the info over the comm channel as these packets:
         {
             app_id: module/name,
             app_name: random string,
@@ -289,15 +285,21 @@ class JobManager(object):
             batch_id: string,
         }
         """
-        job = self.get_job(job_id)
-        info = {
-            "app_id": job.app_id,
-            "app_name": job.app_spec()["info"]["name"],
-            "job_id": job_id,
-            "job_params": job.params,
-            "batch_id": job.batch_id,
-        }
-        return info
+        job_ids, error_ids = self._check_job_list(job_ids)
+
+        infos = dict()
+        for job_id in job_ids:
+            job = self.get_job(job_id)
+            infos[job_id] = {
+                "app_id": job.app_id,
+                "app_name": job.app_spec()["info"]["name"],
+                "job_id": job_id,
+                "job_params": job.params,
+                "batch_id": job.batch_id,
+            }
+        for error_id in error_ids:
+            infos[error_id] = "does_not_exist"
+        return infos
 
     def lookup_all_job_states(self, ignore_refresh_flag=False):
         """
@@ -411,15 +413,15 @@ class JobManager(object):
         :return job_states: dict with keys job IDs and values job state objects
 
         """
-        checked_jobs = self._check_job_list(job_id_list)
+        job_ids, error_ids = self._check_job_list(job_id_list)
 
-        for job_id in checked_jobs["job_id_list"]:
+        for job_id in job_ids:
             if not self.get_job(job_id).was_terminal:
                 self._cancel_job(job_id)
 
-        job_states = self._construct_job_state_set(checked_jobs["job_id_list"])
+        job_states = self._construct_job_state_set(job_ids)
 
-        for job_id in checked_jobs["error"]:
+        for job_id in error_ids:
             job_states[job_id] = {
                 "state": {"job_id": job_id, "status": "does_not_exist"}
             }
@@ -462,10 +464,10 @@ class JobManager(object):
         where the innermost dictionaries are job states from ee2 and are within the
         job states from job.output_state()
         """
-        checked_jobs = self._check_job_list(job_id_list)
+        job_ids, error_ids = self._check_job_list(job_id_list)
         try:
             retry_results = clients.get("execution_engine2").retry_jobs(
-                {"job_ids": checked_jobs["job_id_list"]}
+                {"job_ids": job_ids}
             )
         except Exception as e:
             raise transform_job_exception(e)
@@ -486,7 +488,7 @@ class JobManager(object):
             if "retry_id" in result:
                 result["retry"] = job_states[result["retry_id"]]
                 del result["retry_id"]
-        for job_id in checked_jobs["error"]:
+        for job_id in error_ids:
             retry_results.append(
                 {
                     "job": {"state": {"job_id": job_id, "status": "does_not_exist"}},
@@ -496,16 +498,10 @@ class JobManager(object):
 
         return retry_results
 
-    def get_job_state(self, job_id: str) -> dict:
-        if job_id is None or job_id not in self._running_jobs:
-            raise ValueError(f"No job present with id {job_id}")
-        state = self._running_jobs[job_id]["job"].output_state()
-        return state
-
     def get_job_states(self, job_ids: List[str]) -> dict:
-        checked_jobs = self._check_job_list(job_ids)
-        output_states = self._construct_job_state_set(checked_jobs["job_id_list"])
-        for error_id in checked_jobs["error"]:
+        job_ids, error_ids = self._check_job_list(job_ids)
+        output_states = self._construct_job_state_set(job_ids)
+        for error_id in error_ids:
             output_states[error_id] = get_dne_job_state(error_id)
         return output_states
 
@@ -525,31 +521,26 @@ class JobManager(object):
         """
         Update a batch job and create child jobs if necessary
         """
-        parent_job = self.get_job(batch_id)
-        if not parent_job.batch_job:
+        batch_job = self.get_job(batch_id)
+        if not batch_job.batch_job:
             raise NotBatchException("Not a batch job")
 
-        old_child_ids = parent_job.child_jobs
-        parent_job.state(force_refresh=True)
-        cur_child_ids = parent_job.child_jobs
+        child_ids = batch_job.child_jobs
+        reg_child_jobs = [self.get_job(job_id) for job_id in child_ids if job_id in self._running_jobs]
 
-        if sorted(old_child_ids) != sorted(cur_child_ids):
-            reg_cur_child_ids = [job_id for job_id in cur_child_ids if job_id in self._running_jobs]
-            unreg_cur_child_ids = [job_id for job_id in cur_child_ids if job_id not in self._running_jobs]
+        unreg_child_ids = [job_id for job_id in child_ids if job_id not in self._running_jobs]
+        unreg_child_jobs = []
 
-            reg_cur_child_jobs = [self.get_job(job_id) for job_id in reg_cur_child_ids]
-            unreg_cur_child_jobs = Job.from_job_ids(unreg_cur_child_ids)
-
-            cur_child_jobs = reg_cur_child_jobs + unreg_cur_child_jobs
-
-            for job in unreg_cur_child_jobs:
+        if unreg_child_ids:
+            unreg_child_jobs = Job.from_job_ids(unreg_child_ids)
+            for job in unreg_child_jobs:
                 self.register_new_job(
                     job=job,
                     refresh=int(
-                        job.state().get("status") not in TERMINAL_STATUSES
+                        not job.was_terminal
                     ),
                 )
 
-            parent_job.update_children(cur_child_jobs)
+        batch_job.update_children(reg_child_jobs + unreg_child_jobs)
 
-        return [batch_id] + cur_child_ids
+        return [batch_id] + child_ids

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -510,6 +510,19 @@ class MockStagingHelper:
 
 
 class assert_obj_method_called(object):
+    """
+    Invocations:
+
+    with assert_obj_method_called(MyTargetClass, "my_target_method"):
+    with assert_obj_method_called(MyTargetClass, "my_target_method", False) as aomc:
+
+    aomc.assert_has_calls(
+        [
+            mock.call("fish", 1),
+            mock.call("dog", 2),
+        ]
+    )
+    """
     def __init__(self, target, method_name, call_status=True):
         self.target = target
         self.method_name = method_name

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -5,7 +5,10 @@ import os
 from biokbase.narrative.jobs.job import get_dne_job_state, JOB_ATTR_DEFAULTS
 import biokbase.narrative.jobs.jobcomm
 import biokbase.narrative.jobs.jobmanager
-from biokbase.narrative.jobs.jobcomm import JobRequest
+from biokbase.narrative.jobs.jobcomm import (
+    JobRequest,
+    NO_JOB_ERR,
+)
 from biokbase.narrative.exception_util import (
     NarrativeException,
     NoJobException,
@@ -211,7 +214,7 @@ class JobCommTestCase(unittest.TestCase):
     def test_lookup_job_states__no_job(self):
         job_id_list = [None]
         req = make_comm_msg("job_status", job_id_list, True)
-        with self.assertRaisesRegex(NoJobException, "No valid job ids"):
+        with self.assertRaisesRegex(NoJobException, NO_JOB_ERR):
             self.jc._lookup_job_states(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -338,7 +341,7 @@ class JobCommTestCase(unittest.TestCase):
     def test_lookup_job_info__no_job(self):
         job_id_list = [None]
         req = make_comm_msg("job_info", job_id_list, True)
-        with self.assertRaisesRegex(NoJobException, "No valid job ids"):
+        with self.assertRaisesRegex(NoJobException, NO_JOB_ERR):
             self.jc._lookup_job_info(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -497,7 +500,7 @@ class JobCommTestCase(unittest.TestCase):
 
         job_id_list = [None, ""]
         req = make_comm_msg("cancel_job", job_id_list, True)
-        with self.assertRaisesRegex(NoJobException, "No valid job ids"):
+        with self.assertRaisesRegex(NoJobException, NO_JOB_ERR):
             self.jc._cancel_jobs(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -607,9 +610,8 @@ class JobCommTestCase(unittest.TestCase):
     def test_retry_jobs_no_job(self):
         job_id_list = [None, ""]
         req = make_comm_msg("retry_job", job_id_list, True)
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaisesRegex(ValueError, NO_JOB_ERR):
             self.jc._retry_jobs(req)
-        self.assertIn("No valid job ids", str(e.exception))
         msg = self.jc._comm.last_message
         self.assertEqual(
             {"job_id_list": [], "source": "retry_job"}, msg["data"]["content"]


### PR DESCRIPTION
# Description of PR purpose/changes

* Refresh when getting `job.child_jobs` and `job.retry_ids` & rippling effects
* Add/update tests
* Refactors & bug fixes

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
