### PR TITLE
DATAUP-519: Add cell IDs to the job comm channel init code

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -595,15 +595,22 @@ define([
         }
 
         getJobInitCode() {
-            const currentCells = Jupyter.notebook.get_cells();
+            const currentCells = Jupyter.notebook
+                .get_cells()
+                .map((cell) => {
+                    try {
+                        return cell.metadata.kbase.attributes.id;
+                    } catch (e) {
+                        // do nothing
+                    }
+
+                    return null;
+                })
+                .filter((cellId) => !!cellId);
+
             return [
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
-                'cell_list = ' +
-                    JSON.stringify(
-                        currentCells.map((cell) => {
-                            return cell.cell_id;
-                        })
-                    ),
+                'cell_list = ' + JSON.stringify(currentCells),
                 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
             ].join('\n');
         }

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -595,9 +595,16 @@ define([
         }
 
         getJobInitCode() {
+            const currentCells = Jupyter.notebook.get_cells();
             return [
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
-                'JobComm().start_job_status_loop(init_jobs=True)',
+                'cell_list = ' +
+                    JSON.stringify(
+                        currentCells.map((cell) => {
+                            return cell.cell_id;
+                        })
+                    ),
+                'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
             ].join('\n');
         }
     }

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -128,14 +128,31 @@ define('narrativeMocks', ['jquery', 'uuid', 'narrativeConfig'], ($, UUID, Config
      * Builds a mock Jupyter notebook object with a few keys, but mostly
      * an empty object for modification for whatever testing purposes.
      * @param {object} options a set of options for the mock notebook, with the following:
-     *  - deleteCallback: function to be called when `delete_cell` is called.
-     *  - fullyLoaded: boolean, if true, then treat the notebook as fully loaded
      *  - cells: a list of mocked cells (see buildMockCell)
+     *  - commInfoReturn: object - return from cell.kernel.comm_info()
+     *  - executeReply: object - response to cell.kernel.execute()
+     *  - fullyLoaded: boolean, if true, then treat the notebook as fully loaded
+     *  - deleteCallback: function to be called when `delete_cell` is called.
+     *  - notebookName: string, optional; the notebook name
      *  - readOnly: boolean, true if the Narrative should be read-only
+     *  - registerTargetReturn: object, keys are function names, values are functions
      */
+
+    const DEFAULT_COMM_INFO = {
+        comms: [],
+    };
+    const DEFAULT_COMM = {
+        on_msg: () => {},
+        send: () => {},
+        send_shell_message: () => {},
+    };
+
     function buildMockNotebook(options) {
         options = options || {};
         const cells = options.cells || [];
+        const commInfoReturn = options.commInfoReturn || DEFAULT_COMM_INFO;
+        const registerTargetReturn = options.registerTargetReturn || DEFAULT_COMM;
+        const executeReply = options.executeReply || {};
 
         function insertCell(type, index, data) {
             const cell = buildMockCell(type, '', data);
@@ -161,12 +178,46 @@ define('narrativeMocks', ['jquery', 'uuid', 'narrativeConfig'], ($, UUID, Config
                 }
                 return cells[index];
             },
+            insert_cell_above: (type, index, data) => insertCell(type, index - 1, data),
+            insert_cell_below: (type, index, data) => insertCell(type, index + 1, data),
+            save_checkpoint: () => {
+                /* no op */
+            },
             _fully_loaded: options.fullyLoaded,
             cells: cells,
             writable: !options.readOnly,
-            insert_cell_above: (type, index, data) => insertCell(type, index - 1, data),
-            insert_cell_below: (type, index, data) => insertCell(type, index + 1, data),
-            save_checkpoint: () => null,
+            keyboard_manager: {
+                edit_shortcuts: {
+                    remove_shortcut: () => {
+                        /* no op */
+                    },
+                },
+                command_shortcuts: {
+                    remove_shortcut: () => {
+                        /* no op */
+                    },
+                },
+            },
+            kernel: {
+                is_connected: () => false,
+                comm_info: (_, cb) => {
+                    cb({
+                        content: commInfoReturn,
+                    });
+                },
+                comm_manager: {
+                    register_comm: () => {
+                        /* no op */
+                    },
+                    register_target: (_, cb) => cb(registerTargetReturn, {}),
+                },
+                execute: (_, cb) => {
+                    cb.shell.reply({
+                        content: executeReply,
+                    });
+                },
+            },
+            notebook_name: options.notebookName || 'some notebook',
         };
     }
 

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -4,47 +4,17 @@ define([
     'common/runtime',
     '/test/data/jobsData',
     'testUtil',
-], (JobCommChannel, Jupyter, Runtime, JobsData, TestUtil) => {
+    'narrativeMocks',
+], (JobCommChannel, Jupyter, Runtime, JobsData, TestUtil, Mocks) => {
     'use strict';
 
-    const DEFAULT_COMM_INFO = {
-        content: {
-            comms: [],
-        },
-    };
-    const DEFAULT_COMM = {
-        on_msg: () => {
-            /* do nothing */
-        },
-        send: () => {
-            /* do nothing */
-        },
-        send_shell_message: () => {
-            /* do nothing */
-        },
-    };
-
-    function makeMockNotebook(commInfoReturn, registerTargetReturn, executeReply, cells) {
-        commInfoReturn = commInfoReturn || DEFAULT_COMM_INFO;
-        registerTargetReturn = registerTargetReturn || DEFAULT_COMM;
-        executeReply = executeReply || {};
-        cells = cells || [];
-        return {
-            save_checkpoint: () => {
-                /* no op */
-            },
-            kernel: {
-                comm_info: (name, cb) => cb(commInfoReturn),
-                execute: (code, cb) => cb.shell.reply({ content: executeReply }),
-                comm_manager: {
-                    register_comm: () => {
-                        /* do nothing */
-                    },
-                    register_target: (name, cb) => cb(registerTargetReturn, {}),
-                },
-            },
-            get_cells: () => cells,
-        };
+    function makeMockNotebook(commInfoReturn, registerTargetReturn, executeReply, cells = []) {
+        return Mocks.buildMockNotebook({
+            commInfoReturn,
+            registerTargetReturn,
+            executeReply,
+            cells,
+        });
     }
 
     function makeCommMsg(msgType, content) {
@@ -137,15 +107,16 @@ define([
 
         it('should generate the correct python code for the cells', () => {
             Jupyter.notebook = makeMockNotebook(null, null, null, [
-                { cell_id: '12345' },
-                { cell_id: 'abcde' },
-                { cell_id: 'whatever' },
+                { metadata: { kbase: { attributes: { id: '12345' } } } },
+                { metadata: { kbase: { attributes: { id: 'abcde' } } } },
+                { id: 'whatever' },
+                { metadata: { kbase: { attributes: { id: 'who cares?' } } } },
             ]);
             const comm = new JobCommChannel();
             const jobCommInitString = comm.getJobInitCode();
             expect(jobCommInitString.split('\n')).toEqual([
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
-                'cell_list = ["12345","abcde","whatever"]',
+                'cell_list = ["12345","abcde","who cares?"]',
                 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
             ]);
         });

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -11,7 +11,6 @@ define([
 
     const DEFAULT_FULLY_LOADED = false,
         DEFAULT_WRITABLE = false,
-        DEFAULT_NOTEBOOK_NAME = 'some notebook',
         TEST_TOKEN = 'foo',
         TEST_USER = 'some_user';
 
@@ -62,42 +61,18 @@ define([
 
             // mock a jupyter notebook.
             // namespace should already be loaded
-            Jupyter.notebook = {
-                _fully_loaded: DEFAULT_FULLY_LOADED,
-                writable: DEFAULT_WRITABLE,
-                get_cells: () => [],
-                keyboard_manager: {
-                    edit_shortcuts: {
-                        remove_shortcut: () => {},
-                    },
-                    command_shortcuts: {
-                        remove_shortcut: () => {},
-                    },
-                },
-                kernel: {
-                    is_connected: () => false,
-                    comm_info: (_, callback) => {
-                        callback({
-                            content: {
-                                comms: {
-                                    some_comm_id: {
-                                        target_name: 'KBaseJobs',
-                                    },
-                                },
-                            },
-                        });
-                    },
-                    comm_manager: {
-                        register_comm: () => {},
-                    },
-                    execute: (_, callbacks) => {
-                        callbacks.shell.reply({
-                            content: {},
-                        });
+
+            Jupyter.notebook = Mocks.buildMockNotebook({
+                fullyLoaded: DEFAULT_FULLY_LOADED,
+                readOnly: !DEFAULT_WRITABLE,
+                commInfoReturn: {
+                    comms: {
+                        some_comm_id: {
+                            target_name: 'KBaseJobs',
+                        },
                     },
                 },
-                notebook_name: DEFAULT_NOTEBOOK_NAME,
-            };
+            });
             Jupyter.keyboard_manager = Jupyter.notebook.keyboard_manager;
 
             // The NarrativeLogin.init call invokes both of the above token/user profile calls.

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -65,6 +65,7 @@ define([
             Jupyter.notebook = {
                 _fully_loaded: DEFAULT_FULLY_LOADED,
                 writable: DEFAULT_WRITABLE,
+                get_cells: () => [],
                 keyboard_manager: {
                     edit_shortcuts: {
                         remove_shortcut: () => {},
@@ -75,7 +76,7 @@ define([
                 },
                 kernel: {
                     is_connected: () => false,
-                    comm_info: (comm_name, callback) => {
+                    comm_info: (_, callback) => {
                         callback({
                             content: {
                                 comms: {
@@ -89,7 +90,7 @@ define([
                     comm_manager: {
                         register_comm: () => {},
                     },
-                    execute: (code, callbacks) => {
+                    execute: (_, callbacks) => {
                         callbacks.shell.reply({
                             content: {},
                         });


### PR DESCRIPTION
# Description of PR purpose/changes

Add the IDs of the current narrative cells to the generated python code that starts `jobcomm.py` in the narrative backend.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-519
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and seeing that nothing has changed. How boring!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
