### PR TITLE
DATAUP-557 Listify `*_job_update`, Add `*_job_update_batch`

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -223,13 +223,17 @@ These are organized by the `request_type` field, followed by the expected respon
 
 `stop_update_loop` - request stopping the global job status update thread, no response
 
-`start_job_update` - request updating job(s) during the update thread, no specific response, but generally with `job_status`
+`start_job_update` - request updating job(s) during the update thread, responds with `job_status`
 * `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
 
 `stop_job_update` - request halting update for job(s) during the update thread, no response
 * `job_id` - string OR `job_id_list` - array of strings
-* `parent_job_id` - optional string
+
+`start_job_update_batch` - request updating batch container and children jobs, responds with `job_status`
+* `job_id` - string OR `job_id_list` - array of strings, but generally uses `job_id`
+
+`stop_job_update_batch` - request halting update for batch container and children jobs during the update thread, no response
+* `job_id` - string OR `job_id_list` - array of strings, but generally uses `job_id`
 
 `job_info` - request general information about job(s), responds with `job_info` for each job
 * `job_id` - string OR `job_id_list` - array of strings

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -92,6 +92,13 @@ def get_dne_job_state(job_id, output_state=True):
     return state
 
 
+def get_dne_job_states(job_ids, output_state=True):
+    return {
+        job_id: get_dne_job_state(job_id, output_state)
+        for job_id in job_ids
+    }
+
+
 class Job(object):
     _job_logs = list()
     _acc_state = None  # accumulates state
@@ -345,6 +352,9 @@ class Job(object):
         job_ids: List[str],
         init: bool = True,
     ) -> dict:
+        if not job_ids:
+            return {}
+
         return clients.get("execution_engine2").check_jobs(
             {
                 "job_ids": job_ids,

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -81,7 +81,7 @@ BATCH_CHILDREN = [
     BATCH_RETRY_ERROR,
 ]
 
-saved_jobs = {
+JOBS_TERMINALITY = {
     JOB_COMPLETED: True,
     JOB_CREATED: False,
     JOB_RUNNING: False,
@@ -97,10 +97,10 @@ saved_jobs = {
     BATCH_RETRY_ERROR: True,
 }
 
-ALL_JOBS = list(saved_jobs.keys())
+ALL_JOBS = list(JOBS_TERMINALITY.keys())
 FINISHED_JOBS = []
 ACTIVE_JOBS = []
-for key, value in saved_jobs.items():
+for key, value in JOBS_TERMINALITY.items():
     if value:
         FINISHED_JOBS.append(key)
     else:

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -33,7 +33,7 @@ from .test_job import (
     BATCH_RETRY_RUNNING,
     BATCH_RETRY_ERROR,
     ALL_JOBS,
-    saved_jobs,
+    JOBS_TERMINALITY,
     FINISHED_JOBS,
     ACTIVE_JOBS,
     BATCH_CHILDREN,
@@ -765,12 +765,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id]) + 1
+                    int(not JOBS_TERMINALITY[job_id]) + 1
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
@@ -786,12 +786,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not saved_jobs[job_id]) - 1, 0)
+                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0)
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
@@ -821,15 +821,39 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not saved_jobs[job_id]) - 1, 0)
+                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0)
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
+
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_modify_job_update__stop__loop_still_running(self):
+        """Lookup loop should not get stopped"""
+        self.jc.start_job_status_loop()
+
+        job_id_list = [JOB_COMPLETED, BATCH_PARENT, JOB_RUNNING]
+        req = make_comm_msg("stop_job_update", job_id_list, True)
+        self.jc._modify_job_updates(req)
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0)
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not JOBS_TERMINALITY[job_id])
+                )
+        self.assertTrue(self.jc._lookup_timer)
+        self.assertTrue(self.jc._running_lookup_loop)
 
     # ------------------------
     # Modify job update batch
@@ -854,12 +878,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id]) + 1
+                    int(not JOBS_TERMINALITY[job_id]) + 1
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
@@ -876,12 +900,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not saved_jobs[job_id]) - 1, 0)
+                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0)
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
@@ -1058,12 +1082,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id]) + 1
+                    int(not JOBS_TERMINALITY[job_id]) + 1
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
@@ -1079,12 +1103,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not saved_jobs[job_id]) - 1, 0)
+                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0)
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
@@ -1109,12 +1133,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id]) + 1
+                    int(not JOBS_TERMINALITY[job_id]) + 1
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
@@ -1131,12 +1155,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not saved_jobs[job_id]) - 1, 0)
+                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0)
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not saved_jobs[job_id])
+                    int(not JOBS_TERMINALITY[job_id])
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -33,6 +33,7 @@ from .test_job import (
     BATCH_RETRY_RUNNING,
     BATCH_RETRY_ERROR,
     ALL_JOBS,
+    saved_jobs,
     FINISHED_JOBS,
     ACTIVE_JOBS,
     BATCH_CHILDREN,
@@ -118,6 +119,7 @@ class JobCommTestCase(unittest.TestCase):
     def setUp(self):
         self.jc._comm.clear_message_cache()
         self.jc._jm.initialize_jobs()
+        self.jc.stop_job_status_loop()
         self.job_states = get_test_job_states()
 
     def test_send_comm_msg_ok(self):
@@ -193,7 +195,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_lookup_job_states__2_ok(self):
-        job_id_list = [JOB_COMPLETED, JOB_ERROR]
+        job_id_list = [JOB_COMPLETED, BATCH_PARENT]
         req = make_comm_msg("job_status", job_id_list, True)
         output_states = self.jc._lookup_job_states(req)
         msg = self.jc._comm.last_message
@@ -326,8 +328,8 @@ class JobCommTestCase(unittest.TestCase):
         )
 
     def test_lookup_job_info__batch__ok(self):
-        job_id_list = [BATCH_RETRY_COMPLETED]
-        req = make_comm_msg("job_info", job_id_list, True)
+        job_id_list = [BATCH_ERROR_RETRIED, BATCH_RETRY_COMPLETED]
+        req = make_comm_msg("job_info", job_id_list + [BATCH_PARENT], True)
         self.jc._lookup_job_info(req)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -742,6 +744,198 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual("job_does_not_exist", msg["data"]["msg_type"])
 
     # ------------------------
+    # Modify job update
+    # ------------------------
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_modify_job_update__start__ok(self):
+        job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
+        req = make_comm_msg("start_job_update", job_id_list, True)
+        self.jc._modify_job_updates(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": "job_status",
+                "content": get_test_job_states(job_id_list)
+            },
+            msg["data"]
+        )
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id]) + 1
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertTrue(self.jc._lookup_timer)
+        self.assertTrue(self.jc._running_lookup_loop)
+
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_modify_job_update__stop__ok(self):
+        job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
+        req = make_comm_msg("stop_job_update", job_id_list, True)
+        self.jc._modify_job_updates(req)
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    max(int(not saved_jobs[job_id]) - 1, 0)
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertIsNone(self.jc._lookup_timer)
+        self.assertFalse(self.jc._running_lookup_loop)
+
+    def test_modify_job_update__no_job(self):
+        job_id_list = [None]
+        req = make_comm_msg("start_job_update", job_id_list, True)
+        with self.assertRaisesRegex(NoJobException, NO_JOB_ERR):
+            self.jc._modify_job_updates(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": "job_does_not_exist",
+                "content": {
+                    "source": "start_job_update",
+                    "job_id_list": [],
+                },
+            },
+            msg["data"]
+        )
+
+    def test_modify_job_update__stop__ok_bad_job(self):
+        job_id_list = [JOB_COMPLETED]
+        req = make_comm_msg("stop_job_update", job_id_list + [JOB_NOT_FOUND], True)
+        self.jc._modify_job_updates(req)
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    max(int(not saved_jobs[job_id]) - 1, 0)
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertIsNone(self.jc._lookup_timer)
+        self.assertFalse(self.jc._running_lookup_loop)
+
+    # ------------------------
+    # Modify job update batch
+    # ------------------------
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_modify_job_update_batch__start__ok(self):
+        job_id = BATCH_PARENT
+        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
+        req = make_comm_msg("start_job_update_batch", job_id, True)
+        self.jc._modify_job_updates_batch(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": "job_status",
+                "content": get_test_job_states(job_id_list)
+            },
+            msg["data"]
+        )
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id]) + 1
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertTrue(self.jc._lookup_timer)
+        self.assertTrue(self.jc._running_lookup_loop)
+
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_modify_job_update_batch__stop__ok(self):
+        job_id = BATCH_PARENT
+        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
+        req = make_comm_msg("stop_job_update_batch", job_id, True)
+        self.jc._modify_job_updates_batch(req)
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    max(int(not saved_jobs[job_id]) - 1, 0)
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertIsNone(self.jc._lookup_timer)
+        self.assertFalse(self.jc._running_lookup_loop)
+
+    def test_modify_job_update_batch__no_job(self):
+        job_id = None
+        req = make_comm_msg("start_job_update_batch", job_id, True)
+        with self.assertRaisesRegex(
+            NoJobException,
+            f"Job id required to process {req.request} request"
+        ):
+            self.jc._modify_job_updates_batch(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": "job_does_not_exist",
+                "content": {
+                    "source": "start_job_update_batch",
+                    "job_id": job_id,
+                },
+            },
+            msg["data"]
+        )
+
+    def test_modify_job_update_batch__bad_job(self):
+        job_id = JOB_NOT_FOUND
+        req = make_comm_msg("start_job_update_batch", job_id, True)
+        with self.assertRaisesRegex(
+            NoJobException,
+            f"No job present with id {job_id}"
+        ):
+            self.jc._modify_job_updates_batch(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": "job_does_not_exist",
+                "content": {
+                    "source": "start_job_update_batch",
+                    "job_id": job_id,
+                },
+            },
+            msg["data"]
+        )
+
+    def test_modify_job_update_batch__not_batch(self):
+        job_id = JOB_RUNNING
+        req = make_comm_msg("start_job_update_batch", job_id, True)
+        with self.assertRaisesRegex(
+            NotBatchException,
+            "Not a batch job"
+        ):
+            self.jc._modify_job_updates_batch(req)
+
+    # ------------------------
     # Handle bad comm messages
     # ------------------------
     def test_handle_comm_message_bad(self):
@@ -849,32 +1043,103 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_handle_start_job_update_msg(self):
-        job_id = JOB_COMPLETED
-        refresh_count = self.jm._running_jobs[job_id]["refresh"]
-        req = make_comm_msg("start_job_update", job_id, False)
+        job_id_list = [JOB_CREATED, JOB_COMPLETED, BATCH_PARENT]
+        req = make_comm_msg("start_job_update", job_id_list, False)
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
-        self.assertEqual(msg["data"]["msg_type"], "job_status_all")
-        self.assertEqual(self.jm._running_jobs[job_id]["refresh"], refresh_count + 1)
-        self.assertTrue(self.jc._running_lookup_loop)
-        self.jc.stop_job_status_loop()
-
-    def test_handle_stop_job_update_msg(self):
-        job_id = JOB_COMPLETED
-        refresh_count = self.jm._running_jobs[job_id]["refresh"]
-        req = make_comm_msg("stop_job_update", job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertIsNone(msg)
         self.assertEqual(
-            self.jm._running_jobs[job_id]["refresh"], max(refresh_count - 1, 0)
+            {
+                "msg_type": "job_status",
+                "content": get_test_job_states(job_id_list)
+            },
+            msg["data"]
         )
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id]) + 1
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertTrue(self.jc._lookup_timer)
+        self.assertTrue(self.jc._running_lookup_loop)
 
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_handle_stop_job_update_msg(self):
+        job_id_list = [JOB_CREATED, JOB_COMPLETED, BATCH_PARENT]
+        req = make_comm_msg("stop_job_update", job_id_list, False)
+        self.jc._handle_comm_message(req)
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    max(int(not saved_jobs[job_id]) - 1, 0)
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertIsNone(self.jc._lookup_timer)
+        self.assertFalse(self.jc._running_lookup_loop)
+
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
     def test_handle_start_job_update_batch_msg(self):
-        pass
+        job_id = BATCH_PARENT
+        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
+        req = make_comm_msg("start_job_update_batch", job_id, False)
+        self.jc._handle_comm_message(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": "job_status",
+                "content": get_test_job_states(job_id_list)
+            },
+            msg["data"]
+        )
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id]) + 1
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertTrue(self.jc._lookup_timer)
+        self.assertTrue(self.jc._running_lookup_loop)
 
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
     def test_handle_stop_job_update_batch_msg(self):
-        pass
+        job_id = BATCH_PARENT
+        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
+        req = make_comm_msg("stop_job_update_batch", job_id, False)
+        self.jc._handle_comm_message(req)
+        for job_id in ALL_JOBS:
+            if job_id in job_id_list:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    max(int(not saved_jobs[job_id]) - 1, 0)
+                )
+            else:
+                self.assertEqual(
+                    self.jm._running_jobs[job_id]["refresh"],
+                    int(not saved_jobs[job_id])
+                )
+        self.assertIsNone(self.jc._lookup_timer)
+        self.assertFalse(self.jc._running_lookup_loop)
 
     @mock.patch(
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -30,7 +30,7 @@ from .test_job import (
     BATCH_RETRY_RUNNING,
     BATCH_RETRY_ERROR,
     JOB_NOT_FOUND,
-    saved_jobs,
+    JOBS_TERMINALITY,
     ALL_JOBS,
     FINISHED_JOBS,
     ACTIVE_JOBS,
@@ -685,8 +685,7 @@ class JobManagerTest(unittest.TestCase):
             self.assertCountEqual(batch_job.child_jobs, new_child_ids)
 
     def test_modify_job_refresh(self):
-        for job_id, terminality in saved_jobs.items():
-            print(job_id, terminality)
+        for job_id, terminality in JOBS_TERMINALITY.items():
             self.assertEqual(
                 self.jm._running_jobs[job_id]["refresh"],
                 int(not terminality)


### PR DESCRIPTION
# Description of PR purpose/changes

* `start_job_update` and `stop_job_update` now are tailored to use field `job_id_list` from FE
* Add `start_job_update_batch` and `stop_job_update_batch`, which will use field `job_id` containing batch container job ID to expand to `start_job_update` and `stop_job_update` requests with `job_id_list` fields containing the batch container and children job IDs.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
