### PR TITLE
DATAUP-519 Refresh for init and all status

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -209,10 +209,6 @@ These are organized by the `request_type` field, followed by the expected respon
 `job_status_batch` request job statuses, responds with `job_status`
 * `job_id` - string - job_id of batch container job
 
-`start_update_loop` - request starting the global job status update thread, no specific response, but generally with `job_status_all`
-
-`stop_update_loop` - request stopping the global job status update thread, no response
-
 `start_job_update` - request updating job(s) during the update thread, responds with `job_status`
 * `job_id` - string OR `job_id_list` - array of strings
 

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -249,16 +249,22 @@ class Job(object):
                     child_job.state(force_refresh=True)
         return self.was_terminal
 
-    def in_cells(self, cell_ids):
+    def in_cells(self, cell_ids: List[str]) -> bool:
         """
         For job initialization.
         See if job is associated with present cells
+
+        A batch job technically can have children in different cells,
+        so consider it in any cell a child is in
         """
+        if cell_ids is None:
+            raise ValueError("cell_ids cannot be None")
+
         if self.batch_job:
             for child_job in self.children:
                 if child_job.cell_id in cell_ids:
                     return True
-                return False
+            return False
         else:
             return self.cell_id in cell_ids
 

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -241,6 +241,28 @@ class Job(object):
             return self._acc_state.get("status") in TERMINAL_STATUSES
 
     @property
+    def is_terminal(self):
+        self.state()
+        if self._acc_state.get("batch_job"):
+            for child_job in self.children:
+                if child_job._acc_state.get("status") != COMPLETED_STATUS:
+                    child_job.state(force_refresh=True)
+        return self.was_terminal
+
+    def in_cells(self, cell_ids):
+        """
+        For job initialization.
+        See if job is associated with present cells
+        """
+        if self.batch_job:
+            for child_job in self.children:
+                if child_job.cell_id in cell_ids:
+                    return True
+                return False
+        else:
+            return self.cell_id in cell_ids
+
+    @property
     def final_state(self):
         if self.was_terminal is True:
             return self.state()

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -216,16 +216,18 @@ class JobComm:
 
     def start_job_status_loop(
         self,
+        req: JobRequest = None,
         init_jobs: bool = False,
         cell_list: List[str] = None,
     ) -> None:
         """
-        Starts the job status lookup loop. This runs every 10 seconds.
-        This has the bare *args and **kwargs to handle the case where this comes in as a job
-        channel request (gets a JobRequest arg), or has the "init_jobs" kwarg.
+        Starts the job status lookup loop. This runs every LOOKUP_TIMER_INTERVAL=10 seconds.
 
-        If init_jobs=True, this attempts to reinitialize the JobManager's list of known jobs
-        from the workspace.
+        :param req: first position is reserved for when this is invoked
+            as a job channel request (gets a JobRequest arg)
+        :param init_jobs: If init_jobs=True, this attempts to (re-)initialize
+            the JobManager's list of known jobs from the workspace.
+        :param cell_list: from FE, the list of extant cell IDs
         """
         self._running_lookup_loop = True
         if init_jobs:

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -144,9 +144,6 @@ class JobComm:
     * all_status - return job state for all jobs in this Narrative.
     * job_status - return the job state for a single job (requires a job_id)
     * job_info - return basic job info for a single job (requires a job_id)
-    * start_update_loop - starts a looping thread that runs returns all job info
-        for running jobs
-    * stop_update_loop - stops the automatic update loop
     * start_job_update - tells the update loop to include a job when updating (requires a job_id)
     * stop_job_update - has the update loop not include a job when updating (requires a job_id)
     * cancel_job - cancels a running job, if it hasn't otherwise terminated (requires a job_id)
@@ -186,8 +183,6 @@ class JobComm:
                 "job_status_batch": self._lookup_job_states_batch,
                 "job_info": self._lookup_job_info,
                 "job_info_batch": self._lookup_job_info_batch,
-                "start_update_loop": self.start_job_status_loop,
-                "stop_update_loop": self.stop_job_status_loop,
                 "start_job_update": self._modify_job_updates,
                 "stop_job_update": self._modify_job_updates,
                 "start_job_update_batch": self._modify_job_updates_batch,
@@ -216,15 +211,12 @@ class JobComm:
 
     def start_job_status_loop(
         self,
-        req: JobRequest = None,
         init_jobs: bool = False,
         cell_list: List[str] = None,
     ) -> None:
         """
-        Starts the job status lookup loop. This runs every LOOKUP_TIMER_INTERVAL=10 seconds.
+        Starts the job status lookup loop. This runs every LOOKUP_TIMER_INTERVAL seconds.
 
-        :param req: first position is reserved for when this is invoked
-            as a job channel request (gets a JobRequest arg)
         :param init_jobs: If init_jobs=True, this attempts to (re-)initialize
             the JobManager's list of known jobs from the workspace.
         :param cell_list: from FE, the list of extant cell IDs

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -214,7 +214,11 @@ class JobComm:
             )
             raise NoJobException("No valid job ids")
 
-    def start_job_status_loop(self, *args, **kwargs) -> None:
+    def start_job_status_loop(
+        self,
+        init_jobs: bool = False,
+        cell_list: List[str] = None,
+    ) -> None:
         """
         Starts the job status lookup loop. This runs every 10 seconds.
         This has the bare *args and **kwargs to handle the case where this comes in as a job
@@ -224,9 +228,9 @@ class JobComm:
         from the workspace.
         """
         self._running_lookup_loop = True
-        if kwargs.get("init_jobs", False):
+        if init_jobs:
             try:
-                self._jm.initialize_jobs()
+                self._jm.initialize_jobs(cell_list)
             except Exception as e:
                 error = {
                     "error": "Unable to get initial jobs list",
@@ -269,7 +273,7 @@ class JobComm:
         Fetches status of all jobs in the current workspace and sends them to the front end.
         req can be None, as it's not used.
         """
-        all_job_states = self._jm.lookup_all_job_states(ignore_refresh_flag=True)
+        all_job_states = self._jm.lookup_all_job_states(ignore_refresh_flag=False)
         self.send_comm_message("job_status_all", all_job_states)
         return all_job_states
 

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -102,6 +102,8 @@ class JobManager(object):
 
             job = Job(job_state, children=child_jobs)
 
+            # Set to refresh when job is not in terminal state
+            # and when job is present in cells (if given)
             refresh = not job.was_terminal
             if cell_ids is not None:
                 refresh &= job.in_cells(cell_ids)

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -106,7 +106,7 @@ class JobManager(object):
             # and when job is present in cells (if given)
             refresh = not job.was_terminal
             if cell_ids is not None:
-                refresh &= job.in_cells(cell_ids)
+                refresh = refresh and job.in_cells(cell_ids)
 
             self.register_new_job(job, int(refresh))
 

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -1,7 +1,6 @@
 import biokbase.narrative.clients as clients
 from .job import (
     Job,
-    TERMINAL_STATUSES,
     EXCLUDED_JOB_STATE_FIELDS,
     JOB_INIT_EXCLUDED_JOB_STATE_FIELDS,
     get_dne_job_state,
@@ -64,7 +63,7 @@ class JobManager(object):
 
         return states
 
-    def initialize_jobs(self):
+    def initialize_jobs(self, cell_ids: List[str] = None) -> None:
         """
         Initializes this JobManager.
         This is expected to be run by a running Narrative, and naturally linked to a workspace.
@@ -101,10 +100,13 @@ class JobManager(object):
                     for child_id in job_state.get("child_jobs", [])
                 ]
 
-            self.register_new_job(
-                job=Job(job_state, children=child_jobs),
-                refresh=int(job_state.get("status") not in TERMINAL_STATUSES),
-            )
+            job = Job(job_state, children=child_jobs)
+
+            refresh = not job.was_terminal
+            if cell_ids is not None:
+                refresh &= job.in_cells(cell_ids)
+
+            self.register_new_job(job, int(refresh))
 
     def _create_jobs(self, job_ids) -> dict:
         """

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -848,8 +848,9 @@ class JobTest(unittest.TestCase):
         cell_2_jobs = get_cell_2_jobs(instance=False)
         cell_ids = list(cell_2_jobs.keys())
         # Iterate through all combinations of cell IDs
-        for combo_len in range(1, len(cell_ids) + 1):
+        for combo_len in range(len(cell_ids) + 1):
             for combo in itertools.combinations(cell_ids, combo_len):
+                combo = list(combo)
                 # Get jobs expected to be associated with the cell IDs
                 exp_job_ids = [
                     job_id

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -1,6 +1,7 @@
 import unittest
 import mock
 import copy
+import itertools
 from biokbase.workspace.baseclient import ServerError
 from biokbase.narrative.app_util import map_inputs_from_job, map_outputs_from_state
 from biokbase.narrative.jobs.job import (
@@ -97,11 +98,11 @@ JOBS_TERMINALITY = {
 }
 
 ALL_JOBS = list(JOBS_TERMINALITY.keys())
-FINISHED_JOBS = []
+TERMINAL_JOBS = []
 ACTIVE_JOBS = []
 for key, value in JOBS_TERMINALITY.items():
     if value:
-        FINISHED_JOBS.append(key)
+        TERMINAL_JOBS.append(key)
     else:
         ACTIVE_JOBS.append(key)
 
@@ -162,11 +163,12 @@ def get_widget_info(job_id):
     tag = narr_cell_info.get("tag", JOB_ATTR_DEFAULTS["tag"])
     app_id = job_input.get("app_id", JOB_ATTR_DEFAULTS["app_id"])
     spec = get_test_spec(tag, app_id)
-    output_widget, widget_params = map_outputs_from_state(
-        state,
-        map_inputs_from_job(params, spec),
-        spec,
-    )
+    with mock.patch("biokbase.narrative.app_util.clients.get", get_mock_client):
+        output_widget, widget_params = map_outputs_from_state(
+            state,
+            map_inputs_from_job(params, spec),
+            spec,
+        )
     return {
         "name": output_widget,
         "tag": narr_cell_info.get("tag", "release"),
@@ -225,6 +227,35 @@ def get_batch_family_jobs(return_list=False):
                 for child_id, child_job in zip(BATCH_CHILDREN, child_jobs)
             },
         }
+
+
+def get_all_jobs(return_list=False):
+    # do batch family because
+    # batch container job needs to be
+    # instantiated with child instances
+    jobs = get_batch_family_jobs()
+    for job_id in ALL_JOBS:
+        if job_id not in jobs:
+            jobs[job_id] = create_job_from_ee2(job_id)
+    if return_list:
+        jobs = list(jobs.values())
+    return jobs
+
+
+def get_cell_2_jobs(instance=False):
+    cell_ids = {}
+    for job_id, job in get_all_jobs().items():
+        cell_id = (
+            job.children[0].cell_id  # choose arbitrary child for cell_id
+            if job.batch_job else
+            job.cell_id
+        )
+        payload = job if instance else job_id
+        if cell_id in cell_ids:
+            cell_ids[cell_id] += [payload]
+        else:
+            cell_ids[cell_id] = [payload]
+    return cell_ids
 
 
 class JobTest(unittest.TestCase):
@@ -677,7 +708,7 @@ class JobTest(unittest.TestCase):
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_get_viewer_params__finished(self):
-        for job_id in FINISHED_JOBS:
+        for job_id in TERMINAL_JOBS:
             job = create_job_from_ee2(job_id)
             state = create_state_from_ee2(job_id)
             exp = get_widget_info(job_id)
@@ -739,7 +770,7 @@ class JobTest(unittest.TestCase):
         self.check_job_attrs(job, job_id)
 
         def mock_check_job(self_, params):
-            assert params["job_id"] == job_id
+            self.assertEqual(params["job_id"], job_id)
             return {"retry_ids": self.NEW_RETRY_IDS}
 
         with mock.patch.object(MockClients, "check_job", mock_check_job):
@@ -754,7 +785,7 @@ class JobTest(unittest.TestCase):
         self.check_job_attrs(job, job_id)
 
         def mock_check_job(self_, params):
-            assert params["job_id"] == job_id
+            self.assertEqual(params["job_id"], job_id)
             return {"retry_ids": self.NEW_RETRY_IDS}
 
         with mock.patch.object(MockClients, "check_job", mock_check_job):
@@ -780,8 +811,67 @@ class JobTest(unittest.TestCase):
         self.check_job_attrs(job, job_id)
 
         def mock_check_job(self_, params):
-            assert params["job_id"] == job_id
+            self.assertEqual(params["job_id"], job_id)
             return {"child_jobs": self.NEW_CHILD_JOBS}
 
         with mock.patch.object(MockClients, "check_job", mock_check_job):
             self.check_job_attrs(job, job_id, {"child_jobs": self.NEW_CHILD_JOBS})
+
+    def test_was_terminal(self):
+        all_jobs = get_all_jobs()
+
+        for job_id, job in all_jobs.items():
+            self.assertEqual(
+                JOBS_TERMINALITY[job_id],
+                job.was_terminal
+            )
+
+    @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
+    def test_was_terminal__batch(self):
+        batch_fam = get_batch_family_jobs(return_list=True)
+        batch_job, child_jobs = batch_fam[0], batch_fam[1:]
+
+        self.assertFalse(batch_job.was_terminal)
+
+        def mock_check_job(self_, params):
+            assert params["job_id"] in BATCH_CHILDREN
+            return {"status": COMPLETED_STATUS}
+
+        with mock.patch.object(MockClients, "check_job", mock_check_job):
+            for job in child_jobs:
+                job.state(force_refresh=True)
+
+        self.assertTrue(batch_job.was_terminal)
+
+    def test_in_cells(self):
+        all_jobs = get_all_jobs()
+        cell_2_jobs = get_cell_2_jobs(instance=False)
+        cell_ids = list(cell_2_jobs.keys())
+        for combo_len in range(1, len(cell_ids) + 1):
+            for combo in itertools.combinations(cell_ids, combo_len):
+                exp_job_ids = [
+                    job_id
+                    for cell_id, job_ids in cell_2_jobs.items()
+                    for job_id in job_ids
+                    if cell_id in combo
+                ]
+                for job_id, job in all_jobs.items():
+                    self.assertEqual(
+                        job_id in exp_job_ids,
+                        job.in_cells(combo)
+                    )
+
+    def test_in_cells__batch(self):
+        batch_fam = get_batch_family_jobs(return_list=True)
+        batch_job, child_jobs = batch_fam[0], batch_fam[1:]
+
+        for job in child_jobs:
+            job.cell_id = "hello"
+
+        self.assertTrue(
+            batch_job.in_cells(["hi", "hello"])
+        )
+
+        self.assertFalse(
+            batch_job.in_cells(["goodbye", "hasta manana"])
+        )

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -847,8 +847,10 @@ class JobTest(unittest.TestCase):
         all_jobs = get_all_jobs()
         cell_2_jobs = get_cell_2_jobs(instance=False)
         cell_ids = list(cell_2_jobs.keys())
+        # Iterate through all combinations of cell IDs
         for combo_len in range(1, len(cell_ids) + 1):
             for combo in itertools.combinations(cell_ids, combo_len):
+                # Get jobs expected to be associated with the cell IDs
                 exp_job_ids = [
                     job_id
                     for cell_id, job_ids in cell_2_jobs.items()

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -194,7 +194,7 @@ class JobCommTestCase(unittest.TestCase):
         "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
     )
     def test_start_job_status_loop__cell_ids(self):
-        cell_2_jobs = get_cell_2_jobs(instance=False)
+        cell_2_jobs = get_cell_2_jobs()
         cell_ids = list(cell_2_jobs.keys())
         # Iterate through all combinations of cell IDs
         for combo_len in range(len(cell_ids) + 1):
@@ -1211,27 +1211,6 @@ class JobCommTestCase(unittest.TestCase):
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
         self.assertEqual(msg["data"]["msg_type"], "job_status")
-
-    @mock.patch(
-        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
-    )
-    def test_handle_start_update_loop(self):
-        req = make_comm_msg("start_update_loop", None, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": "job_status_all",
-                "content": get_test_job_states(ACTIVE_JOBS)
-            },
-            msg["data"]
-        )
-
-    def test_handle_stop_update_loop(self):
-        req = make_comm_msg("stop_update_loop", None, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertIsNone(msg)
 
 
 class JobRequestTestCase(unittest.TestCase):

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -197,8 +197,9 @@ class JobCommTestCase(unittest.TestCase):
         cell_2_jobs = get_cell_2_jobs(instance=False)
         cell_ids = list(cell_2_jobs.keys())
         # Iterate through all combinations of cell IDs
-        for combo_len in range(1, len(cell_ids) + 1):
+        for combo_len in range(len(cell_ids) + 1):
             for combo in itertools.combinations(cell_ids, combo_len):
+                combo = list(combo)
                 # Get jobs expected to be associated with the cell IDs and are terminal
                 exp_job_ids = [
                     job_id
@@ -220,8 +221,12 @@ class JobCommTestCase(unittest.TestCase):
                     },
                     msg["data"]
                 )
-                self.assertTrue(self.jc._running_lookup_loop)
-                self.assertIsNotNone(self.jc._lookup_timer)
+                self.assertEqual(
+                    len(combo) > 0,
+                    self.jc._running_lookup_loop
+                )
+                assert_method = self.assertIsNotNone if len(combo) else self.assertIsNone
+                assert_method(self.jc._lookup_timer)
 
                 self.jc.stop_job_status_loop()
                 self.assertFalse(self.jc._running_lookup_loop)

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -196,8 +196,10 @@ class JobCommTestCase(unittest.TestCase):
     def test_start_job_status_loop__cell_ids(self):
         cell_2_jobs = get_cell_2_jobs(instance=False)
         cell_ids = list(cell_2_jobs.keys())
+        # Iterate through all combinations of cell IDs
         for combo_len in range(1, len(cell_ids) + 1):
             for combo in itertools.combinations(cell_ids, combo_len):
+                # Get jobs expected to be associated with the cell IDs and are terminal
                 exp_job_ids = [
                     job_id
                     for cell_id, job_ids in cell_2_jobs.items()
@@ -1204,6 +1206,27 @@ class JobCommTestCase(unittest.TestCase):
         self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
         self.assertEqual(msg["data"]["msg_type"], "job_status")
+
+    @mock.patch(
+        "biokbase.narrative.jobs.jobcomm.jobmanager.clients.get", get_mock_client
+    )
+    def test_handle_start_update_loop(self):
+        req = make_comm_msg("start_update_loop", None, False)
+        self.jc._handle_comm_message(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": "job_status_all",
+                "content": get_test_job_states(ACTIVE_JOBS)
+            },
+            msg["data"]
+        )
+
+    def test_handle_stop_update_loop(self):
+        req = make_comm_msg("stop_update_loop", None, False)
+        self.jc._handle_comm_message(req)
+        msg = self.jc._comm.last_message
+        self.assertIsNone(msg)
 
 
 class JobRequestTestCase(unittest.TestCase):

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -168,8 +168,10 @@ class JobManagerTest(unittest.TestCase):
         """
         cell_2_jobs = get_cell_2_jobs(instance=False)
         cell_ids = list(cell_2_jobs.keys())
+        # Iterate through all combinations of cell IDs
         for combo_len in range(1, len(cell_ids) + 1):
             for combo in itertools.combinations(cell_ids, combo_len):
+                # Get jobs expected to be associated with the cell IDs
                 exp_job_ids = [
                     job_id
                     for cell_id, job_ids in cell_2_jobs.items()

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -169,8 +169,9 @@ class JobManagerTest(unittest.TestCase):
         cell_2_jobs = get_cell_2_jobs(instance=False)
         cell_ids = list(cell_2_jobs.keys())
         # Iterate through all combinations of cell IDs
-        for combo_len in range(1, len(cell_ids) + 1):
+        for combo_len in range(len(cell_ids) + 1):
             for combo in itertools.combinations(cell_ids, combo_len):
+                combo = list(combo)
                 # Get jobs expected to be associated with the cell IDs
                 exp_job_ids = [
                     job_id

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -166,7 +166,7 @@ class JobManagerTest(unittest.TestCase):
         """
         Invoke initialize_jobs with cell_ids
         """
-        cell_2_jobs = get_cell_2_jobs(instance=False)
+        cell_2_jobs = get_cell_2_jobs()
         cell_ids = list(cell_2_jobs.keys())
         # Iterate through all combinations of cell IDs
         for combo_len in range(len(cell_ids) + 1):


### PR DESCRIPTION
# Description of PR purpose/changes

* FE should be able to invoke `start_job_status_loop` with a `cell_list` so BE evermore does not have to send job state for job not in a cell
* Lookup loop and `all_status` requests now respect `"refresh"`
* Special batch parent cases
* Tests

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
