### PR TITLE
bump pillow to 8.3.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
 ### Version 4.5.1
 - Python dependency updates
+  - pillow 8.3.1 -> 8.3.2
   - plotly 5.1.0 -> 5.3.1
   - pygments 2.9.0 -> 2.10.0
   - pytest 6.2.4 -> 6.2.5

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ markupsafe==2.0.1
 mock==4.0.3
 pexpect==4.8.0
 pickleshare==0.7.5
-pillow==8.3.1
+pillow==8.3.2
 plotly==5.3.1
 pyasn1==0.4.8
 pycrypto>=2.6


### PR DESCRIPTION
This is a Python requirement with a security vulnerability fix.

Adding a separate PR from Dependabot to capture the change in `RELEASE_NOTES.md`
