### PR TITLE
DATAUP-564 app_name for batch job info

### DIFF
--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -224,6 +224,13 @@ class Job(object):
             object.__setattr__(self, name, value)
 
     @property
+    def app_name(self):
+        return (
+            "batch"
+            if self.batch_job else
+            self.app_spec()["info"]["name"]
+        )
+
     def was_terminal(self):
         """
         Checks if last queried ee2 state (or those of its children) was terminal.
@@ -240,14 +247,13 @@ class Job(object):
         else:
             return self._acc_state.get("status") in TERMINAL_STATUSES
 
-    @property
     def is_terminal(self):
         self.state()
         if self._acc_state.get("batch_job"):
             for child_job in self.children:
                 if child_job._acc_state.get("status") != COMPLETED_STATUS:
                     child_job.state(force_refresh=True)
-        return self.was_terminal
+        return self.was_terminal()
 
     def in_cells(self, cell_ids: List[str]) -> bool:
         """
@@ -270,7 +276,7 @@ class Job(object):
 
     @property
     def final_state(self):
-        if self.was_terminal is True:
+        if self.was_terminal() is True:
             return self.state()
         return None
 
@@ -346,7 +352,7 @@ class Job(object):
         Queries the job service to see the state of the current job.
         """
 
-        if not force_refresh and self.was_terminal:
+        if not force_refresh and self.was_terminal():
             state = copy.deepcopy(self._acc_state)
         else:
             state = self.query_ee2_state(self.job_id, init=False)

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -295,7 +295,7 @@ class JobComm:
         self._verify_job_id(req)
         try:
             job_ids = self._jm.update_batch_job(req.job_id)
-            job_info_batch = self._jm.lookup_job_info(job_ids[1:])
+            job_info_batch = self._jm.lookup_job_info(job_ids)
         except NoJobException:
             self.send_error_message("job_does_not_exist", req)
             raise

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -104,7 +104,7 @@ class JobManager(object):
 
             # Set to refresh when job is not in terminal state
             # and when job is present in cells (if given)
-            refresh = not job.was_terminal
+            refresh = not job.was_terminal()
             if cell_ids is not None:
                 refresh = refresh and job.in_cells(cell_ids)
 
@@ -249,7 +249,7 @@ class JobManager(object):
         # These are already post-processed and ready to return.
         for job_id in job_ids:
             job = self.get_job(job_id)
-            if job.was_terminal:
+            if job.was_terminal():
                 job_states[job_id] = job.output_state()
             elif states and job_id in states:
                 state = states[job_id]
@@ -279,7 +279,6 @@ class JobManager(object):
 
     def lookup_job_info(self, job_ids: List[str]) -> dict:
         """
-        Will raise a NoJobException if job_id doesn't exist.
         Sends the info over the comm channel as these packets:
         {
             app_id: module/name,
@@ -288,20 +287,20 @@ class JobManager(object):
             job_params: dictionary,
             batch_id: string,
         }
+        Will set packet to "does_not_exist" if job_id doesn't exist.
         """
         job_ids, error_ids = self._check_job_list(job_ids)
 
         infos = dict()
         for job_id in job_ids:
             job = self.get_job(job_id)
-            if not job.batch_job:
-                infos[job_id] = {
-                    "app_id": job.app_id,
-                    "app_name": job.app_spec()["info"]["name"],
-                    "job_id": job_id,
-                    "job_params": job.params,
-                    "batch_id": job.batch_id,
-                }
+            infos[job_id] = {
+                "app_id": job.app_id,
+                "app_name": job.app_name,
+                "job_id": job_id,
+                "job_params": job.params,
+                "batch_id": job.batch_id,
+            }
         for error_id in error_ids:
             infos[error_id] = "does_not_exist"
         return infos
@@ -419,7 +418,7 @@ class JobManager(object):
         job_ids, error_ids = self._check_job_list(job_id_list)
 
         for job_id in job_ids:
-            if not self.get_job(job_id).was_terminal:
+            if not self.get_job(job_id).was_terminal():
                 self._cancel_job(job_id)
 
         job_states = self._construct_job_state_set(job_ids)
@@ -545,7 +544,7 @@ class JobManager(object):
             for job in unreg_child_jobs:
                 self.register_new_job(
                     job=job,
-                    refresh=int(not job.was_terminal),
+                    refresh=int(not job.was_terminal()),
                 )
 
         batch_job.update_children(reg_child_jobs + unreg_child_jobs)


### PR DESCRIPTION
# Description of PR purpose/changes

The batch container job was previously being skipped when sending `job_info` requests BE->FE. That's because it couldn't quite fill the `"app_name"` field since it couldn't get an app spec due to its `app_id` being `"batch"`.

@ialarmedalien thought of a design where a batch container job's de facto `"app_name"` should be `"batch"`, thus allowing the batch container job to be included when sending `job_info` requests BE->FE. I.e., the `job` object's `app_name` attribute should be set to `"batch"` for batch container jobs.

`app_name` is not looked up in `__getattr__` because conventionally that's more for the attributes from the EE2 state. Also, `was_terminal` seems like it should be more an action than a `property` 

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
