### PR TITLE
DATAUP-575: remove frontend cruft

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -129,7 +129,6 @@ define([
          */
         constructor(config = {}) {
             this.runtime = Runtime.make();
-            this.jobStates = {};
             this.handleBusMessages();
             this.devMode = config.devMode || devMode.mode;
             this.debug = this.devMode
@@ -387,68 +386,19 @@ define([
                     break;
 
                 /*
-                 * The job status for one or more jobs. See job_status_all
-                 * for a message which covers all active jobs.
+                 * The job status for one or more jobs.
+                 * The job_status_all message covers all active jobs.
                  *
                  * data structure: object with key jobId and value { jobState: job.state, outputWidgetInfo: job.widget_info }
                  */
                 case BACKEND_RESPONSES.STATUS:
+                case 'job_status_all':
                     Object.keys(msgData).forEach((_jobId) => {
-                        this.jobStates[_jobId] = msgData[_jobId].state;
-
                         this.sendBusMessage(JOB, _jobId, RESPONSES.STATUS, {
                             jobId: _jobId,
                             jobState: msgData[_jobId].state,
                             outputWidgetInfo: msgData[_jobId].widget_info,
                         });
-                    });
-                    break;
-
-                /*
-                 * This message must carry all jobs linked to this narrative.
-                 * The job deletion logic, specifically, requires that the job
-                 * actually not exist in the job service.
-                 * NB there is logic in the job management back end to allow
-                 * job notification to be turned off per job -- this would
-                 * be incompatible with the logic here and we should address
-                 * that.
-                 * E.g. if that behavior is allowed, then deletion detection
-                 * would need to move to the back end, since that is the only
-                 * place that would truly know about all jobs for this narrative.
-                 */
-                case 'job_status_all':
-                    /*
-                     * Ensure there is a locally cached copy of each job.
-                     *
-                     */
-                    for (jobId in msgData) {
-                        const jobStateMessage = msgData[jobId];
-                        // cache state data
-                        this.jobStates[jobId] = jobStateMessage.state;
-
-                        this.sendBusMessage(JOB, jobId, RESPONSES.STATUS, {
-                            jobId: jobId,
-                            jobState: jobStateMessage.state,
-                            outputWidgetInfo: jobStateMessage.widget_info,
-                        });
-                    }
-
-                    Object.keys(this.jobStates).forEach((_jobId) => {
-                        if (!msgData[_jobId]) {
-                            // If this job is not found in the incoming list of all
-                            // jobs, then we must both delete it locally, and
-                            // notify any interested parties.
-                            this.sendBusMessage(JOB, _jobId, RESPONSES.STATUS, {
-                                jobId: _jobId,
-                                jobState: {
-                                    job_id: _jobId,
-                                    status: 'does_not_exist',
-                                },
-                            });
-
-                            // it is safe to delete properties here
-                            delete this.jobStates[_jobId];
-                        }
                     });
                     break;
 

--- a/kbase-extension/static/kbase/js/util/appCellUtil.js
+++ b/kbase-extension/static/kbase/js/util/appCellUtil.js
@@ -97,11 +97,11 @@ define(['common/runtime', 'narrativeConfig', 'StagingServiceClient'], (
      *   are the validation options for each mapped input
      */
     function getFilePathOptionsForValidation(model, fileType, missingFiles) {
-        let fpIds = model.getItem(['app', 'fileParamIds', fileType]);
-        const outIds = model.getItem(['app', 'outputParamIds', fileType]);
+        let fpIds = model.getItem(['app', 'fileParamIds', fileType]) || [];
+        const outIds = model.getItem(['app', 'outputParamIds', fileType]) || [];
         // overwrite fpIds with JUST the file inputs (not the outputs)
         fpIds = new Set(fpIds.filter((id) => !outIds.includes(id)));
-        const fpVals = model.getItem(['params', fileType, 'filePaths']);
+        const fpVals = model.getItem(['params', fileType, 'filePaths']) || [];
 
         // fpVals = Array of input file path rows from the importer for the current fileType
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,9 +2147,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001257",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-            "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+            "version": "1.0.30001258",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
+            "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15306,9 +15306,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001257",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
-            "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
+            "version": "1.0.30001258",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
+            "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
             "dev": true
         },
         "chalk": {


### PR DESCRIPTION
# Description of PR purpose/changes

Removing some cruft associated with saving job IDs in the JobCommChannel widget. For now, the JobCommChannel  will not hold an index of the jobs associated with the narrative.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-575
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, creating a bulk import cell, and seeing that there aren't a load of `does_not_exist` job status updates that go out.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
