### PR TITLE
DATAUP-468 cleanup - make StagingService cache

### DIFF
--- a/kbase-extension/static/kbase/js/util/appCellUtil.js
+++ b/kbase-extension/static/kbase/js/util/appCellUtil.js
@@ -1,7 +1,4 @@
-define(['narrativeConfig', 'util/stagingFileCache'], (
-    Config,
-    StagingFileCache
-) => {
+define(['narrativeConfig', 'util/stagingFileCache'], (Config, StagingFileCache) => {
     'use strict';
 
     /**

--- a/kbase-extension/static/kbase/js/util/appCellUtil.js
+++ b/kbase-extension/static/kbase/js/util/appCellUtil.js
@@ -1,7 +1,6 @@
-define(['common/runtime', 'narrativeConfig', 'StagingServiceClient'], (
-    Runtime,
+define(['narrativeConfig', 'util/stagingFileCache'], (
     Config,
-    StagingServiceClient
+    StagingFileCache
 ) => {
     'use strict';
 
@@ -164,12 +163,7 @@ define(['common/runtime', 'narrativeConfig', 'StagingServiceClient'], (
      *
      */
     function getMissingFiles(expectedFiles) {
-        const runtime = Runtime.make();
-        const stagingService = new StagingServiceClient({
-            root: runtime.config('services.staging_api_url.url'),
-            token: runtime.authToken(),
-        });
-        return Promise.resolve(stagingService.list())
+        return StagingFileCache.getFileList()
             .then((data) => {
                 // turn data into a Set of files with the first path (the root, username)
                 // stripped, as those don't get used.

--- a/kbase-extension/static/kbase/js/util/stagingFileCache.js
+++ b/kbase-extension/static/kbase/js/util/stagingFileCache.js
@@ -1,0 +1,45 @@
+define(['bluebird', 'StagingServiceClient', 'common/runtime'], (
+    Promise,
+    StagingServiceClient,
+    Runtime
+) => {
+    'use strict';
+
+    let lastUpdateTime = 0,
+        getListPromise = null;
+    const REFRESH_INTERVAL = 30000; // ms
+
+    /**
+     * Returns a Promise that resolves into the result of StagingService.list. This
+     * is typically a JSON string that will need to be parsed (this doesn't parse,
+     * keeping in line with the API call).
+     * @param {boolean} forceRefresh if true, forces the cache to update,
+     *  regardless of the remaining time.
+     * @returns
+     */
+    function getFileList(forceRefresh = false) {
+        // if forceRefresh, just get the update
+        // if there's an existing Promise and we haven't reached the timeout limit, return it
+        if (forceRefresh || Date.now() - lastUpdateTime > REFRESH_INTERVAL) {
+            const runtime = Runtime.make();
+            const stagingClient = new StagingServiceClient({
+                root: runtime.config('services.staging_api_url.url'),
+                token: runtime.authToken(),
+            });
+            getListPromise = Promise.resolve(stagingClient.list());
+            lastUpdateTime = Date.now();
+        }
+        return getListPromise;
+    }
+
+    function clearCache() {
+        getListPromise = null;
+        lastUpdateTime = 0;
+    }
+
+    return {
+        getFileList,
+        clearCache,
+        REFRESH_INTERVAL,
+    };
+});

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -13,6 +13,7 @@ define([
     'util/timeFormat',
     './uploadTour',
     'util/kbaseApiUtil',
+    'util/stagingFileCache',
     'text!kbase/templates/data_staging/ftp_file_table.html',
     'text!kbase/templates/data_staging/ftp_file_header.html',
     'text!kbase/templates/data_staging/file_path.html',
@@ -34,6 +35,7 @@ define([
     TimeFormat,
     UploadTour,
     APIUtil,
+    StagingFileCache,
     FtpFileTableHtml,
     FtpFileHeaderHtml,
     FilePathHtml,
@@ -118,7 +120,7 @@ define([
         },
 
         updateView: function () {
-            return Promise.resolve(this.stagingServiceClient.list())
+            return StagingFileCache.getFileList(true)
                 .then((data) => {
                     const files = JSON.parse(data).map((f) => {
                         f.path = f.path.substring(f.path.indexOf('/') + 1);

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -78,11 +78,11 @@ define([
             jasmine.Ajax.uninstall();
             container.remove();
             runtime.destroy();
+            TestUtil.clearRuntime();
         });
 
         afterAll(() => {
             Jupyter.narrative = null;
-            TestUtil.clearRuntime();
         });
 
         [

--- a/test/unit/spec/util/stagingFileCacheSpec.js
+++ b/test/unit/spec/util/stagingFileCacheSpec.js
@@ -1,4 +1,9 @@
-define(['util/stagingFileCache', 'narrativeConfig', 'base/js/namespace', 'testUtil'], (StagingFileCache, Config, Jupyter, TestUtil) => {
+define(['util/stagingFileCache', 'narrativeConfig', 'base/js/namespace', 'testUtil'], (
+    StagingFileCache,
+    Config,
+    Jupyter,
+    TestUtil
+) => {
     'use strict';
 
     describe('staging file cache tests', () => {
@@ -15,7 +20,7 @@ define(['util/stagingFileCache', 'narrativeConfig', 'base/js/namespace', 'testUt
 
         beforeEach(() => {
             Jupyter.narrative = {
-                getAuthToken: () => 'fakeAuthToken'
+                getAuthToken: () => 'fakeAuthToken',
             };
             jasmine.Ajax.install();
             jasmine.Ajax.stubRequest(new RegExp(`${stagingUrl}/list/`)).andReturn({
@@ -69,7 +74,7 @@ define(['util/stagingFileCache', 'narrativeConfig', 'base/js/namespace', 'testUt
             const fileListResult = await StagingFileCache.getFileList();
             const fileList = JSON.parse(fileListResult);
 
-            expect(fileList.length).toBe(3);  // assume the response is the same as the other test, as long as there's 3 files
+            expect(fileList.length).toBe(3); // assume the response is the same as the other test, as long as there's 3 files
             const fakeStagingResponse2 = ['fileX', 'fileY'].map((fileName) => {
                 return {
                     name: fileName,
@@ -91,7 +96,9 @@ define(['util/stagingFileCache', 'narrativeConfig', 'base/js/namespace', 'testUt
             const duplicateCall = await StagingFileCache.getFileList();
             expect(fileListResult).toEqual(duplicateCall);
 
-            jasmine.clock().mockDate(new Date(Date.now() + StagingFileCache.REFRESH_INTERVAL + 100));
+            jasmine
+                .clock()
+                .mockDate(new Date(Date.now() + StagingFileCache.REFRESH_INTERVAL + 100));
 
             const newFileResult = await StagingFileCache.getFileList();
             expect(newFileResult).not.toEqual(fileListResult);

--- a/test/unit/spec/util/stagingFileCacheSpec.js
+++ b/test/unit/spec/util/stagingFileCacheSpec.js
@@ -1,0 +1,104 @@
+define(['util/stagingFileCache', 'narrativeConfig', 'base/js/namespace', 'testUtil'], (StagingFileCache, Config, Jupyter, TestUtil) => {
+    'use strict';
+
+    describe('staging file cache tests', () => {
+        const stagingUrl = Config.url('staging_api_url');
+        const fakeStagingResponse = ['file1', 'file2', 'file3'].map((fileName) => {
+            return {
+                name: fileName,
+                path: 'someUser' + '/' + fileName,
+                mtime: 1532738637499,
+                size: 34,
+                isFolder: false,
+            };
+        });
+
+        beforeEach(() => {
+            Jupyter.narrative = {
+                getAuthToken: () => 'fakeAuthToken'
+            };
+            jasmine.Ajax.install();
+            jasmine.Ajax.stubRequest(new RegExp(`${stagingUrl}/list/`)).andReturn({
+                status: 200,
+                statusText: 'success',
+                contentType: 'text/plain',
+                responseHeaders: '',
+                responseText: JSON.stringify(fakeStagingResponse),
+            });
+        });
+
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+            TestUtil.clearRuntime();
+            StagingFileCache.clearCache();
+        });
+
+        it('should have the expected functions', () => {
+            ['getFileList', 'clearCache'].forEach((fn) => {
+                expect(StagingFileCache[fn]).toEqual(jasmine.any(Function));
+            });
+        });
+
+        it('should load staging area files as expected', async () => {
+            const fileListResult = await StagingFileCache.getFileList();
+            const fileList = JSON.parse(fileListResult);
+
+            expect(fileList.length).toBe(3);
+            const files = fileList.map((fileInfo) => {
+                expect(fileInfo.size).toBe(34);
+                expect(fileInfo.isFolder).toBeFalse();
+                expect(fileInfo.mtime).toBe(1532738637499);
+                expect(fileInfo.path).toContain('someUser/');
+                return fileInfo.name;
+            });
+            expect(files).toEqual(['file1', 'file2', 'file3']);
+        });
+
+        it('should load the same Promise with staging files if run multiple consecutive times', () => {
+            const fileListPromise = StagingFileCache.getFileList();
+            expect(fileListPromise).toBe(StagingFileCache.getFileList());
+        });
+
+        it('should make a new run when forced', () => {
+            const fileListPromise = StagingFileCache.getFileList();
+            expect(fileListPromise).not.toBe(StagingFileCache.getFileList(true));
+        });
+
+        it('should clear the cache after a timeout period', async () => {
+            jasmine.clock().install();
+            const fileListResult = await StagingFileCache.getFileList();
+            const fileList = JSON.parse(fileListResult);
+
+            expect(fileList.length).toBe(3);  // assume the response is the same as the other test, as long as there's 3 files
+            const fakeStagingResponse2 = ['fileX', 'fileY'].map((fileName) => {
+                return {
+                    name: fileName,
+                    path: 'someUser' + '/' + fileName,
+                    mtime: 1678901234567,
+                    size: 45,
+                    isFolder: false,
+                };
+            });
+            jasmine.Ajax.stubRequest(new RegExp(`${stagingUrl}/list/`)).andReturn({
+                status: 200,
+                statusText: 'success',
+                contentType: 'text/plain',
+                responseHeaders: '',
+                responseText: JSON.stringify(fakeStagingResponse2),
+            });
+
+            // continue to expect that the new call returns the same Promise, though we've set up a new AJAX mock
+            const duplicateCall = await StagingFileCache.getFileList();
+            expect(fileListResult).toEqual(duplicateCall);
+
+            jasmine.clock().mockDate(new Date(Date.now() + StagingFileCache.REFRESH_INTERVAL + 100));
+
+            const newFileResult = await StagingFileCache.getFileList();
+            expect(newFileResult).not.toEqual(fileListResult);
+            const newFileList = JSON.parse(newFileResult);
+            expect(newFileList.length).toBe(2);
+
+            jasmine.clock().uninstall();
+        });
+    });
+});

--- a/test/unit/testUtil.js
+++ b/test/unit/testUtil.js
@@ -1,4 +1,8 @@
-define('testUtil', ['bluebird', 'util/stagingFileCache', 'json!/test/testConfig.json'], (Promise, StagingFileCache, TestConfig) => {
+define('testUtil', ['bluebird', 'util/stagingFileCache', 'json!/test/testConfig.json'], (
+    Promise,
+    StagingFileCache,
+    TestConfig
+) => {
     'use strict';
 
     let token = null,

--- a/test/unit/testUtil.js
+++ b/test/unit/testUtil.js
@@ -1,4 +1,4 @@
-define('testUtil', ['bluebird', 'json!/test/testConfig.json'], (Promise, TestConfig) => {
+define('testUtil', ['bluebird', 'util/stagingFileCache', 'json!/test/testConfig.json'], (Promise, StagingFileCache, TestConfig) => {
     'use strict';
 
     let token = null,
@@ -168,6 +168,9 @@ define('testUtil', ['bluebird', 'json!/test/testConfig.json'], (Promise, TestCon
         });
     }
 
+    /**
+     * Clears the global Runtime element and other KBase-used caches.
+     */
     function clearRuntime() {
         if (window.kbaseRuntime) {
             if (window.kbaseRuntime.clock) {
@@ -175,6 +178,7 @@ define('testUtil', ['bluebird', 'json!/test/testConfig.json'], (Promise, TestCon
             }
             window.kbaseRuntime = null;
         }
+        StagingFileCache.clearCache();
     }
 
     return {


### PR DESCRIPTION
# Description of PR purpose/changes

This adds a wrapper call to the StagingService client's `list` function that caches the result for 30 seconds (same time as the refresh of the staging area viewer). This prevents spamming the service and bogging the browser down in the case that lots of bulk import cells try to find out how many missing files there are.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-468
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Run multiple bulk import cells with the network tab open
* Watch for traffic when toggling open/closed the Configure tab.
* Reload the page and see that there should only be one call to `StagingService.llist` (would probably show up as `<env>.kbase.us/services/staging_service/list/`)
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
