### PR TITLE
DATAUP-575 JC ignore_refresh_flag

### DIFF
--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -253,7 +253,7 @@ class JobComm:
         Run a loop that will look up job info. After running, this spawns a Timer thread on
         a loop to run itself again. LOOKUP_TIMER_INTERVAL sets the frequency at which the loop runs.
         """
-        all_job_states = self._lookup_all_job_states(None)
+        all_job_states = self._lookup_all_job_states()
         if len(all_job_states) == 0 or not self._running_lookup_loop:
             self.stop_job_status_loop()
         else:
@@ -262,12 +262,12 @@ class JobComm:
             )
             self._lookup_timer.start()
 
-    def _lookup_all_job_states(self, req: JobRequest) -> dict:
+    def _lookup_all_job_states(self, req: JobRequest = None) -> dict:
         """
         Fetches status of all jobs in the current workspace and sends them to the front end.
         req can be None, as it's not used.
         """
-        all_job_states = self._jm.lookup_all_job_states(ignore_refresh_flag=False)
+        all_job_states = self._jm.lookup_all_job_states(ignore_refresh_flag=True)
         self.send_comm_message("job_status_all", all_job_states)
         return all_job_states
 

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -93,7 +93,7 @@ class JobManager(object):
         job_states = self._reorder_parents_children(job_states)
 
         for job_state in job_states.values():
-            child_jobs = []
+            child_jobs = None
             if job_state.get("batch_job"):
                 child_jobs = [
                     self.get_job(child_id)
@@ -324,7 +324,7 @@ class JobManager(object):
             return self._construct_job_state_set(jobs_to_lookup)
         return dict()
 
-    def register_new_job(self, job: Job, refresh: int = 0) -> None:
+    def register_new_job(self, job: Job, refresh: int = None) -> None:
         """
         Registers a new Job with the manager and stores the job locally.
         This should only be invoked when a new Job gets started.
@@ -335,6 +335,9 @@ class JobManager(object):
             The new Job that was started.
         """
         kblogging.log_event(self._log, "register_new_job", {"job_id": job.job_id})
+
+        if refresh is None:
+            refresh = int(not job.was_terminal())
         self._running_jobs[job.job_id] = {"job": job, "refresh": refresh}
 
     def get_job(self, job_id):

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -240,6 +240,8 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertEqual(self.jm.get_job(self.test_job_id), new_job)
         self._verify_comm_success(c.return_value.send_comm_message, False)
 
+        self.assertEqual(1, self.jm._running_jobs[new_job.job_id]["refresh"])
+
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
     @mock.patch(
@@ -394,6 +396,8 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertIsInstance(new_job, Job)
         self.assertEqual(self.jm.get_job(self.test_job_id), new_job)
         self._verify_comm_success(c.return_value.send_comm_message, False)
+
+        self.assertEqual(1, self.jm._running_jobs[new_job.job_id]["refresh"])
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -639,6 +643,9 @@ class AppManagerTestCase(unittest.TestCase):
             [f"{self.test_job_id}_child_{i}" for i in range(len(child_jobs))],
         )
         self._verify_comm_success(c.return_value.send_comm_message, True, num_jobs=4)
+
+        for job in [parent_job] + child_jobs:
+            self.assertEqual(1, self.jm._running_jobs[job.job_id]["refresh"])
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -48,6 +48,7 @@ from .test_jobmanager import get_test_job_info, get_test_job_infos
 
 
 APP_NAME = "The Best App in the World"
+EXP_ALL_STATE_IDS = ALL_JOBS   # or ACTIVE_JOBS
 
 
 def make_comm_msg(
@@ -156,7 +157,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": "job_status_all",
-                "content": get_test_job_states(ACTIVE_JOBS)
+                "content": get_test_job_states(EXP_ALL_STATE_IDS)
             },
             msg["data"]
         )
@@ -177,13 +178,6 @@ class JobCommTestCase(unittest.TestCase):
         for combo_len in range(len(cell_ids) + 1):
             for combo in itertools.combinations(cell_ids, combo_len):
                 combo = list(combo)
-                # Get jobs expected to be associated with the cell IDs and are terminal
-                exp_job_ids = [
-                    job_id
-                    for cell_id, job_ids in cell_2_jobs.items()
-                    for job_id in job_ids
-                    if cell_id in combo and not JOBS_TERMINALITY[job_id]
-                ]
 
                 self.jm._running_jobs = {}
                 self.assertFalse(self.jc._running_lookup_loop)
@@ -194,16 +188,13 @@ class JobCommTestCase(unittest.TestCase):
                 self.assertEqual(
                     {
                         "msg_type": "job_status_all",
-                        "content": get_test_job_states(exp_job_ids)
+                        "content": get_test_job_states(EXP_ALL_STATE_IDS)  # consult version history for when this was exp_job_ids
                     },
                     msg["data"]
                 )
-                self.assertEqual(
-                    len(combo) > 0,
-                    self.jc._running_lookup_loop
-                )
-                assert_method = self.assertIsNotNone if len(combo) else self.assertIsNone
-                assert_method(self.jc._lookup_timer)
+
+                self.assertTrue(self.jc._running_lookup_loop)
+                self.assertTrue(self.jc._lookup_timer)
 
                 self.jc.stop_job_status_loop()
                 self.assertFalse(self.jc._running_lookup_loop)
@@ -222,7 +213,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": "job_status_all",
-                "content": get_test_job_states(ACTIVE_JOBS)
+                "content": get_test_job_states(EXP_ALL_STATE_IDS)
             },
             msg["data"]
         )


### PR DESCRIPTION
# Description of PR purpose/changes

* Set `jc._lookup_all_job_states` to query job states with `ignore_refresh_flag=True`. Upstream calls affected are `all_status` requests and `_lookup_job_status_loop`.
* Set `jm.register_new_job` to default set `"refresh"` to be the negation of the terminality of the last queried state.
* Test that `appmanager.AppManager.run_app*` has new jobs with `"refresh"` of `1`

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [n/a] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
