### PR TITLE
DATAUP-575: quick frontend fix

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -561,7 +561,7 @@ define([
             return [
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
                 'cell_list = ' + JSON.stringify(currentCells),
-                'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
+                'JobComm().start_job_status_loop(init_jobs=True)',
             ].join('\n');
         }
     }

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -561,6 +561,7 @@ define([
             return [
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
                 'cell_list = ' + JSON.stringify(currentCells),
+                // DATAUP-575: temporarily removing cell_list
                 'JobComm().start_job_status_loop(init_jobs=True)',
             ].join('\n');
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,9 +2147,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001258",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-            "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+            "version": "1.0.30001259",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
+            "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15306,9 +15306,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001258",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-            "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+            "version": "1.0.30001259",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz",
+            "integrity": "sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -107,7 +107,9 @@ define([
             expect(jobCommInitString.split('\n')).toEqual([
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
                 'cell_list = ["12345","abcde","who cares?"]',
-                'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
+                // DATAUP-575: temporary disabling of cell_list
+                // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
+                'JobComm().start_job_status_loop(init_jobs=True)',
             ]);
         });
 
@@ -118,7 +120,9 @@ define([
             expect(jobCommInitString.split('\n')).toEqual([
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
                 'cell_list = []',
-                'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
+                // DATAUP-575: temporary disabling of cell_list
+                // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
+                'JobComm().start_job_status_loop(init_jobs=True)',
             ]);
         });
 


### PR DESCRIPTION
# Description of PR purpose/changes

Temporarily disable `cell_list` param to stop the backend from filtering out jobs that are still active.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-575
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, creating a new bulk import cell, running an import, and seeing that it doesn't automatically say that all jobs are not found.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
