### PR TITLE
DATAUP-494: table layout change prep

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -115,10 +115,7 @@ When the kernel sends a message to the front end, the only module set up to list
   * `jobId` - string, the job id
   * `logs` - the raw message data from the kernel. (see the **Data Structures** section below)
   * `latest` - if truthy, then these are the latest logs, if falsy, then they don't have to be the latest logs.
-
-`job-log-deleted` - a log request has thrown an error
-  * `jobId` - string, the job id
-  * `message` - string, a reason for the error
+  * `error` - if exists, the log request has thrown an error. The error key contains the error details.
 
 `job-status` - contains the current job state
   * `jobId` - string, the job id
@@ -295,7 +292,7 @@ A general job comm error, capturing most errors that get thrown by the kernel
   * `job_id` - string OR `job_id_list` - array of strings, the job id(s) (if present)
   * `message` - string, an error message
 
-**bus** one of `job-cancel-error`, `job-log-deleted`, `job-error`
+**bus** `job-error`
 
 ### `job_info`
 Includes information about the running job

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -146,7 +146,7 @@ define([
         }
 
         validOutgoingMessageTypes() {
-            return Object.values(RESPONSES).concat(['job-error', 'job-log-deleted']);
+            return Object.values(RESPONSES).concat(['job-error']);
         }
 
         /**
@@ -304,22 +304,19 @@ define([
                         case JOB_REQUESTS.LOGS:
                             this.sendBusMessage(JOB, jobId, RESPONSES.LOGS, {
                                 jobId,
-                                error: msgData.message,
-                            });
-                            this.sendBusMessage(JOB, jobId, 'job-log-deleted', {
-                                jobId,
-                                message: msgData.message,
+                                error: msgData,
                             });
                             break;
                         case JOB_REQUESTS.RETRY:
                             this.sendBusMessage(JOB, jobId, RESPONSES.RETRY, {
-                                jobId: jobId,
-                                error: msgData.message,
+                                jobId,
+                                error: msgData,
                             });
                             break;
                         default:
                             this.sendBusMessage(JOB, jobId, 'job-error', {
                                 jobId,
+                                error: msgData,
                                 message: msgData.message,
                                 request: msgData.source,
                             });

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -614,7 +614,7 @@ define([
             cell.metadata = meta;
             render()
                 .then(() => {
-                    jobManager.addHandler('modelUpdate', {
+                    jobManager.addEventHandler('modelUpdate', {
                         execMessage: (jobManagerContext) => {
                             // Update the execMessage panel with details of the active jobs
                             controlPanel.setExecMessage(

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -9,7 +9,7 @@ from biokbase.narrative.common import kblogging
 UNKNOWN_REASON = "Unknown reason"
 NO_JOB_ERR = "No valid job ids"
 
-LOOKUP_TIMER_INTERVAL = 10
+LOOKUP_TIMER_INTERVAL = 5
 
 
 class JobRequest:

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -553,19 +553,24 @@ define([
                     job_id: 'jobCancelWithErrors',
                     message: 'cancel error',
                     source: 'cancel_job',
+                    code: 'RED',
                 },
-                expectedMultiple: [
-                    [
-                        {
-                            jobId: 'jobCancelWithErrors',
+                expected: [
+                    {
+                        jobId: 'jobCancelWithErrors',
+                        error: {
+                            job_id: 'jobCancelWithErrors',
                             message: 'cancel error',
-                            request: 'cancel_job',
+                            source: 'cancel_job',
+                            code: 'RED',
                         },
-                        {
-                            channel: { jobId: 'jobCancelWithErrors' },
-                            key: { type: 'job-error' },
-                        },
-                    ],
+                        message: 'cancel error',
+                        request: 'cancel_job',
+                    },
+                    {
+                        channel: { jobId: 'jobCancelWithErrors' },
+                        key: { type: 'job-error' },
+                    },
                 ],
             },
             {
@@ -574,28 +579,22 @@ define([
                     job_id: 'jobLogWithErrors',
                     message: 'log error',
                     source: 'job_logs',
+                    code: -32000,
                 },
-                expectedMultiple: [
-                    [
-                        {
-                            jobId: 'jobLogWithErrors',
+                expected: [
+                    {
+                        jobId: 'jobLogWithErrors',
+                        error: {
+                            job_id: 'jobLogWithErrors',
                             message: 'log error',
+                            source: 'job_logs',
+                            code: -32000,
                         },
-                        {
-                            channel: { jobId: 'jobLogWithErrors' },
-                            key: { type: 'job-log-deleted' },
-                        },
-                    ],
-                    [
-                        {
-                            jobId: 'jobLogWithErrors',
-                            error: 'log error',
-                        },
-                        {
-                            channel: { jobId: 'jobLogWithErrors' },
-                            key: { type: 'job-logs' },
-                        },
-                    ],
+                    },
+                    {
+                        channel: { jobId: 'jobLogWithErrors' },
+                        key: { type: 'job-logs' },
+                    },
                 ],
             },
             {
@@ -605,10 +604,17 @@ define([
                     source: 'some-unknown-error',
                     job_id: 'unknownJobErrors',
                     message: 'some random error',
+                    code: 404,
                 },
                 expected: [
                     {
                         jobId: 'unknownJobErrors',
+                        error: {
+                            source: 'some-unknown-error',
+                            job_id: 'unknownJobErrors',
+                            message: 'some random error',
+                            code: 404,
+                        },
                         message: 'some random error',
                         request: 'some-unknown-error',
                     },


### PR DESCRIPTION
# Description of PR purpose/changes

Some prep work for altering the job status table structure and general cleanup. It includes:

- save all the jobInfo in the model (including app ID, which will be needed for the next step)
- if the retry button is clicked, close the details row so that the job log doesn't keep showing info about the old job
- add a note above the table to indicate users should click on a row to view more details

General cleanup:
- remove the `job-log-deleted` message type, use the `job-logs` message type instead
- use `addEventHandler` and `removeEventHandler` in the jobManager in place of `addHandler` and `removeHandler` -- more descriptive
- switch to using the new `*-batch` endpoints in the backend

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-494
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see the exciting new instructions above the job status table

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
