### PR TITLE
add ADR for output cells from bulk import

### DIFF
--- a/docs/adrs/0004-bulk-import-output-cells.md
+++ b/docs/adrs/0004-bulk-import-output-cells.md
@@ -8,7 +8,7 @@ This ADR details the decision to not provide output cells for those apps run by 
 
 ## Author
 
-@briehl
+@briehl, @ialarmedalien
 
 ## Status
 
@@ -22,9 +22,23 @@ Accepted
 
 ## Decision Outcome and Consequences
 
-The Bulk Import cell will not produce new Output Cells on app completion. It will, instead, ensure that there is a Report view available for each imported object. This carries the consequence that users may expect an output cell for one or two uploaded object types based on the single uploader. Extra documentation should help with that.
+The Bulk Import cell will not produce new Output Cells on app completion. It will, instead, ensure that there is a report view available for each imported object. This carries the consequence that users may expect an output cell for one or two uploaded object types based on the single uploader. Extra documentation should help with that.
 
-A workaround could be to guide the user to choose one or more generated data objects to view by clicking on them in the data panel on the left side of the Narrative.
+Bulk Import cell importer apps that employ an output cell:
+
+| Importer | Output cell |
+|---|---|
+| Import GenBank as genome from staging | Genome viewer |
+| Import GFF/FASTA as genome from staging | Genome viewer |
+
+Other importer apps with output cells:
+
+| Importer | Output cell |
+|---|---|
+| Load paired end reads from file | Reads viewer |
+| Load single end reads from file | Reads viewer |
+
+Workaround: users can click on the object name in the "Objects" section of the result panel or click on the object in the data panel on the left side of the narrative. Either action will create the appropriate viewer in their narrative.
 
 ## Pros and Cons of Alternatives
 

--- a/docs/adrs/0004-bulk-import-output-cells.md
+++ b/docs/adrs/0004-bulk-import-output-cells.md
@@ -1,6 +1,6 @@
 # Bulk Import Output Cells
 
-Date: 2021-10-12
+Date: 2021-10-05
 
 One of the features of the App Cell is that it can produce Output Cells after a run. These typically contain views of the data that was transformed via the app, including new calculations being made or new data being created. However, in the Bulk Import cell, this could result in dozens or more new cells all being created at once, which could overwhelm a user or lead to other confusion from what should be an easy upload process.
 

--- a/docs/adrs/0004-bulk-import-output-cells.md
+++ b/docs/adrs/0004-bulk-import-output-cells.md
@@ -1,0 +1,48 @@
+# Bulk Import Output Cells
+
+Date: 2020-10-12
+
+One of the features of the App Cell is that it can produce Output Cells after a run. These typically contain views of the data that was transformed via the app, including new calculations being made or new data being created. However, in the Bulk Import cell, this could result in dozens or more new cells all being created at once, which could overwhelm a user or lead to other confusion from what should be an easy upload process.
+
+This ADR details the decision to not provide output cells for those apps run by the Bulk Import cell.
+
+## Author
+
+@briehl
+
+## Status
+
+Accepted
+
+## Alternatives Considered
+
+* Include Output Cells when Apps finish
+* Don't include Output Cells when Apps finish
+* Group Output Cells in a single, tabbed Output
+
+## Decision Outcome and Consequences
+
+The Bulk Import cell will not produce new Output Cells on app completion. It will, instead, ensure that there is a Report view available for each imported object. This carries the consequence that users may expect an output cell for one or two uploaded object types based on the single uploader. Extra documentation should help with that.
+
+## Pros and Cons of Alternatives
+
+### Include Output Cells when Apps finish
+
+* `+` Keeps same behavior as the current App Cell.
+* `+` Shows the expected output from the newly created upload object.
+* `-` Will likely create a ton of Output Cells at once.
+* `-` Could clog a Narrative with lots of extra cells.
+* `-` Order of outputs would be semi-random (whenever a job finishes).
+* `-` Retrying jobs would further confuse the output order.
+
+### Don't include Output Cells when Apps finish
+
+* `+` Prevents spamming the Narrative with Output Cells.
+* `+` Consolidates outputs under the Results tab.
+* `+` Results of retried jobs will be handled more efficiently.
+* `-` Users could miss their expected outputs, and might need guidance to see their data as expected.
+
+### Group Output Cells in a single, tabbed Output
+
+* `+` Maintains expected flow of outputs produced from Bulk Import apps
+* `-` New, unscoped, undesigned work.

--- a/docs/adrs/0004-bulk-import-output-cells.md
+++ b/docs/adrs/0004-bulk-import-output-cells.md
@@ -1,6 +1,6 @@
 # Bulk Import Output Cells
 
-Date: 2020-10-12
+Date: 2021-10-12
 
 One of the features of the App Cell is that it can produce Output Cells after a run. These typically contain views of the data that was transformed via the app, including new calculations being made or new data being created. However, in the Bulk Import cell, this could result in dozens or more new cells all being created at once, which could overwhelm a user or lead to other confusion from what should be an easy upload process.
 
@@ -24,6 +24,8 @@ Accepted
 
 The Bulk Import cell will not produce new Output Cells on app completion. It will, instead, ensure that there is a Report view available for each imported object. This carries the consequence that users may expect an output cell for one or two uploaded object types based on the single uploader. Extra documentation should help with that.
 
+A workaround could be to guide the user to choose one or more generated data objects to view by clicking on them in the data panel on the left side of the Narrative.
+
 ## Pros and Cons of Alternatives
 
 ### Include Output Cells when Apps finish
@@ -46,3 +48,4 @@ The Bulk Import cell will not produce new Output Cells on app completion. It wil
 
 * `+` Maintains expected flow of outputs produced from Bulk Import apps
 * `-` New, unscoped, undesigned work.
+* `-` Creates output view that the user may or may not want and may be difficult to navigate, given there could be hundreds or thousands of items in the view.


### PR DESCRIPTION
# Description of PR purpose/changes

This came up as an Action Item from a couple of Retrospectives - document the decision to have Bulk Import cells NOT produce output cells after individual app runs. Short version = would make a zillion, possibly unexpected, unordered data viewer cells.