### PR TITLE
DATAUP-450: Fully implement the bulk import reset action

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -64,4 +64,7 @@ jobs:
 
     - name: outcome
       if: steps.test_backend.outcome != 'success' || steps.test_frontend.outcome != 'success'
-      run: exit 1
+      run: |
+        echo "backend tests: ${{ steps.test_backend.outcome }}"
+        echo "frontend tests: ${{ steps.test_frontend.outcome }}"
+        exit 1

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -54,6 +54,7 @@ jobs:
       continue-on-error: true
 
     - name: Send to Codecov
+      id: send_to_codecov
       uses: codecov/codecov-action@v1.5.2
       continue-on-error: true
       with:
@@ -63,8 +64,9 @@ jobs:
         fail_ci_if_error: true
 
     - name: outcome
-      if: steps.test_backend.outcome != 'success' || steps.test_frontend.outcome != 'success'
+      if: steps.test_backend.outcome != 'success' || steps.test_frontend.outcome != 'success' || steps.send_to_codecov.outcome != 'success'
       run: |
         echo "backend tests: ${{ steps.test_backend.outcome }}"
         echo "frontend tests: ${{ steps.test_frontend.outcome }}"
+        echo "upload coverage: ${{ steps.send_to_codecov.outcome }}"
         exit 1

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -42,24 +42,26 @@ jobs:
         echo "KBASE_TEST_TOKEN=${{ secrets.NARRATIVE_TEST_TOKEN }}" >> $GITHUB_ENV
 
     - name: Run Narrative Backend Tests
+      id: test_backend
       shell: bash -l {0}
       run: make test-backend
+      continue-on-error: true
 
     - name: Run Narrative Frontend Unit Tests
+      id: test_frontend
       shell: bash -l {0}
       run: make test-frontend-unit
-
-    - name: make test output available as artifact in case of failure
-      if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: karma-result.json
-        path: karma-result.json
+      continue-on-error: true
 
     - name: Send to Codecov
       uses: codecov/codecov-action@v1.5.2
+      continue-on-error: true
       with:
         file: |
           ./python-coverage/coverage.xml
           ./js-coverage/lcov/lcov.info
         fail_ci_if_error: true
+
+    - name: outcome
+      if: steps.test_backend.outcome != 'success' || steps.test_frontend.outcome != 'success'
+      run: exit 1

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -528,8 +528,8 @@ define([
          */
         function requestLatestJobLog() {
             scrollToEndOnNext = true;
-            awaitingLog = true;
             ui.showElement('spinner');
+            awaitingLog = true;
             bus.emit('request-job-log', {
                 jobId,
                 options: {

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -784,10 +784,10 @@ define([
                     doRunCellAction();
                     break;
                 case 'cancel':
-                    doCellAction('cancel');
+                    doCellAction('cancelBulkImport');
                     break;
                 case 'resetApp':
-                    doCellAction('reset');
+                    doCellAction('appReset');
                     break;
                 case 'offline':
                     // TODO implement / test better
@@ -822,13 +822,12 @@ define([
          * If a job run has been triggered, the batch job will be terminated, which
          * will also terminate all the child jobs.
          *
-         * @param {string} actionType - either 'cancel' or 'reset'; defaults to 'reset'
+         * @param {string} action - either 'cancelBulkImport' or 'appReset'; defaults to 'appReset'
          */
-        async function doCellAction(actionType) {
-            if (!actionType) {
-                actionType = 'reset';
+        async function doCellAction(action) {
+            if (!action || (action !== 'cancelBulkImport' && action !== 'appReset')) {
+                action = 'appReset';
             }
-            const action = actionType === 'cancel' ? 'cancelBulkImport' : 'appReset';
             const confirmed = await DialogMessages.showDialog({ action });
 
             if (confirmed) {
@@ -837,7 +836,7 @@ define([
                 // handleRunStatus will cancel the batch job when it receives that message
                 cancelBatch = true;
                 controlPanel.setExecMessage(
-                    actionType === 'cancel' ? 'Canceling...' : 'Resetting app...'
+                    action === 'cancelBulkImport' ? 'Canceling...' : 'Resetting app...'
                 );
 
                 // if runStatusListener is null, the batch job data is available and

--- a/package-lock.json
+++ b/package-lock.json
@@ -2241,9 +2241,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001264",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
-            "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
+            "version": "1.0.30001265",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+            "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15899,9 +15899,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001264",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz",
-            "integrity": "sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==",
+            "version": "1.0.30001265",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
+            "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
             "dev": true
         },
         "chalk": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
         "sassv": "sass --version",
         "stylelint": "stylelint --config .stylelintrc.yaml --fix kbase-extension/scss/**/*.scss",
         "tdd": "karma start test/unit/karma.local.conf.js --auto-watch --no-single-run",
+        "test_bulk_import": "karma start test/unit/karma.bulkImport.conf.js",
         "test_chrome": "karma start test/unit/karma.local.conf.js --browsers=Chrome --single-run=false",
         "test_firefox": "karma start test/unit/karma.local.conf.js --browsers=Firefox --single-run=false",
         "test_local": "karma start test/unit/karma.local.conf.js",

--- a/test/unit/karma.bulkImport.conf.js
+++ b/test/unit/karma.bulkImport.conf.js
@@ -1,0 +1,22 @@
+// karma config for running the bulk import cell tests
+
+module.exports = function (config) {
+    'use strict';
+    const karmaConfig = require('./karma.conf');
+    karmaConfig(config);
+    const bulkImportTestPath = 'test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js';
+    config.files.forEach((line) => {
+        if (typeof line === 'object' && line.pattern.indexOf('.js') >= 0) {
+            line.nocache = true;
+            if (line.pattern === 'test/unit/spec/**/*.js') {
+                line.pattern = bulkImportTestPath;
+            }
+        }
+    });
+
+    config.exclude = config.exclude.filter((line) => {
+        return line !== bulkImportTestPath;
+    });
+
+    config.reporters = ['mocha', 'json-result'];
+};

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -1,4 +1,3 @@
-// process.env.CHROME_BIN = require('puppeteer').executablePath();
 module.exports = function (config) {
     'use strict';
     config.set({
@@ -28,9 +27,8 @@ module.exports = function (config) {
         ],
         preprocessors: {
             'kbase-extension/static/kbase/js/**/!(api)/*.js': ['coverage'],
-            'kbase-extension/static/kbase/js/api/!(*[Cc]lient*|Catalog|KBaseFeatureValues|NarrativeJobServiceWrapper|NewWorkspace)*.js': [
-                'coverage',
-            ],
+            'kbase-extension/static/kbase/js/api/!(*[Cc]lient*|Catalog|KBaseFeatureValues|NarrativeJobServiceWrapper|NewWorkspace)*.js':
+                ['coverage'],
             'kbase-extension/static/kbase/js/api/RestAPIClient.js': ['coverage'],
             'nbextensions/appCell2/widgets/tabs/*.js': ['coverage'],
             'nbextensions/bulkImportCell/**/*.js': ['coverage'],
@@ -83,6 +81,7 @@ module.exports = function (config) {
             'kbase-extension/static/buildTools/*.js',
             'kbase-extension/static/ext_components/**/test/**/*.js',
             'kbase-extension/static/kbase/js/patched-components/**/*',
+            'test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js',
         ],
         // test results reporter to use
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter

--- a/test/unit/run_tests.py
+++ b/test/unit/run_tests.py
@@ -98,6 +98,16 @@ try:
         nb_server = run_narrative()
         print("narrative started")
         try:
+            print("running bulk import tests")
+            resp_unit = subprocess.check_call(
+                ["npm", "run", "test_bulk_import"],
+                stderr=subprocess.STDOUT,
+                shell=False,
+            )  # nosec
+        except subprocess.CalledProcessError as e:
+            resp_unit = e.returncode
+        try:
+            print("running unit tests")
             resp_unit = subprocess.check_call(
                 ["npm", "run", "test"],
                 stderr=subprocess.STDOUT,

--- a/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/filePathWidget-Spec.js
@@ -73,6 +73,7 @@ define([
             container = document.createElement('div');
             this.node = document.createElement('div');
             container.appendChild(this.node);
+            document.body.append(container);
             this.fpwArgs = Object.assign({ bus: this.bus }, this.defaultArgs);
         });
 

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -1,7 +1,9 @@
 define([
     '/narrative/nbextensions/bulkImportCell/bulkImportCell',
+    'util/appCellUtil',
     'base/js/namespace',
     'common/dialogMessages',
+    'common/jobs',
     'common/runtime',
     'narrativeMocks',
     'testUtil',
@@ -11,8 +13,10 @@ define([
     'narrativeConfig',
 ], (
     BulkImportCell,
+    BulkImportUtil,
     Jupyter,
     DialogMessages,
+    Jobs,
     Runtime,
     Mocks,
     TestUtil,
@@ -62,7 +66,7 @@ define([
         });
     }
 
-    xdescribe('The bulk import cell module', () => {
+    describe('The bulk import cell module', () => {
         let runtime;
         beforeAll(() => {
             Jupyter.narrative = {
@@ -95,7 +99,6 @@ define([
         describe('construction', () => {
             it('should construct a bulk import cell class', () => {
                 const cell = Mocks.buildMockCell('code');
-                expect(cell.getIcon).not.toBeDefined();
                 expect(cell.renderIcon).not.toBeDefined();
                 const cellWidget = BulkImportCell.make({
                     cell,
@@ -306,6 +309,10 @@ define([
                     };
                     // remove job data
                     delete cell.metadata.kbase.bulkImportCell.exec;
+                    spyOn(BulkImportUtil, 'getMissingFiles').and.resolveTo([]);
+                    spyOn(BulkImportUtil, 'evaluateConfigReadyState').and.resolveTo({
+                        fastq_reads: 'complete',
+                    });
                     BulkImportCell.make({ cell, devMode });
                     const testElem = cell.element[0].querySelector(testCase.testSelector);
                     // wait for the actionButton to get initialized as hidden
@@ -320,7 +327,6 @@ define([
                             cancelButton.classList.contains('hidden')
                         );
                     });
-
                     runButton.click();
                     await TestUtil.waitForElementState(
                         testElem,
@@ -394,13 +400,39 @@ define([
             });
         });
 
-        describe('cancel', () => {
-            ['launching', 'inProgress', 'inProgressResultsAvailable'].forEach((testCase) => {
-                it(`should cancel the ${testCase} state and return to a previous state`, () => {
+        describe('cancel and reset', () => {
+            const tests = [
+                {
+                    state: 'inProgressResultsAvailable',
+                    action: 'cancel',
+                },
+                {
+                    state: 'inProgress',
+                    action: 'cancel',
+                },
+                {
+                    state: 'launching',
+                    action: 'cancel',
+                },
+                {
+                    state: 'jobsFinished',
+                    action: 'reset',
+                },
+                {
+                    state: 'jobsFinishedResultsAvailable',
+                    action: 'reset',
+                },
+                {
+                    state: 'error',
+                    action: 'reset',
+                },
+            ];
+            tests.forEach((testCase) => {
+                it(`should ${testCase.action} the ${testCase.state} state and return to a previous state`, () => {
                     // init cell with the test case state and jobs (they're all run-related)
-                    // wait for the cancel button to appear and be ready, and for the run button to disappear
+                    // wait for the cancel/reset button to appear and be ready, and for the run button to disappear
                     // click it
-                    // wait for it to reset so the run button is visible
+                    // wait for the cell to reset so the run button is visible
                     // expect the state to be editingComplete
                     const cell = Mocks.buildMockCell('code');
                     // mock the Jupyter execute function.
@@ -410,12 +442,13 @@ define([
                     // I'm guessing it's a jquery fadeIn event thing.
                     spyOn(UI, 'showConfirmDialog').and.resolveTo(true);
                     spyOn(Jupyter.notebook, 'save_checkpoint');
+                    spyOn(Jobs, 'getFsmStateFromJobs').and.returnValue(testCase.state);
                     // add dummy metadata so we can make a cell that's in the ready-to-run state.
                     const state = {
                         state: {
-                            state: testCase,
+                            state: testCase.state,
                             selectedFileType: 'fastq_reads',
-                            selectedTab: 'configure',
+                            selectedTab: 'viewConfigure',
                             params: {
                                 fastq_reads: 'complete',
                             },
@@ -430,18 +463,18 @@ define([
                             ),
                             type: 'app-bulk-import',
                             attributes: {
-                                id: `${testCase}-state-test-cell`,
+                                id: `${testCase.state}-state-test-cell`,
                             },
                         },
                     };
                     const bulkImportCellInstance = BulkImportCell.make({ cell, devMode });
-                    const cancelButton = cell.element[0].querySelector(selectors.cancel);
+                    const actionButton = cell.element[0].querySelector(selectors[testCase.action]);
                     const runButton = cell.element[0].querySelector(selectors.run);
-                    // wait for the cancel button to appear and the run button to disappear
-                    return TestUtil.waitForElementState(cancelButton, () => {
+                    // wait for the cancel/reset button to appear and the run button to disappear
+                    return TestUtil.waitForElementState(actionButton, () => {
                         return (
-                            !cancelButton.classList.contains('hidden') &&
-                            !cancelButton.classList.contains('disabled') &&
+                            !actionButton.classList.contains('hidden') &&
+                            !actionButton.classList.contains('disabled') &&
                             runButton.classList.contains('hidden')
                         );
                     })
@@ -461,7 +494,7 @@ define([
                                     );
                                 },
                                 () => {
-                                    cancelButton.click();
+                                    actionButton.click();
                                 }
                             );
                         })
@@ -512,6 +545,10 @@ define([
                 };
                 // remove job data
                 delete cell.metadata.kbase.bulkImportCell.exec;
+                spyOn(BulkImportUtil, 'getMissingFiles').and.resolveTo([]);
+                spyOn(BulkImportUtil, 'evaluateConfigReadyState').and.resolveTo({
+                    fastq_reads: 'complete',
+                });
                 const bulkImportCellInstance = BulkImportCell.make({ cell, devMode });
                 spyOn(UI, 'showConfirmDialog').and.resolveTo(true);
                 spyOn(bulkImportCellInstance.jobManager, 'initBatchJob').and.callThrough();
@@ -593,21 +630,12 @@ define([
                 expect(bulkImportCellInstance.jobManager.initBatchJob).toHaveBeenCalledTimes(1);
                 const batchId = JobsData.batchParentJob.job_id;
                 // bus calls to init jobs, request info, cancel jobs, and stop updates
-                const callArgs = JobsData.allJobsWithBatchParent
-                    .map((jobState) => {
-                        return ['request-job-updates-start', { jobId: jobState.job_id }];
-                    })
-                    .concat(
-                        [['request-job-status', { batchId }]],
-                        [['request-job-info', { batchId }]],
-                        [['request-job-cancel', { jobIdList: [batchId] }]]
-                    )
-                    .concat(
-                        JobsData.allJobsWithBatchParent.map((jobState) => {
-                            return ['request-job-updates-stop', { jobId: jobState.job_id }];
-                        })
-                    );
-
+                const callArgs = [
+                    ['request-job-updates-start', { batchId }],
+                    ['request-job-info', { batchId }],
+                    ['request-job-cancel', { jobIdList: [batchId] }],
+                    ['request-job-updates-stop', { batchId }],
+                ];
                 expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
                 expect(bulkImportCellInstance.jobManager.bus.emit.calls.allArgs()).toEqual(
                     jasmine.arrayWithExactContents(callArgs)


### PR DESCRIPTION
# Description of PR purpose/changes

- Fully implemented the bulk import reset action -- I added in code to terminate the batch job so there can be no doubt that this cell has been well and truly reset!
- added tests for the bulk import reset
- fixed failing bulk import tests
- added a separate karma config for the bulk import cell tests
- edited run_tests.py to run both the bulk import cell tests and the rest of the unit tests when `make test-frontend-unit` is called

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-450
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and resetting a few bulk import cells. It's a lot more fun than you might think!

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
