### PR TITLE
DATAUP-338: widget info retrieval error

### DIFF
--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -195,9 +195,11 @@ def get_test_job_state(job_id):
     for f in EXCLUDED_JOB_STATE_FIELDS:
         if f in state:
             del state[f]
+
     output_state = {
         "state": state,
         "widget_info": get_widget_info(job_id),
+        "cell_id": state.get("cell_id"),
         "user": state.get("user"),
     }
     return output_state
@@ -833,10 +835,7 @@ class JobTest(unittest.TestCase):
         all_jobs = get_all_jobs()
 
         for job_id, job in all_jobs.items():
-            self.assertEqual(
-                JOBS_TERMINALITY[job_id],
-                job.was_terminal()
-            )
+            self.assertEqual(JOBS_TERMINALITY[job_id], job.was_terminal())
 
     @mock.patch("biokbase.narrative.jobs.job.clients.get", get_mock_client)
     def test_was_terminal__batch(self):
@@ -871,10 +870,7 @@ class JobTest(unittest.TestCase):
                     if cell_id in combo
                 ]
                 for job_id, job in all_jobs.items():
-                    self.assertEqual(
-                        job_id in exp_job_ids,
-                        job.in_cells(combo)
-                    )
+                    self.assertEqual(job_id in exp_job_ids, job.in_cells(combo))
 
     def test_in_cells__none(self):
         job = create_job_from_ee2(JOB_COMPLETED)
@@ -888,23 +884,16 @@ class JobTest(unittest.TestCase):
         for job in child_jobs:
             job.cell_id = "hello"
 
-        self.assertTrue(
-            batch_job.in_cells(["hi", "hello"])
-        )
+        self.assertTrue(batch_job.in_cells(["hi", "hello"]))
 
-        self.assertFalse(
-            batch_job.in_cells(["goodbye", "hasta manana"])
-        )
+        self.assertFalse(batch_job.in_cells(["goodbye", "hasta manana"]))
 
     def test_in_cells__batch__diff_cells(self):
         batch_fam = get_batch_family_jobs(return_list=True)
         batch_job, child_jobs = batch_fam[0], batch_fam[1:]
 
         children_cell_ids = ["hi", "hello", "greetings"]
-        for job, cell_id in zip(
-            child_jobs,
-            itertools.cycle(children_cell_ids)
-        ):
+        for job, cell_id in zip(child_jobs, itertools.cycle(children_cell_ids)):
             job.cell_id = cell_id
 
         for cell_id in children_cell_ids:
@@ -913,9 +902,7 @@ class JobTest(unittest.TestCase):
             self.assertTrue(batch_job.in_cells([cell_id, "B", "A"]))
             self.assertTrue(batch_job.in_cells(["B", "A", cell_id]))
 
-        self.assertFalse(
-            batch_job.in_cells(["goodbye", "hasta manana"])
-        )
+        self.assertFalse(batch_job.in_cells(["goodbye", "hasta manana"]))
 
     def test_app_name(self):
         for job in get_all_jobs().values():

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -48,7 +48,7 @@ from .test_jobmanager import get_test_job_info, get_test_job_infos
 
 
 APP_NAME = "The Best App in the World"
-EXP_ALL_STATE_IDS = ALL_JOBS   # or ACTIVE_JOBS
+EXP_ALL_STATE_IDS = ALL_JOBS  # or ACTIVE_JOBS
 
 
 def make_comm_msg(
@@ -157,9 +157,9 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": "job_status_all",
-                "content": get_test_job_states(EXP_ALL_STATE_IDS)
+                "content": get_test_job_states(EXP_ALL_STATE_IDS),
             },
-            msg["data"]
+            msg["data"],
         )
         self.assertTrue(self.jc._running_lookup_loop)
         self.assertIsNotNone(self.jc._lookup_timer)
@@ -188,9 +188,11 @@ class JobCommTestCase(unittest.TestCase):
                 self.assertEqual(
                     {
                         "msg_type": "job_status_all",
-                        "content": get_test_job_states(EXP_ALL_STATE_IDS)  # consult version history for when this was exp_job_ids
+                        "content": get_test_job_states(
+                            EXP_ALL_STATE_IDS
+                        ),  # consult version history for when this was exp_job_ids
                     },
-                    msg["data"]
+                    msg["data"],
                 )
 
                 self.assertTrue(self.jc._running_lookup_loop)
@@ -213,9 +215,9 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": "job_status_all",
-                "content": get_test_job_states(EXP_ALL_STATE_IDS)
+                "content": get_test_job_states(EXP_ALL_STATE_IDS),
             },
-            msg["data"]
+            msg["data"],
         )
         for job_id, state in states.items():
             self.assertIsInstance(job_id, str)

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -86,16 +86,14 @@ def get_retry_job_state(orig_id, status="unmocked"):
             "run_id": None,
             "child_jobs": [],
         },
+        "cell_id": None,
         "widget_info": None,
         "user": None,
     }
 
 
 def get_test_job_infos(job_ids):
-    return {
-        job_id: get_test_job_info(job_id)
-        for job_id in job_ids
-    }
+    return {job_id: get_test_job_info(job_id) for job_id in job_ids}
 
 
 def get_test_job_info(job_id):
@@ -109,9 +107,7 @@ def get_test_job_info(job_id):
     )
     params = test_job.get("job_input", {}).get("params", JOB_ATTR_DEFAULTS["params"])
     batch_job = test_job.get("batch_job", JOB_ATTR_DEFAULTS["batch_job"])
-    app_name = (
-        "batch" if batch_job else get_test_spec(tag, app_id)["info"]["name"]
-    )
+    app_name = "batch" if batch_job else get_test_spec(tag, app_id)["info"]["name"]
     batch_id = (
         job_id if batch_job else test_job.get("batch_id", JOB_ATTR_DEFAULTS["batch_id"])
     )
@@ -221,7 +217,7 @@ class JobManagerTest(unittest.TestCase):
 
                     self.assertEqual(
                         int(job_id in exp_job_ids and not JOBS_TERMINALITY[job_id]),
-                        refresh
+                        refresh,
                     )
 
     def test__check_job_list_fail(self):
@@ -793,10 +789,7 @@ class JobManagerTest(unittest.TestCase):
         infos = self.jm.lookup_job_info(ALL_JOBS)
 
         self.assertCountEqual(ALL_JOBS, infos.keys())
-        self.assertEqual(
-            get_test_job_infos(ALL_JOBS),
-            infos
-        )
+        self.assertEqual(get_test_job_infos(ALL_JOBS), infos)
 
 
 if __name__ == "__main__":

--- a/src/biokbase/narrative/tests/util.py
+++ b/src/biokbase/narrative/tests/util.py
@@ -316,6 +316,7 @@ def validate_job_state(job_state: dict) -> None:
     assert isinstance(job_state["state"], dict), "state is not a dict"
     assert "user" in job_state, "user key missing"
     assert isinstance(job_state["user"], str), "user is not a string"
+    assert "cell_id" in job_state, "cell_id key missing"
     state = job_state["state"]
     # list of tuples - first = key name, second = value type
     # details for other cases comes later. This is just the expected basic set of


### PR DESCRIPTION
# Description of PR purpose/changes

- changing job.py so that if the widget info cannot be accessed, it does not change the status of the job
- adding cell_id to the output state of the job
- updating tests

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see that nowt has changed

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
