### PR TITLE
Fix ws.list_objects requiring ws ids

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
 ### Version 4.5.1
+Code changes
+- DATAUP-599 - Adjusted the kernel code and tests to account for a Workspace service update.
+
+Dependency Changes
 - Python dependency updates
   - pillow 8.3.1 -> 8.3.2
   - plotly 5.1.0 -> 5.3.1

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -2,6 +2,22 @@ from ..util import ConfigTests
 from biokbase.workspace.baseclient import ServerError
 
 
+def get_nar_obj(i):
+    return [
+        i,
+        "My_Test_Narrative",
+        "KBaseNarrative.Narrative",
+        "2017-03-31T23:42:59+0000",
+        1,
+        "wjriehl",
+        18836,
+        "wjriehl:1490995018528",
+        "278abf8f0dbf8ab5ce349598a8674a6e",
+        109180038,
+        {},
+    ]
+
+
 class MockClients:
     """
     Mock KBase service clients as needed for Narrative backend tests.
@@ -215,6 +231,10 @@ class MockClients:
         paths = [["18836/5/1"]]
         num_objects = len(params.get("objects", [0]))
         return {"infos": infos * num_objects, "paths": paths * num_objects}
+
+    def list_objects(self, params):
+        ws_ids = params["ids"]
+        return [get_nar_obj(int(id)) for id in ws_ids]  # assert int
 
     # ----- Narrative Job Service functions -----
 

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -3,11 +3,13 @@ Tests for Mixin class that handles IO between the
 Narrative and workspace service.
 """
 import unittest
-from biokbase.narrative.contents.narrativeio import KBaseWSManagerMixin
+from unittest.mock import patch
+from biokbase.narrative.contents.narrativeio import KBaseWSManagerMixin, LIST_OBJECTS_FIELDS
 from biokbase.narrative.common.exceptions import WorkspaceError
 import biokbase.auth
 from tornado.web import HTTPError
 from . import util
+from .narrative_mock.mockclients import get_mock_client, MockClients, get_nar_obj
 from biokbase.narrative.common.url_config import URLS
 from biokbase.narrative.common.narrative_ref import NarrativeRef
 import biokbase.narrative.clients as clients
@@ -30,6 +32,10 @@ metadata_fields = set(
     ]
 )
 HAS_TEST_TOKEN = False
+
+
+def get_exp_nar(i):
+    return dict(zip(LIST_OBJECTS_FIELDS, get_nar_obj(i)))
 
 
 def skipUnlessToken():
@@ -71,9 +77,10 @@ class NarrIOTestCase(unittest.TestCase):
         if self.test_token is None or self.private_token is None:
             print("Skipping most narrativeio.py tests due to missing tokens.")
             print(
-                "To enable these, place a valid auth token in files\n{}\nand\n{}".format(
-                    config.get_path("token_files", "test_user"),
-                    config.get_path("token_files", "private_user"),
+                "To enable these, update {} and place a valid auth token in files\n{}\nand\n{}".format(
+                    config.config_file_path,
+                    config.get_path("token_files", "test_user", from_root=True),
+                    config.get_path("token_files", "private_user", from_root=True),
                 )
             )
             print("Note that these should belong to different users.")
@@ -511,6 +518,46 @@ class NarrIOTestCase(unittest.TestCase):
         res = self.mixin.list_narratives(ws_id=self.private_nar["ws"])
         self.validate_narrative_list(res)
         self.logout()
+
+    @patch("biokbase.narrative.clients.get", get_mock_client)
+    def test_list_narratives__no_ws_id__0_ws_ids(self):
+        ws_ids = {"workspaces": [], "pub": []}
+
+        with patch.object(MockClients, "list_workspace_ids", create=True, return_value=ws_ids):
+            nar_l = self.mixin.list_narratives()
+
+        self.assertEqual([], nar_l)
+        self.validate_narrative_list(nar_l)
+
+    @patch("biokbase.narrative.clients.get", get_mock_client)
+    def test_list_narratives__no_ws_id__9999_ws_ids(self):
+        ws_ids = {"workspaces": list(range(9999)), "pub": []}
+
+        with patch.object(MockClients, "list_workspace_ids", create=True, return_value=ws_ids):
+            nar_l = self.mixin.list_narratives()
+
+        self.assertEqual([get_exp_nar(i) for i in range(9999)], nar_l)
+        self.validate_narrative_list(nar_l)
+
+    @patch("biokbase.narrative.clients.get", get_mock_client)
+    def test_list_narratives__no_ws_id__10000_ws_ids(self):
+        ws_ids = {"workspaces": list(range(10000)), "pub": []}
+
+        with patch.object(MockClients, "list_workspace_ids", create=True, return_value=ws_ids):
+            nar_l = self.mixin.list_narratives()
+
+        self.assertEqual([get_exp_nar(i) for i in range(10000)], nar_l)
+        self.validate_narrative_list(nar_l)
+
+    @patch("biokbase.narrative.clients.get", get_mock_client)
+    def test_list_narratives__no_ws_id__10001_ws_ids(self):
+        ws_ids = {"workspaces": list(range(10000)), "pub": [10000]}
+
+        with patch.object(MockClients, "list_workspace_ids", create=True, return_value=ws_ids):
+            nar_l = self.mixin.list_narratives()
+
+        self.assertEqual([get_exp_nar(i) for i in range(10001)], nar_l)
+        self.validate_narrative_list(nar_l)
 
     def test_list_narrative_ws_invalid(self):
         with self.assertRaises(WorkspaceError) as err:

--- a/src/biokbase/narrative/tests/util.py
+++ b/src/biokbase/narrative/tests/util.py
@@ -43,9 +43,9 @@ class ConfigTests(object):
             os.environ["NARRATIVE_DIR"], "src", "biokbase", "narrative", "tests"
         )
         self._path_root = os.path.join(os.environ["NARRATIVE_DIR"])
-        config_file_path = self.file_path(_config_file)
+        self.config_file_path = self.file_path(_config_file)
         self._config = configparser.ConfigParser()
-        self._config.read(config_file_path)
+        self._config.read(self.config_file_path)
 
     def get(self, *args, **kwargs):
         return self._config.get(*args, **kwargs)

--- a/src/biokbase/workspace/client.py
+++ b/src/biokbase/workspace/client.py
@@ -2942,6 +2942,35 @@ class Workspace(object):
             "Workspace.list_workspace_info", [params], self._service_ver, context
         )
 
+    def list_workspace_ids(self, params, context=None):
+        """
+        List workspace IDs to which the user has access.
+        This function returns a subset of the information in the
+        list_workspace_info method and should be substantially faster.
+        :param params: instance of type "ListWorkspaceIDsParams" (Input
+           parameters for the "list_workspace_ids" function. Optional
+           parameters: permission perm - filter workspaces by minimum
+           permission level. 'None' and 'readable' are ignored. boolean
+           onlyGlobal - if onlyGlobal is true only include world readable
+           workspaces. Defaults to false. If true, excludeGlobal is ignored.
+           boolean excludeGlobal - if excludeGlobal is true exclude world
+           readable workspaces. Defaults to true.) -> structure: parameter
+           "perm" of type "permission" (Represents the permissions a user or
+           users have to a workspace: 'a' - administrator. All operations
+           allowed. 'w' - read/write. 'r' - read. 'n' - no permissions.),
+           parameter "excludeGlobal" of type "boolean" (A boolean. 0 = false,
+           other = true.), parameter "onlyGlobal" of type "boolean" (A
+           boolean. 0 = false, other = true.)
+        :returns: instance of type "ListWorkspaceIDsResults" (Results of the
+           "list_workspace_ids" function. list<int> workspaces - the
+           workspaces to which the user has explicit access. list<int> pub -
+           the workspaces to which the user has access because they're
+           globally readable.) -> structure: parameter "workspaces" of list
+           of Long, parameter "pub" of list of Long
+        """
+        return self._client.call_method('Workspace.list_workspace_ids',
+                                        [params], self._service_ver, context)
+
     def list_workspace_objects(self, params, context=None):
         """
         Lists the metadata of all objects in the specified workspace with the


### PR DESCRIPTION
Cherry-picking the change from #2509 into `develop` to unblock some things. Thanks for the fixes, @n1mus!

# Description of PR purpose/changes

(copied from other PR)
* WS API was changed so that list_objects requires 1-10000 ws ids.
* BE called ws.list_objects with 0 ws ids so thinks started breaking. E.g., spinning up local narrative with kbase-narrative would throw a huge error.
* Change it to call ws.get_workspace_ids and then call ws.list_objects with batches of ws ids

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Should be no visible changes, except viewing the Jupyter tree page should work again, as should the backend tests
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
