### PR TITLE
DATAUP-587: Resetting the bulk import cell sets a new cell ID

### DIFF
--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -859,8 +859,10 @@ define([
             jobManager.resetJobs();
             cancelBatch = null;
             updateEditingState();
-            Jupyter.notebook.save_checkpoint();
             switchToTab('configure');
+            // set a new KBase cell ID
+            cell.metadata.kbase.attributes.id = new Uuid(4).format();
+            Jupyter.notebook.save_checkpoint();
         }
 
         function resetRunStatusListener() {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -507,6 +507,11 @@ define([
                             );
                             expect(bulkImportCellInstance.jobManager.listeners).toEqual({});
                             expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
+                            if (testCase.action === 'reset') {
+                                expect(cell.metadata.kbase.attributes.id).not.toEqual(
+                                    `${testCase.state}-state-test-cell`
+                                );
+                            }
                         });
                 });
             });


### PR DESCRIPTION
# Description of PR purpose/changes

Create a new cell ID when resetting the bulk import cell.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-587
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
