### PR TITLE
DATAUP-466 remove stdout errors from GUI app cells

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -74,15 +74,15 @@ def _app_error_wrapper(app_func: Callable) -> any:
                 if key in kwargs:
                     msg_info[key] = kwargs[key]
             self._send_comm_message("run_status", msg_info)
-            print(
-                f"Error while trying to start your app ({app_func.__name__})!\n"
-                + "-----------------------------------------------------\n"
-                + str(e)
-                + "\n"
-                + "-----------------------------------------------------\n"
-                + e_trace
-            )
-
+            if "cell_id" not in kwargs:
+                print(
+                    f"Error while trying to start your app ({app_func.__name__})!\n"
+                    + "-----------------------------------------------------\n"
+                    + str(e)
+                    + "\n"
+                    + "-----------------------------------------------------\n"
+                    + e_trace
+                )
     return wrapper
 
 


### PR DESCRIPTION
# Description of PR purpose/changes

The observed error was like this picture:
![Screen Shot 2021-10-21 at 10 40 27 PM](https://user-images.githubusercontent.com/2152243/138500174-dd774c6b-4489-48bf-9688-4fcfe36a5ee6.png)
If an app cell fails to run, it coughs up a block of text under the actual error tab. It's kind of a standard Jupyter Notebook-ism, printing errors to the output area of the cell.

However, this has the side effect of not going away when the user goes to a different tab, as that whole app cell GUI sits above the output area and has no effect on it.

Since the same information is also present in the error tab, an option here is just to not show those errors when running `run_app_bulk` (or `run_app`, `run_local_app`, or `run_app_batch`) from a GUI cell. That should still show up when running from a code cell without a cell id, so we can see the errors happen. This is kind of a superuser edge case, though, so a few speedbumps are to be expected.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-466
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Set up any app cell to run, then open code and do something like mangle the app id that would prevent running.
* Don't touch the configuration anymore, and just hit run (poking the config would reset the generated code).
* The error tab should pop up, and be dismissable this time.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
