### PR TITLE
DATAUP-602: ensure bulk cell deletion cancels the batch import job

### DIFF
--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -878,6 +878,7 @@ define([
         async function deleteCell() {
             const confirmed = await DialogMessages.showDialog({ action: 'deleteCell' });
             if (confirmed) {
+                jobManager.cancelBatchJob();
                 busEventManager.removeAll();
                 stopWidget();
                 const cellIndex = Jupyter.notebook.find_cell_index(cell);

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -180,12 +180,15 @@ define([
 
                 const cellWidget = BulkImportCell.make({
                     cell,
+                    devMode,
                     importData: fakeInputs,
                     specs: fakeSpecs,
                     initialize: true,
                 });
+                spyOn(cellWidget.jobManager, 'cancelBatchJob');
                 await cellWidget.deleteCell();
                 expect(Jupyter.notebook.delete_cell).toHaveBeenCalled();
+                expect(cellWidget.jobManager.cancelBatchJob).toHaveBeenCalled();
             });
 
             it('will not delete its cell if the user says no', async () => {
@@ -197,12 +200,15 @@ define([
 
                 const cellWidget = BulkImportCell.make({
                     cell,
+                    devMode,
                     importData: fakeInputs,
                     specs: fakeSpecs,
                     initialize: true,
                 });
+                spyOn(cellWidget.jobManager, 'cancelBatchJob');
                 await cellWidget.deleteCell();
                 expect(Jupyter.notebook.delete_cell).not.toHaveBeenCalled();
+                expect(cellWidget.jobManager.cancelBatchJob).not.toHaveBeenCalled();
             });
 
             it('responds to a delete-cell bus message', () => {
@@ -211,17 +217,20 @@ define([
                     Jupyter.notebook = Mocks.buildMockNotebook({
                         deleteCallback: () => {
                             expect(Jupyter.notebook.delete_cell).toHaveBeenCalled();
+                            expect(cellWidget.jobManager.cancelBatchJob).toHaveBeenCalled();
                             resolve();
                         },
                     });
                     spyOn(Jupyter.notebook, 'delete_cell').and.callThrough();
                     spyOn(DialogMessages, 'showDialog').and.resolveTo(true);
-                    BulkImportCell.make({
+                    const cellWidget = BulkImportCell.make({
                         cell,
+                        devMode,
                         importData: fakeInputs,
                         specs: fakeSpecs,
                         initialize: true,
                     });
+                    spyOn(cellWidget.jobManager, 'cancelBatchJob');
                     runtime.bus().send(
                         {},
                         {


### PR DESCRIPTION
# Description of PR purpose/changes

Ensure that when a BI cell is deleted, the import job (if still running) gets terminated.

Adding batch job cancellation to the BI deletion call, plus tests

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-602
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, starting a bulk import job, deleting the cell, and then checking the jobs list to see that the batch import task has the status 'terminated'

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
