### PR TITLE
DATAUP-595 fix issue with standalone report viewer widget not rendering

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -293,7 +293,7 @@ define([
                             params.showReportText = false;
                             params.showCreatedObjects = true;
                             const $newObjDiv = $('<div>');
-                            new KBaseReportView($newObjDiv, params).loadAndRender();
+                            new KBaseReportView($newObjDiv, params);
                             return $newObjDiv;
                         }.bind(this),
                     });

--- a/nbextensions/appCell2/widgets/tabs/resultsViewer.js
+++ b/nbextensions/appCell2/widgets/tabs/resultsViewer.js
@@ -143,7 +143,10 @@ define([
         function renderReportView(params) {
             // Override the option to show created objects listed in the report
             // object. For some reason this single option defaults to false!
-            reportParams = Object.assign({}, params, { showCreatedObjects: true });
+            reportParams = Object.assign({}, params, {
+                showCreatedObjects: true,
+                autoRender: false,
+            });
             ui.setContent('report', div({ dataElement: 'report-widget' }));
             return lazyRenderReport();
         }

--- a/test/unit/spec/function_output/kbaseReportView-spec.js
+++ b/test/unit/spec/function_output/kbaseReportView-spec.js
@@ -147,12 +147,15 @@ define([
 
         it('should build a report view without object info or file links from a report object', async function () {
             // copy the base report here so we don't modify it for future tests
-            const reportData = Object.assign({}, REPORT_OBJ);
+            const reportData = TestUtil.JSONcopy(REPORT_OBJ);
             reportData.file_links = [];
             reportData.objects_created = [];
             mockReportLookup(reportData);
             mockCreatedObjectInfo([]);
-            const reportWidget = new ReportView(this.$node, { report_ref: REPORT_REF });
+            const reportWidget = new ReportView(this.$node, {
+                report_ref: REPORT_REF,
+                autoRender: false,
+            });
             await reportWidget.loadAndRender();
             verifyPanelPresence(
                 {
@@ -177,13 +180,14 @@ define([
         });
 
         it('should build a report view with object info and no file links', async function () {
-            const reportData = Object.assign({}, REPORT_OBJ);
+            const reportData = TestUtil.JSONcopy(REPORT_OBJ);
             reportData.file_links = [];
             mockReportLookup(reportData);
             mockCreatedObjectInfo(CREATED_OBJECTS_INFO);
             const reportWidget = new ReportView(this.$node, {
                 report_ref: REPORT_REF,
                 showCreatedObjects: true,
+                autoRender: false,
             });
             await reportWidget.loadAndRender();
             verifyPanelPresence(
@@ -207,6 +211,7 @@ define([
             const reportWidget = new ReportView(this.$node, {
                 report_ref: REPORT_REF,
                 showCreatedObjects: true,
+                autoRender: false,
             });
             await reportWidget.loadAndRender();
             verifyPanelPresence(
@@ -228,11 +233,12 @@ define([
         });
 
         it('should build a report view with direct HTML content, not in an HTML tag', async function () {
-            const reportData = Object.assign({}, REPORT_OBJ);
+            const reportData = TestUtil.JSONcopy(REPORT_OBJ);
             delete reportData.direct_html_link_index; // the link index takes precedence, so take it out.
             mockReportLookup(reportData);
             const reportWidget = new ReportView(this.$node, {
                 report_ref: REPORT_REF,
+                autoRender: false,
             });
             await reportWidget.loadAndRender();
             // get the iframe node
@@ -245,6 +251,7 @@ define([
             mockReportLookup(REPORT_OBJ);
             const reportWidget = new ReportView(this.$node, {
                 report_ref: REPORT_REF,
+                autoRender: false,
             });
             await reportWidget.loadAndRender();
             const $iframe = this.$node.find('iframe.kb-report-view__report_iframe');
@@ -264,11 +271,14 @@ define([
 
         it('should build a report view with direct HTML content, in an HTML tag, and warn the console', async function () {
             const fakeReportHtml = '<html><body>This is a dummy report. BEHOLD!</body></html>';
-            const reportData = Object.assign({}, REPORT_OBJ);
+            const reportData = TestUtil.JSONcopy(REPORT_OBJ);
             reportData.direct_html = fakeReportHtml;
             delete reportData.direct_html_link_index;
             mockReportLookup(reportData);
-            const reportWidget = new ReportView(this.$node, { report_ref: REPORT_REF });
+            const reportWidget = new ReportView(this.$node, {
+                report_ref: REPORT_REF,
+                autoRender: false,
+            });
             spyOn(console, 'warn');
             await reportWidget.loadAndRender();
             const $iframe = this.$node.find('iframe.kb-report-view__report_iframe');
@@ -284,13 +294,16 @@ define([
             it(`should make a list of warnings ${
                 withCounter ? 'with a counter ' : ''
             }for ${count} html report(s)`, async function () {
-                const reportData = Object.assign({}, REPORT_OBJ);
+                const reportData = TestUtil.JSONcopy(REPORT_OBJ);
                 reportData.warnings = [];
                 for (let i = 0; i < count; i++) {
                     reportData.warnings.push(`warning #${i}`);
                 }
                 mockReportLookup(reportData);
-                const reportWidget = new ReportView(this.$node, { report_ref: REPORT_REF });
+                const reportWidget = new ReportView(this.$node, {
+                    report_ref: REPORT_REF,
+                    autoRender: false,
+                });
                 await reportWidget.loadAndRender();
                 const $reportWarnings = this.$node.find('div.kb-report-view__warning__container');
                 expect($reportWarnings.length).toEqual(1);
@@ -337,7 +350,10 @@ define([
                 statusText: 'HTTP 1.1 / 500 internal service error',
                 isError: true,
             });
-            const reportWidget = new ReportView(this.$node, { report_ref: REPORT_REF });
+            const reportWidget = new ReportView(this.$node, {
+                report_ref: REPORT_REF,
+                autoRender: false,
+            });
             await reportWidget.loadAndRender();
             verifyPanelPresence(
                 {
@@ -352,6 +368,24 @@ define([
             const $errorNode = this.$node.find('div.alert.alert-danger');
             expect($errorNode.html()).toContain('Error:');
             expect($errorNode.html()).toContain(errorMessage);
+        });
+
+        it('should render automatically by default', async function () {
+            mockReportLookup(REPORT_OBJ);
+            mockCreatedObjectInfo(CREATED_OBJECTS_INFO);
+            const reportWidget = new ReportView(this.$node, { report_ref: REPORT_REF });
+            expect(reportWidget.options.autoRender).toBeTrue();
+            expect(reportWidget.loadRenderPromise).not.toBeNull();
+            await reportWidget.loadRenderPromise; // test control flow - finish after Promise resolves
+        });
+
+        it('should not autorender when given the right option', function () {
+            const reportWidget = new ReportView(this.$node, {
+                report_ref: REPORT_REF,
+                autoRender: false,
+            });
+            expect(reportWidget.options.autoRender).toBeFalse();
+            expect(reportWidget.loadRenderPromise).toBeNull();
         });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

When we last modified the `kbaseReportView` widget, we put in some control flow code such that it only rendered (and looked up data, etc.) on command, returning a Promise. This doesn't work when `kbaseReportView` is used as a standalone widget / output viewer - those are expected to render as part of their startup code. 

This adds an `autoRender` option to the widget, with a default of `true`. If set to `true`, this renders during the startup (so we don't need extra custom code for every invocation of `kbaseReportView` when used as an app output widget). It adjusts the other invocations that create the widget before calling `loadAndRender` on it in a thennable way to set the `autoRender` option to `false`.

* Please include a summary of the change and which issue is fixed.
* Please also include relevant motivation and context.
* List any dependencies that are required for this change.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-595
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* This popped up on CI - run the "Insert Genome into Genome Set" app there (probably set up locally) and see that the generated output widget gets built as expected.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook