### PR TITLE
SAM-40: add name column to SampleSet viewer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Unreleased
+
+Code Changes
+
+- SAM-40 - Add Name/ID column to SampleSet viewer
+
 ### Version 4.6.0
 Code changes
 - DATAUP-599 - Adjusted the kernel code and tests to account for a Workspace service update.

--- a/kbase-extension/static/kbase/js/widgets/function_output/samples/SampleSet.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/samples/SampleSet.js
@@ -157,7 +157,7 @@ define([
             const columnGroups = [];
             const headerFields = [];
 
-            // Here we dynamiclly create an group to hold non-metadata columns.
+            // Here we dynamically create a group to hold non-metadata columns.
             columnGroups.push({
                 name: 'rowInfo',
                 title: 'Sample',

--- a/kbase-extension/static/kbase/js/widgets/function_output/samples/SampleSet.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/samples/SampleSet.js
@@ -156,11 +156,14 @@ define([
 
             const columnGroups = [];
             const headerFields = [];
+
+            // Here we dynamiclly create an group to hold non-metadata columns.
             columnGroups.push({
                 name: 'rowInfo',
-                title: '',
-                columnCount: 1,
+                title: 'Sample',
+                columnCount: 2,
             });
+
             headerFields.push({
                 id: 'rowNumber',
                 title: '#',
@@ -169,6 +172,16 @@ define([
                 group: 'rowInfo',
                 schema: null,
             });
+            headerFields.push({
+                id: 'userSampleName',
+                title: 'Name/ID',
+                isSortable: true,
+                type: 'sample',
+                key: 'name',
+                group: 'rowInfo',
+                schema: null,
+            });
+
             for (const group of this.groups) {
                 const groupFields = [];
                 for (const field of group.fields) {
@@ -237,21 +250,22 @@ define([
             return this.samples.map((sample, index) => {
                 const controlled = sample.node_tree[0].meta_controlled;
                 const user = sample.node_tree[0].meta_user;
-                const row = this.headerFields.map(({ id, type }) => {
+                const row = this.headerFields.map(({ id, type, key }) => {
                     // NB: id is the field key.
-                    if (type === 'controlled') {
-                        return controlled[id] ? controlled[id].value : EMPTY_CHAR;
-                    } else if (type === 'user') {
-                        return user[id] ? user[id].value : EMPTY_CHAR;
-                    } else if (type === 'rowInfo') {
-                        switch (id) {
-                            case 'rowNumber':
-                                return index + 1;
-                            default:
-                                return EMPTY_CHAR;
-                        }
-                    } else {
-                        return EMPTY_CHAR;
+
+                    switch (type) {
+                        case 'controlled': return controlled[id] ? controlled[id].value : EMPTY_CHAR;
+                        case 'user': return user[id] ? user[id].value : EMPTY_CHAR;
+                        case 'rowInfo': 
+                            switch (id) {
+                                case 'rowNumber':
+                                    return index + 1;
+                                default:
+                                    return EMPTY_CHAR;
+                            }
+                        case 'sample': return sample[key];
+                        case 'sample-node': return sample.node_tree[0][key];
+                        default: return EMPTY_CHAR;
                     }
                 });
                 return {

--- a/kbase-extension/static/kbase/js/widgets/function_output/samples/kbaseSampleSet.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/samples/kbaseSampleSet.js
@@ -282,11 +282,9 @@ define([
             // create table
             const $table = $('<table>').addClass('SampleSetTable').attr('role', 'table');
 
-            // create thead
             const $thead = $('<thead>').attr('role', 'rowgroup');
             $table.append($thead);
 
-            // create column group header
             const $columnGroupRow = $('<tr>').attr('role', 'row');
             $thead.append($columnGroupRow);
             for (const columnGroup of this.model.columnGroups) {
@@ -327,7 +325,6 @@ define([
                 );
             }
 
-            // create tbody
             const $tbody = $('<tbody>').attr('role', 'rowgroup');
             $table.append($tbody);
 

--- a/test/unit/spec/function_output/kbaseSampleSet/kbaseSampleSet-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleSet/kbaseSampleSet-spec.js
@@ -329,7 +329,7 @@ define([
         });
     });
 
-    fdescribe('The kbaseSampleSet viewer widget with an ENIGMA sample set', () => {
+    describe('The kbaseSampleSet viewer widget with an ENIGMA sample set', () => {
         let mock = null;
         beforeAll(async () => {
             mock = new MockWorker();

--- a/test/unit/spec/function_output/kbaseSampleSet/kbaseSampleSet-spec.js
+++ b/test/unit/spec/function_output/kbaseSampleSet/kbaseSampleSet-spec.js
@@ -286,6 +286,7 @@ define([
             // Tests first sample in the set.
             [
                 '1',
+                'altamaha_2018_pw_15hr_WHONDRS-PP48-000107',
                 'SESAR',
                 'HRV003M16',
                 'Other',
@@ -312,7 +313,7 @@ define([
                 expectCell($samplesTabContent, 2, 1, index + 1, text);
             });
 
-            // Check second column.
+            // Check 4th column.
             [
                 'HRV003M16',
                 'WHO000BC7',
@@ -323,12 +324,12 @@ define([
                 'IECUR0002Y',
                 'IECUR0002Z',
             ].forEach((text, rowIndex) => {
-                expectCell($samplesTabContent, 2, rowIndex + 1, 3, text);
+                expectCell($samplesTabContent, 2, rowIndex + 1, 4, text);
             });
         });
     });
 
-    describe('The kbaseSampleSet viewer widget with an ENIGMA sample set', () => {
+    fdescribe('The kbaseSampleSet viewer widget with an ENIGMA sample set', () => {
         let mock = null;
         beforeAll(async () => {
             mock = new MockWorker();
@@ -471,6 +472,7 @@ define([
             // Tests first sample in the set.
             [
                 '1',
+                '0408-FW021.46.11.27.12.02',
                 'ENIGMA',
                 'filtered groundwater',
                 '100 Well',
@@ -490,7 +492,7 @@ define([
                 expectCell($samplesTabContent, 2, 1, index + 1, text);
             });
 
-            // Check 6th column, Well Name
+            // Check 7th column, Well Name
             [
                 'FW021',
                 'FW021',
@@ -503,7 +505,7 @@ define([
                 'FW303',
                 'FW303',
             ].forEach((text, rowIndex) => {
-                expectCell($samplesTabContent, 2, rowIndex + 1, 6, text);
+                expectCell($samplesTabContent, 2, rowIndex + 1, 7, text);
             });
         });
     });


### PR DESCRIPTION
# Description of PR purpose/changes

The KBaseSets.SampleSet viewer was missing a "name" column; it has now been added.

This column represents the user provided "name" or "id" column of a sample. The sample service validation spec defines which sample files map to the name column. Existing examples are ENIGMA's "SampleID" column and SESAR's "Sample Name" column.

This also necessitated the addition of a new dynamic group "Sample", which currently contains the sample row number and the sample name.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [-] [Version has been bumped](https://semver.org/) for each release
- [-] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
