### PR TITLE
DATAUP-613: remove job does not exist listeners

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -99,10 +99,6 @@ When the kernel sends a message to the front end, the only module set up to list
 
 ### Job-related
 
-`job-does-not-exist` - sent in response to a request for information about a job that doesn't exist. Jobs might not exist if (1) they have been previously canceled, or (2) a malformed request was sent.
-  * `jobId` - string, the job id
-  * `source` - string, the source of the message in the kernel (what service, or module, was invoked. Usually "JobManager" or "ExecutionEngine2")
-
 `job-error` - sent in response to an error that happened on job information lookup, or another error that happened while processing some other message to the JobManager.
   * `jobId` - string, the job id
   * `message` - string, some message about the error

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -70,7 +70,6 @@ define([
             STOP_UPDATE: 'stop_job_update',
         },
         BACKEND_RESPONSES = {
-            DOES_NOT_EXIST: 'job_does_not_exist',
             INFO: JOB_REQUESTS.INFO,
             LOGS: JOB_REQUESTS.LOGS,
             RESULT: RESULT,
@@ -80,7 +79,7 @@ define([
         },
         RESPONSES = {
             CELL_JOB_STATUS: 'cell-job-status',
-            DOES_NOT_EXIST: 'job-does-not-exist',
+            ERROR: 'job-error',
             INFO: 'job-info',
             LOGS: 'job-logs',
             RESULT: RESULT,
@@ -163,7 +162,7 @@ define([
             const channel = {};
             channel[channelName] = channelId;
             this.runtime.bus().send(JSON.parse(JSON.stringify(message)), {
-                channel: channel,
+                channel,
                 key: {
                     type: msgType,
                 },
@@ -244,7 +243,8 @@ define([
                 throw new Error(
                     'ERROR sending comm message: ' +
                         JSON.stringify({
-                            error: err.toString(),
+                            // error: err.toString(),
+                            error: err,
                             msgType: msgType,
                             message: message,
                         })
@@ -293,8 +293,7 @@ define([
         handleCommMessages(msg) {
             const msgType = msg.content.data.msg_type;
             const msgData = msg.content.data.content;
-            let jobId = null,
-                msgTypeToSend = null;
+            let msgTypeToSend = null;
             this.debug(`received ${msgType} from backend`);
             switch (msgType) {
                 case 'start':
@@ -352,24 +351,6 @@ define([
                     console.error('Error from job comm:', msg);
                     break;
 
-                case BACKEND_RESPONSES.DOES_NOT_EXIST:
-                    jobId = msgData.job_id;
-                    if (msgData.source === 'job_status') {
-                        this.sendBusMessage(JOB, jobId, RESPONSES.STATUS, {
-                            jobId,
-                            jobState: {
-                                job_id: msgData.job_id,
-                                status: 'does_not_exist',
-                            },
-                        });
-                        break;
-                    }
-                    this.sendBusMessage(JOB, jobId, RESPONSES.DOES_NOT_EXIST, {
-                        jobId,
-                        source: msgData.source,
-                    });
-                    break;
-
                 // job information for one or more jobs
                 // Object with keys jobId and values { jobId: jobId, jobInfo: { ...job params... } }
                 case BACKEND_RESPONSES.INFO:
@@ -414,17 +395,31 @@ define([
                  * The job status for one or more jobs.
                  * The job_status_all message covers all active jobs.
                  *
-                 * data structure: object with key jobId and value { jobState: job.state, outputWidgetInfo: job.widget_info }
+                 * data structure: object with key jobId and value
+                 * { jobState: job.state, outputWidgetInfo: job.widget_info }
                  */
                 case BACKEND_RESPONSES.STATUS:
                 case 'job_status_all':
                     Object.keys(msgData).forEach((_jobId) => {
-                        this.sendBusMessage(
-                            JOB,
-                            _jobId,
-                            RESPONSES.STATUS,
-                            this.convertJobState(msgData[_jobId])
-                        );
+                        // check whether or not this is an ee2 error
+                        if (msgData[_jobId].state.status === 'ee2_error') {
+                            this.sendBusMessage(JOB, _jobId, RESPONSES.ERROR, {
+                                jobId: _jobId,
+                                error: {
+                                    job_id: _jobId,
+                                    message: 'ee2 connection error',
+                                    code: msgData[_jobId].state.status,
+                                },
+                                request: 'job-status',
+                            });
+                        } else {
+                            this.sendBusMessage(
+                                JOB,
+                                _jobId,
+                                RESPONSES.STATUS,
+                                this.convertJobState(msgData[_jobId])
+                            );
+                        }
                     });
                     break;
 

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -127,7 +127,7 @@ define([
             return Object.keys(requestTranslation);
         },
         validOutgoingMessageTypes: function () {
-            return Object.values(RESPONSES).concat(['job-error']);
+            return Object.values(RESPONSES);
         },
     };
 
@@ -243,10 +243,9 @@ define([
                 throw new Error(
                     'ERROR sending comm message: ' +
                         JSON.stringify({
-                            // error: err.toString(),
                             error: err,
-                            msgType: msgType,
-                            message: message,
+                            msgType,
+                            message,
                         })
                 );
             });

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -83,10 +83,20 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
          * (e.g. the message and job ID in the case of job listeners)
          *
          * @param {string} event - event that triggers the handler
-         * @param {object} handlerObject with the handler name as keys and the handler function as values
+         * @param {object|array} handlers
+         *              object: handlers has handler name as keys and the handler function as values
          *              if the handler function is already installed on the job manager,
          *              'null' can be supplied in place of the function
+         *              array: handlers is a list of handler names; these are assumed to be installed
+         *              on the job manager already
+         * Example:
          *
+         * jm.addEventListener('job-status', {
+         *      handlerA: () => {}, // this function gets added to the job manager
+         *      handlerB: null,     // this handler function is expected to exist
+         * })
+         * // handlers assumed to already exist:
+         * jm.addEventListener('job-error', ['handlerA', 'handlerB']);
          */
 
         addEventHandler(event, handlers) {

--- a/kbase-extension/static/kbase/js/util/jobStateViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobStateViewer.js
@@ -246,9 +246,8 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
     /**
      * Initializes this state viewer widget.
      * Inits the internal viewModel as well.
-     * @param {object} config - the config passed to this widget (not used, but in the format)
      */
-    function factory(config) {
+    function factory() {
         const runtime = Runtime.make(),
             listeners = [];
         let container,
@@ -338,17 +337,6 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
         }
 
         /**
-         * If the job doesn't exist, then we need to set a different job state.
-         * We don't care what the message is, but it's passed here anyway.
-         * @param {object} message
-         */
-        function handleJobDoesNotExistUpdate(message) {
-            jobState = {
-                job_state: 'does_not_exist',
-            };
-        }
-
-        /**
          * Called when the job-status message is received.
          * This parses the job status message. Takes into account both NJS and EE2 style messages.
          * @param {object} message
@@ -365,6 +353,7 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
                 case 'completed':
                 case 'error':
                 case 'terminated':
+                case 'does_not_exist':
                     stopJobUpdates();
                     break;
                 default:
@@ -378,42 +367,19 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
          * Sets up handlers and listeners for job status updates.
          * Listens on the jobId channel for these messages:
          *  - job-status -> respond to job update
-         *  - job-canceled -> no-op
-         *  - job-does-not-exist -> respond to the not found exception
          */
         function listenForJobStatus() {
-            let ev = runtime.bus().listen({
-                channel: {
-                    jobId: jobId,
-                },
-                key: {
-                    type: 'job-status',
-                },
-                handle: handleJobStatusUpdate,
-            });
-            listeners.push(ev);
-
-            ev = runtime.bus().listen({
-                channel: {
-                    jobId: jobId,
-                },
-                key: {
-                    type: 'job-canceled',
-                },
-                handle: () => {},
-            });
-            listeners.push(ev);
-
-            ev = runtime.bus().listen({
-                channel: {
-                    jobId: jobId,
-                },
-                key: {
-                    type: 'job-does-not-exist',
-                },
-                handle: handleJobDoesNotExistUpdate,
-            });
-            listeners.push(ev);
+            listeners.push(
+                runtime.bus().listen({
+                    channel: {
+                        jobId: jobId,
+                    },
+                    key: {
+                        type: 'job-status',
+                    },
+                    handle: handleJobStatusUpdate,
+                })
+            );
         }
 
         /**
@@ -480,15 +446,15 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
         }
 
         return {
-            start: start,
-            stop: stop,
-            detach: detach,
+            start,
+            stop,
+            detach,
         };
     }
 
     return {
-        make: function (config) {
-            return factory(config);
+        make: () => {
+            return factory();
         },
     };
 });

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -315,44 +315,6 @@ define([
                 ],
             },
             {
-                type: 'job_does_not_exist',
-                message: {
-                    job_id: testJobId,
-                    source: 'someSource',
-                },
-                expected: [
-                    {
-                        jobId: testJobId,
-                        source: 'someSource',
-                    },
-                    {
-                        channel: { jobId: testJobId },
-                        key: { type: 'job-does-not-exist' },
-                    },
-                ],
-            },
-            {
-                // does_not_exist from job status call => convert to job_status
-                type: 'job_does_not_exist',
-                message: {
-                    job_id: testJobId,
-                    source: 'job_status',
-                },
-                expected: [
-                    {
-                        jobId: testJobId,
-                        jobState: {
-                            job_id: testJobId,
-                            status: 'does_not_exist',
-                        },
-                    },
-                    {
-                        channel: { jobId: testJobId },
-                        key: { type: 'job-status' },
-                    },
-                ],
-            },
-            {
                 // info for a single job
                 type: 'job_info',
                 message: (() => {
@@ -516,6 +478,34 @@ define([
                     {
                         channel: { jobId: JobsData.allJobs[0].job_id },
                         key: { type: 'job-status' },
+                    },
+                ],
+            },
+            {
+                // single job status message, ee2 error
+                type: 'job_status',
+                message: {
+                    ee2_error_job: {
+                        job_id: 'ee2_error_job',
+                        state: {
+                            job_id: 'ee2_error_job',
+                            status: 'ee2_error',
+                        },
+                    },
+                },
+                expected: [
+                    {
+                        jobId: 'ee2_error_job',
+                        error: {
+                            job_id: 'ee2_error_job',
+                            message: 'ee2 connection error',
+                            code: 'ee2_error',
+                        },
+                        request: 'job-status',
+                    },
+                    {
+                        channel: { jobId: 'ee2_error_job' },
+                        key: { type: 'job-error' },
                     },
                 ],
             },

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -325,8 +325,6 @@ define([
                     expect(() => {
                         this.jobManagerInstance.addEventHandler(event, { shout: { key: 'value' } });
                     }).toThrowError(recheckHandlersErr + 'shout');
-                    //     /addEventHandler: handlers must be of type function. Recheck these handlers: shout/
-                    // );
                     expectHandlersDefined(this.jobManagerInstance, event, false, ['shout']);
                     expect(this.jobManagerInstance.handlers[event]).toEqual({});
                 });


### PR DESCRIPTION
# Description of PR purpose/changes

Plus a few other bits:
- remove job-does-not-exist listeners globally, replacing where appropriate
- jobManager.js: allow handlers to be added using just the handler name
- alter jobCommChannel to deal with status: ee2_error
- update tests

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-613
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
