### PR TITLE
DATAUP-600 results tab crashes with deleted files

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
@@ -51,22 +51,31 @@ define([
                     thead(tr([th('Created Object Name'), th('Type'), th('Description')])),
                     tbody([
                         ...objectData.map((obj) => {
-                            const parsedType = APIUtil.parseWorkspaceType(obj.type);
-                            const objLink = a(
-                                {
-                                    class: 'kb-output-widget__object_link',
-                                    dataObjRef: obj.ref,
-                                    type: 'button',
-                                    ariaLabel: 'show viewer for ' + obj.name,
-                                    id: events.addEvent({
-                                        type: 'click',
-                                        handler: () => {
-                                            Jupyter.narrative.addViewerCell(obj.wsInfo);
-                                        },
-                                    }),
-                                },
-                                [obj.name]
-                            );
+                            const parsedType = APIUtil.parseWorkspaceType(obj.type) || {
+                                type: 'Unknown type',
+                            };
+                            let objLink = '';
+                            if (obj.wsInfo) {
+                                objLink = a(
+                                    {
+                                        class: 'kb-output-widget__object_link',
+                                        dataObjRef: obj.ref,
+                                        type: 'button',
+                                        ariaLabel: 'show viewer for ' + obj.name,
+                                        id: events.addEvent({
+                                            type: 'click',
+                                            handler: () => {
+                                                if (obj.wsInfo) {
+                                                    Jupyter.narrative.addViewerCell(obj.wsInfo);
+                                                }
+                                            },
+                                        }),
+                                    },
+                                    [obj.name]
+                                );
+                            } else {
+                                objLink = obj.name;
+                            }
                             return tr([td(objLink), td(parsedType.type), td(obj.description)]);
                         }),
                     ]),
@@ -145,8 +154,8 @@ define([
         }
 
         return {
-            start: start,
-            stop: stop,
+            start,
+            stop,
         };
     }
 

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
@@ -54,19 +54,17 @@ define([
                     thead(tr([th('Created Object Name'), th('Type'), th('Description')])),
                     tbody([
                         ...objectData.map((obj) => {
-                            const name = obj.name
-                                ? obj.name
-                                : obj.wsInfo
-                                ? obj.wsInfo[1]
-                                : 'Unknown object name';
-                            const type = obj.type
-                                ? obj.type
-                                : obj.wsInfo
-                                ? obj.wsInfo[2]
-                                : 'Missing type';
+                            let name = obj.name;
+                            if (!name) {
+                                name = obj.wsInfo ? obj.wsInfo[1] : 'Unknown object name';
+                            }
+                            let type = obj.type;
+                            if (!type) {
+                                type = obj.wsInfo ? obj.wsInfo[2] : 'Missing type';
+                            }
                             const parsedType = APIUtil.parseWorkspaceType(type) || { type };
                             const description = obj.description || 'Missing description';
-                            let objLink = '';
+                            let objLink = name;
                             if (obj.wsInfo) {
                                 objLink = a(
                                     {
@@ -83,8 +81,6 @@ define([
                                     },
                                     [name]
                                 );
-                            } else {
-                                objLink = name;
                             }
                             return tr([td(objLink), td(parsedType.type), td(description)]);
                         }),

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/outputWidget.js
@@ -28,12 +28,15 @@ define([
         let container, ui;
 
         /**
-         *
+         * Renders the table of created output objects. Each row will have 3 elements:
+         * - name - the name of the created object. This will be a link that, when clicked, will spawn a
+         *    viewer cell for that object
+         * - type - a string for the object's type
+         * - description - a string for the object's description
+         * - wsInfo - the object info array from the Workspace service,
+         * - ref - string - the object's workspace reference
          * @param {Array} objectData an array of object data. Each element is expected
-         *  to have these properties:
-         *  - type - the workspace object type
-         *  - name - the name of the object
-         *  - description - a description of the object
+         *  to have the properties detailed above. If any are missing, they'll get placeholder values instead.
          */
         function renderOutput(objectData) {
             if (objectData.length === 0) {
@@ -51,9 +54,18 @@ define([
                     thead(tr([th('Created Object Name'), th('Type'), th('Description')])),
                     tbody([
                         ...objectData.map((obj) => {
-                            const parsedType = APIUtil.parseWorkspaceType(obj.type) || {
-                                type: 'Unknown type',
-                            };
+                            const name = obj.name
+                                ? obj.name
+                                : obj.wsInfo
+                                ? obj.wsInfo[1]
+                                : 'Unknown object name';
+                            const type = obj.type
+                                ? obj.type
+                                : obj.wsInfo
+                                ? obj.wsInfo[2]
+                                : 'Missing type';
+                            const parsedType = APIUtil.parseWorkspaceType(type) || { type };
+                            const description = obj.description || 'Missing description';
                             let objLink = '';
                             if (obj.wsInfo) {
                                 objLink = a(
@@ -61,22 +73,20 @@ define([
                                         class: 'kb-output-widget__object_link',
                                         dataObjRef: obj.ref,
                                         type: 'button',
-                                        ariaLabel: 'show viewer for ' + obj.name,
+                                        ariaLabel: 'show viewer for ' + name,
                                         id: events.addEvent({
                                             type: 'click',
                                             handler: () => {
-                                                if (obj.wsInfo) {
-                                                    Jupyter.narrative.addViewerCell(obj.wsInfo);
-                                                }
+                                                Jupyter.narrative.addViewerCell(obj.wsInfo);
                                             },
                                         }),
                                     },
-                                    [obj.name]
+                                    [name]
                                 );
                             } else {
-                                objLink = obj.name;
+                                objLink = name;
                             }
-                            return tr([td(objLink), td(parsedType.type), td(obj.description)]);
+                            return tr([td(objLink), td(parsedType.type), td(description)]);
                         }),
                     ]),
                 ]

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/reportWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/reportWidget.js
@@ -41,7 +41,7 @@ define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events', 'kbas
                     }
                 }
 
-                let reportElem = '';
+                let reportElem = name + ' (report not found)';
                 if (objInfo.reportRef) {
                     reportElem = a(
                         {
@@ -55,8 +55,6 @@ define(['bluebird', 'jquery', 'common/html', 'common/ui', 'common/events', 'kbas
                         },
                         name
                     );
-                } else {
-                    reportElem = name + ' (report not found)';
                 }
                 return div([reportElem]);
             });

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
@@ -193,7 +193,8 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
                 .catch((error) => {
                     console.error('An error occurred while starting the results tab', error);
                     const errorNode = document.createElement('div');
-                    errorNode.innerHTML = "OMG ERROR'D!";
+                    errorNode.innerHTML =
+                        'An error occurred preventing results from being displayed.';
                     containerNode.appendChild(errorNode);
                 })
                 .finally(() => {

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
@@ -132,7 +132,7 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
                     // the same order.
                     objectKeys = Object.keys(createdObjects);
                     // turn the refs into an array: [{"ref": ref}]
-                    const infoLookupParam = objectKeys.map((ref) => ({ ref: ref }));
+                    const infoLookupParam = objectKeys.map((ref) => ({ ref }));
                     return workspaceClient.get_object_info_new({
                         objects: infoLookupParam,
                         ignoreErrors: 1,
@@ -192,7 +192,7 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
                     containerNode.classList.remove('hidden');
                 })
                 .catch((error) => {
-                    console.error('errors, yo', error);
+                    console.error('An error occurred while starting the report tab', error);
                 })
                 .finally(() => {
                     container.removeChild(spinnerNode);

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/results/resultsTab.js
@@ -176,9 +176,9 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
             const reportNode = document.createElement('div');
             const containerNode = document.createElement('div');
             containerNode.classList.add('hidden', 'kb-result-tab__container');
+            container.appendChild(containerNode);
             return fetchReportData(reports)
                 .then((reportData) => {
-                    container.appendChild(containerNode);
                     containerNode.appendChild(objectNode);
                     containerNode.appendChild(reportNode);
 
@@ -189,13 +189,16 @@ define(['bluebird', 'common/ui', 'common/events', './outputWidget', './reportWid
                 })
                 .then(() => {
                     events.attachEvents(container);
-                    containerNode.classList.remove('hidden');
                 })
                 .catch((error) => {
-                    console.error('An error occurred while starting the report tab', error);
+                    console.error('An error occurred while starting the results tab', error);
+                    const errorNode = document.createElement('div');
+                    errorNode.innerHTML = "OMG ERROR'D!";
+                    containerNode.appendChild(errorNode);
                 })
                 .finally(() => {
                     container.removeChild(spinnerNode);
+                    containerNode.classList.remove('hidden');
                 });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -420,7 +420,7 @@ define([
                         params.showReportText = true;
                         params.showCreatedObjects = false;
                         const $reportDiv = $('<div>');
-                        new KBaseReportView($reportDiv, params).loadAndRender();
+                        new KBaseReportView($reportDiv, params);
                         return $reportDiv;
                     }.bind(this),
                 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,9 +2210,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001271",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-            "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+            "version": "1.0.30001272",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
+            "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15438,9 +15438,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001271",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-            "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+            "version": "1.0.30001272",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
+            "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
             "dev": true
         },
         "chalk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,9 +2210,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001269",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz",
-            "integrity": "sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==",
+            "version": "1.0.30001271",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
+            "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15438,9 +15438,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001269",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz",
-            "integrity": "sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==",
+            "version": "1.0.30001271",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
+            "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/common/cellComponents/tabs/results/outputWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/outputWidget-spec.js
@@ -57,5 +57,65 @@ define([
             await this.widget.stop();
             expect(container.innerHTML).toEqual('');
         });
+
+        const baseObjData = {
+            name: 'SomeObject',
+            type: 'SomeModule.someType-1.0',
+            description: 'an object',
+            wsInfo: [
+                2,
+                'SomeObject',
+                'SomeModule.someType-1.0',
+                '2021-10-22T20:16:36+0000',
+                1,
+                'someuser',
+                12345,
+                'someuser:narrative_123456789',
+                'ahash',
+                123,
+                null,
+            ],
+        };
+        Object.keys(baseObjData).forEach((key) => {
+            it(`should start and render data missing ${key}`, async function () {
+                const objData = TestUtil.JSONcopy(baseObjData);
+                delete objData[key];
+                await this.widget.start({
+                    node: container,
+                    objectData: [objData],
+                });
+                expect(container.innerHTML).toContain('Objects');
+                // should basically all be the same, except for description and wsInfo
+                const row = container.querySelector('table.dataTable tbody tr');
+                const nameElem = row.querySelector('td:first-child');
+                const objLink = nameElem.querySelector('a.kb-output-widget__object_link');
+                const description = row.querySelector('td:last-child').innerHTML;
+                expect(nameElem.innerHTML).toContain(baseObjData.name);
+                expect(row.querySelector('td:nth-child(2)').innerHTML).toContain('someType');
+                if ('description' in objData) {
+                    expect(description).toContain(objData.description);
+                } else {
+                    expect(description).toBe('Missing description');
+                }
+                if ('wsInfo' in objData) {
+                    expect(objLink).not.toBeNull();
+                } else {
+                    expect(objLink).toBeNull();
+                }
+            });
+        });
+
+        it(`should show a default string when missing wsInfo, and other values`, async function () {
+            await this.widget.start({
+                node: container,
+                objectData: [{}],
+            });
+            expect(container.innerHTML).toContain('Objects');
+            const row = container.querySelector('table.dataTable tbody tr');
+            const expectedStrings = ['Unknown object name', 'Missing type', 'Missing description'];
+            expectedStrings.forEach((value, idx) => {
+                expect(row.querySelector(`td:nth-child(${idx + 1})`).innerHTML).toBe(value);
+            });
+        });
     });
 });

--- a/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
@@ -144,8 +144,67 @@ define([
             expect(toggleNode.nextSibling).toBeNull();
         });
 
-        it('should start with deleted data objects', async () => {});
+        it('should start with empty data', async function () {
+            await this.widget.start({
+                node: container,
+                objectData: [],
+            });
+            const mainNode = container.querySelector('div.kb-reports-view');
+            expect(mainNode.innerHTML).toBe('');
+        });
 
-        it('should start with objects with missing data', async () => {});
+        [
+            {
+                label: 'missing name',
+                obj: { reportRef: '1/2/3' },
+                expect: {
+                    hasToggle: true,
+                    text: 'Object not found',
+                },
+            },
+            {
+                label: 'missing report',
+                obj: { name: 'some_object' },
+                expect: {
+                    hasToggle: false,
+                    text: 'some_object (report not found)',
+                },
+            },
+            {
+                label: 'missing name, ref, and report',
+                obj: {},
+                expect: {
+                    hasToggle: false,
+                    text: 'Object not found (report not found)',
+                },
+            },
+            {
+                label: 'missing name and report',
+                obj: { ref: '1/2/3', reportRef: '4/5/6' },
+                expect: {
+                    hasToggle: true,
+                    text: 'Object 1/2/3 not found, may have been deleted',
+                },
+            },
+        ].forEach((testCase) => {
+            it(`should show report objects with a ${testCase.label}`, async function () {
+                await this.widget.start({
+                    node: container,
+                    objectData: [testCase.obj],
+                });
+                const listParent = container.querySelector(
+                    '.kb-reports-view .panel-body[data-element="body"]'
+                );
+                expect(listParent.childElementCount).toEqual(1);
+                const reportItem = listParent.firstChild;
+                if (testCase.expect.hasToggle) {
+                    const toggleNode = reportItem.querySelector('a.kb-report__toggle');
+                    expect(toggleNode).not.toBeNull();
+                    expect(toggleNode.innerHTML).toContain(testCase.expect.text);
+                } else {
+                    expect(reportItem.innerHTML).toBe(testCase.expect.text);
+                }
+            });
+        });
     });
 });

--- a/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
@@ -143,5 +143,9 @@ define([
             expect(toggleNode).toHaveClass('collapsed');
             expect(toggleNode.nextSibling).toBeNull();
         });
+
+        it('should start with deleted data objects', async () => {});
+
+        it('should start with objects with missing data', async () => {});
     });
 });

--- a/test/unit/spec/common/cellComponents/tabs/results/resultsTab-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/resultsTab-spec.js
@@ -32,7 +32,7 @@ define([
         null,
     ];
 
-    fdescribe('test the bulk import cell results tab', () => {
+    describe('test the bulk import cell results tab', () => {
         let container;
         beforeAll(() => {
             Jupyter.narrative = {

--- a/test/unit/spec/common/cellComponents/tabs/results/resultsTab-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/resultsTab-spec.js
@@ -32,7 +32,7 @@ define([
         null,
     ];
 
-    describe('test the bulk import cell results tab', () => {
+    fdescribe('test the bulk import cell results tab', () => {
         let container;
         beforeAll(() => {
             Jupyter.narrative = {
@@ -73,8 +73,8 @@ define([
                 })
                 .then(() => {
                     // just make sure it renders the "Objects" and "Report" headers
-                    expect(container.innerHTML).toContain('Objects');
-                    expect(container.innerHTML).toContain('Report');
+                    expect(container.querySelector('.kb-created-objects')).not.toBeNull();
+                    expect(container.querySelector('.kb-reports-view')).not.toBeNull();
                 });
         });
 
@@ -122,6 +122,43 @@ define([
                     expect(reportNode).toBeDefined();
                     expect(reportNode.innerHTML).toContain('Test_contigs');
                 });
+        });
+
+        it('should render a brief error if the workspace call fails', async function () {
+            const workspaceClient = {
+                get_objects2: () => Promise.reject(new Error('workspace not available')),
+                get_object_info_new: () => Promise.reject(new Error('workspace not available')),
+            };
+            const resultsTab = ResultsTab.make({
+                model: this.model,
+                workspaceClient,
+            });
+
+            await resultsTab.start({ node: container });
+            expect(container.textContent).toBe(
+                'An error occurred preventing results from being displayed.'
+            );
+        });
+
+        it('should recover from seeing workspace missing data', async function () {
+            const workspaceClient = {
+                get_objects2: () =>
+                    Promise.resolve({
+                        data: [reportObject],
+                    }),
+                get_object_info_new: () => Promise.resolve([null]),
+            };
+            const resultsTab = ResultsTab.make({
+                model: this.model,
+                workspaceClient,
+            });
+
+            await resultsTab.start({ node: container });
+            const objNode = container.querySelector('div.kb-created-objects');
+            expect(objNode.innerHTML).toContain('Object 11/22/33 not found');
+
+            const reportNode = container.querySelector('div.kb-reports-view');
+            expect(reportNode.innerHTML).toContain('Object 11/22/33 not found');
         });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

The results tab was crashing on a later load if any of the generated files were deleted in the meantime. This handles those errors in a somewhat more elegant way and shows some placeholder text for missing data.

This screenshot demonstrates the various missing data states:
![Screen Shot 2021-10-29 at 2 09 00 PM](https://user-images.githubusercontent.com/2152243/139482392-c3afe287-6bbc-442c-b529-cf7dc62be5e1.png)

Some of them, in a few rare cases, are recoverable - if there's no object name given in the results, the name from the fetched workspace object info can be used. Same for the type. However, these are also fetched from the workspace, so if there's an error with one ws call, there's likely an error with others, so this is kind of an odd edge case.

For the reports area, if the report itself isn't found, I left a row for it, and just put some dummy text with "report not found" next to it. These will only show up if there's expected to be a report associated with an object, but the viewer gets a null - if no report is expected anyway, then nothing should show up. But all of our uploaders have reports, so that's how this will work for now.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-600
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Run a bulk import cell, delete some or all of the generated data, and load up the results.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
