### PR TITLE
DATAUP-613: remove 'job-does-not-exist' handler from the app cell

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/cellTabs.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/cellTabs.js
@@ -67,8 +67,8 @@ define(['bluebird', 'common/html', 'common/ui', 'common/events'], (Promise, html
                     [buildTabButtons(events)]
                 );
             return {
-                content: content,
-                events: events,
+                content,
+                events,
             };
         }
 
@@ -142,7 +142,7 @@ define(['bluebird', 'common/html', 'common/ui', 'common/events'], (Promise, html
                 container = args.node;
                 ui = UI.make({
                     node: container,
-                    bus: bus,
+                    bus,
                 });
                 const layout = renderLayout();
                 container.innerHTML = layout.content;
@@ -155,9 +155,9 @@ define(['bluebird', 'common/html', 'common/ui', 'common/events'], (Promise, html
         }
 
         return {
-            start: start,
-            stop: stop,
-            setState: setState,
+            start,
+            stop,
+            setState,
         };
     }
 

--- a/kbase-extension/static/kbase/js/common/fsm.js
+++ b/kbase-extension/static/kbase/js/common/fsm.js
@@ -149,13 +149,13 @@ define(['underscore', 'common/runtime'], (_, Runtime) => {
         // API
 
         const api = Object.freeze({
-            start: start,
-            stop: stop,
-            newState: newState,
-            updateState: updateState,
-            getCurrentState: getCurrentState,
-            findState: findState,
-            bus: bus,
+            start,
+            stop,
+            newState,
+            updateState,
+            getCurrentState,
+            findState,
+            bus,
         });
 
         return api;

--- a/nbextensions/appCell2/widgets/appCellWidget-fsm.js
+++ b/nbextensions/appCell2/widgets/appCellWidget-fsm.js
@@ -1,6 +1,137 @@
 define([], () => {
     'use strict';
 
+    const uiTabs = {
+        inProgress: {
+            info: {
+                enabled: true,
+            },
+            configure: {
+                enabled: false,
+                hidden: true,
+            },
+            viewConfigure: {
+                enabled: true,
+            },
+            jobStatus: {
+                enabled: true,
+            },
+            results: {
+                enabled: false,
+            },
+            error: {
+                enabled: false,
+                hidden: true,
+            },
+        },
+        error: {
+            info: {
+                enabled: true,
+            },
+            configure: {
+                enabled: false,
+                hidden: true,
+            },
+            viewConfigure: {
+                enabled: true,
+            },
+            jobStatus: {
+                enabled: false,
+            },
+            results: {
+                enabled: false,
+                hidden: true,
+            },
+            error: {
+                enabled: true,
+                selected: true,
+            },
+        },
+    };
+
+    const configureTabSettings = [
+            {
+                selector: {
+                    viewOnly: false,
+                },
+                settings: {
+                    enabled: true,
+                    hidden: false,
+                    selected: true,
+                },
+            },
+            {
+                selector: {
+                    viewOnly: true,
+                },
+                settings: {
+                    enabled: false,
+                    hidden: true,
+                    selected: false,
+                },
+            },
+        ],
+        viewConfigureTabSettings = [
+            {
+                selector: {
+                    viewOnly: false,
+                },
+                settings: {
+                    enabled: false,
+                    hidden: true,
+                    selected: false,
+                },
+            },
+            {
+                selector: {
+                    viewOnly: true,
+                },
+                settings: {
+                    enabled: true,
+                    hidden: false,
+                    selected: true,
+                },
+            },
+        ],
+        batchModeTabs = {
+            info: {
+                enabled: true,
+            },
+            configureBatch: configureTabSettings,
+            viewConfigure: viewConfigureTabSettings,
+            configure: {
+                enabled: false,
+                hidden: true,
+            },
+            jobStatus: {
+                enabled: false,
+            },
+            results: {
+                enabled: false,
+            },
+            error: {
+                enabled: false,
+                hidden: true,
+            },
+        },
+        standardModeTabs = {
+            info: {
+                enabled: true,
+            },
+            configure: configureTabSettings,
+            viewConfigure: viewConfigureTabSettings,
+            jobStatus: {
+                enabled: false,
+            },
+            results: {
+                enabled: false,
+            },
+            error: {
+                enabled: false,
+                hidden: true,
+            },
+        };
+
     const appStates = [
         // new
         {
@@ -34,24 +165,6 @@ define([], () => {
                     name: 'runApp',
                     disabled: true,
                 },
-                elements: {
-                    show: [],
-                    hide: [
-                        'internal-error',
-                        'parameters-group',
-                        'output-group',
-                        'parameters-display-group',
-                        'exec-group',
-                    ],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-default'],
-                    icon: {
-                        type: 'minus',
-                    },
-                },
-                label: 'new',
-                message: '',
             },
             next: [
                 {
@@ -70,82 +183,11 @@ define([], () => {
                 params: 'incomplete',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                    ],
-                    viewConfigure: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                    ],
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                    },
-                    error: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                },
+                tabs: standardModeTabs,
                 actionButton: {
                     name: 'runApp',
                     disabled: true,
                 },
-                elements: {
-                    show: ['parameters-group', 'output-group'],
-                    hide: ['internal-error', 'parameters-display-group', 'exec-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-warning'],
-                    icon: {
-                        type: 'pencil',
-                    },
-                },
-                label: 'editing',
-                message:
-                    'You may edit the parameters for this App. You must fill in all required parameters (indicated by red arrows) before you can run the App.',
             },
             next: [
                 {
@@ -174,82 +216,11 @@ define([], () => {
                 code: 'built',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                    ],
-                    viewConfigure: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                    ],
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                    },
-                    error: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                },
+                tabs: standardModeTabs,
                 actionButton: {
                     name: 'runApp',
                     disabled: false,
                 },
-                elements: {
-                    show: ['parameters-group', 'output-group'],
-                    hide: ['internal-error', 'parameters-display-group', 'exec-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-ok'],
-                    icon: {
-                        type: 'pencil',
-                    },
-                },
-                label: 'editing',
-                message:
-                    'You have completed the required parameters for this App; you may run it or continue to edit parameters.',
             },
             next: [
                 {
@@ -293,14 +264,7 @@ define([], () => {
                 },
                 {
                     mode: 'error',
-                    stage: 'queued',
-                },
-                {
-                    mode: 'error',
-                    stage: 'running',
-                },
-                {
-                    mode: 'error',
+                    stage: 'runtime',
                 },
                 {
                     mode: 'internal-error',
@@ -314,86 +278,11 @@ define([], () => {
                 params: 'incomplete',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configureBatch: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                    ],
-                    viewConfigure: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                    ],
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                    },
-                    error: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                },
+                tabs: batchModeTabs,
                 actionButton: {
                     name: 'runApp',
                     disabled: true,
                 },
-                elements: {
-                    show: ['parameters-group', 'output-group'],
-                    hide: ['internal-error', 'parameters-display-group', 'exec-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-warning'],
-                    icon: {
-                        type: 'pencil',
-                    },
-                },
-                label: 'editing',
-                message:
-                    'You may edit the parameters for this App. You must fill in all required parameters (indicated by red arrows) before you can run the App.',
             },
             next: [
                 {
@@ -422,86 +311,11 @@ define([], () => {
                 code: 'built',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configureBatch: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                    ],
-                    viewConfigure: [
-                        {
-                            selector: {
-                                viewOnly: false,
-                            },
-                            settings: {
-                                enabled: false,
-                                hidden: true,
-                                selected: false,
-                            },
-                        },
-                        {
-                            selector: {
-                                viewOnly: true,
-                            },
-                            settings: {
-                                enabled: true,
-                                hidden: false,
-                                selected: true,
-                            },
-                        },
-                    ],
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                    },
-                    error: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                },
+                tabs: batchModeTabs,
                 actionButton: {
                     name: 'runApp',
                     disabled: false,
                 },
-                elements: {
-                    show: ['parameters-group', 'output-group'],
-                    hide: ['internal-error', 'parameters-display-group', 'exec-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-ok'],
-                    icon: {
-                        type: 'pencil',
-                    },
-                },
-                label: 'editing',
-                message:
-                    'You have completed the required parameters for this App; you may run it or continue to edit parameters.',
             },
             next: [
                 {
@@ -545,14 +359,7 @@ define([], () => {
                 },
                 {
                     mode: 'error',
-                    stage: 'queued',
-                },
-                {
-                    mode: 'error',
-                    stage: 'running',
-                },
-                {
-                    mode: 'error',
+                    stage: 'runtime',
                 },
                 {
                     mode: 'internal-error',
@@ -598,30 +405,6 @@ define([], () => {
                     name: 'cancel',
                     disabled: false,
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                messages: [
-                    {
-                        widget: 'paramsDisplayWidget',
-                        message: {},
-                        address: {
-                            key: {
-                                type: 'sync-all-parameters',
-                            },
-                        },
-                    },
-                ],
-                appStatus: {
-                    classes: ['kb-app-status-primary'],
-                    icon: {
-                        color: 'blue',
-                        type: 'rocket',
-                    },
-                },
-                label: 'sending...',
-                message: 'Launching the App...',
             },
             on: {
                 enter: {
@@ -679,14 +462,11 @@ define([], () => {
                 },
                 {
                     mode: 'error',
-                },
-                {
-                    mode: 'error',
                     stage: 'launching',
                 },
                 {
                     mode: 'error',
-                    stage: 'running',
+                    stage: 'runtime',
                 },
                 {
                     mode: 'internal-error',
@@ -726,18 +506,6 @@ define([], () => {
                     name: 'cancel',
                     disabled: true,
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-ok'],
-                    icon: {
-                        type: 'rocket',
-                    },
-                },
-                label: 'executing...',
-                message: 'The App has now entered the execution engine.',
             },
             on: {
                 enter: {
@@ -790,9 +558,6 @@ define([], () => {
                 },
                 {
                     mode: 'error',
-                },
-                {
-                    mode: 'error',
                     stage: 'launching',
                 },
                 {
@@ -812,43 +577,10 @@ define([], () => {
                 stage: 'queued',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: true,
-                    },
-                    jobStatus: {
-                        enabled: true,
-                    },
-                    results: {
-                        enabled: false,
-                    },
-                    error: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                },
+                tabs: uiTabs.inProgress,
                 actionButton: {
                     name: 'cancel',
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-ok'],
-                    icon: {
-                        type: 'list',
-                    },
-                },
-                label: 'queued',
-                message: 'The App is queued for running.',
             },
             on: {
                 enter: {
@@ -895,22 +627,15 @@ define([], () => {
                 {
                     mode: 'success',
                 },
-                {
-                    mode: 'error',
-                },
-                {
-                    mode: 'error',
-                    stage: 'queued',
-                },
                 // This can happen if there is no in-progress message received
                 // before an error occurs.
                 {
                     mode: 'error',
-                    stage: 'running',
+                    stage: 'runtime',
                 },
                 // This can happen if the job disappeared while the app thinks
                 // it is queued, yet the user still wants to cancel (which can't really
-                // cancel, it just has to return to editing mode.
+                // cancel, it just has to return to editing mode).
                 {
                     mode: 'editing',
                     params: 'complete',
@@ -928,43 +653,10 @@ define([], () => {
                 stage: 'running',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: true,
-                    },
-                    jobStatus: {
-                        enabled: true,
-                    },
-                    results: {
-                        enabled: false,
-                    },
-                    error: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                },
+                tabs: uiTabs.inProgress,
                 actionButton: {
                     name: 'cancel',
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-ok'],
-                    icon: {
-                        type: 'bolt',
-                    },
-                },
-                label: 'running',
-                message: 'The App is now running.',
             },
             on: {
                 enter: {
@@ -1010,10 +702,7 @@ define([], () => {
                 },
                 {
                     mode: 'error',
-                },
-                {
-                    mode: 'error',
-                    stage: 'running',
+                    stage: 'runtime',
                 },
                 {
                     mode: 'editing',
@@ -1057,18 +746,6 @@ define([], () => {
                 actionButton: {
                     name: 'cancel',
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-ok'],
-                    icon: {
-                        type: 'bolt',
-                    },
-                },
-                label: 'running',
-                message: 'The App is now running.',
             },
             on: {
                 enter: {
@@ -1098,7 +775,6 @@ define([], () => {
                     mode: 'processing',
                     stage: 'partial-complete',
                 },
-
                 {
                     mode: 'canceled',
                 },
@@ -1110,10 +786,7 @@ define([], () => {
                 },
                 {
                     mode: 'error',
-                },
-                {
-                    mode: 'error',
-                    stage: 'running',
+                    stage: 'runtime',
                 },
                 {
                     mode: 'editing',
@@ -1131,44 +804,11 @@ define([], () => {
                 mode: 'canceling',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: true,
-                    },
-                    jobStatus: {
-                        enabled: true,
-                    },
-                    results: {
-                        enabled: false,
-                    },
-                    error: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                },
+                tabs: uiTabs.inProgress,
                 actionButton: {
                     name: 'cancel',
                     default: true,
                 },
-                elements: {
-                    show: ['exec-group', 'output-group'],
-                    hide: ['parameters-display-group', 'parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-warning'],
-                    icon: {
-                        type: 'bolt',
-                    },
-                },
-                label: 'canceling...',
-                message: 'Canceling App execution...',
             },
             on: {
                 enter: {
@@ -1208,7 +848,7 @@ define([], () => {
                 },
                 {
                     mode: 'error',
-                    stage: 'running',
+                    stage: 'runtime',
                 },
                 {
                     mode: 'editing',
@@ -1252,18 +892,6 @@ define([], () => {
                 actionButton: {
                     name: 'reRunApp',
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-error'],
-                    icon: {
-                        type: 'ban',
-                    },
-                },
-                label: 'canceled',
-                message: 'App execution has been successfully canceled.',
             },
             on: {
                 enter: {
@@ -1331,18 +959,6 @@ define([], () => {
                 actionButton: {
                     name: 'reRunApp',
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-ok'],
-                    icon: {
-                        type: 'check',
-                    },
-                },
-                label: 'finished',
-                message: 'The App has successfully finished.',
             },
             on: {
                 enter: {
@@ -1388,44 +1004,10 @@ define([], () => {
                 stage: 'launching',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: true,
-                    },
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    error: {
-                        enabled: true,
-                        selected: true,
-                    },
-                },
+                tabs: uiTabs.error,
                 actionButton: {
                     name: 'reRunApp',
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-danger'],
-                    icon: {
-                        type: 'exclamation-circle',
-                    },
-                },
-                label: 'error',
-                message: 'There was an error launching the App.',
             },
             next: [
                 {
@@ -1442,51 +1024,17 @@ define([], () => {
                 },
             ],
         },
-        // error during queueing
+        // error during job execution (including whilst queueing)
         {
             state: {
                 mode: 'error',
-                stage: 'queued',
+                stage: 'runtime',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: true,
-                    },
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    error: {
-                        enabled: true,
-                        selected: true,
-                    },
-                },
+                tabs: uiTabs.error,
                 actionButton: {
                     name: 'reRunApp',
                 },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-danger'],
-                    icon: {
-                        type: 'exclamation-circle',
-                    },
-                },
-                label: 'error',
-                message: 'An error was encountered while the App was queued.',
             },
             on: {
                 enter: {
@@ -1514,150 +1062,7 @@ define([], () => {
             next: [
                 {
                     mode: 'error',
-                    stage: 'queued',
-                },
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built',
-                },
-                {
-                    mode: 'internal-error',
-                },
-            ],
-        },
-        // runtime app error
-        {
-            state: {
-                mode: 'error',
-                stage: 'running',
-            },
-            ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: true,
-                    },
-                    jobStatus: {
-                        enabled: true,
-                    },
-                    results: {
-                        enabled: true,
-                        hidden: true,
-                    },
-                    error: {
-                        enabled: true,
-                        selected: true,
-                    },
-                },
-                actionButton: {
-                    name: 'reRunApp',
-                },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-app-status-danger'],
-                    icon: {
-                        type: 'exclamation-circle',
-                    },
-                },
-                label: 'error',
-                message: 'An error was encountered running the App.',
-            },
-            on: {
-                enter: {
-                    messages: [
-                        {
-                            emit: 'on-error',
-                        },
-                    ],
-                },
-                resume: {
-                    messages: [
-                        {
-                            emit: 'on-error',
-                        },
-                    ],
-                },
-                exit: {
-                    messages: [
-                        {
-                            emit: 'exit-error',
-                        },
-                    ],
-                },
-            },
-            next: [
-                {
-                    mode: 'error',
-                    stage: 'running',
-                },
-                {
-                    mode: 'editing',
-                    params: 'complete',
-                    code: 'built',
-                },
-                {
-                    mode: 'internal-error',
-                },
-            ],
-        },
-        // Just a plain error state ... not sure how we get here...
-        {
-            state: {
-                mode: 'error',
-            },
-            ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: true,
-                    },
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    error: {
-                        enabled: true,
-                        selected: true,
-                    },
-                },
-                actionButton: {
-                    name: 'reRunApp',
-                },
-                elements: {
-                    show: ['parameters-display-group', 'exec-group', 'output-group'],
-                    hide: ['parameters-group'],
-                },
-                appStatus: {
-                    classes: ['kb-status-danger'],
-                    icon: {
-                        type: 'exclamation-circle',
-                    },
-                },
-                label: 'error',
-                message: 'An error was encountered.',
-            },
-            next: [
-                {
-                    mode: 'error',
+                    stage: 'runtime',
                 },
                 {
                     mode: 'editing',
@@ -1675,49 +1080,10 @@ define([], () => {
                 mode: 'internal-error',
             },
             ui: {
-                tabs: {
-                    info: {
-                        enabled: true,
-                    },
-                    configure: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    viewConfigure: {
-                        enabled: false,
-                    },
-                    jobStatus: {
-                        enabled: false,
-                    },
-                    results: {
-                        enabled: false,
-                        hidden: true,
-                    },
-                    error: {
-                        enabled: true,
-                        selected: true,
-                    },
-                },
+                tabs: uiTabs.error,
                 actionButton: {
                     name: 'resetApp',
                 },
-                elements: {
-                    show: ['internal-error'],
-                    hide: [
-                        'parameters-group',
-                        'parameters-display-group',
-                        'exec-group',
-                        'output-group',
-                    ],
-                },
-                appStatus: {
-                    classes: ['kb-status-danger'],
-                    icon: {
-                        type: 'exclamation-circle',
-                    },
-                },
-                label: 'error',
-                message: 'An internal error was encountered.',
             },
             next: [
                 {

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -951,7 +951,7 @@ define([
             }
 
             FSMBar.showFsmBar({
-                ui: ui,
+                ui,
                 state: {},
                 job: model.getItem('exec.jobState'),
             });
@@ -967,7 +967,7 @@ define([
         function buildControlPanel(events) {
             controlPanel = CellControlPanel.make({
                 bus: cellBus,
-                ui: ui,
+                ui,
                 action: {
                     runAction: runAction.bind(this),
                     actions: actionButtons,
@@ -989,7 +989,7 @@ define([
             });
 
             return cellTabs.start({
-                node: node,
+                node,
             });
         }
 
@@ -1040,8 +1040,8 @@ define([
                     ]
                 );
             return {
-                content: content,
-                events: events,
+                content,
+                events,
             };
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,9 +2210,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001272",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
-            "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
+            "version": "1.0.30001274",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
+            "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15438,9 +15438,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001272",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
-            "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
+            "version": "1.0.30001274",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
+            "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-fsm-spec.js
+++ b/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-fsm-spec.js
@@ -6,7 +6,7 @@ define(['/narrative/nbextensions/appCell2/widgets/appCellWidget-fsm', 'underscor
 
     describe('app cell states', () => {
         const uiTabs = ['info', 'configure', 'viewConfigure', 'jobStatus', 'results', 'error'];
-        const uiKeys = ['tabs', 'actionButton', 'elements', 'appStatus', 'label', 'message'];
+        const uiKeys = ['tabs', 'actionButton'];
         const stateKeys = ['next', 'state', 'ui'];
         const states = AppCellStates.appStates;
 
@@ -49,7 +49,9 @@ define(['/narrative/nbextensions/appCell2/widgets/appCellWidget-fsm', 'underscor
                             .withContext(`duplicate next state: ${JSON.stringify(next[i])}`)
                             .toBeFalse();
                     }
-                    const matchingState = states.filter((state) => _.isEqual(next[i], state.state));
+                    const matchingState = states.filter((_state) =>
+                        _.isEqual(next[i], _state.state)
+                    );
                     expect(matchingState.length).toBe(1);
                 }
             });


### PR DESCRIPTION
# Description of PR purpose/changes

Finishing off the work done in DATAUP-613_rm_job_does_not_exist_handlers:

- Removing job-does-not-exist handler from the appCell and add in handling for the "does_not_exist" job status.
- Compact the appCell FSM states
- Use the messages from DialogMessage for various app cell actions (cancel, retry, etc)
- Make the job status tab slightly more efficient
- minor object key/value assignment edits

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-613
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, doing things with the app cell, and noting that it is in full working order, despite having halved the size of the appCell FSM states file. 🎉 
 
# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
