### PR TITLE
DATAUP-587: force job refresh on cell load

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -776,6 +776,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
                 ['status', 'error'].forEach((type) => {
                     this.addListener(`job-${type}`, allJobIds);
                 });
+
                 // request job updates
                 this.bus.emit('request-job-updates-start', { batchId });
             }
@@ -801,7 +802,13 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
                     allJobIds: Object.keys(allJobs),
                 });
 
-                return this.getFsmStateFromJobs();
+                return this._forceDataRefresh(batchJob);
+            }
+
+            _forceDataRefresh(jobArray) {
+                // delete all job data apart from the batch parent term to force a data refresh
+                Jobs.populateModelFromJobArray(this.model, jobArray);
+                return 'inProgress';
             }
 
             /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2210,9 +2210,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001272",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
-            "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
+            "version": "1.0.30001274",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
+            "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -15438,9 +15438,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001272",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz",
-            "integrity": "sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==",
+            "version": "1.0.30001274",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz",
+            "integrity": "sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -1538,13 +1538,20 @@ define([
                 );
                 expect(this.jobManagerInstance.listeners).toEqual({});
                 spyOn(this.jobManagerInstance.bus, 'emit');
-                this.jobManagerInstance.restoreFromSaved();
+
+                const response = this.jobManagerInstance.restoreFromSaved();
+                expect(response).toEqual('inProgress');
 
                 check_initJobs(this, {
                     batchId: JobsData.batchParentJob.job_id,
                     allJobIds: JobsData.allJobsWithBatchParent.map((job) => job.job_id),
                     listenerArray: ['job-status', 'job-error'],
                 });
+                const expectedJobsById = {};
+                expectedJobsById[JobsData.batchParentJob.job_id] = JobsData.batchParentJob;
+                expect(this.jobManagerInstance.model.getItem('exec.jobs.byId')).toEqual(
+                    expectedJobsById
+                );
             });
 
             it('sets up the appropriate listeners even if child jobs are missing', function () {
@@ -1555,13 +1562,20 @@ define([
                 );
                 expect(this.jobManagerInstance.listeners).toEqual({});
                 spyOn(this.jobManagerInstance.bus, 'emit');
-                this.jobManagerInstance.restoreFromSaved();
+
+                const response = this.jobManagerInstance.restoreFromSaved();
+                expect(response).toEqual('inProgress');
 
                 check_initJobs(this, {
                     batchId: JobsData.batchParentJob.job_id,
                     allJobIds: JobsData.allJobsWithBatchParent.map((job) => job.job_id),
                     listenerArray: ['job-status', 'job-error'],
                 });
+                const expectedJobsById = {};
+                expectedJobsById[JobsData.batchParentJob.job_id] = JobsData.batchParentJob;
+                expect(this.jobManagerInstance.model.getItem('exec.jobs.byId')).toEqual(
+                    expectedJobsById
+                );
             });
         });
 

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -4,6 +4,7 @@ define([
     'base/js/namespace',
     'common/dialogMessages',
     'common/jobs',
+    'common/jobManager',
     'common/runtime',
     'narrativeMocks',
     'testUtil',
@@ -17,6 +18,7 @@ define([
     Jupyter,
     DialogMessages,
     Jobs,
+    JobManagerModule,
     Runtime,
     Mocks,
     TestUtil,
@@ -26,6 +28,8 @@ define([
     Config
 ) => {
     'use strict';
+
+    const { JobManager } = JobManagerModule;
     const fakeInputs = {
             dataType: {
                 files: ['some_file'],
@@ -92,6 +96,9 @@ define([
             });
         }
 
+        if (args.noDataRefresh) {
+            spyOn(JobManager.prototype, '_forceDataRefresh').and.returnValue(args.state);
+        }
         const bulkImportCellInstance = BulkImportCell.make({ cell, devMode });
         return { cell, bulkImportCellInstance };
     }
@@ -489,6 +496,7 @@ define([
                     Jupyter.notebook = Mocks.buildMockNotebook();
                     spyOn(Jupyter.notebook, 'save_checkpoint');
                     testCase.cellId = `${testCase.state}-${testCase.action}`;
+                    testCase.noDataRefresh = true;
                     const { cell, bulkImportCellInstance } = initCell(testCase);
 
                     // kind of a cheat, but waiting on the dialogs to show up is really really inconsistent.


### PR DESCRIPTION

# Description of PR purpose/changes

Reset jobs to force bulk import cell to refresh its cached data on cell load to avoid issues with out-of-data jobs data doing strange things.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-587
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, creating a bulk import cell, running it, and then reloading the narrative.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
