### PR TITLE
DATAUP-323: remove "info" menu item

### DIFF
--- a/nbextensions/appCell2/appCell.js
+++ b/nbextensions/appCell2/appCell.js
@@ -55,7 +55,6 @@ define([
          * - maximize: restore / maxmize the cell
          * - getIcon: figure out what Icon the cell should have
          * - renderIcon: put the fetched icon into the cell's view
-         * - showInfo: opens a dialog that shows the cell's info
          * - toggleBatch: toggles the alpha version of the batch mode (deprecated)
          */
         function specializeCell() {
@@ -103,15 +102,6 @@ define([
                 if (iconNode) {
                     iconNode.innerHTML = this.getIcon();
                 }
-            };
-            cell.showInfo = function () {
-                const app = utils.getCellMeta(cell, 'kbase.appCell.app');
-                appInfoDialog.show({
-                    id: app.spec.info.id,
-                    version: app.spec.info.ver,
-                    module: app.spec.info.module_name,
-                    tag: app.tag,
-                });
             };
             cell.toggleBatch = function () {
                 cellBus.emit('toggle-batch-mode');


### PR DESCRIPTION
# Description of PR purpose/changes

Removing "info" dropdown menu item from the app cell, which was causing buggy behaviour with the "delete cell" item.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-323
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, opening an app cell, and noting with glee that it no longer has the 'Info' menu item in the dropdown menu.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook