### PR TITLE
DATAUP-497: very minor variable substitution

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -31,8 +31,6 @@ A module for managing apps, specs, requirements, and for starting jobs.
 """
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
-BATCH_ID_KEY = "batch_id"
-
 BATCH_APP = {
     "APP_ID": "kb_BatchApp/run_batch",
     "METHOD": "kb_BatchApp.run_batch",
@@ -523,7 +521,7 @@ class AppManager(object):
             kblogging.log_event(self._log, "run_job_bulk_error", log_info)
             raise transform_job_exception(e)
 
-        batch_id = batch_submission[BATCH_ID_KEY]
+        batch_id = batch_submission["batch_id"]
         child_ids = batch_submission["child_job_ids"]
 
         self._send_comm_message(
@@ -533,7 +531,7 @@ class AppManager(object):
                 "event_at": datetime.datetime.utcnow().isoformat() + "Z",
                 "cell_id": cell_id,
                 "run_id": run_id,
-                BATCH_ID_KEY: batch_id,
+                "batch_id": batch_id,
                 "child_job_ids": child_ids,
             },
         )

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -1,7 +1,7 @@
 """
 Tests for the app manager.
 """
-from biokbase.narrative.jobs.appmanager import AppManager, BATCH_ID_KEY, BATCH_APP
+from biokbase.narrative.jobs.appmanager import AppManager, BATCH_APP
 from biokbase.narrative.jobs.jobmanager import JobManager
 import biokbase.narrative.jobs.specmanager as specmanager
 import biokbase.narrative.app_util as app_util
@@ -1170,9 +1170,9 @@ class AppManagerTestCase(unittest.TestCase):
             },
         ]
         if is_batch:
-            expected_keys[0].append(BATCH_ID_KEY)
+            expected_keys[0].append("batch_id")
             expected_keys[0].append("child_job_ids")
-            expected_values[0][BATCH_ID_KEY] = self.test_job_id
+            expected_values[0]["batch_id"] = self.test_job_id
         else:
             expected_keys[0].append("job_id")
             expected_values[0]["job_id"] = self.test_job_id


### PR DESCRIPTION
# Description of PR purpose/changes

Extremely minor cleanup: switch out BATCH_ID_KEY for the correct variable name, "batch_id"

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating around to see that nothing has changed

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
