### PR TITLE
fix dockerfile, update nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,22 @@ ARG SKIP_MINIFY
 
 EXPOSE 8888
 
+# install NodeJS 16.x (latest LTS until ~October 2022, https://nodejs.org/en/about/releases/)
+RUN \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
+    sudo apt-get install -y nodejs
+
 # install pyopenssl cryptography idna and requests is the same as installing
 # requests[security]
 RUN source activate base && \
-    conda install -c conda-forge ndg-httpsclient==0.5.1 pyasn1==0.4.5 pyopenssl==19.0.0 cryptography==2.7 idna==2.8 requests==2.21.0 \
-          beautifulsoup4==4.8.1 html5lib==1.0.1
+    conda install -c conda-forge ndg-httpsclient==0.5.1 \
+          pyasn1==0.4.5 \
+          pyopenssl==19.0.0 \
+          cryptography==2.7 \
+          idna==2.8 \
+          requests==2.21.0 \
+          beautifulsoup4==4.8.1 \
+          html5lib==1.0.1
 
 # Copy in the narrative repo
 ADD ./ /kb/dev_container/narrative


### PR DESCRIPTION
# Description of PR purpose/changes

In the last push, the Dockerfile wasn't updated properly to include the NodeJS LTS update. This resulted in the installation failing silently until someone tried to open a narrative on CI. So that's bad.

This fixes that problem to get things installed as expected. 

No code changes, just fixed the Dockerfile install process.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Fetch the built image with `docker pull ghcr.io/kbase/narrative-develop:pr-2588`
* exec into it with `docker run -it --entrypoint bash ghcr.io/kbase/narrative-develop:pr-2588`
* run `kbase-narrative` then quit (or just run it in the background)
* verify that `kbase-extenson/static/ext_components` exists and `kbase-extension/static/kbase/config/config.json` exists.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:
(all n/a)
- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook