### PR TITLE
DATAUP-587: reset cell stuck in launching

### DIFF
--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -662,17 +662,25 @@ define([
                     const curState = model.getItem('state');
                     const curReadyState = curState.params;
                     const updatedReadyState = !_.isEqual(readyState, curReadyState);
+                    let newState;
 
                     if (updatedReadyState) {
                         model.setItem(['state', 'params'], readyState);
                     }
+                    if (curState.state === 'launching') {
+                        // TODO: if the cell has got stuck in 'launching' mode,
+                        // we should get jobs by cell_id
+                        // for now, reset the cell to 'editingComplete'
+                        newState = 'editingComplete';
+                    }
+
                     if (
                         updatedReadyState &&
                         ['editingComplete', 'editingIncomplete'].includes(curState.state)
                     ) {
                         updateEditingState();
                     } else {
-                        updateState();
+                        updateState(newState);
                     }
                     cell.renderMinMax();
                     runTab(state.tab.selected);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001278",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
-            "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==",
+            "version": "1.0.30001279",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+            "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001278",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
-            "integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg==",
+            "version": "1.0.30001279",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
+            "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ==",
             "dev": true
         },
         "center-align": {

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -1,6 +1,5 @@
 from ..util import ConfigTests
 from biokbase.workspace.baseclient import ServerError
-from biokbase.narrative.jobs.appmanager import BATCH_ID_KEY
 import copy
 import functools
 from unittest.mock import call
@@ -258,7 +257,7 @@ class MockClients:
         child_job_ids = [
             self.test_job_id + f"_child_{i}" for i in range(len(batch_job_inputs))
         ]
-        return {BATCH_ID_KEY: self.test_job_id, "child_job_ids": child_job_ids}
+        return {"batch_id": self.test_job_id, "child_job_ids": child_job_ids}
 
     def cancel_job(self, job_id):
         return {}

--- a/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/results/reportWidget-spec.js
@@ -75,7 +75,7 @@ define([
             });
             // we should have a div with two <a> elements, each with the
             // name of an object
-            expect(container.querySelectorAll('a').length).toBe(2);
+            expect(container.querySelectorAll('.kb-report__item_container').length).toBe(2);
             expect(container.innerHTML).toContain('Reports');
             ResultsData.objectData.forEach((obj) => {
                 expect(container.innerHTML).toContain(obj.name);
@@ -102,9 +102,9 @@ define([
                 objectData: [singleDataObject],
             });
             // there should be only one
-            expect(container.querySelectorAll('a.kb-report__toggle').length).toBe(1);
+            expect(container.querySelectorAll('.kb-report__item_toggle').length).toBe(1);
             // get a handle on it
-            const toggleNode = container.querySelector('a.kb-report__toggle');
+            const toggleNode = container.querySelector('.kb-report__item_toggle');
             // expect it to be collapsed and not to have any siblings
             expect(toggleNode).toHaveClass('collapsed');
             expect(toggleNode.nextSibling).toBeNull();
@@ -127,7 +127,7 @@ define([
                 node: container,
                 objectData: [singleDataObject],
             });
-            const toggleNode = container.querySelector('a.kb-report__toggle');
+            const toggleNode = container.querySelector('.kb-report__item_toggle');
             // expect it to be collapsed and not to have any siblings
             expect(toggleNode).toHaveClass('collapsed');
             expect(toggleNode.nextSibling).toBeNull();
@@ -193,12 +193,12 @@ define([
                     objectData: [testCase.obj],
                 });
                 const listParent = container.querySelector(
-                    '.kb-reports-view .panel-body[data-element="body"]'
+                    '.kb-reports-view .panel-body[data-element="body"] .kb-report__container'
                 );
                 expect(listParent.childElementCount).toEqual(1);
                 const reportItem = listParent.firstChild;
                 if (testCase.expect.hasToggle) {
-                    const toggleNode = reportItem.querySelector('a.kb-report__toggle');
+                    const toggleNode = reportItem.querySelector('.kb-report__item_toggle');
                     expect(toggleNode).not.toBeNull();
                     expect(toggleNode.innerHTML).toContain(testCase.expect.text);
                 } else {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -396,6 +396,28 @@ define([
                 });
             });
 
+            it('should revert to editingComplete mode if it starts off in launching', async () => {
+                // TODO: this should find what jobs are associated with the cell
+                const { cell } = initCell({
+                    state: 'launching',
+                    selectedTab: 'info',
+                    deleteJobData: true,
+                });
+
+                const runButton = cell.element[0].querySelector(selectors.run);
+                const cancelButton = cell.element[0].querySelector(selectors.cancel);
+                const resetButton = cell.element[0].querySelector(selectors.reset);
+                await TestUtil.waitForElementState(cell.element[0], () => {
+                    return (
+                        !runButton.classList.contains('hidden') &&
+                        !runButton.classList.contains('disabled') &&
+                        cancelButton.classList.contains('hidden') &&
+                        resetButton.classList.contains('hidden')
+                    );
+                });
+                expect(cell.metadata.kbase.bulkImportCell.state.state).toBe('editingComplete');
+            });
+
             // FIXME: this test fails as the input does not validate. Fix the input to
             // pass validation and reenable this test.
             xit('Should start up in "editingComplete" state when initialized with proper data', async () => {


### PR DESCRIPTION
# Description of PR purpose/changes

Prevent cell getting stuck in launching by resetting it to 'editingComplete'

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-587
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
