### PR TITLE
DATAUP-497: generate file type mappings centrally

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -83,7 +83,7 @@ define([
      * @param {Object} args with keys
      *      {Object} appData: specs and outputParamIds from the cell config
      *      {Object} jobInfo: job data from the backend, including app ID and params
-     *      {Object} fileTypesDisplay: display text for each import type
+     *      {Object} fileTypeMapping: display text for each import type
      *      {Object} typesToFiles: mapping of import type to app ID
      * @returns {Object} with keys
      *      analysisType:   abbreviated name for the app
@@ -92,7 +92,7 @@ define([
      */
 
     function generateJobDisplayData(args) {
-        const { appData, jobInfo, fileTypesDisplay, typesToFiles } = args;
+        const { appData, jobInfo, fileTypeMapping, typesToFiles } = args;
         let analysisType = '';
         const params = {};
         const outputParams = {};
@@ -100,7 +100,7 @@ define([
         Object.keys(typesToFiles).forEach((type) => {
             // match app_id to get the abbreviated name for the analysis
             if (typesToFiles[type].appId === jobInfo.app_id) {
-                analysisType = fileTypesDisplay.fileTypeMapping[type];
+                analysisType = fileTypeMapping[type];
                 Object.keys(jobInfo.job_params[0]).forEach((param) => {
                     // find each parameter in job_params in the app specs
                     appData.specs[jobInfo.app_id].parameters.forEach((appParam) => {
@@ -207,7 +207,7 @@ define([
             this.jobManager = jobManager;
             this.toggleTab = toggleTab;
 
-            this.fileTypesDisplay = Util.generateFileTypeMappings(config.typesToFiles);
+            this.fileTypeMapping = config.fileTypeMapping;
             this.jobsByRetryParent = {};
             this.widgetsById = {};
             this.errors = {};
@@ -287,7 +287,7 @@ define([
                     if (allJobInfo[jobId]) {
                         const jobDisplayData = generateJobDisplayData({
                             jobInfo: allJobInfo[jobId],
-                            fileTypesDisplay: this.fileTypesDisplay,
+                            fileTypeMapping: this.fileTypeMapping,
                             appData,
                             typesToFiles: this.config.typesToFiles,
                         });
@@ -706,7 +706,7 @@ define([
 
             const jobDisplayData = generateJobDisplayData({
                 jobInfo,
-                fileTypesDisplay: this.fileTypesDisplay,
+                fileTypeMapping: this.fileTypeMapping,
                 appData,
                 typesToFiles: this.config.typesToFiles,
             });

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -129,7 +129,8 @@ define([
                 bus: runtime.bus(),
             }),
             typesToFiles = setupFileData(options.importData),
-            { fileTypesDisplay } = BulkImportUtil.generateFileTypeMappings(typesToFiles),
+            { fileTypesDisplay, fileTypeMapping } =
+                BulkImportUtil.generateFileTypeMappings(typesToFiles),
             workspaceClient = getWorkspaceClient(),
             tabSet = {
                 selected: 'configure',
@@ -765,6 +766,7 @@ define([
                 bus: controllerBus,
                 cell,
                 fileTypesDisplay,
+                fileTypeMapping,
                 jobId: undefined,
                 jobManager,
                 model,

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -25,13 +25,14 @@ define([
      *     bus: message bus
      *     model: cell metadata, contains such fun items as the app parameters and state
      *     specs: app specs, keyed by their app id
+     *     fileTypesDisplay: mapping of file type to display label
      *     typesToFiles: map from object type to appId and list of input files,
      *     viewOnly: boolean - if true, then will start child widgets in view only mode
      * @returns
      */
     function ConfigureWidget(options) {
         const viewOnly = options.viewOnly || false;
-        const { model, specs, typesToFiles } = options;
+        const { model, specs, fileTypesDisplay, typesToFiles } = options;
         const cellBus = options.bus,
             runtime = Runtime.make(),
             FILE_PATH_TYPE = 'filePaths',
@@ -44,8 +45,6 @@ define([
             selectedFileType = model.getItem('state.selectedFileType'),
             unavailableFiles,
             ui;
-
-        const { fileTypesDisplay } = Util.generateFileTypeMappings(typesToFiles);
 
         /**
          * args includes:

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -42,6 +42,7 @@ define([
             files: ['SRR976988.1'],
         },
     };
+    const { fileTypeMapping } = AppCellUtil.generateFileTypeMappings(typesToFiles);
 
     const appData = {
         outputParamIds: {
@@ -196,7 +197,7 @@ define([
     }
 
     function createInstance(config = {}) {
-        // add in typesToFiles
+        // add in typesToFiles and fileTypeMapping
         return new JobStatusTable(
             Object.assign(
                 {},
@@ -206,6 +207,7 @@ define([
                         bus: Runtime.make().bus(),
                     }),
                     typesToFiles,
+                    fileTypeMapping,
                 },
                 config
             )
@@ -471,12 +473,11 @@ define([
                 expect(JobStatusTableModule.generateJobDisplayData).toEqual(jasmine.any(Function));
             });
             it('can pull out the relevant info for displaying a job in a table', () => {
-                const fileTypesDisplay = AppCellUtil.generateFileTypeMappings(typesToFiles);
                 paramTests.forEach((test) => {
                     const result = JobStatusTableModule.generateJobDisplayData({
                         jobInfo: test.input,
                         appData,
-                        fileTypesDisplay,
+                        fileTypeMapping,
                         typesToFiles,
                     });
                     expect(result).toEqual(test.displayData);

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -17,6 +17,11 @@ define([
                     files: ['file1', 'file2'],
                 },
             },
+            fileTypesDisplay = {
+                fastq_reads: 'FASTQ Reads Interleaved',
+                dataType1: 'Data Type One',
+                dataType2: 'Data Type II',
+            },
             appSpec = Spec.make({
                 appSpec: TestBulkImportObject.app.specs[appId],
             }),
@@ -114,6 +119,7 @@ define([
                     model,
                     specs,
                     typesToFiles,
+                    fileTypesDisplay,
                 });
 
                 return configure
@@ -145,6 +151,7 @@ define([
                 model,
                 specs,
                 typesToFiles,
+                fileTypesDisplay,
             });
 
             return configure
@@ -185,6 +192,7 @@ define([
                     model,
                     specs,
                     typesToFiles,
+                    fileTypesDisplay,
                 });
 
                 const paramErrorSelector = '[data-parameter="name"] .kb-field-cell__message_panel';
@@ -218,6 +226,7 @@ define([
                     model,
                     specs,
                     typesToFiles,
+                    fileTypesDisplay,
                 });
 
                 const paramErrorSelector =
@@ -274,6 +283,7 @@ define([
                     model: this._model,
                     specs,
                     typesToFiles: this._typesToFiles,
+                    fileTypesDisplay,
                 });
 
                 return configure
@@ -340,6 +350,7 @@ define([
                     model: this._model,
                     specs,
                     typesToFiles: this._typesToFiles,
+                    fileTypesDisplay,
                 });
 
                 await configure.start({ node: container });


### PR DESCRIPTION
# Description of PR purpose/changes

Pass in file type mappings from the bulk import cell, rather than generating them in the job status table and configure tabs

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see that nothing has changed. How boring!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
