### PR TITLE
DATAUP-626 fix non-batch app cell disabling job status on error

### DIFF
--- a/nbextensions/appCell2/widgets/appCellWidget-fsm.js
+++ b/nbextensions/appCell2/widgets/appCellWidget-fsm.js
@@ -1031,7 +1031,7 @@ define([], () => {
                 stage: 'runtime',
             },
             ui: {
-                tabs: uiTabs.error,
+                tabs: Object.assign({}, uiTabs.error, { jobStatus: { enabled: true } }),
                 actionButton: {
                     name: 'reRunApp',
                 },

--- a/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-fsm-spec.js
+++ b/test/unit/spec/nbextensions/appCell2/widgets/appCellWidget-fsm-spec.js
@@ -1,6 +1,7 @@
-define(['/narrative/nbextensions/appCell2/widgets/appCellWidget-fsm', 'underscore'], (
+define(['/narrative/nbextensions/appCell2/widgets/appCellWidget-fsm', 'underscore', 'common/fsm'], (
     AppCellStates,
-    _
+    _,
+    Fsm
 ) => {
     'use strict';
 
@@ -54,6 +55,28 @@ define(['/narrative/nbextensions/appCell2/widgets/appCellWidget-fsm', 'underscor
                     );
                     expect(matchingState.length).toBe(1);
                 }
+            });
+        });
+
+        // a special case that modifies the set of error tabs
+        it('should show the job status tab when a run results in an error', () => {
+            const fsm = Fsm.make({
+                states,
+                initialState: {
+                    mode: 'error',
+                    stage: 'runtime',
+                },
+                onNewState: () => {},
+            });
+            fsm.start();
+            const state = fsm.getCurrentState();
+            const trueTabs = ['jobStatus', 'error', 'viewConfigure', 'info'];
+            const falseTabs = ['configure', 'results'];
+            trueTabs.forEach((tab) => {
+                expect(state.ui.tabs[tab].enabled).toBeTrue();
+            });
+            falseTabs.forEach((tab) => {
+                expect(state.ui.tabs[tab].enabled).toBeFalse();
             });
         });
     });


### PR DESCRIPTION
# Description of PR purpose/changes

A minor regression on the app cell state management prevented enabling the job status tab when an app ended in error. This fixes that. Hooray!

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-626
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Run an app that fails (like the App Fail app in CI), or any app with bad data
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
