### PR TITLE
DATAUP-614 (related) migrate common/lang -> util/util

### DIFF
--- a/kbase-extension/static/buildTools/loadAppWidgets.js
+++ b/kbase-extension/static/buildTools/loadAppWidgets.js
@@ -81,7 +81,6 @@ define([
     'common/html',
     'common/jobs',
     'common/jupyter',
-    'common/lang',
     'common/messages',
     'common/microBus',
     'common/miniBus',
@@ -95,6 +94,7 @@ define([
     'common/spec',
     'common/ui',
     'common/validation',
+    'util/util',
     'util/icon',
 ], () => {
     'use strict';

--- a/kbase-extension/static/kbase/js/common/monoBus.js
+++ b/kbase-extension/static/kbase/js/common/monoBus.js
@@ -14,7 +14,7 @@
  *
  *
  */
-define(['uuid', 'bluebird', 'underscore', './lang'], (Uuid, Promise, _, lang) => {
+define(['uuid', 'bluebird', 'underscore', 'util/util'], (Uuid, Promise, _, Util) => {
     'use strict';
 
     function factory(cfg) {
@@ -370,7 +370,7 @@ define(['uuid', 'bluebird', 'underscore', './lang'], (Uuid, Promise, _, lang) =>
             if (!persistentMessage) {
                 return;
             }
-            const envelope = lang.copy(persistentMessage.envelope);
+            const envelope = Util.copy(persistentMessage.envelope);
             envelope.listenerId = id;
             transientMessages.push({
                 message: persistentMessage.message,

--- a/kbase-extension/static/kbase/js/common/spec.js
+++ b/kbase-extension/static/kbase/js/common/spec.js
@@ -2,9 +2,9 @@
  * Provides app spec functionality.
  */
 
-define(['bluebird', 'common/lang', 'common/sdk', 'widgets/appWidgets2/validators/resolver'], (
+define(['bluebird', 'util/util', 'common/sdk', 'widgets/appWidgets2/validators/resolver'], (
     Promise,
-    lang,
+    Util,
     sdk,
     validationResolver
 ) => {
@@ -46,12 +46,12 @@ define(['bluebird', 'common/lang', 'common/sdk', 'widgets/appWidgets2/validators
                 let modelValue;
                 if (paramSpec.data.type === 'struct') {
                     if (paramSpec.data.constraints.required) {
-                        modelValue = lang.copy(paramSpec.data.defaultValue);
+                        modelValue = Util.copy(paramSpec.data.defaultValue);
                     } else {
                         modelValue = paramSpec.data.nullValue;
                     }
                 } else {
-                    modelValue = lang.copy(paramSpec.data.defaultValue);
+                    modelValue = Util.copy(paramSpec.data.defaultValue);
                 }
                 if (appType === 'bulkImport') {
                     model.params[id] = modelValue;

--- a/kbase-extension/static/kbase/js/common/validation.js
+++ b/kbase-extension/static/kbase/js/common/validation.js
@@ -2,7 +2,7 @@ define([
     'bluebird',
     'kb_service/client/workspace',
     'kb_service/utils',
-    'common/lang',
+    'util/util',
     'util/string',
 ], (Promise, Workspace, serviceUtils, Util, StringUtil) => {
     'use strict';

--- a/kbase-extension/static/kbase/js/util/util.js
+++ b/kbase-extension/static/kbase/js/util/util.js
@@ -1,6 +1,15 @@
+/**
+ * A collection of general utility functions that don't fit well anywhere else.
+ */
 define(['bluebird'], (Promise) => {
     'use strict';
 
+    /**
+     * Copies an object so that it occupies a separate memory space. That is,
+     * modifying the copied object does not modify the original.
+     * @param {*} obj
+     * @returns the copied object
+     */
     function copyValue(obj) {
         if (obj !== undefined) {
             return JSON.parse(JSON.stringify(obj));
@@ -29,7 +38,7 @@ define(['bluebird'], (Promise) => {
      * Floats are not reduced into integers, unless the decimal part === 0.
      * @param {string|number} value
      * @returns {number} the integer version of the value.
-     * @throws {*} an error if:
+     * @throws {Error} an error if:
      * - the value is a non-integer number,
      * - if the value is a non-int-parseable string,
      * - if value is anything else (like an Array or Object)

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/customInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/customInput.js
@@ -1,13 +1,13 @@
 define([
     'bluebird',
     '../validators/text',
-    'common/lang',
+    'util/util',
     'common/ui',
     'common/props',
     'common/runtime',
 
     'bootstrap',
-], (Promise, Validation, Lang, UI, Props, Runtime) => {
+], (Promise, Validation, Util, UI, Props, Runtime) => {
     'use strict';
 
     function factory(config) {
@@ -36,7 +36,7 @@ define([
 
         // sync the dom to the model.
         function syncModelToControl() {
-            console.log('syncing...', inputWidget, model.getItem('value', null));
+            console.warn('syncing...', inputWidget, model.getItem('value', null));
         }
 
         // VALIDATION
@@ -59,7 +59,7 @@ define([
             // For now all custom inputs live in the
             // customInputs directory of the input collection directory
             // and are named like <type>Input.js
-            return Lang.pRequire(['./customInputs/' + subtype + 'Input']).spread((Module) => {
+            return Util.pRequire(['./customInputs/' + subtype + 'Input']).spread((Module) => {
                 const inputWidget = Module.make({
                     runtime: runtime,
                 });

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/sequenceInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/sequenceInput.js
@@ -5,7 +5,7 @@ define([
     'common/events',
     'common/ui',
     'common/runtime',
-    'common/lang',
+    'util/util',
     'common/props',
     '../paramResolver',
     '../validators/sequence',
@@ -19,7 +19,7 @@ define([
     Events,
     UI,
     Runtime,
-    lang,
+    Util,
     Props,
     Resolver,
     Validation,
@@ -30,18 +30,15 @@ define([
     // Constants
     const t = html.tag,
         div = t('div'),
-        span = t('span'),
         button = t('button');
 
     function factory(config) {
-        let spec = config.parameterSpec,
+        let container, parent, ui;
+        const spec = config.parameterSpec,
             itemSpec = spec.parameters.specs.item,
-            container,
-            parent,
             runtime = Runtime.make(),
             busConnection = runtime.bus().connect(),
             channel = busConnection.channel(config.channelName),
-            ui,
             model = {
                 value: [],
             },
@@ -155,9 +152,7 @@ define([
         function makeSingleInputControl(control, events) {
             return resolver.loadInputControl(itemSpec).then((widgetFactory) => {
                 // CONTROL
-                let preButton,
-                    postButton,
-                    widgetId = html.genId(),
+                const widgetId = html.genId(),
                     inputBus = runtime.bus().makeChannelBus({
                         description: 'Array input control',
                     }),
@@ -207,18 +202,7 @@ define([
                     },
                 });
 
-                preButton = div(
-                    {
-                        class: 'input-group-addon kb-input-group-addon',
-                        dataElement: 'index-label',
-                        style: {
-                            width: '5ex',
-                            padding: '0',
-                        },
-                    },
-                    [span({ dataElement: 'index' }, String(control.index + 1)), '.']
-                );
-                postButton = div(
+                const postButton = div(
                     {
                         class: 'input-group-addon kb-app-row-close-btn-addon',
                         style: {
@@ -327,7 +311,7 @@ define([
 
         function addNewControl(initialValue) {
             if (initialValue === undefined) {
-                initialValue = lang.copy(itemSpec.data.defaultValue);
+                initialValue = Util.copy(itemSpec.data.defaultValue);
             }
             return Promise.try(() => {
                 const events = Events.make({ node: container });
@@ -423,7 +407,7 @@ define([
                 ui = UI.make({ node: container });
 
                 return render(config.initialValue).then(() => {
-                    channel.on('reset-to-defaults', (message) => {
+                    channel.on('reset-to-defaults', () => {
                         resetModelValue();
                     });
                     channel.on('update', (message) => {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
@@ -4,12 +4,12 @@ define([
     '../validators/resolver',
     'common/events',
     'common/ui',
-    'common/lang',
+    'util/util',
     '../paramResolver',
     '../fieldWidgetCompact',
 
     'bootstrap',
-], (Promise, html, Validation, Events, UI, lang, Resolver, FieldWidget) => {
+], (Promise, html, Validation, Events, UI, Util, Resolver, FieldWidget) => {
     'use strict';
 
     // Constants
@@ -20,18 +20,19 @@ define([
         resolver = Resolver.make();
 
     function factory(config) {
-        let spec = config.parameterSpec,
-            bus = config.bus,
-            container,
+        let container,
             hostNode,
             ui,
+            structFields = {};
+
+        const spec = config.parameterSpec,
+            bus = config.bus,
             viewModel = {
                 data: {},
                 state: {
                     enabled: null,
                 },
             },
-            structFields = {},
             fieldLayout = spec.ui.layout,
             struct = spec.parameters,
             places = {};
@@ -61,7 +62,7 @@ define([
 
         function resetModelValue() {
             if (spec.defaultValue) {
-                setModelValue(lang.copy(spec.defaultValue));
+                setModelValue(Util.copy(spec.defaultValue));
             } else {
                 unsetModelValue();
             }
@@ -100,7 +101,7 @@ define([
                         state: viewModel.state,
                     });
                     bus.emit('changed', {
-                        newValue: lang.copy(viewModel.data),
+                        newValue: Util.copy(viewModel.data),
                     });
                     renderSubcontrols();
                 });
@@ -110,13 +111,13 @@ define([
                 // Enable it
                 viewModel.state.enabled = true;
                 button.innerHTML = 'Disable';
-                viewModel.data = lang.copy(spec.data.defaultValue);
+                viewModel.data = Util.copy(spec.data.defaultValue);
             }
             bus.emit('set-param-state', {
                 state: viewModel.state,
             });
             bus.emit('changed', {
-                newValue: lang.copy(viewModel.data),
+                newValue: Util.copy(viewModel.data),
             });
             renderSubcontrols();
         }
@@ -191,9 +192,9 @@ define([
 
         function doChanged(id, newValue) {
             // Absorb and propagate the new value...
-            viewModel.data[id] = lang.copy(newValue);
+            viewModel.data[id] = Util.copy(newValue);
             bus.emit('changed', {
-                newValue: lang.copy(viewModel.data),
+                newValue: Util.copy(viewModel.data),
             });
 
             // Validate and propagate.
@@ -210,7 +211,7 @@ define([
          * The single input control wraps a field widget, which provides the
          * wrapper around the input widget itself.
          */
-        function makeSingleInputControl(value, fieldSpec, events) {
+        function makeSingleInputControl(value, fieldSpec) {
             return resolver.loadInputControl(fieldSpec).then((widgetFactory) => {
                 const id = html.genId(),
                     fieldWidget = FieldWidget.make({
@@ -235,7 +236,7 @@ define([
                 fieldWidget.bus.on('validation', (message) => {
                     if (message.diagnosis === 'optional-empty') {
                         bus.emit('changed', {
-                            newValue: lang.copy(viewModel.data),
+                            newValue: Util.copy(viewModel.data),
                         });
                     }
                 });
@@ -348,7 +349,7 @@ define([
                 container = hostNode.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
                 events = Events.make({ node: container });
-                viewModel.data = lang.copy(config.initialValue);
+                viewModel.data = Util.copy(config.initialValue);
             });
             return init
                 .then(() => {
@@ -370,7 +371,7 @@ define([
                         // TODO: container environment should know about enable/disabled state?
                         // FORNOW: just ignore
                         if (viewModel.state.enabled) {
-                            viewModel.data = lang.copy(message.value);
+                            viewModel.data = Util.copy(message.value);
                             Object.keys(message.value).forEach((id) => {
                                 structFields[id].instance.bus.emit('update', {
                                     value: message.value[id],
@@ -381,7 +382,7 @@ define([
 
                     bus.on('submit', () => {
                         bus.emit('submitted', {
-                            value: lang.copy(viewModel.data),
+                            value: Util.copy(viewModel.data),
                         });
                     });
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
@@ -2,7 +2,7 @@ define([
     'bluebird',
     'kb_service/client/workspace',
     'kb_service/utils',
-    'common/lang',
+    'util/util',
     'util/string',
 ], (Promise, Workspace, serviceUtils, Util, StringUtil) => {
     'use strict';

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/int.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/int.js
@@ -1,4 +1,4 @@
-define(['bluebird', 'common/lang'], (Promise, Util) => {
+define(['bluebird', 'util/util'], (Promise, Util) => {
     'use strict';
 
     function importString(value) {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/sequenceView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/sequenceView.js
@@ -5,7 +5,7 @@ define([
     'common/events',
     'common/ui',
     'common/runtime',
-    'common/lang',
+    'util/util',
     'common/props',
     '../paramResolver',
     '../validators/sequence',
@@ -19,7 +19,7 @@ define([
     Events,
     UI,
     Runtime,
-    lang,
+    Util,
     Props,
     Resolver,
     Validation,
@@ -33,14 +33,12 @@ define([
         button = t('button');
 
     function factory(config) {
-        let spec = config.parameterSpec,
+        let container, parent, ui;
+        const spec = config.parameterSpec,
             itemSpec = spec.parameters.specs.item,
-            container,
-            parent,
             runtime = Runtime.make(),
             busConnection = runtime.bus().connect(),
             channel = busConnection.channel(config.channelName),
-            ui,
             model = {
                 value: [],
             },
@@ -109,8 +107,7 @@ define([
         function makeSingleViewControl(control) {
             return resolver.loadViewControl(itemSpec).then((widgetFactory) => {
                 // CONTROL
-                let postButton,
-                    widgetId = html.genId(),
+                const widgetId = html.genId(),
                     inputBus = runtime.bus().makeChannelBus({
                         description: 'Array input control',
                     }),
@@ -153,7 +150,7 @@ define([
                     },
                 });
 
-                postButton = div(
+                const postButton = div(
                     {
                         class: 'input-group-addon kb-input-group-addon',
                         style: {
@@ -204,7 +201,7 @@ define([
 
         function addNewControl(initialValue) {
             if (initialValue === undefined) {
-                initialValue = lang.copy(itemSpec.data.defaultValue);
+                initialValue = Util.copy(itemSpec.data.defaultValue);
             }
             return Promise.try(() => {
                 const events = Events.make({ node: container });

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/structView.js
@@ -4,12 +4,12 @@ define([
     '../validators/resolver',
     'common/events',
     'common/ui',
-    'common/lang',
+    'util/util',
     '../paramResolver',
     '../fieldWidgetCompact',
 
     'bootstrap',
-], (Promise, html, Validation, Events, UI, lang, Resolver, FieldWidget) => {
+], (Promise, html, Validation, Events, UI, Util, Resolver, FieldWidget) => {
     'use strict';
 
     // Constants
@@ -18,23 +18,18 @@ define([
         resolver = Resolver.make();
 
     function factory(config) {
-        let spec = config.parameterSpec,
-            bus = config.bus,
-            container,
+        let container,
             parent,
             ui,
+            structFields = {};
+        const spec = config.parameterSpec,
+            bus = config.bus,
             viewModel = {
                 data: {},
                 state: {
                     enabled: null,
                 },
             },
-            structFields = {},
-            // model = {
-            //     value: {},
-            //     enabled: null
-            // },
-            // structFields,
             fieldLayout = spec.ui.layout,
             struct = spec.parameters;
 
@@ -66,7 +61,7 @@ define([
 
         function resetModelValue() {
             if (spec.defaultValue) {
-                setModelValue(lang.copy(spec.defaultValue));
+                setModelValue(Util.copy(spec.defaultValue));
             } else {
                 unsetModelValue();
             }
@@ -115,9 +110,9 @@ define([
 
         function doChanged(id, newValue) {
             // Absorb and propagate the new value...
-            viewModel.data[id] = lang.copy(newValue);
+            viewModel.data[id] = Util.copy(newValue);
             bus.emit('changed', {
-                newValue: lang.copy(viewModel.data),
+                newValue: Util.copy(viewModel.data),
             });
 
             // Validate and propagate.
@@ -161,7 +156,7 @@ define([
                 fieldWidget.bus.on('validation', (message) => {
                     if (message.diagnosis === 'optional-empty') {
                         bus.emit('changed', {
-                            newValue: lang.copy(viewModel.data),
+                            newValue: Util.copy(viewModel.data),
                         });
                     }
                 });
@@ -258,7 +253,7 @@ define([
                 ui = UI.make({ node: container });
                 events = Events.make({ node: container });
 
-                viewModel.data = lang.copy(config.initialValue);
+                viewModel.data = Util.copy(config.initialValue);
 
                 // return bus.request({}, {
                 //     key: 'get-param-state'
@@ -284,7 +279,7 @@ define([
                         // TODO: container environment should know about enable/disabled state?
                         // FORNOW: just ignore
                         if (viewModel.state.enabled) {
-                            viewModel.data = lang.copy(message.value);
+                            viewModel.data = Util.copy(message.value);
                             Object.keys(message.value).forEach((id) => {
                                 structFields[id].instance.bus.emit('update', {
                                     value: message.value[id],
@@ -296,7 +291,7 @@ define([
                     // A fake submit.
                     bus.on('submit', () => {
                         bus.emit('submitted', {
-                            value: lang.copy(viewModel.data),
+                            value: Util.copy(viewModel.data),
                         });
                     });
 

--- a/nbextensions/advancedViewCell/widgets/appParamsWidget.js
+++ b/nbextensions/advancedViewCell/widgets/appParamsWidget.js
@@ -5,7 +5,7 @@ define([
     'common/ui',
     'common/events',
     'common/props',
-    'common/lang',
+    'util/util',
     // Wrapper for inputs
     'common/cellComponents/inputWrapperWidget',
     'widgets/appWidgets2/paramResolver',
@@ -19,7 +19,7 @@ define([
     UI,
     Events,
     Props,
-    Lang,
+    Util,
     //Wrappers
     RowWidget,
     ParamResolver,
@@ -61,7 +61,7 @@ define([
 
             return Promise.all([
                 paramResolver.loadInputControl(parameterSpec),
-                Lang.pRequire(['widgets/appWidgets2/' + fieldWidgetModule]),
+                Util.pRequire(['widgets/appWidgets2/' + fieldWidgetModule]),
             ]).spread((inputWidget, [FieldWidget]) => {
                 const fieldWidget = FieldWidget.make({
                     inputControlFactory: inputWidget,

--- a/nbextensions/viewCell/widgets/viewCellWidget.js
+++ b/nbextensions/viewCell/widgets/viewCellWidget.js
@@ -4,7 +4,6 @@ define(
         'bluebird',
         'uuid',
         'base/js/namespace',
-        'common/lang',
         'common/runtime',
         'common/events',
         'common/html',
@@ -12,7 +11,6 @@ define(
         'common/jupyter',
         'common/busEventManager',
         'kb_service/client/narrativeMethodStore',
-        'kb_service/client/workspace',
         'common/pythonInterop',
         'common/cellUtils',
         'common/ui',
@@ -28,7 +26,6 @@ define(
         Promise,
         Uuid,
         JupyterNamespace,
-        Lang,
         Runtime,
         Events,
         html,
@@ -36,7 +33,6 @@ define(
         Narrative,
         BusEventManager,
         NarrativeMethodStore,
-        Workspace,
         PythonInterop,
         utils,
         Ui,
@@ -257,19 +253,14 @@ define(
             ];
 
         function factory(config) {
-            let container,
-                ui,
-                workspaceInfo = config.workspaceInfo,
+            let container, ui, cellBus, paramsWidget, fsm;
+            const workspaceInfo = config.workspaceInfo,
                 runtime = Runtime.make(),
                 cell = config.cell,
                 parentBus = config.bus,
-                spec,
                 // TODO: the cell bus should be created and managed through main.js,
                 // that is, the extension.
-                cellBus,
                 bus = runtime.bus().makeChannelBus({ description: 'A view cell widget' }),
-                model,
-                paramsWidget,
                 eventManager = BusEventManager.make({
                     bus: runtime.bus(),
                 }),
@@ -292,8 +283,7 @@ define(
                         type: 'toggle',
                         element: 'about-app',
                     },
-                },
-                fsm;
+                };
 
             if (runtime.config('features.developer')) {
                 settings.showDeveloper = {
@@ -411,14 +401,13 @@ define(
             }
 
             function renderSetting(settingName) {
-                let setting = settings[settingName],
-                    value;
+                const setting = settings[settingName];
 
                 if (!setting) {
                     return;
                 }
 
-                value = model.getItem(['user-settings', settingName], setting.defaultValue);
+                const value = model.getItem(['user-settings', settingName], setting.defaultValue);
                 switch (setting.type) {
                     case 'toggle':
                         if (value) {
@@ -702,8 +691,8 @@ define(
                         ]
                     );
                 return {
-                    content: content,
-                    events: events,
+                    content,
+                    events,
                 };
             }
 
@@ -803,10 +792,10 @@ define(
             }
 
             function toggleSettings() {
-                let name = 'showSettings',
+                const name = 'showSettings',
                     selector = 'settings',
-                    node = ui.getElement(selector),
-                    showing = model.getItem(['user-settings', name]);
+                    node = ui.getElement(selector);
+                let showing = model.getItem(['user-settings', name]);
                 if (showing) {
                     model.setItem(['user-settings', name], false);
                 } else {
@@ -1323,22 +1312,22 @@ define(
             }
 
             // INIT
-            model = Props.make({
+            const model = Props.make({
                 data: utils.getMeta(cell, 'viewCell'),
                 onUpdate: function (props) {
                     utils.setMeta(cell, 'viewCell', props.getRawObject());
                 },
             });
 
-            spec = Spec.make({
+            const spec = Spec.make({
                 appSpec: model.getItem('app.spec'),
             });
 
             return {
-                init: init,
-                attach: attach,
-                start: start,
-                run: run,
+                init,
+                attach,
+                start,
+                run,
             };
         }
 

--- a/test/unit/spec/util/util-Spec.js
+++ b/test/unit/spec/util/util-Spec.js
@@ -1,9 +1,9 @@
-define(['common/lang'], (Utils) => {
+define(['util/util'], (Utils) => {
     'use strict';
 
-    describe('Lang Util functions', () => {
+    describe('Basic Util functions', () => {
         it('should have expected functions', () => {
-            ['copy', 'pRequire'].forEach((fn) => {
+            ['copy', 'pRequire', 'toInteger'].forEach((fn) => {
                 expect(Utils[fn]).toEqual(jasmine.any(Function));
             });
         });
@@ -71,6 +71,45 @@ define(['common/lang'], (Utils) => {
             it('should fail to load a non-existent module', async () => {
                 const module = 'not_a_real_module';
                 await expectAsync(Utils.pRequire([module])).toBeRejected();
+            });
+        });
+
+        describe('the toInteger function', () => {
+            [undefined, null, {}, { a: 1 }, [], () => {}].forEach((input) => {
+                it(`should not convert "${input}" to an integer`, () => {
+                    expect(() => Utils.toInteger(input)).toThrowError(
+                        /cannot be converted to integer/
+                    );
+                });
+            });
+
+            it('should convert number strings', () => {
+                const okCases = {
+                    '-1': -1,
+                    '+1': 1,
+                    1: 1,
+                    100000000: 100000000,
+                    0: 0,
+                };
+                Object.keys(okCases).forEach((testCase) => {
+                    expect(Utils.toInteger(testCase)).toEqual(okCases[testCase]);
+                });
+            });
+
+            it('should fail to convert non-integer numbers', () => {
+                const badCases = [1.1, -1.01, 10.00000001];
+                badCases.forEach((bad) => {
+                    expect(() => Utils.toInteger(bad)).toThrowError(
+                        'Integer is a non-integer number'
+                    );
+                });
+            });
+
+            it('should fail to convert non-integer strings', () => {
+                const badCases = ['-1.1', '0.00000001', '1.1', 'foo', '1 '];
+                badCases.forEach((bad) => {
+                    expect(() => Utils.toInteger(bad)).toThrowError('Invalid integer format');
+                });
             });
         });
     });


### PR DESCRIPTION
# Description of PR purpose/changes

As talked about here: [#2593 comment](https://github.com/kbase/narrative/pull/2592#discussion_r750329883) , this PR moves the `common/lang` utility module to the `util` directory with the rest of them. It updates all the other module that used it to the new resource.

ESlint and Prettier threw a collective tantrum as well, so most of the code changes are due to that. Will comment inline.

# Jira Ticket / Issue #
https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* should be no visible changes
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
