### PR TITLE
DATAUP-497: simplify conversions between backend and frontend jobs

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -478,8 +478,9 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
              * @param {Object} message
              */
             handleJobStatus(self, message) {
-                const { jobId, jobState } = message;
-                const { status, updated } = jobState;
+                const { jobState } = message,
+                    { status, updated } = jobState,
+                    jobId = jobState.job_id;
 
                 // if the job is in a terminal state and cannot be retried,
                 // stop listening for updates

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -963,7 +963,7 @@ define([
                 const errorModel = Props.make({
                     data: {
                         exec: {
-                            jobState: jobState,
+                            jobState,
                         },
                     },
                 });
@@ -1163,6 +1163,7 @@ define([
                                 this.startLogAutoFetch();
                                 break;
                             case 'finished':
+                                this.requestJobLog(0);
                                 // the FSM turns off log fetch and status updates
                                 newState = {
                                     mode: 'finished',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001280",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-            "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
+            "version": "1.0.30001282",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
+            "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001280",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001280.tgz",
-            "integrity": "sha512-kFXwYvHe5rix25uwueBxC569o53J6TpnGu0BEEn+6Lhl2vsnAumRFWEBhDft1fwyo6m1r4i+RqA4+163FpeFcA==",
+            "version": "1.0.30001282",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
+            "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
             "dev": true
         },
         "center-align": {

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -385,10 +385,8 @@ class Job(object):
         :return: dict, with structure
 
         {
-            user: string (username, who started the job),
-            spec: app spec (optional)
-            widget_info: (if not finished, None, else...) job.get_viewer_params result
-            state: {
+            outputWidgetInfo: (if not finished, None, else...) job.get_viewer_params result
+            jobState: {
                 job_id: string,
                 status: string,
                 created: epoch ms,
@@ -451,13 +449,10 @@ class Job(object):
                 # update timestamp if there was an error
                 state.update({"updated": int(time.time())})
 
-        job_state = {
-            "state": state,
-            "widget_info": widget_info,
-            "user": self.user,
-            "cell_id": self.cell_id,
+        return {
+            "jobState": state,
+            "outputWidgetInfo": widget_info,
         }
-        return job_state
 
     def show_output_widget(self, state=None):
         """

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -368,7 +368,7 @@ class JobComm:
                 "job_status",
                 {
                     req.job_id: {
-                        "state": {"job_id": req.job_id, "status": "does_not_exist"}
+                        "jobState": {"job_id": req.job_id, "status": "does_not_exist"}
                     }
                 },
             )
@@ -431,12 +431,12 @@ class JobComm:
 
     def _retry_jobs(self, req: JobRequest) -> None:
         retry_results = self._jm.retry_jobs(req.job_id_list)
-        self.send_comm_message("jobs_retried", retry_results)
+        self.send_comm_message("job_retries", retry_results)
         self.send_comm_message(
             "new_job",
             {
                 "job_id_list": [
-                    result["retry"]["state"]["job_id"]
+                    result["retry"]["jobState"]["job_id"]
                     for result in retry_results
                     if "retry" in result
                 ]

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -41,7 +41,7 @@ CELLS_NOT_PROVIDED_ERR = "cell_id_list not provided"
 def get_error_output_state(job_id, error="does_not_exist"):
     if error not in ["does_not_exist", "ee2_error"]:
         raise ValueError(f"Unknown error type: {error}")
-    return {"state": {"job_id": job_id, "status": error}}
+    return {"jobState": {"job_id": job_id, "status": error}}
 
 
 class JobManager(object):
@@ -207,7 +207,7 @@ class JobManager(object):
         """
         try:
             all_states = self.lookup_all_job_states(ignore_refresh_flag=True)
-            state_list = [copy.deepcopy(s["state"]) for s in all_states.values()]
+            state_list = [copy.deepcopy(s["jobState"]) for s in all_states.values()]
 
             if not len(state_list):
                 return "No running jobs!"
@@ -221,6 +221,7 @@ class JobManager(object):
                 state["run_time"] = "Not started"
                 state["owner"] = job.user
                 state["app_id"] = job.app_id
+                state["batch_id"] = job.batch_id
                 exec_start = state.get("running", None)
 
                 if state.get("finished"):
@@ -247,6 +248,7 @@ class JobManager(object):
                     <th>Id</th>
                     <th>Name</th>
                     <th>Submitted</th>
+                    <th>Batch ID</th>
                     <th>Submitted By</th>
                     <th>Status</th>
                     <th>Run Time</th>
@@ -257,6 +259,7 @@ class JobManager(object):
                     <td>{{ j.job_id|e }}</td>
                     <td>{{ j.app_id|e }}</td>
                     <td>{{ j.created|e }}</td>
+                    <td>{{ j.batch_id|e }}</td>
                     <td>{{ j.user|e }}</td>
                     <td>{{ j.status|e }}</td>
                     <td>{{ j.run_time|e }}</td>
@@ -483,9 +486,7 @@ class JobManager(object):
         job_states = self._construct_job_output_state_set(job_ids)
 
         for job_id in error_ids:
-            job_states[job_id] = {
-                "state": {"job_id": job_id, "status": "does_not_exist"}
-            }
+            job_states[job_id] = get_error_output_state(job_id)
 
         return job_states
 
@@ -552,7 +553,7 @@ class JobManager(object):
         for job_id in error_ids:
             retry_results.append(
                 {
-                    "job": {"state": {"job_id": job_id, "status": "does_not_exist"}},
+                    "job": get_error_output_state(job_id),
                     "error": "does_not_exist",
                 }
             )

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -228,10 +228,8 @@ def get_test_job_state(job_id):
             del state[f]
 
     output_state = {
-        "state": state,
-        "widget_info": get_widget_info(job_id),
-        "cell_id": state.get("cell_id"),
-        "user": state.get("user"),
+        "jobState": state,
+        "outputWidgetInfo": get_widget_info(job_id),
     }
     return output_state
 

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -1155,8 +1155,6 @@ class JobCommTestCase(unittest.TestCase):
         states = msg["data"]["content"]
         self.assertIsInstance(states, dict)
         for job_id in states:
-            print("ALL JOB STATE TESTING")
-            print(states[job_id])
             validate_job_state(states[job_id])
 
     def test_handle_job_status_msg(self):

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -88,7 +88,7 @@ def create_jm_message(r_type, job_id=None, data=None):
 
 def get_retry_job_state(orig_id, status="unmocked"):
     return {
-        "state": {
+        "jobState": {
             "job_id": orig_id[::-1],
             "status": status,
             "batch_id": None,
@@ -97,9 +97,7 @@ def get_retry_job_state(orig_id, status="unmocked"):
             "run_id": None,
             "child_jobs": [],
         },
-        "cell_id": None,
-        "widget_info": None,
-        "user": None,
+        "outputWidgetInfo": None,
     }
 
 
@@ -145,27 +143,6 @@ class JobManagerTest(unittest.TestCase):
         self.jm = biokbase.narrative.jobs.jobmanager.JobManager()
         self.jm.initialize_jobs()
         self.job_states = get_test_job_states()
-
-    def validate_status_message(self, msg):
-        core_keys = set(["widget_info", "user", "state"])
-        state_keys = set(
-            ["user", "authstrat", "wsid", "status", "updated", "job_input"]
-        )
-        if not core_keys.issubset(set(msg.keys())):
-            print(
-                "Missing core key(s) - [{}]".format(
-                    ", ".join(core_keys.difference(set(msg.keys())))
-                )
-            )
-            return False
-        if not state_keys.issubset(set(msg["state"].keys())):
-            print(
-                "Missing status key(s) - [{}]".format(
-                    ", ".join(state_keys.difference(set(msg["state"].keys())))
-                )
-            )
-            return False
-        return True
 
     @mock.patch(CLIENTS, get_failing_mock_client)
     def test_initialize_jobs_ee2_fail(self):
@@ -438,7 +415,7 @@ class JobManagerTest(unittest.TestCase):
             JOB_COMPLETED: self.job_states[JOB_COMPLETED],
             JOB_TERMINATED: self.job_states[JOB_TERMINATED],
             JOB_NOT_FOUND: {
-                "state": {
+                "jobState": {
                     "job_id": JOB_NOT_FOUND,
                     "status": "does_not_exist",
                 }
@@ -486,19 +463,19 @@ class JobManagerTest(unittest.TestCase):
         self.assertEqual(expected, retry_results)
 
         orig_ids = [
-            result["job"]["state"]["job_id"]
+            result["job"]["jobState"]["job_id"]
             for result in retry_results
             if "error" not in result
         ]
         retry_ids = [
-            result["retry"]["state"]["job_id"]
+            result["retry"]["jobState"]["job_id"]
             for result in retry_results
             if "error" not in result
         ]
         dne_ids = [
-            result["job"]["state"]["job_id"]
+            result["job"]["jobState"]["job_id"]
             for result in retry_results
-            if result["job"]["state"]["status"] == "does_not_exist"
+            if result["job"]["jobState"]["status"] == "does_not_exist"
         ]
 
         for job_id in orig_ids + retry_ids:

--- a/src/biokbase/narrative/tests/util.py
+++ b/src/biokbase/narrative/tests/util.py
@@ -312,17 +312,17 @@ def validate_job_state(job_state: dict) -> None:
     If any keys are missing, or extra keys exist, or values are weird, then this
     raises an AssertionError.
     """
-    assert "state" in job_state, "state key missing"
-    assert isinstance(job_state["state"], dict), "state is not a dict"
-    assert "user" in job_state, "user key missing"
-    assert isinstance(job_state["user"], str), "user is not a string"
-    assert "cell_id" in job_state, "cell_id key missing"
-    state = job_state["state"]
+    NoneType = type(None)
+
+    assert "jobState" in job_state, "jobState key missing"
+    assert isinstance(job_state["jobState"], dict), "jobState is not a dict"
+    assert "outputWidgetInfo" in job_state, "outputWidgetInfo key missing"
+    assert isinstance(job_state["outputWidgetInfo"], (dict, NoneType)), "outputWidgetInfo is not a dict or None"
+    state = job_state["jobState"]
     # list of tuples - first = key name, second = value type
     # details for other cases comes later. This is just the expected basic set of
     # keys for EVERY job, once it's been created in EE2.
 
-    NoneType = type(None)
     state_keys = {
         "required": {
             "job_id": str,


### PR DESCRIPTION

# Description of PR purpose/changes

There's a load of unnecessary conversion between back and frontend data; this PR aims to decrease that.
Convert backend to emit job data in format used by the frontend to cut down on conversions required
Update frontend to deal with new backend output format
Update job architecture docs

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see that nothing has changed

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
