### PR TITLE
DATAUP-497: simplify cell message types

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -101,6 +101,7 @@ define([
             STOP_UPDATE: 'stop_job_update',
         },
         BACKEND_RESPONSES = {
+            ERROR: 'job_comm_error',
             INFO: BACKEND_REQUESTS.INFO,
             LOGS: BACKEND_REQUESTS.LOGS,
             RESULT: RESULT,
@@ -141,6 +142,10 @@ define([
         validOutgoingMessageTypes: function () {
             return Object.values(RESPONSES);
         },
+        RESPONSES,
+        REQUESTS,
+        BACKEND_REQUESTS,
+        BACKEND_RESPONSES,
     };
 
     class JobCommChannel {
@@ -344,7 +349,7 @@ define([
                 // filtering.
                 //
                 // errors
-                case 'job_comm_error':
+                case BACKEND_RESPONSES.ERROR:
                     console.error('Error from job comm:', msg);
                     if (!msgData) {
                         break;
@@ -355,7 +360,7 @@ define([
                     if (msgData.source === BACKEND_REQUESTS.LOGS) {
                         msgTypeToSend = RESPONSES.LOGS;
                     } else {
-                        msgTypeToSend = 'job-error';
+                        msgTypeToSend = RESPONSES.ERROR;
                     }
 
                     jobIdList.forEach((_jobId) => {
@@ -423,7 +428,7 @@ define([
                                     message: 'ee2 connection error',
                                     code: msgData[_jobId].jobState.status,
                                 },
-                                request: 'job-status',
+                                request: 'job_status',
                             });
                         } else {
                             this.sendBusMessage(JOB, _jobId, RESPONSES.STATUS, msgData[_jobId]);

--- a/kbase-extension/static/kbase/js/util/jobStateViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobStateViewer.js
@@ -3,20 +3,22 @@
  * The viewer updates based on changes to the job state and view model.
  * It reports the current job state, runtime, and how long it has been / was queued for.
  */
-define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html', 'common/jobs'], (
-    Promise,
-    Runtime,
-    UI,
-    format,
-    html,
-    Jobs
-) => {
+define([
+    'bluebird',
+    'common/runtime',
+    'common/ui',
+    'common/format',
+    'common/html',
+    'common/jobs',
+    'common/jobCommChannel',
+], (Promise, Runtime, UI, format, html, Jobs, JobComms) => {
     'use strict';
 
     const t = html.tag,
         div = t('div'),
         p = t('p'),
-        span = t('span');
+        span = t('span'),
+        jcm = JobComms.JobCommMessages;
 
     /**
      * Updates the view stats.
@@ -323,7 +325,7 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
             if (listeningForJob) {
                 return;
             }
-            runtime.bus().emit('request-job-updates-start', {
+            runtime.bus().emit(jcm.REQUESTS.START_UPDATE, {
                 jobId,
             });
             listeningForJob = true;
@@ -375,7 +377,7 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
                         jobId: jobId,
                     },
                     key: {
-                        type: 'job-status',
+                        type: jcm.RESPONSES.STATUS,
                     },
                     handle: handleJobStatusUpdate,
                 })
@@ -413,7 +415,7 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'common/html
                     listenForJobStatus();
 
                     // request a new job status update from the kernel on start
-                    runtime.bus().emit('request-job-status', {
+                    runtime.bus().emit(jcm.REQUESTS.STATUS, {
                         jobId: jobId,
                         parentJobId: parentJobId,
                     });

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -14,6 +14,7 @@ define([
     'kbaseAuthenticatedWidget',
     'kbaseTabs',
     'kbaseReportView',
+    'common/jobCommChannel',
     'common/runtime',
     'common/semaphore',
     'common/cellUtils',
@@ -38,6 +39,7 @@ define([
     KBaseAuthenticatedWidget,
     KBaseTabs,
     KBaseReportView,
+    JobComms,
     Runtime,
     Semaphore,
     utils,
@@ -49,7 +51,8 @@ define([
 ) => {
     'use strict';
 
-    const { JobLogViewer } = JobLogViewerModule;
+    const { JobLogViewer } = JobLogViewerModule,
+        jcm = JobComms.JobCommMessages;
 
     return new KBWidget({
         name: 'kbaseNarrativeJobStatus',
@@ -147,7 +150,7 @@ define([
                             jobId: this.jobId,
                         },
                         key: {
-                            type: 'job-info',
+                            type: jcm.RESPONSES.INFO,
                         },
                         handle: function (message) {
                             this.handleJobInfo(message);
@@ -159,18 +162,18 @@ define([
                             jobId: this.jobId,
                         },
                         key: {
-                            type: 'job-status',
+                            type: jcm.RESPONSES.STATUS,
                         },
                         handle: function (message) {
                             this.handleJobStatus(message);
                         }.bind(this),
                     });
 
-                    this.channel.emit('request-job-info', {
+                    this.channel.emit(jcm.REQUESTS.INFO, {
                         jobId: this.jobId,
                     });
 
-                    this.channel.emit('request-job-status', {
+                    this.channel.emit(jcm.REQUESTS.STATUS, {
                         jobId: this.jobId,
                     });
                 })
@@ -497,7 +500,7 @@ define([
                 case 'completed':
                     if (this.requestedUpdates) {
                         this.requestedUpdates = false;
-                        this.channel.emit('request-job-updates-stop', {
+                        this.channel.emit(jcm.REQUESTS.STOP_UPDATE, {
                             jobId: this.jobId,
                         });
                     }
@@ -521,14 +524,14 @@ define([
         },
 
         requestJobInfo: function () {
-            this.channel.emit('request-job-info', {
+            this.channel.emit(jcm.REQUESTS.INFO, {
                 jobId: this.jobId,
             });
         },
 
         requestJobStatus: function () {
             window.setTimeout(() => {
-                this.channel.emit('request-job-status', {
+                this.channel.emit(jcm.REQUESTS.STATUS, {
                     jobId: this.jobId,
                 });
             }, this.statusRequestInterval);

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -23,6 +23,7 @@ define(
         'common/spec',
         'common/semaphore',
         'common/jobs',
+        'common/jobCommChannel',
         'common/cellComponents/actionButtons',
         'narrativeConfig',
         'google-code-prettify/prettify',
@@ -60,6 +61,7 @@ define(
         Spec,
         Semaphore,
         Jobs,
+        JobComms,
         ActionButtons,
         Config,
         PR,
@@ -79,7 +81,8 @@ define(
             span = t('span'),
             a = t('a'),
             p = t('p'),
-            cssCellType = 'kb-app-cell';
+            cssCellType = 'kb-app-cell',
+            jcm = JobComms.JobCommMessages;
 
         function factory(config) {
             const runtime = Runtime.make(),
@@ -1196,7 +1199,7 @@ define(
              * narrative metadata.
              */
             function cancelJob(jobId) {
-                runtime.bus().emit('request-job-cancel', {
+                runtime.bus().emit(jcm.REQUESTS.CANCEL, {
                     jobId,
                 });
             }
@@ -1205,7 +1208,7 @@ define(
                 if (!jobId) {
                     return;
                 }
-                runtime.bus().emit('request-job-status', {
+                runtime.bus().emit(jcm.REQUESTS.STATUS, {
                     jobId,
                 });
             }
@@ -1412,13 +1415,13 @@ define(
                             jobId,
                         },
                         key: {
-                            type: 'job-status',
+                            type: jcm.RESPONSES.STATUS,
                         },
                         handle: doJobStatus,
                     })
                 );
 
-                runtime.bus().emit('request-job-updates-start', {
+                runtime.bus().emit(jcm.REQUESTS.START_UPDATE, {
                     jobId,
                 });
             }
@@ -1462,7 +1465,7 @@ define(
 
                 const jobId = model.getItem('exec.jobState.job_id');
                 if (jobId) {
-                    runtime.bus().emit('request-job-updates-stop', {
+                    runtime.bus().emit(jcm.REQUESTS.STOP_UPDATE, {
                         jobId,
                     });
                 }
@@ -1752,7 +1755,7 @@ define(
 
                         // TODO: only turn this on when we need it!
                         busEventManager.add(
-                            cellBus.on('run-status', (message) => {
+                            cellBus.on(jcm.RESPONSES.RUN_STATUS, (message) => {
                                 updateFromLaunchEvent(message);
 
                                 model.setItem('exec.launchState', message);

--- a/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
+++ b/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
@@ -1,17 +1,19 @@
-define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'kb_common/html'], (
-    Promise,
-    Runtime,
-    UI,
-    format,
-    html
-) => {
+define([
+    'bluebird',
+    'common/runtime',
+    'common/ui',
+    'common/format',
+    'kb_common/html',
+    'common/jobCommChannel',
+], (Promise, Runtime, UI, format, html, JobComms) => {
     'use strict';
 
     const t = html.tag,
         table = t('table'),
         tr = t('tr'),
         td = t('td'),
-        th = t('th');
+        th = t('th'),
+        jcm = JobComms.JobCommMessages;
 
     function renderTable() {
         return table({ class: 'table' }, [tr([th('Input'), th('Value')])]);
@@ -59,7 +61,7 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'kb_common/h
                     jobId: jobId,
                 },
                 key: {
-                    type: 'job-info',
+                    type: jcm.RESPONSES.INFO,
                 },
                 handle: (message) => {
                     updateRowStatus(ui, message.jobInfo.job_params[0], container);
@@ -81,7 +83,7 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/format', 'kb_common/h
                 isParentJob = arg.isParentJob;
 
                 startParamsListener();
-                runtime.bus().emit('request-job-info', {
+                runtime.bus().emit(jcm.REQUESTS.INFO, {
                     jobId: jobId,
                     parentJobId: arg.parentJobId,
                 });

--- a/nbextensions/appCell2/widgets/tabs/status/jobStateList.js
+++ b/nbextensions/appCell2/widgets/tabs/status/jobStateList.js
@@ -1,15 +1,17 @@
-define(['bluebird', 'common/runtime', 'common/ui', 'common/html', './jobStateListRow'], (
-    Promise,
-    Runtime,
-    UI,
-    html,
-    JobStateListRow
-) => {
+define([
+    'bluebird',
+    'common/runtime',
+    'common/ui',
+    'common/html',
+    './jobStateListRow',
+    'common/jobCommChannel',
+], (Promise, Runtime, UI, html, JobStateListRow, JobComms) => {
     'use strict';
 
     const t = html.tag,
         table = t('table'),
-        tbody = t('tbody');
+        tbody = t('tbody'),
+        jcm = JobComms.JobCommMessages;
 
     function renderTable() {
         return table({ class: 'table' }, [tbody()]);
@@ -69,7 +71,7 @@ define(['bluebird', 'common/runtime', 'common/ui', 'common/html', './jobStateLis
                     jobId: parentJobId,
                 },
                 key: {
-                    type: 'job-status',
+                    type: jcm.RESPONSES.STATUS,
                 },
                 handle: handleJobStatusUpdate,
             });

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -8,6 +8,7 @@ define([
     'common/html',
     'common/jobManager',
     'common/jobs',
+    'common/jobCommChannel',
     'common/props',
     'common/runtime',
     'common/spec',
@@ -37,6 +38,7 @@ define([
     html,
     JobManagerModule,
     Jobs,
+    JobComms,
     Props,
     Runtime,
     Spec,
@@ -58,7 +60,8 @@ define([
     DevMode
 ) => {
     'use strict';
-    const { JobManager } = JobManagerModule;
+    const { JobManager } = JobManagerModule,
+        jcm = JobComms.JobCommMessages;
 
     const CELL_TYPE = 'app-bulk-import';
     const div = html.tag('div'),
@@ -818,7 +821,7 @@ define([
          * Then changes the global cell state to "launching".
          */
         function doRunCellAction() {
-            runStatusListener = cellBus.on('run-status', handleRunStatus);
+            runStatusListener = cellBus.on(jcm.RESPONSES.RUN_STATUS, handleRunStatus);
             busEventManager.add(runStatusListener);
             cell.execute();
             updateState('launching');

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -4,6 +4,7 @@ define([
     'base/js/namespace',
     'common/dialogMessages',
     'common/jobs',
+    'common/jobCommChannel',
     'common/runtime',
     'narrativeMocks',
     'testUtil',
@@ -17,6 +18,7 @@ define([
     Jupyter,
     DialogMessages,
     Jobs,
+    JobComms,
     Runtime,
     Mocks,
     TestUtil,
@@ -26,6 +28,7 @@ define([
     Config
 ) => {
     'use strict';
+    const jcm = JobComms.JobCommMessages;
     const fakeInputs = {
             dataType: {
                 files: ['some_file'],
@@ -383,7 +386,7 @@ define([
                                     cell: cell.metadata.kbase.attributes.id,
                                 },
                                 key: {
-                                    type: 'run-status',
+                                    type: jcm.RESPONSES.RUN_STATUS,
                                 },
                             });
                         }
@@ -652,7 +655,7 @@ define([
                                     cell: cell.metadata.kbase.attributes.id,
                                 },
                                 key: {
-                                    type: 'run-status',
+                                    type: jcm.RESPONSES.RUN_STATUS,
                                 },
                             }
                         );
@@ -663,10 +666,10 @@ define([
                 const batchId = JobsData.batchParentJob.job_id;
                 // bus calls to init jobs, request info, cancel jobs, and stop updates
                 const callArgs = [
-                    ['request-job-updates-start', { batchId }],
-                    ['request-job-info', { batchId }],
-                    ['request-job-cancel', { jobIdList: [batchId] }],
-                    ['request-job-updates-stop', { batchId }],
+                    [jcm.REQUESTS.START_UPDATE, { batchId }],
+                    [jcm.REQUESTS.INFO, { batchId }],
+                    [jcm.REQUESTS.CANCEL, { jobIdList: [batchId] }],
+                    [jcm.REQUESTS.STOP_UPDATE, { batchId }],
                 ];
                 expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
                 expect(bulkImportCellInstance.jobManager.bus.emit.calls.allArgs()).toEqual(


### PR DESCRIPTION
# Description of PR purpose/changes

A big search-n-replace to switch out strings representing job message types to values from the JobCommMessages module. This is to make it easier to rename the messages without having to find the zillion places in the code that they are mentioned. 😖 

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to see that all is working as expected

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
