### PR TITLE
DATAUP-608 add uploader app docs

### DIFF
--- a/docs/developer/data_import.md
+++ b/docs/developer/data_import.md
@@ -8,12 +8,17 @@ The general flow of data goes from an external data source, to files uploaded to
 
 ## Staging Service
 
-This fetches the list of files from the Staging service every 
-Each row represents one file - these get rendered by the [StagingAreaViewer](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js) module. 
+The Staging Service acts as a first stop for importing data. This service provides an API to a KBase-hosted file system. Each user has separate file storage under their username. The Narrative front end uses a [REST client](../../kbase-extension/static/kbase/js/api/StagingServiceClient.js) to get access to that service.
+
+## Staging Service Viewer
+
+Users can interact with the Staging Service through the Import tab of the data slideout. The top portion of this tab is controlled by the [FileUploadWidget](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js). This uses [Dropzone](https://www.dropzone.dev/js/) to provide a drag-and-drop interface for uploading files. If the user's account is linked to Globus, an active link is also provided.
+
+The bottom portion of the Import tab acts as a file browser and selector for starting the Import process. The staged files get rendered by the [StagingAreaViewer](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js) module. This viewer fetches the list of files from the Staging Service, updating every 30 seconds (by default, configured in [config.json](../../src/config.json.templ)).
 
 ## Data Import
 
-Data import is initiated by selecting one or more data files from the Import tab, then running the Importer app for that data type. When at least one file has a data type chosen and its checkbox selected, the `Import Selected` button will activate. Clicking that will close the slideout and open a Bulk Import cell and/or at least one App Cell with the relative file path entered. File paths are given as the relative path from the root of the Staging Area without the username - the username is assumed and will be added at app run time.
+Data import is initiated by selecting one or more data files from the Import tab, then running the Importer app for that data type. When at least one file has a data type chosen and its checkbox selected, the `Import Selected` button will activate. Clicking that will close the slideout and open a Bulk Import cell and/or at least one App Cell with the relative file path entered. File paths are given as the relative path from the root of the Staging Area without the username - the username is assumed to be the root, and will be added at app run time.
 
 ### Importer App Configuration
 

--- a/docs/developer/data_import.md
+++ b/docs/developer/data_import.md
@@ -4,17 +4,17 @@ This document highlights some development details about importing data into the 
 
 ## Introduction
 
-The general flow of data goes from an external data source, to files uploaded to the Staging Area, to data objects imported to the Workspace service. The two main user actions here - uploading and importing - are separated by accessing the Staging Service, and running one or more Import apps. Both of these are started by opening the Import tab of the data slideout.
+The general flow of data goes from an external data source, to files uploaded to the Staging Area, to data objects imported to the Workspace service and available in the Narrative. The two main user actions here - uploading and importing - are performed by accessing the Staging Service, and running one or more Import apps, respectively. Both of these are started by opening the Import tab of the data slideout.
 
 ## Staging Service
 
-The Staging Service acts as a first stop for importing data. This service provides an API to a KBase-hosted file system. Each user has separate file storage under their username. The Narrative front end uses a [REST client](../../kbase-extension/static/kbase/js/api/StagingServiceClient.js) to get access to that service.
+The Staging Service acts as a first stop for importing data. This service provides an API to a KBase-hosted file system, where each user has a separate file storage directory under their username. The Narrative front end uses a [REST client](../../kbase-extension/static/kbase/js/api/StagingServiceClient.js) to access that service and manipulate files.
 
 ## Staging Service Viewer
 
-Users can interact with the Staging Service through the Import tab of the data slideout. The top portion of this tab is controlled by the [FileUploadWidget](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js). This uses [Dropzone](https://www.dropzone.dev/js/) to provide a drag-and-drop interface for uploading files. If the user's account is linked to Globus, an active link is also provided.
+Users can interact with the Staging Service through the Import tab of the data slideout. The top portion of this tab is controlled by the [FileUploadWidget](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/fileUploadWidget.js). This uses [Dropzone](https://www.dropzone.dev/js/) to provide a drag-and-drop interface for uploading files. If the user's account is linked to Globus, a link is also provided. Another option is to upload via URL. This requires running an app that imports data to the Staging Service from an external, public URL.
 
-The bottom portion of the Import tab acts as a file browser and selector for starting the Import process. The staged files get rendered by the [StagingAreaViewer](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js) module. This viewer fetches the list of files from the Staging Service, updating every 30 seconds (by default, configured in [config.json](../../src/config.json.templ)).
+The bottom portion of the Import tab acts as a file browser and selector for starting the Import process. The staged files get rendered by the [StagingAreaViewer](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js) module. This viewer fetches the list of files from the Staging Service, updating every 30 seconds.
 
 ## Data Import
 
@@ -38,11 +38,11 @@ Each `app_info` object has the following accepted keys:
 
 ### Configuring a new Bulk Import app
 The steps for adding a bulk import app to the configuration are fairly simple.
-1. Add the `app_info` object field as described above with a unique id.
-2. Add the new data type's id to `bulk_import_types`.
+1. Add the `app_info` object field as described above, with a unique id.
+2. Add the new data uploader's id to `bulk_import_types`.
 
-Be aware that as of Narrative 5.0.0 (with the bulk import app MVP), there are several issues to be aware of before adding a new bulk import app:
-* Apps that parallelize themselves (e.g. make use of the KBParallel module, or otherwise create extra jobs in the Execution Engine) may not work, or may cause user deadlocking. These are not recommended for use.
+Be aware that as of Narrative 5.0.0, there are several issues to be aware of before adding a new bulk import app:
+* Apps that parallelize themselves (e.g. make use of the KBParallel module, or otherwise create extra jobs in the Execution Engine) may not work, or may cause a deadlock where no further app runs may be submitted by that user. These are not recommended for use.
 * Apps that make use of Grouped Parameters (the `"parameter-groups"` field in an app spec) will not work correctly in a Bulk Import cell.
 * Apps that require subobject selection may not work, and have not been tested in the Bulk Import cell.
-* Apps that require the use of a dynamic dropdown may not work as expected in a Bulk Import cell. This is especially apparent on page reload once a Bulk Import cell has been configured.
+* Apps that require the use of a dynamic dropdown (a select box that gets its available selections from a service) may not work as expected in a Bulk Import cell.

--- a/docs/developer/data_import.md
+++ b/docs/developer/data_import.md
@@ -1,0 +1,43 @@
+# Data Importing in the KBase Narrative
+
+This document highlights some development details about importing data into the KBase Narrative. For user documentation on how to use it, see the [KBase Data Upload and Download Guide](https://docs.kbase.us/data/upload-download-guide).
+
+## Introduction
+
+The general flow of data goes from an external data source, to files uploaded to the Staging Area, to data objects imported to the Workspace service. The two main user actions here - uploading and importing - are separated by accessing the Staging Service, and running one or more Import apps. Both of these are started by opening the Import tab of the data slideout.
+
+## Staging Service
+
+This fetches the list of files from the Staging service every 
+Each row represents one file - these get rendered by the [StagingAreaViewer](../../kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js) module. 
+
+## Data Import
+
+Data import is initiated by selecting one or more data files from the Import tab, then running the Importer app for that data type. When at least one file has a data type chosen and its checkbox selected, the `Import Selected` button will activate. Clicking that will close the slideout and open a Bulk Import cell and/or at least one App Cell with the relative file path entered. File paths are given as the relative path from the root of the Staging Area without the username - the username is assumed and will be added at app run time.
+
+### Importer App Configuration
+
+The data import app selection is configured in [`staging_upload.json`](../../kbase-extension/static/kbase/config/staging_upload.json). This JSON file has the following top-level keys:
+* `dropdown_order`: this describes the order of the file selection dropdown. Each item here has an `id` field, which must be unique, and acts as the app descriptor (more in the `app_info` field below), and a `name` field. The `name` field is displayed to the user in the dropdown.
+* `bulk_import_types`: This array contains data type `id`s that should trigger a Bulk Import cell. If a user imports at least one file with a data type in this list, it'll map that file and import app into a bulk import cell.
+* `app_info`: This object has a set of app ids for keys that map onto info about each app. These keys are used as the app `id`s elsewhere in the configuration.
+
+Each `app_info` object has the following accepted keys:
+* `app_id`: the app to use for importing the file in the format `module_name/app_name` (e.g. `kb_uploadmethods/import_genbank_as_genome_from_staging`). This is the only required field.
+* `app_input_param`: this is the parameter for setting the file name in the app
+* `app_input_param_type`: describes what the `app_input_param` is expected to be. Accepts either `string` or `list` (list of strings)
+* `app_static_params`: an object with key-value pairs of other app parameters that should be preset when creating the app cell.
+* `app_output_param`: the app's parameter id for the created object
+* `app_output_suffix`: an automatic suffix to add to the data file name for a created object. E.g. if the file name is "e_coli.gbk", and the `app_output_suffix` is "_genome", then the automatically set output name will be "e_coli.gbk_genome"
+* `multiselect`: originally intended to denote files with multiple inputs, this is not currently implemented
+
+### Configuring a new Bulk Import app
+The steps for adding a bulk import app to the configuration are fairly simple.
+1. Add the `app_info` object field as described above with a unique id.
+2. Add the new data type's id to `bulk_import_types`.
+
+Be aware that as of Narrative 5.0.0 (with the bulk import app MVP), there are several issues to be aware of before adding a new bulk import app:
+* Apps that parallelize themselves (e.g. make use of the KBParallel module, or otherwise create extra jobs in the Execution Engine) may not work, or may cause user deadlocking. These are not recommended for use.
+* Apps that make use of Grouped Parameters (the `"parameter-groups"` field in an app spec) will not work correctly in a Bulk Import cell.
+* Apps that require subobject selection may not work, and have not been tested in the Bulk Import cell.
+* Apps that require the use of a dynamic dropdown may not work as expected in a Bulk Import cell. This is especially apparent on page reload once a Bulk Import cell has been configured.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001282",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-            "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+            "version": "1.0.30001283",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+            "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001282",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-            "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+            "version": "1.0.30001283",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+            "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
             "dev": true
         },
         "center-align": {


### PR DESCRIPTION
# Description of PR purpose/changes

The main goal of this PR is to provide documentation on how to add more bulk import apps to the Narrative configuration. I also wrote some pretty high level docs on how the Import tab is assembled, with some detail on how the import app mapping is configured.

No code changes here.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-608
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

no code changes - all of the checklist below is n/a

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
