### PR TITLE
DATAUP-653 set an initial action button state to avoid showing all buttons

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/actionButtons.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/actionButtons.js
@@ -18,7 +18,6 @@ define(['common/html'], (html) => {
          *      - type - Bootstrap class types
          *      - classes - array of classes to add to the button component
          *      - label - button text
-
          */
 
         const t = html.tag,
@@ -84,8 +83,8 @@ define(['common/html'], (html) => {
         }
 
         return {
-            setState: setState,
-            buildLayout: buildLayout,
+            setState,
+            buildLayout,
         };
     }
 

--- a/kbase-extension/static/kbase/js/common/cellComponents/cellControlPanel.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/cellControlPanel.js
@@ -70,9 +70,9 @@ define(['common/html', 'common/cellComponents/actionButtons'], (html, ActionButt
         }
 
         return {
-            buildLayout: buildLayout,
-            setActionState: setActionState,
-            setExecMessage: setExecMessage,
+            buildLayout,
+            setActionState,
+            setExecMessage,
         };
     }
 

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -193,6 +193,10 @@ define([
                         label: 'Offline',
                     },
                 },
+            },
+            initialActionState = {
+                disabled: true,
+                name: 'runApp',
             };
         let runStatusListener = null, // only used while listening for the jobs to start
             kbaseNode = null, // the DOM element used as the container for everything in this cell
@@ -1066,6 +1070,7 @@ define([
             kbaseNode.innerHTML = layout.content;
             return buildTabs(ui.getElement('body.run-control-panel.toolbar')).then(() => {
                 layout.events.attachEvents(kbaseNode);
+                controlPanel.setActionState(initialActionState);
             });
         }
 


### PR DESCRIPTION
# Description of PR purpose/changes

When the bulk import cell first starts, if there's some lag in initial param and file validation, it can look like this:
![Screen Shot 2021-12-02 at 4 52 49 PM](https://user-images.githubusercontent.com/2152243/144515899-6203295c-5940-417f-855a-785c5be396a4.png)

This change immediately sets the button state to something possibly more expected while it figures out what state it should be:
![Screen Shot 2021-12-02 at 4 52 08 PM](https://user-images.githubusercontent.com/2152243/144515911-fc39505e-17b1-4233-8218-d7b25adc1703.png)

screenshots are greyish because they're taken while paused in the browser debugger.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* open a new BI cell!
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [n/a] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook

