### PR TITLE
DATAUP-630: fix lagging job status table

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -155,7 +155,8 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
          *  {string}    handlerName - the name of the handler to add
          *  {function}  handlerFn - the function to be performed
          *              if the handler function is already installed on the job manager,
-         *              'null' can be supplied in place of the function
+         *              `handlerFn` will replace the existing function. If the existing
+         *              function can be used, `null` can be supplied.
          *
          * Example:
          *
@@ -172,10 +173,12 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
                 return handlerName;
             } else if (this.__handlerFns[handlerName]) {
                 // a function with this name already exists
-                if (handlerFn !== null) {
-                    console.warn(`A handler with the name ${handlerName} already exists`);
+                // this handler can be used unchanged
+                if (handlerFn === null) {
+                    return;
                 }
-                return;
+                // otherwise, replace the handler
+                console.warn(`Replaced existing ${handlerName} handler`);
             } else if (handlerFn === null && !this.__handlerFns[handlerName]) {
                 // expected the handler to exist already, but it does not
                 console.error(`No handler function supplied for ${handlerName}`);
@@ -226,6 +229,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
          * @param  {...any} args
          */
         runHandler(event, ...args) {
+            const ctx = this;
             if (
                 !this._isValidEvent(event) ||
                 !this.handlers[event] ||
@@ -238,7 +242,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
                 .sort()
                 .forEach((handlerName) => {
                     try {
-                        this.handlers[event][handlerName](this, ...args);
+                        this.handlers[event][handlerName](ctx, ...args);
                     } catch (err) {
                         console.warn(`Error executing handler ${handlerName}:`, err);
                     }

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -447,6 +447,7 @@ define([
                         secondEvent = 'job-status';
                     expect(this.jobManagerInstance.handlers).toEqual({});
                     spyOn(console, 'warn');
+                    spyOn(console, 'error');
                     this.jobManagerInstance.addEventHandler(event, { scream, shout });
                     expectHandlersDefined(this.jobManagerInstance, event, true, [
                         'scream',
@@ -455,16 +456,18 @@ define([
                     this.jobManagerInstance.addEventHandler(secondEvent, { shout: scream });
                     expect(console.warn).toHaveBeenCalledTimes(1);
                     expect(console.warn.calls.allArgs()).toEqual([
-                        ['A handler with the name shout already exists'],
+                        ['Replaced existing shout handler'],
                     ]);
                     expect(this.jobManagerInstance.handlers[event]).toEqual({ scream, shout });
-                    expect(this.jobManagerInstance.handlers[secondEvent]).toEqual({ shout });
-                    // trigger the second event handler; 'shout' should run, not 'scream'
+                    expect(this.jobManagerInstance.handlers[secondEvent]).toEqual({
+                        shout: scream,
+                    });
+                    // trigger the second event handler; 'scream' should run, not 'shout'
                     this.jobManagerInstance.runHandler(secondEvent);
                     expect(console.warn.calls.allArgs()).toEqual([
-                        ['A handler with the name shout already exists'],
-                        [shoutStr],
+                        ['Replaced existing shout handler'],
                     ]);
+                    expect(console.error.calls.allArgs()).toEqual([[screamStr]]);
                 });
 
                 const badArguments = [


### PR DESCRIPTION
# Description of PR purpose/changes

The job status table was lagging behind the other places where job status is visible because it was using functions bound to instances of the job status table that were no longer extant. This PR fixes the issue by ensuring that the job manager always has the most current version of the handler functions (and their bound arguments) available. See inline notes for more.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-630
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, running a batch job, and then switch back and forth between tabs and observe the job status table staying in sync with the statuses as reported in the cell header.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
