### PR TITLE
DATAUP-654: Add a timestamp to the cell reset message

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -727,6 +727,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel'], (
                 if (this.cellId) {
                     this.bus.emit('reset-cell', {
                         cellId: this.cellId,
+                        ts: Date.now(),
                     });
                 }
             }

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -1373,6 +1373,7 @@ define([
             describe('resetJobs', () => {
                 function runResetTest(ctx, thisCellId = null) {
                     spyOn(ctx.bus, 'emit');
+                    spyOn(Date, 'now').and.returnValue(1234567890);
                     expect(
                         Object.keys(ctx.jobManagerInstance.model.getItem('exec.jobs.byId'))
                     ).toEqual(
@@ -1390,7 +1391,7 @@ define([
                     expect(ctx.bus.emit).toHaveBeenCalled();
                     let expected = [resetJobsCallArgs];
                     if (thisCellId) {
-                        expected = [resetJobsCallArgs, ['reset-cell', { cellId }]];
+                        expected = [resetJobsCallArgs, ['reset-cell', { cellId, ts: 1234567890 }]];
                     }
                     const callArgs = ctx.bus.emit.calls.allArgs();
                     expect(callArgs).toEqual(jasmine.arrayWithExactContents(expected));

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -511,6 +511,7 @@ define([
                     // expect the state to be editingComplete
                     Jupyter.notebook = Mocks.buildMockNotebook();
                     spyOn(Jupyter.notebook, 'save_checkpoint');
+                    spyOn(Date, 'now').and.returnValue(1234567890);
                     testCase.cellId = `${testCase.state}-${testCase.action}`;
                     const { cell, bulkImportCellInstance } = initCell(testCase);
 
@@ -573,7 +574,10 @@ define([
                                     ['request-job-updates-start', { batchId }],
                                     ['request-job-cancel', { jobIdList: [batchId] }],
                                     ['request-job-updates-stop', { batchId }],
-                                    ['reset-cell', { cellId: `${testCase.cellId}-test-cell` }],
+                                    [
+                                        'reset-cell',
+                                        { cellId: `${testCase.cellId}-test-cell`, ts: 1234567890 },
+                                    ],
                                 ]).toEqual(allEmissions);
                             }
                         });
@@ -584,6 +588,7 @@ define([
                 const cellId = 'cancelDuringSubmit';
                 Jupyter.notebook = Mocks.buildMockNotebook();
                 spyOn(Jupyter.notebook, 'save_checkpoint');
+                spyOn(Date, 'now').and.returnValue(1234567890);
                 const { cell, bulkImportCellInstance } = initCell({
                     cellId,
                     state: 'editingComplete',
@@ -675,7 +680,7 @@ define([
                     ['request-job-info', { batchId }],
                     ['request-job-cancel', { jobIdList: [batchId] }],
                     ['request-job-updates-stop', { batchId }],
-                    ['reset-cell', { cellId: `${cellId}-test-cell` }],
+                    ['reset-cell', { cellId: `${cellId}-test-cell`, ts: 1234567890 }],
                 ];
                 expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
                 expect(bulkImportCellInstance.jobManager.bus.emit.calls.allArgs()).toEqual(


### PR DESCRIPTION
# Description of PR purpose/changes

Adds a timestamp to the cell reset message -- will be used by the backend implementation of the cell reset.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-654
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, resetting a bulk import cell, and see that the reset message sent by the job manager has a timestamp on it.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
