### PR TITLE
DATAUP-497: more job message edits

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -48,10 +48,9 @@ All the `request-job-*` requests take as arguments either a single job ID string
 `request-job-log` - request the job logs starting at some given line.
   * `jobId` - a string, the job id OR
   * `jobIdList` - an array of job IDs
-  * `options` - an object, with attributes:
-    * `first_line` - the first line (0-indexed) to request
-    * `num_lines` - the number of lines to request (will get back up to that many if there aren't more)
-    * `latest` -  true if requesting just the latest set of logs
+  * `first_line` - the first line (0-indexed) to request (optional)
+  * `num_lines` - the number of lines to request (will get back up to that many if there aren't more) (optional)
+  * `latest` -  true if requesting just the latest set of logs (optional)
 
 ### Usage Example
 The comm channel is used through the main Bus object that's instantiated through the global `Runtime` object. That needs to be included in the `define` statement for all AMD modules. The bus is then used with its `emit` function (you have the bus *emit* a message to its listeners), and any inputs are passed along with it.
@@ -78,10 +77,8 @@ define(
     let runtime = Runtime.make();
     runtime.bus().emit('request-job-log', {
       jobId: 'some_job_id',
-      options: {
-        first_line: 0,
-        num_lines: 10
-      }
+      first_line: 0,
+      num_lines: 10
     });
   }
 );
@@ -93,7 +90,7 @@ When the kernel sends a message to the front end, the only module set up to list
 ### Cell-related
 
 `run-status` - updates the run status of the job - this is part of the initial flow of starting a job through the AppManager.
-  * TODO
+  * see `run_status` below for the message format.
 
 ### Job-related
 
@@ -101,12 +98,9 @@ When the kernel sends a message to the front end, the only module set up to list
   * `jobId` - string, the job id
   * `message` - string, some message about the error
 
-`job-info` - contains information about the current job
-  * `jobInfo` - object, the job information object (see the **Data Structures** section below)
+`job-info` - contains information about the current job. The format is described under `job_info` in the **Messages sent from the kernel to the browser** section below.
 
-`job-logs` - sent with information about some job logs.
-  * `logs` - the raw message data from the kernel. (see the **Data Structures** section below)
-  * `error` - if exists, the log request has thrown an error. The error key contains the error details.
+`job-logs` - sent with information about some job logs. The format is described under `job_logs` in the **Messages sent from the kernel to the browser** section below.
 
 `job-status` - contains the current job state
   * `jobState` - object, describes the job state (see the **Data Structures** section below for the structure)
@@ -308,7 +302,7 @@ i.e.
 
 **bus** `job-info` sent by `job_id`
 
-Job info is split out into individual jobs and sent to `job_id` under the key `jobInfo` (see above)
+Job info is split out into individual jobs for distribution.
 
 ### `job_status`
 The current job state. This one is probably most common.

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -701,14 +701,13 @@ define([
          * @param {object} message
          */
         handleJobInfo(_, message) {
-            const { jobInfo } = message,
-                jobId = jobInfo.job_id;
+            const jobId = message.job_id;
             const jobState = this.jobManager.model.getItem(`exec.jobs.byId.${jobId}`);
             const appData = this.jobManager.model.getItem('app');
             const rowIx = jobState && jobState.retry_parent ? jobState.retry_parent : jobId;
 
             const jobDisplayData = generateJobDisplayData({
-                jobInfo,
+                jobInfo: message,
                 fileTypeMapping: this.fileTypeMapping,
                 appData,
                 typesToFiles: this.config.typesToFiles,

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -64,11 +64,11 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
         _isValidMessage(type, message) {
             switch (type) {
                 case jcm.RESPONSES.STATUS:
-                    return Jobs.isValidJobStateObject(message.jobState);
+                    return Jobs.isValidBackendJobStateObject(message);
                 case jcm.RESPONSES.INFO:
-                    return Jobs.isValidJobInfoObject(message.jobInfo);
+                    return Jobs.isValidJobInfoObject(message);
                 case jcm.RESPONSES.LOGS:
-                    return Jobs.isValidJobLogsObject(message.logs);
+                    return Jobs.isValidJobLogsObject(message);
                 case jcm.RESPONSES.RETRY:
                     return Jobs.isValidJobRetryObject(message);
                 case type.indexOf('job') !== -1:
@@ -447,12 +447,12 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
              * @param {object} message
              */
             handleJobInfo(self, message) {
-                const { jobInfo, error } = message;
-                if (error) {
+                if (message.error) {
                     return;
                 }
-                self.model.setItem(`exec.jobs.info.${jobInfo.job_id}`, jobInfo);
-                self.removeListener(jobInfo.job_id, jcm.RESPONSES.INFO);
+                const jobId = message.job_id;
+                self.model.setItem(`exec.jobs.info.${jobId}`, message);
+                self.removeListener(jobId, jcm.RESPONSES.INFO);
             }
 
             handleJobRetry(self, message) {

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -1195,8 +1195,6 @@ define([
                 this.ui.hideElement('spinner');
                 /* message has structure:
                  * {
-                 *   jobId: string,
-                 *   logs: {
                  *      first: int (first line of the log batch), 0-indexed
                  *      job_id: string,
                  *      latest: bool,
@@ -1207,7 +1205,6 @@ define([
                  *          linepos: int, position in log. helpful!
                  *          ts: timestamp
                  *      }]
-                 *   }
                  * }
                  */
                 this.state.awaitingLog = false;
@@ -1215,8 +1212,8 @@ define([
                 if (message.error) {
                     return this.handleLogDeleted(message);
                 }
-                if (message.logs.lines.length !== 0) {
-                    const viewLines = message.logs.lines.map((line) => {
+                if (message.lines.length !== 0) {
+                    const viewLines = message.lines.map((line) => {
                         return {
                             text: line.line,
                             isError: line.is_error === 1 ? true : false,
@@ -1224,9 +1221,9 @@ define([
                         };
                     });
                     this.model.setItem('lines', viewLines);
-                    this.model.setItem('firstLine', message.logs.first + 1);
-                    this.model.setItem('lastLine', message.logs.first + viewLines.length);
-                    this.model.setItem('totalLines', message.logs.max_lines);
+                    this.model.setItem('firstLine', message.first + 1);
+                    this.model.setItem('lastLine', message.first + viewLines.length);
+                    this.model.setItem('totalLines', message.max_lines);
                     this.renderLog();
                 }
                 if (this.state.looping) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -122,10 +122,6 @@ define([
                 this.state = utils.getCellMeta(this.cell, 'kbase.codeCell.jobInfo.state');
             }
 
-            // if (cellMeta && cellMeta.codeCell && cellMeta.codeCell && cellMeta.codeCell.jobInfo.state.jobId === this.jobId) {
-            //     // use this and not the state input.
-            //     this.state = cellMeta.codeCell.jobInfo.state;
-            // }
             if (cellMeta && cellMeta.attributes && cellMeta.attributes.id) {
                 this.cellId = cellMeta.attributes.id;
             } else {
@@ -184,10 +180,10 @@ define([
         },
 
         handleJobInfo: function (info) {
-            if (utils.getCellMeta(this.cell, 'kbase.attributes.title') !== info.jobInfo.app_name) {
+            if (utils.getCellMeta(this.cell, 'kbase.attributes.title') !== info.app_name) {
                 const { metadata } = this.cell;
                 if (metadata.kbase && metadata.kbase.attributes) {
-                    metadata.kbase.attributes.title = info.jobInfo.app_name;
+                    metadata.kbase.attributes.title = info.app_name;
                     metadata.kbase.attributes.subtitle = 'App Status';
                     metadata.kbase.attributes.icon = 'code';
                 }

--- a/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
+++ b/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
@@ -64,7 +64,7 @@ define([
                     type: jcm.RESPONSES.INFO,
                 },
                 handle: (message) => {
-                    updateRowStatus(ui, message.jobInfo.job_params[0], container);
+                    updateRowStatus(ui, message.job_params[0], container);
                 },
             });
         }

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -398,14 +398,7 @@ define([
      */
     function updateInfo(ctx) {
         const { jobId, jobInfo } = ctx;
-        sendBusMessage(
-            ctx,
-            {
-                jobInfo,
-            },
-            { jobId },
-            jcm.RESPONSES.INFO
-        );
+        sendBusMessage(ctx, jobInfo, { jobId }, jcm.RESPONSES.INFO);
     }
 
     /**
@@ -1570,9 +1563,7 @@ define([
                                 });
                                 const expectedCallArgs = [
                                     jcm.RESPONSES.INFO,
-                                    {
-                                        jobInfo: { job_id: 'job_update_test', ...test.input },
-                                    },
+                                    { job_id: 'job_update_test', ...test.input },
                                     'job_update_test',
                                 ];
                                 postUpdateChecks(this, expectedCallArgs);
@@ -1588,27 +1579,20 @@ define([
                                 await TestUtil.waitForElementChange(
                                     this.container.querySelector('#' + indicatorId),
                                     () => {
-                                        this.jobManager.bus.send(
-                                            {
-                                                jobInfo: test.input,
+                                        this.jobManager.bus.send(test.input, {
+                                            channel: {
+                                                jobId: this.job.retry_parent,
                                             },
-                                            {
-                                                channel: {
-                                                    jobId: this.job.retry_parent,
-                                                },
-                                                key: { type: jcm.RESPONSES.INFO },
-                                            }
-                                        );
+                                            key: { type: jcm.RESPONSES.INFO },
+                                        });
                                     }
                                 );
 
                                 const expectedCallArgs = [
                                     jcm.RESPONSES.INFO,
                                     {
-                                        jobInfo: {
-                                            job_id: this.job.retry_parent,
-                                            ...test.input,
-                                        },
+                                        job_id: this.job.retry_parent,
+                                        ...test.input,
                                     },
                                     this.job.retry_parent,
                                 ];

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -39,7 +39,6 @@ define([
 
     const convertToJobState = (acc, curr) => {
         acc[curr.job_id] = {
-            jobId: curr.job_id,
             jobState: curr,
             outputWidgetInfo: {},
         };
@@ -49,7 +48,6 @@ define([
     const convertToJobStateBusMessage = (job) => {
         return [
             {
-                jobId: job.job_id,
                 jobState: job,
                 outputWidgetInfo: {},
             },
@@ -329,11 +327,6 @@ define([
 
         const busMsgCases = [
             {
-                channel: 'ping',
-                message: { pingId: 'ping!', pongId: 'pong!' },
-                expected: { request_type: 'ping', ping_id: 'ping!', pongId: 'pong!' },
-            },
-            {
                 channel: jcm.REQUESTS.LOGS,
                 message: { jobId: TEST_JOB_ID },
                 expected: {
@@ -520,23 +513,6 @@ define([
                 ],
             },
             {
-                type: jcm.RESPONSES.RESULT,
-                message: {
-                    result: [1, true, 3],
-                    address: { cell_id: 'bar' },
-                },
-                expected: [
-                    {
-                        result: [1, true, 3],
-                        address: { cell_id: 'bar' },
-                    },
-                    {
-                        channel: { cell: 'bar' },
-                        key: { type: jcm.RESPONSES.RESULT },
-                    },
-                ],
-            },
-            {
                 // info for a single job
                 type: jcm.BACKEND_RESPONSES.INFO,
                 message: (() => {
@@ -545,9 +521,7 @@ define([
                     return output;
                 })(),
                 expected: [
-                    {
-                        jobInfo: JobsData.example.Info.valid[0],
-                    },
+                    JobsData.example.Info.valid[0],
                     {
                         channel: { jobId: JobsData.example.Info.valid[0].job_id },
                         key: { type: jcm.RESPONSES.INFO },
@@ -563,9 +537,7 @@ define([
                 }, {}),
                 expectedMultiple: JobsData.example.Info.valid.map((info) => {
                     return [
-                        {
-                            jobInfo: info,
-                        },
+                        info,
                         {
                             channel: { jobId: info.job_id },
                             key: { type: jcm.RESPONSES.INFO },
@@ -579,10 +551,7 @@ define([
                     someJob: JobsData.example.Logs.valid[0],
                 },
                 expected: [
-                    {
-                        jobId: TEST_JOB_ID,
-                        logs: JobsData.example.Logs.valid[0],
-                    },
+                    JobsData.example.Logs.valid[0],
                     {
                         channel: { jobId: TEST_JOB_ID },
                         key: { type: jcm.RESPONSES.LOGS },
@@ -628,7 +597,6 @@ define([
                 })(),
                 expected: [
                     {
-                        jobId: JobsData.allJobs[0].job_id,
                         jobState: JobsData.allJobs[0],
                         outputWidgetInfo: {},
                     },
@@ -651,7 +619,6 @@ define([
                 },
                 expected: [
                     {
-                        jobId: TEST_JOB_ID,
                         jobState: {
                             job_id: TEST_JOB_ID,
                             status: 'ee2_error',
@@ -681,7 +648,6 @@ define([
                 expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage).concat([
                     [
                         {
-                            jobId: '1234567890abcdef',
                             jobState: {
                                 job_id: '1234567890abcdef',
                                 status: 'does_not_exist',
@@ -696,12 +662,12 @@ define([
                 ]),
             },
             {
-                type: 'job_status_all',
+                type: jcm.BACKEND_RESPONSES.STATUS_ALL,
                 message: JobsData.allJobsWithBatchParent.reduce(convertToJobState, {}),
                 expectedMultiple: JobsData.allJobsWithBatchParent.map(convertToJobStateBusMessage),
             },
             {
-                type: jcm.BACKEND_RESPONSES.ERROR,
+                type: jcm.BACKEND_RESPONSES.COMM_ERROR,
                 message: {
                     job_id: TEST_JOB_ID,
                     message: 'cancel error',
@@ -726,7 +692,7 @@ define([
                 ],
             },
             {
-                type: jcm.BACKEND_RESPONSES.ERROR,
+                type: jcm.BACKEND_RESPONSES.COMM_ERROR,
                 message: {
                     job_id: TEST_JOB_ID,
                     message: 'log error',
@@ -752,7 +718,7 @@ define([
             },
             {
                 // unrecognised error type
-                type: jcm.BACKEND_RESPONSES.ERROR,
+                type: jcm.BACKEND_RESPONSES.COMM_ERROR,
                 message: {
                     source: 'some-unknown-error',
                     job_id: TEST_JOB_ID,
@@ -777,7 +743,7 @@ define([
                 ],
             },
             {
-                type: jcm.BACKEND_RESPONSES.ERROR,
+                type: jcm.BACKEND_RESPONSES.COMM_ERROR,
                 message: {
                     job_id_list: [
                         'job_1_RetryWithErrors',

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -814,7 +814,7 @@ define([
                     ).not.toBeDefined();
                     // rather than faffing around with sending messages over the bus,
                     // trigger the job handler directly
-                    this.jobManagerInstance.runHandler(jcm.RESPONSES.INFO, { jobInfo }, jobId);
+                    this.jobManagerInstance.runHandler(jcm.RESPONSES.INFO, jobInfo, jobId);
 
                     expect(
                         this.jobManagerInstance.model.getItem(`exec.jobs.info.${jobId}`)

--- a/test/unit/spec/util/jobLogViewerSpec.js
+++ b/test/unit/spec/util/jobLogViewerSpec.js
@@ -66,11 +66,10 @@ define([
 
     function formatLogMessage(jobId, logMessages) {
         return formatMessage(jobId, 'logs', {
-            logs: {
-                first: 0,
-                max_lines: logMessages.length,
-                lines: logMessages,
-            },
+            job_id: jobId,
+            first: 0,
+            max_lines: logMessages.length,
+            lines: logMessages,
         });
     }
 


### PR DESCRIPTION
# Description of PR purpose/changes

Continue simplification of job-related messages.

jobCommChannel.js: 
- more tokenising of message strings
- remove unused `RESULT` and `PING` message types and tests for those messages
- pass most backend messages as-is to the frontend without any faffing around with "translating" them
- remove nesting / "options" in job logs requests

jobManager, jobStatusTable, jobInputParams, jobLogViewer, kbaseNarrativeJobStatus:
- adapt code to account for new message structure
- update tests to take into account all the above changes

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Don't check the narrative yet as there are some more edits to go in first.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
