### PR TITLE
DATAUP-666: no one is listening to those table rows!

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -257,7 +257,6 @@ define([
                 this.renderTable(jobs);
                 this.setUpEventHandlers();
                 this.setUpJobListeners(jobs);
-                this.addTableClickListeners();
             });
         }
 
@@ -406,6 +405,25 @@ define([
                         },
                     },
                 ],
+                createdRow: (el) => {
+                    el.onclick = (e) => {
+                        e.stopPropagation();
+                        const $currentButton = $(e.target).closest(
+                            '[data-element="job-action-button"]'
+                        );
+                        const $currentRow = $(e.target).closest('tr.odd, tr.even');
+                        // not an expandable row or a job action button
+                        if (!$currentRow[0] && !$currentButton[0]) {
+                            return Promise.resolve();
+                        }
+                        // job action button
+                        if ($currentButton[0]) {
+                            return Promise.resolve(this.doSingleJobAction(e));
+                        }
+                        // expandable row
+                        return this.showHideChildRow(e);
+                    };
+                },
                 drawCallback: function () {
                     // Hide pagination controls if length is less than or equal to table length
                     if (this.api().data().length <= dataTablePageLength) {
@@ -454,32 +472,6 @@ define([
             }
             // this is a new job that is part of the same batch
             this.dataTable.DataTable().row.add(jobState).draw();
-            this.addTableClickListeners();
-        }
-
-        /**
-         * add the listeners to the table that allow row expansion
-         */
-        addTableClickListeners() {
-            this.container.querySelectorAll('tbody tr.odd, tbody tr.even').forEach((el) => {
-                el.onclick = (e) => {
-                    e.stopPropagation();
-                    const $currentButton = $(e.target).closest(
-                        '[data-element="job-action-button"]'
-                    );
-                    const $currentRow = $(e.target).closest('tr.odd, tr.even');
-                    // not an expandable row or a job action button
-                    if (!$currentRow[0] && !$currentButton[0]) {
-                        return Promise.resolve();
-                    }
-                    // job action button
-                    if ($currentButton[0]) {
-                        return Promise.resolve(this.doSingleJobAction(e));
-                    }
-                    // expandable row
-                    return this.showHideChildRow(e);
-                };
-            });
         }
 
         /**


### PR DESCRIPTION
# Description of PR purpose/changes

Add listeners to the job status table after row creation, rather than waiting until after the table is drawn

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-666
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, finding a BI cell with more than 50 inputs, clicking to page two, and then using the action buttons or clicking on the row.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
