### PR TITLE
DATAUP-570 Reconcile config with staging service recommendations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Unreleased
+- DATAUP-570 - Only use the Narrative configuration to set available import types in the Import area dropdowns
+- DATAUP-577 - Sanitize suggested output object names for bulk import jobs so they follow the rules
+
 ### Version 5.0.0
 This new major version of the KBase Narrative Interface introduces a way to import data from your data staging area in large batches using a single Bulk Import cell. See more details about the new workflows here: [Bulk Import Guide](https://docs.kbase.us/data/upload-download-guide/bulk-import-guide)
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -73,6 +73,10 @@ define([
             this.filePathTmpl = Handlebars.compile(FilePathHtml);
             this.updatePathFn = options.updatePathFn || this.setPath;
             this.uploaders = Config.get('uploaders');
+            this.uploaderNames = this.uploaders.dropdown_order.reduce((acc, uploader) => {
+                acc[uploader.id] = uploader.name;
+                return acc;
+            }, {});
             this.bulkImportTypes = this.uploaders.bulk_import_types;
             this.userInfo = options.userInfo;
 
@@ -560,7 +564,8 @@ define([
                                             {
                                                 value: uploader.id,
                                             },
-                                            uploader.title
+                                            stagingAreaViewer.uploaderNames[uploader.id]
+                                            //uploader.title
                                         );
                                     })
                                 );

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -565,7 +565,6 @@ define([
                                                 value: uploader.id,
                                             },
                                             stagingAreaViewer.uploaderNames[uploader.id]
-                                            //uploader.title
                                         );
                                     })
                                 );

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -317,12 +317,25 @@ define([
                         return accumulator.concat(JSON.parse(dataItem)['mappings']);
                     }, []);
 
+                    // from each file mapping, if not null, remove any mappings the Narrative doesn't know about
+                    for (let i = 0; i < mappings.length; i++) {
+                        if (mappings[i]) {
+                            mappings[i] = mappings[i].filter(
+                                (mapping) => mapping.id in this.uploaders.app_info
+                            );
+                            if (mappings[i].length === 0) {
+                                mappings[i] = null;
+                            }
+                        }
+                    }
+
                     // Extract mappings, sort by weight, assign mappings to staging files
                     mappings.forEach((mapping) => {
                         if (mapping) {
                             mapping.sort((a, b) => a.app_weight < b.app_weight);
                         }
                     });
+
                     stagingFiles.map((element, index) => {
                         element['mappings'] = mappings[index] || null;
                     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001286",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
-            "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
+            "version": "1.0.30001287",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001287.tgz",
+            "integrity": "sha512-4udbs9bc0hfNrcje++AxBuc6PfLNHwh3PO9kbwnfCQWyqtlzg3py0YgFu8jyRTTo85VAz4U+VLxSlID09vNtWA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001286",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
-            "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
+            "version": "1.0.30001287",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001287.tgz",
+            "integrity": "sha512-4udbs9bc0hfNrcje++AxBuc6PfLNHwh3PO9kbwnfCQWyqtlzg3py0YgFu8jyRTTo85VAz4U+VLxSlID09vNtWA==",
             "dev": true
         },
         "center-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001285",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
-            "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
+            "version": "1.0.30001286",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
+            "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001285",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
-            "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
+            "version": "1.0.30001286",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
+            "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
             "dev": true
         },
         "center-align": {

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -601,7 +601,7 @@ define([
                 expect($fourthSelect.find('optgroup[label="Suggested Types"]').length).toBe(0);
             });
 
-            xit('should use the Narrative-configured display names for mappings', async () => {
+            it('should use the Narrative-configured display names for mappings', async () => {
                 const mappings = {
                     mappings: [
                         null,

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -536,14 +536,13 @@ define([
         describe('autodetect mapping tests', () => {
             const filename = 'fake_sra_reads.sra',
                 typeId = 'sra_reads';
-            let $selectInput;
 
-            beforeEach(async () => {
+            it('should render autodetected mappings in the type select dropdown', async () => {
                 await stagingViewer.render();
-                $selectInput = $container.find(`[data-download="${filename}"]`).siblings('select');
-            });
+                const $selectInput = $container
+                    .find(`[data-download="${filename}"]`)
+                    .siblings('select');
 
-            it('should render autodetected mappings in the type select dropdown', () => {
                 const $suggestedOptGroup = $selectInput.find('optgroup[label="Suggested Types"]');
                 const $otherOptGroup = $selectInput.find('optgroup[label="Other Types"]');
                 expect($suggestedOptGroup.length).toBe(1);
@@ -553,9 +552,85 @@ define([
                 expect($suggestedOptGroup.find(`option[value="${typeId}"]`).length).toBe(1);
             });
 
-            it('should automatically select the mapping if there is only one suggested file type', () => {
+            it('should automatically select the mapping if there is only one suggested file type', async () => {
                 // only one suggested file type for the sra reads file, so just make sure it's selected!
+                await stagingViewer.render();
+                const $selectInput = $container
+                    .find(`[data-download="${filename}"]`)
+                    .siblings('select');
+
                 expect($selectInput.val()).toBe(typeId);
+            });
+
+            it('should not include mappings that are not configured in the Narrative', async () => {
+                // change the mappings, not the fake files described above
+                const mappings = {
+                    mappings: [
+                        null,
+                        null,
+                        [
+                            { id: 'sra_reads', app_weight: 1, title: 'SRA Reads' },
+                            { id: 'also_not_real', app_weight: 1, title: 'Some Other Data' },
+                        ],
+                        [{ id: 'not_real', app_weight: 1, title: 'Some Random Data' }],
+                    ],
+                };
+                jasmine.Ajax.stubRequest(
+                    new RegExp(`${stagingServiceUrl}/importer_mappings/`)
+                ).andReturn({
+                    status: 200,
+                    statusText: 'success',
+                    contentType: 'text/plain',
+                    responseHeaders: '',
+                    responseText: JSON.stringify(mappings),
+                });
+                await stagingViewer.render();
+
+                // filename -> 3rd row
+                // otherFileName -> 4th row
+                const otherFileName = 'unknown_file.txt';
+                const [$thirdSelect, $fourthSelect] = [filename, otherFileName].map((name) =>
+                    $container.find(`[data-download="${name}"]`).siblings('select')
+                );
+
+                const $thirdSuggestions = $thirdSelect.find('optgroup[label="Suggested Types"]');
+                expect($thirdSuggestions.length).toBe(1);
+                expect($thirdSuggestions.find('option').length).toBe(1);
+                expect($thirdSuggestions.find('option').text()).toEqual('SRA Reads');
+
+                expect($fourthSelect.find('optgroup[label="Suggested Types"]').length).toBe(0);
+            });
+
+            xit('should use the Narrative-configured display names for mappings', async () => {
+                const mappings = {
+                    mappings: [
+                        null,
+                        null,
+                        [
+                            {
+                                id: 'sra_reads',
+                                app_weight: 1,
+                                title: 'omg this is a special data type!',
+                            },
+                        ],
+                        null,
+                    ],
+                };
+                jasmine.Ajax.stubRequest(
+                    new RegExp(`${stagingServiceUrl}/importer_mappings/`)
+                ).andReturn({
+                    status: 200,
+                    statusText: 'success',
+                    contentType: 'text/plain',
+                    responseHeaders: '',
+                    responseText: JSON.stringify(mappings),
+                });
+                await stagingViewer.render();
+                const $select = $container.find(`[data-download="${filename}"]`).siblings('select');
+                const $suggestions = $select.find('optgroup[label="Suggested Types"]');
+                expect($suggestions.length).toBe(1);
+                expect($suggestions.find('option').length).toBe(1);
+                expect($suggestions.find('option').text()).toEqual('SRA Reads');
             });
         });
 


### PR DESCRIPTION
# Description of PR purpose/changes

The staging service can return any number of recommendations for file types. However, only those with a matching app configuration in the Narrative are usable as import inputs. This patch politely ignores any returned types from the staging service that do not match the Narrative configured types. It also graciously accepts any display names from the staging service and sets them aside in favor of its own configuration.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-570
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Kinda tricky without differences in the staging service. You could set up a local staging service, maybe?
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

