### PR TITLE
DATAUP-497: Standardising the params used for job queries in the frontend

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -94,15 +94,15 @@ When the kernel sends a message to the front end, the only module set up to list
 
 ### Job-related
 
-`job-error` - sent in response to an error that happened on job information lookup, or another error that happened while processing some other message to the JobManager.
+`job_error` - sent in response to an error that happened on job information lookup, or another error that happened while processing some other message to the JobManager.
   * `jobId` - string, the job id
   * `message` - string, some message about the error
 
-`job-info` - contains information about the current job. The format is described under `job_info` in the **Messages sent from the kernel to the browser** section below.
+`job_info` - contains information about the current job. The format is described under `job_info` in the **Messages sent from the kernel to the browser** section below.
 
-`job-logs` - sent with information about some job logs. The format is described under `job_logs` in the **Messages sent from the kernel to the browser** section below.
+`job_logs` - sent with information about some job logs. The format is described under `job_logs` in the **Messages sent from the kernel to the browser** section below.
 
-`job-status` - contains the current job state
+`job_status` - contains the current job state
   * `jobState` - object, describes the job state (see the **Data Structures** section below for the structure)
   * `outputWidgetInfo` - object, contains the parameters to be sent to an output widget. This will be different for all widgets, depending on the App that invokes them.
 
@@ -120,7 +120,7 @@ define(['common/runtime'],
         jobId: 'some_job_id'
       },
       key: {
-        type: 'job-status'
+        type: 'job_status'
       },
       handle: (message) => {
         ...process the message...
@@ -273,7 +273,7 @@ A general job comm error, capturing most errors that get thrown by the kernel
   * `job_id` - string OR `job_id_list` - array of strings, the job id(s) (if present)
   * `message` - string, an error message
 
-**bus** `job-error`
+**bus** `job_error`
 
 ### `job_info`
 Includes information about the running job
@@ -300,7 +300,7 @@ i.e.
 }
 ```
 
-**bus** `job-info` sent by `job_id`
+**bus** `job_info` sent by `job_id`
 
 Job info is split out into individual jobs for distribution.
 
@@ -327,7 +327,7 @@ Sample response JSON:
 }
 ```
 
-**bus** - `job-status` sent to `job_id`
+**bus** - `job_status` sent to `job_id`
 
 Job status data is split out into individual jobs and sent to `job_id`
 
@@ -345,7 +345,7 @@ The set of all job states for all running jobs, or at least the set that should 
   * `jobState` - the job state (see the **Data Structures** section below for details
   * `outputWidgetInfo` - the parameters to send to output widgets, only available for a completed job
 
-**bus** - see `job-status`
+**bus** - see `job_status`
 
 
 ### `job_logs`
@@ -361,7 +361,7 @@ Dictionary with key(s) job ID and value dictionaries with the following structur
     * `line` - string, the log line
     * `is_error` - 0 or 1, if 1 then the line is an "error" as reported by the server
 
-**bus** `job-logs` sent by `job_id`
+**bus** `job_logs` sent by `job_id`
 
 Logs data is split out into individual jobs and sent to `job_id` (see above)
 
@@ -394,7 +394,7 @@ Outer keys:
   * `retry` - string, the job id of the job that was launched
   * `error` - string, appears if there was an error when trying to retry the job
 
-**bus** `job-retry-response` sent by `job_id`
+**bus** `retry_job` sent by `job_id`
 
 Retry data is split out into individual jobs and sent to `job_id`
 
@@ -427,7 +427,7 @@ All cases:
 (if ok)
   * `job_id` - if the job was launched successfully
 
-**bus** `run-status` sent to `cell_id`
+**bus** `run_status` sent to `cell_id`
 
 Sent unchanged to `cell_id`
 

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -516,7 +516,7 @@ define([
                 },
                 [
                     div({
-                        dataElement: `job-logs-div`,
+                        dataElement: 'job-logs-div',
                     }),
                 ]
             );
@@ -659,11 +659,11 @@ define([
                 this.jobManager.addListener(jcm.RESPONSES.INFO, paramsRequired);
                 const jobInfoRequestParams =
                     paramsRequired.length === jobIdList.length
-                        ? { batchId }
-                        : { jobIdList: paramsRequired };
+                        ? { [jcm.PARAMS.BATCH_ID]: batchId }
+                        : { [jcm.PARAMS.JOB_ID_LIST]: paramsRequired };
                 this.jobManager.bus.emit(jcm.REQUESTS.INFO, jobInfoRequestParams);
             }
-            this.jobManager.bus.emit(jcm.REQUESTS.STATUS, { batchId });
+            this.jobManager.bus.emit(jcm.REQUESTS.STATUS, { [jcm.PARAMS.BATCH_ID]: batchId });
         }
 
         // HANDLERS
@@ -704,7 +704,7 @@ define([
          * parse and update the row with job info
          * @param {object} message
          */
-        handleJobInfo(_, message) {
+        handleJobInfo(message) {
             const jobId = message.job_id;
             const jobState = this.jobManager.model.getItem(`exec.jobs.byId.${jobId}`);
             const appData = this.jobManager.model.getItem('app');

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -466,11 +466,11 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
                 }
 
                 // request job updates for the new job
-                ['status', 'error'].forEach((type) => {
-                    self.addListener(`job-${type}`, [retry.jobState.job_id]);
+                ['STATUS', 'ERROR'].forEach((type) => {
+                    self.addListener(jcm.RESPONSES[type], [retry.jobState.job_id]);
                 });
                 self.bus.emit(jcm.REQUESTS.START_UPDATE, {
-                    jobId: retry.jobState.job_id,
+                    [jcm.PARAMS.JOB_ID]: retry.jobState.job_id,
                 });
                 // update the model with the job data
                 self.updateModel(
@@ -495,9 +495,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
                     if (status === 'does_not_exist') {
                         self.removeJobListeners(jobId);
                     }
-                    self.bus.emit(jcm.REQUESTS.STOP_UPDATE, {
-                        jobId,
-                    });
+                    self.bus.emit(jcm.REQUESTS.STOP_UPDATE, { [jcm.PARAMS.JOB_ID]: jobId });
                     self.updateModel([jobState]);
                     return;
                 }
@@ -517,11 +515,11 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
                         }
                     });
                     if (missingJobIds.length) {
-                        ['status', 'error', 'info'].forEach((type) => {
-                            self.addListener(`job-${type}`, missingJobIds);
+                        ['STATUS', 'ERROR', 'INFO'].forEach((type) => {
+                            self.addListener(jcm.RESPONSES[type], missingJobIds);
                         });
                         self.bus.emit(jcm.REQUESTS.START_UPDATE, {
-                            jobIdList: missingJobIds,
+                            [jcm.PARAMS.JOB_ID_LIST]: missingJobIds,
                         });
                     }
                 }
@@ -541,7 +539,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
              */
             requestJobInfo(jobIdList) {
                 this.addListener(jcm.RESPONSES.INFO, jobIdList);
-                this.bus.emit(jcm.REQUESTS.INFO, { jobIdList });
+                this.bus.emit(jcm.REQUESTS.INFO, { [jcm.PARAMS.JOB_ID_LIST]: jobIdList });
             }
 
             /**
@@ -550,7 +548,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
              */
             requestJobStatus(jobIdList) {
                 this.addListener(jcm.RESPONSES.STATUS, jobIdList);
-                this.bus.emit(jcm.REQUESTS.STATUS, { jobIdList });
+                this.bus.emit(jcm.REQUESTS.STATUS, { [jcm.PARAMS.JOB_ID_LIST]: jobIdList });
             }
         };
 
@@ -565,9 +563,7 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
              * @param {array} jobIdList
              */
             doJobAction(action, jobIdList) {
-                this.bus.emit(jobCommand[action].command, {
-                    jobIdList,
-                });
+                this.bus.emit(jobCommand[action].command, { [jcm.PARAMS.JOB_ID_LIST]: jobIdList });
                 // add the appropriate listener
                 this.addListener(jobCommand[action].listener, jobIdList);
             }
@@ -714,9 +710,8 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
                     allJobs[batchJob.job_id] = batchJob;
                 }
 
-                this.bus.emit(jcm.REQUESTS.STOP_UPDATE, {
-                    batchId: batchJob.job_id,
-                });
+                this.bus.emit(jcm.REQUESTS.STOP_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchJob.job_id });
+
                 // ensure that job updates are turned off and listeners removed
                 Object.keys(allJobs).forEach((jobId) => {
                     this.removeJobListeners(jobId);
@@ -783,17 +778,17 @@ define(['common/dialogMessages', 'common/jobs', 'common/jobCommChannel', 'util/u
 
                 // request job info
                 this.addListener(jcm.RESPONSES.INFO, allJobIds);
-                this.bus.emit(jcm.REQUESTS.INFO, { batchId: batch_id });
+                this.bus.emit(jcm.REQUESTS.INFO, { [jcm.PARAMS.BATCH_ID]: batch_id });
             }
 
             _initJobs(args) {
                 const { allJobIds, batchId } = args;
 
-                ['status', 'error'].forEach((type) => {
-                    this.addListener(`job-${type}`, allJobIds);
+                ['STATUS', 'ERROR'].forEach((type) => {
+                    this.addListener(jcm.RESPONSES[type], allJobIds);
                 });
                 // request job updates
-                this.bus.emit(jcm.REQUESTS.START_UPDATE, { batchId });
+                this.bus.emit(jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId });
             }
 
             restoreFromSaved() {

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -410,7 +410,7 @@ define([
                 this.renderJobState(this.lastJobState || { job_id: this.jobId });
 
                 this.bus.emit(jcm.REQUESTS.STATUS, {
-                    jobId: this.jobId,
+                    [jcm.PARAMS.JOB_ID]: this.jobId,
                 });
                 this.state.listeningForJob = true;
             }).catch((err) => {
@@ -446,7 +446,7 @@ define([
          */
         startJobStatusUpdates() {
             this.bus.emit(jcm.REQUESTS.START_UPDATE, {
-                jobId: this.jobId,
+                [jcm.PARAMS.JOB_ID]: this.jobId,
             });
             this.state.listeningForJob = true;
         }
@@ -475,7 +475,7 @@ define([
             this.ui.showElement('spinner');
             this.state.awaitingLog = true;
             this.bus.emit(jcm.REQUESTS.LOGS, {
-                jobId: this.jobId,
+                [jcm.PARAMS.JOB_ID]: this.jobId,
                 first_line: firstLine,
             });
         }
@@ -489,7 +489,7 @@ define([
             this.ui.showElement('spinner');
             this.state.awaitingLog = true;
             this.bus.emit(jcm.REQUESTS.LOGS, {
-                jobId: this.jobId,
+                [jcm.PARAMS.JOB_ID]: this.jobId,
                 latest: true,
             });
         }

--- a/kbase-extension/static/kbase/js/util/jobStateViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobStateViewer.js
@@ -256,8 +256,7 @@ define([
             ui,
             jobState = null,
             listeningForJob = false,
-            jobId,
-            parentJobId;
+            jobId;
 
         const viewModel = {
             lastUpdated: {
@@ -326,7 +325,7 @@ define([
                 return;
             }
             runtime.bus().emit(jcm.REQUESTS.START_UPDATE, {
-                jobId,
+                [jcm.PARAMS.JOB_ID]: jobId,
             });
             listeningForJob = true;
         }
@@ -402,9 +401,7 @@ define([
                     ui = UI.make({ node: container });
 
                     container.innerHTML = renderRunStats();
-
                     jobId = arg.jobId;
-                    parentJobId = arg.parentJobId ? arg.parentJobId : null;
 
                     listeners.push(
                         runtime.bus().on('clock-tick', () => {
@@ -416,8 +413,7 @@ define([
 
                     // request a new job status update from the kernel on start
                     runtime.bus().emit(jcm.REQUESTS.STATUS, {
-                        jobId: jobId,
-                        parentJobId: parentJobId,
+                        [jcm.PARAMS.JOB_ID]: jobId,
                     });
                     listeningForJob = true;
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -166,11 +166,11 @@ define([
                     });
 
                     this.channel.emit(jcm.REQUESTS.INFO, {
-                        jobId: this.jobId,
+                        [jcm.PARAMS.JOB_ID]: this.jobId,
                     });
 
                     this.channel.emit(jcm.REQUESTS.STATUS, {
-                        jobId: this.jobId,
+                        [jcm.PARAMS.JOB_ID]: this.jobId,
                     });
                 })
                 .catch((err) => {
@@ -497,7 +497,7 @@ define([
                     if (this.requestedUpdates) {
                         this.requestedUpdates = false;
                         this.channel.emit(jcm.REQUESTS.STOP_UPDATE, {
-                            jobId: this.jobId,
+                            [jcm.PARAMS.JOB_ID]: this.jobId,
                         });
                     }
                     // TODO: we need to remove all of the job listeners at this point, but
@@ -521,14 +521,14 @@ define([
 
         requestJobInfo: function () {
             this.channel.emit(jcm.REQUESTS.INFO, {
-                jobId: this.jobId,
+                [jcm.PARAMS.JOB_ID]: this.jobId,
             });
         },
 
         requestJobStatus: function () {
             window.setTimeout(() => {
                 this.channel.emit(jcm.REQUESTS.STATUS, {
-                    jobId: this.jobId,
+                    [jcm.PARAMS.JOB_ID]: this.jobId,
                 });
             }, this.statusRequestInterval);
         },

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1200,7 +1200,7 @@ define(
              */
             function cancelJob(jobId) {
                 runtime.bus().emit(jcm.REQUESTS.CANCEL, {
-                    jobId,
+                    [jcm.PARAMS.JOB_ID]: jobId,
                 });
             }
 
@@ -1209,7 +1209,7 @@ define(
                     return;
                 }
                 runtime.bus().emit(jcm.REQUESTS.STATUS, {
-                    jobId,
+                    [jcm.PARAMS.JOB_ID]: jobId,
                 });
             }
 
@@ -1422,7 +1422,7 @@ define(
                 );
 
                 runtime.bus().emit(jcm.REQUESTS.START_UPDATE, {
-                    jobId,
+                    [jcm.PARAMS.JOB_ID]: jobId,
                 });
             }
 
@@ -1466,7 +1466,7 @@ define(
                 const jobId = model.getItem('exec.jobState.job_id');
                 if (jobId) {
                     runtime.bus().emit(jcm.REQUESTS.STOP_UPDATE, {
-                        jobId,
+                        [jcm.PARAMS.JOB_ID]: jobId,
                     });
                 }
             }

--- a/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
+++ b/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
@@ -84,8 +84,7 @@ define([
 
                 startParamsListener();
                 runtime.bus().emit(jcm.REQUESTS.INFO, {
-                    jobId: jobId,
-                    parentJobId: arg.parentJobId,
+                    [jcm.PARAMS.JOB_ID]: jobId,
                 });
                 params = arg.params;
                 updateRowStatus(ui, params, container);

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -607,9 +607,9 @@ define([
                 });
                 expect(this.jobManager.bus.emit.calls.allArgs()).toEqual([
                     // job status request for the full batch
-                    [jcm.REQUESTS.STATUS, { batchId }],
+                    [jcm.REQUESTS.STATUS, { [jcm.PARAMS.BATCH_ID]: batchId }],
                 ]);
-                // this table already has the info populated, so the 'job-info'
+                // this table already has the info populated, so the job info
                 // listener is not required
                 jobIdList.forEach((jobId) => {
                     expect(Object.keys(this.jobManager.listeners[jobId])).toEqual(
@@ -643,19 +643,26 @@ define([
                 });
                 expect(this.jobManager.bus.emit.calls.allArgs()).toEqual([
                     // job info request for missing IDs
-                    [jcm.REQUESTS.INFO, { jobIdList: this.missingJobIds }],
+                    [jcm.REQUESTS.INFO, { [jcm.PARAMS.JOB_ID_LIST]: this.missingJobIds }],
                     // job status request for the full batch
-                    [jcm.REQUESTS.STATUS, { batchId }],
+                    [jcm.REQUESTS.STATUS, { [jcm.PARAMS.BATCH_ID]: batchId }],
                 ]);
-                // job-info listeners only required for some jobs
+                // job info listeners only required for some jobs
                 jobIdList.forEach((jobId) => {
                     if (missingJobIds.includes(jobId)) {
                         expect(Object.keys(this.jobManager.listeners[jobId])).toEqual(
-                            jasmine.arrayWithExactContents(['job-status', 'job-error', 'job-info'])
+                            jasmine.arrayWithExactContents([
+                                jcm.RESPONSES.STATUS,
+                                jcm.RESPONSES.ERROR,
+                                jcm.RESPONSES.INFO,
+                            ])
                         );
                     } else {
                         expect(Object.keys(this.jobManager.listeners[jobId])).toEqual(
-                            jasmine.arrayWithExactContents(['job-status', 'job-error'])
+                            jasmine.arrayWithExactContents([
+                                jcm.RESPONSES.STATUS,
+                                jcm.RESPONSES.ERROR,
+                            ])
                         );
                     }
                 });

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -17,6 +17,12 @@ define([
     const TEST_JOB_ID = 'someJob',
         TEST_JOB_LIST = [TEST_JOB_ID, 'anotherJob', 'aThirdJob'];
 
+    const JOB_ID = jcm.PARAMS.JOB_ID,
+        JOB_ID_LIST = jcm.PARAMS.JOB_ID_LIST,
+        BATCH_ID = jcm.PARAMS.BATCH_ID,
+        BACKEND_JOB_ID = 'job_id',
+        BACKEND_JOB_ID_LIST = 'job_id_list';
+
     function makeMockNotebook(commInfoReturn, registerTargetReturn, executeReply, cells = []) {
         return Mocks.buildMockNotebook({
             commInfoReturn,
@@ -328,57 +334,69 @@ define([
         const busMsgCases = [
             {
                 channel: jcm.REQUESTS.LOGS,
-                message: { jobId: TEST_JOB_ID },
+                message: { [JOB_ID]: TEST_JOB_ID },
                 expected: {
                     request_type: jcm.BACKEND_REQUESTS.LOGS,
-                    job_id: TEST_JOB_ID,
+                    [BACKEND_JOB_ID]: TEST_JOB_ID,
                 },
             },
             {
                 channel: jcm.REQUESTS.LOGS,
                 message: {
-                    jobId: TEST_JOB_ID,
+                    [JOB_ID]: TEST_JOB_ID,
                     latest: true,
                 },
                 expected: {
                     request_type: jcm.BACKEND_REQUESTS.LOGS,
-                    job_id: TEST_JOB_ID,
+                    [BACKEND_JOB_ID]: TEST_JOB_ID,
                     latest: true,
                 },
             },
             {
                 channel: jcm.REQUESTS.LOGS,
                 message: {
-                    jobId: TEST_JOB_ID,
+                    [JOB_ID]: TEST_JOB_ID,
                     first_line: 2000,
                     latest: true,
                 },
                 expected: {
                     request_type: jcm.BACKEND_REQUESTS.LOGS,
-                    job_id: TEST_JOB_ID,
+                    [BACKEND_JOB_ID]: TEST_JOB_ID,
                     first_line: 2000,
                     latest: true,
                 },
             },
             {
                 channel: jcm.REQUESTS.CANCEL,
-                message: { jobId: TEST_JOB_ID },
-                expected: { request_type: jcm.BACKEND_REQUESTS.CANCEL, job_id: TEST_JOB_ID },
+                message: { [JOB_ID]: TEST_JOB_ID },
+                expected: {
+                    request_type: jcm.BACKEND_REQUESTS.CANCEL,
+                    [BACKEND_JOB_ID]: TEST_JOB_ID,
+                },
             },
             {
                 channel: jcm.REQUESTS.CANCEL,
-                message: { jobIdList: TEST_JOB_LIST },
-                expected: { request_type: jcm.BACKEND_REQUESTS.CANCEL, job_id_list: TEST_JOB_LIST },
+                message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                expected: {
+                    request_type: jcm.BACKEND_REQUESTS.CANCEL,
+                    [BACKEND_JOB_ID_LIST]: TEST_JOB_LIST,
+                },
             },
             {
                 channel: jcm.REQUESTS.RETRY,
-                message: { jobId: TEST_JOB_ID },
-                expected: { request_type: jcm.BACKEND_REQUESTS.RETRY, job_id: TEST_JOB_ID },
+                message: { [JOB_ID]: TEST_JOB_ID },
+                expected: {
+                    request_type: jcm.BACKEND_REQUESTS.RETRY,
+                    [BACKEND_JOB_ID]: TEST_JOB_ID,
+                },
             },
             {
                 channel: jcm.REQUESTS.RETRY,
-                message: { jobIdList: TEST_JOB_LIST },
-                expected: { request_type: jcm.BACKEND_REQUESTS.RETRY, job_id_list: TEST_JOB_LIST },
+                message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                expected: {
+                    request_type: jcm.BACKEND_REQUESTS.RETRY,
+                    [BACKEND_JOB_ID_LIST]: TEST_JOB_LIST,
+                },
             },
         ];
 
@@ -388,26 +406,26 @@ define([
             busMsgCases.push(
                 {
                     channel: jcm.REQUESTS[type],
-                    message: { jobId: TEST_JOB_ID },
+                    message: { [JOB_ID]: TEST_JOB_ID },
                     expected: {
                         request_type: jcm.BACKEND_REQUESTS[type],
-                        job_id: TEST_JOB_ID,
+                        [BACKEND_JOB_ID]: TEST_JOB_ID,
                     },
                 },
                 {
                     channel: jcm.REQUESTS[type],
-                    message: { jobIdList: TEST_JOB_LIST },
+                    message: { [JOB_ID_LIST]: TEST_JOB_LIST },
                     expected: {
                         request_type: jcm.BACKEND_REQUESTS[type],
-                        job_id_list: TEST_JOB_LIST,
+                        [BACKEND_JOB_ID_LIST]: TEST_JOB_LIST,
                     },
                 },
                 {
                     channel: jcm.REQUESTS[type],
-                    message: { batchId: 'batch_job' },
+                    message: { [BATCH_ID]: 'batch_job' },
                     expected: {
                         request_type: `${jcm.BACKEND_REQUESTS[type]}_batch`,
-                        job_id: 'batch_job',
+                        [BACKEND_JOB_ID]: 'batch_job',
                     },
                 }
             );
@@ -745,7 +763,7 @@ define([
             {
                 type: jcm.BACKEND_RESPONSES.ERROR,
                 message: {
-                    job_id_list: [
+                    [BACKEND_JOB_ID_LIST]: [
                         'job_1_RetryWithErrors',
                         'job_2_RetryWithErrors',
                         'job_3_RetryWithErrors',
@@ -759,7 +777,7 @@ define([
                         {
                             jobId: 'job_1_RetryWithErrors',
                             error: {
-                                job_id_list: [
+                                [BACKEND_JOB_ID_LIST]: [
                                     'job_1_RetryWithErrors',
                                     'job_2_RetryWithErrors',
                                     'job_3_RetryWithErrors',
@@ -779,7 +797,7 @@ define([
                         {
                             jobId: 'job_2_RetryWithErrors',
                             error: {
-                                job_id_list: [
+                                [BACKEND_JOB_ID_LIST]: [
                                     'job_1_RetryWithErrors',
                                     'job_2_RetryWithErrors',
                                     'job_3_RetryWithErrors',
@@ -799,7 +817,7 @@ define([
                         {
                             jobId: 'job_3_RetryWithErrors',
                             error: {
-                                job_id_list: [
+                                [BACKEND_JOB_ID_LIST]: [
                                     'job_1_RetryWithErrors',
                                     'job_2_RetryWithErrors',
                                     'job_3_RetryWithErrors',

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -704,16 +704,18 @@ define([
 
                 it('will remove a specified job ID / type listener combo', function () {
                     spyOn(this.bus, 'removeListener').and.returnValue(true);
-                    const fakeJob = {};
-                    fakeJob[jcm.RESPONSES.INFO] = 'job-info-fake-job';
-                    fakeJob[jcm.RESPONSES.STATUS] = 'job-status-fake-job';
-                    fakeJob[jcm.RESPONSES.LOGS] = 'job-logs-fake-job';
+                    const fakeJob = {
+                        [jcm.RESPONSES.INFO]: 'job-info-fake-job',
+                        [jcm.RESPONSES.STATUS]: 'job-status-fake-job',
+                        [jcm.RESPONSES.LOGS]: 'job-logs-fake-job',
+                    };
                     this.jobManagerInstance.listeners.fakeJob = fakeJob;
 
                     this.jobManagerInstance.removeListener('fakeJob', jcm.RESPONSES.INFO);
-                    const expected = {};
-                    expected[jcm.RESPONSES.STATUS] = 'job-status-fake-job';
-                    expected[jcm.RESPONSES.LOGS] = 'job-logs-fake-job';
+                    const expected = {
+                        [jcm.RESPONSES.STATUS]: 'job-status-fake-job',
+                        [jcm.RESPONSES.LOGS]: 'job-logs-fake-job',
+                    };
 
                     expect(this.jobManagerInstance.listeners.fakeJob).toEqual(expected);
                     expect(this.bus.removeListener).toHaveBeenCalledTimes(1);
@@ -728,10 +730,11 @@ define([
                     this.jobManagerInstance = createJobManagerInstance(this, JobManagerCore);
                 });
                 it('will remove all listeners from a certain job ID', function () {
-                    const fakeJob = {};
-                    fakeJob[jcm.RESPONSES.INFO] = 'job-info-fake-job';
-                    fakeJob[jcm.RESPONSES.STATUS] = 'job-status-fake-job';
-                    fakeJob[jcm.RESPONSES.LOGS] = 'job-logs-fake-job';
+                    const fakeJob = {
+                        [jcm.RESPONSES.INFO]: 'job-info-fake-job',
+                        [jcm.RESPONSES.STATUS]: 'job-status-fake-job',
+                        [jcm.RESPONSES.LOGS]: 'job-logs-fake-job',
+                    };
                     this.jobManagerInstance.listeners.fakeJob = fakeJob;
 
                     this.jobManagerInstance.removeJobListeners('fakeJob');
@@ -760,11 +763,13 @@ define([
 
         function checkForHandlers(jobManagerInstance) {
             const currentHandlers = jobManagerInstance.handlers;
-            expect(Object.keys(currentHandlers).sort()).toEqual([
-                jcm.RESPONSES.INFO,
-                jcm.RESPONSES.RETRY,
-                jcm.RESPONSES.STATUS,
-            ]);
+            expect(Object.keys(currentHandlers)).toEqual(
+                jasmine.arrayWithExactContents([
+                    jcm.RESPONSES.INFO,
+                    jcm.RESPONSES.RETRY,
+                    jcm.RESPONSES.STATUS,
+                ])
+            );
             Object.keys(currentHandlers).forEach((handlerName) => {
                 const expected = {};
                 expected[`__default_${handlerName}`] = jasmine.any(Function);
@@ -894,8 +899,10 @@ define([
                     expect(storedJobs[jobId]).toEqual(updatedJobState);
                     expect(storedJobs[newJobId]).toEqual(retryJobState);
                     expect(this.bus.emit).toHaveBeenCalled();
+                    // eslint-disable-next-line no-console
+                    console.log(this.jobManagerInstance.bus.emit.calls.allArgs());
                     expect(this.jobManagerInstance.bus.emit.calls.allArgs()).toEqual([
-                        [jcm.REQUESTS.START_UPDATE, { jobId: newJobId }],
+                        [jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.JOB_ID]: newJobId }],
                     ]);
                 });
 
@@ -1054,7 +1061,7 @@ define([
                     expect(this.jobManagerInstance.updateModel).toHaveBeenCalledTimes(1);
                     expect(console.error).toHaveBeenCalledTimes(1);
 
-                    // all child jobs should have job-status and job-info listeners
+                    // all child jobs should have job status and job info listeners
                     batchParentUpdate.child_jobs.forEach((_jobId) => {
                         expect(
                             this.jobManagerInstance.listeners[_jobId][jcm.RESPONSES.STATUS]
@@ -1069,7 +1076,7 @@ define([
                         [
                             jcm.REQUESTS.START_UPDATE,
                             {
-                                jobIdList: jasmine.arrayWithExactContents(
+                                [jcm.PARAMS.JOB_ID_LIST]: jasmine.arrayWithExactContents(
                                     batchParentUpdate.child_jobs
                                 ),
                             },

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -899,8 +899,6 @@ define([
                     expect(storedJobs[jobId]).toEqual(updatedJobState);
                     expect(storedJobs[newJobId]).toEqual(retryJobState);
                     expect(this.bus.emit).toHaveBeenCalled();
-                    // eslint-disable-next-line no-console
-                    console.log(this.jobManagerInstance.bus.emit.calls.allArgs());
                     expect(this.jobManagerInstance.bus.emit.calls.allArgs()).toEqual([
                         [jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.JOB_ID]: newJobId }],
                     ]);

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -574,9 +574,9 @@ define([
                                 const allEmissions =
                                     bulkImportCellInstance.jobManager.bus.emit.calls.allArgs();
                                 expect([
-                                    ['request-job-updates-start', { batchId }],
-                                    ['request-job-cancel', { jobIdList: [batchId] }],
-                                    ['request-job-updates-stop', { batchId }],
+                                    [jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
+                                    [jcm.REQUESTS.CANCEL, { [jcm.PARAMS.JOB_ID_LIST]: [batchId] }],
+                                    [jcm.REQUESTS.STOP_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
                                     [
                                         'reset-cell',
                                         { cellId: `${testCase.cellId}-test-cell`, ts: 1234567890 },
@@ -679,11 +679,10 @@ define([
                 expect(bulkImportCellInstance.jobManager.initBatchJob).toHaveBeenCalledTimes(1);
                 // bus calls to init jobs, request info, cancel jobs, and stop updates
                 const callArgs = [
-                    [jcm.REQUESTS.START_UPDATE, { batchId }],
-                    [jcm.REQUESTS.INFO, { batchId }],
-                    [jcm.REQUESTS.CANCEL, { jobIdList: [batchId] }],
-                    [jcm.REQUESTS.STOP_UPDATE, { batchId }],
-                    ['reset-cell', { cellId: `${cellId}-test-cell`, ts: 1234567890 }],
+                    [jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
+                    [jcm.REQUESTS.INFO, { [jcm.PARAMS.BATCH_ID]: batchId }],
+                    [jcm.REQUESTS.CANCEL, { [jcm.PARAMS.JOB_ID_LIST]: [batchId] }],
+                    [jcm.REQUESTS.STOP_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
                 ];
                 expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
                 expect(bulkImportCellInstance.jobManager.bus.emit.calls.allArgs()).toEqual(

--- a/test/unit/spec/util/jobLogViewerSpec.js
+++ b/test/unit/spec/util/jobLogViewerSpec.js
@@ -48,13 +48,13 @@ define([
      */
     function formatMessage(jobId, type, messageData = {}) {
         return [
-            Object.assign({}, { jobId }, messageData),
+            Object.assign({}, { [jcm.PARAMS.JOB_ID]: jobId }, messageData),
             {
                 channel: {
                     jobId,
                 },
                 key: {
-                    type: `job-${type}`,
+                    type: jcm.RESPONSES[type.toUpperCase()],
                 },
             },
         ];
@@ -246,7 +246,7 @@ define([
 
             return new Promise((resolve) => {
                 this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ jobId });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                     resolve();
                 });
             });
@@ -376,7 +376,7 @@ define([
                     }`, async function () {
                         this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
                             testJobStatus(this, mode);
-                            expect(msg).toEqual({ jobId: jobState.job_id });
+                            expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
                         });
 
                         await this.jobLogViewerInstance.start({
@@ -400,7 +400,7 @@ define([
 
                 this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
                     testJobStatus(this);
-                    expect(msg).toEqual({ jobId: jobState.job_id });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
                 });
 
                 await this.jobLogViewerInstance.start({
@@ -453,7 +453,7 @@ define([
                     });
 
                     this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ jobId });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                         testJobStatus(this);
                         this.runtimeBus.send(
                             ...formatMessage(jobId, 'status', { jobState: state })
@@ -492,12 +492,12 @@ define([
                     jlv = this.jobLogViewerInstance;
                     container = this.node;
                     this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ jobId });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                         this.runtimeBus.send(...formatStatusMessage(jobState));
                     });
 
                     this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ jobId, latest: true });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, latest: true });
                         this.runtimeBus.send(...formatLogMessage(jobId, lotsOfLogLines));
                     });
 
@@ -589,7 +589,7 @@ define([
                 const jobId = jobState.job_id;
 
                 this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ jobId: jobState.job_id });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
                     // send the job message
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
@@ -613,7 +613,7 @@ define([
                     const jobId = jobState.job_id;
 
                     this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ jobId: jobState.job_id });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
                         // send the job message
                         const jobMessage = formatStatusMessage(jobState);
                         this.runtimeBus.send(...jobMessage);
@@ -644,12 +644,12 @@ define([
                 let acc = 0;
 
                 this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ jobId });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
                 this.runtimeBus.on(jcm.REQUESTS.START_UPDATE, (msg) => {
-                    expect(msg).toEqual({ jobId });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
@@ -660,7 +660,7 @@ define([
 
                 return new Promise((resolve) => {
                     this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ jobId, latest: true });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, latest: true });
                         const logUpdate = logs[acc];
                         acc += 1;
                         // set up the mutation observer to watch for UI spinner changes
@@ -692,18 +692,18 @@ define([
                 const jobId = jobState.job_id;
 
                 this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ jobId });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
                 this.runtimeBus.on(jcm.REQUESTS.START_UPDATE, (msg) => {
-                    expect(msg).toEqual({ jobId });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
                 // this is called when the state is 'running'
                 this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                    expect(msg).toEqual({ jobId, latest: true });
+                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, latest: true });
                     this.runtimeBus.send(
                         ...formatMessage(jobId, 'logs', {
                             error: 'summat went wrong',
@@ -740,12 +740,12 @@ define([
                     const jobId = jobState.job_id;
 
                     this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ jobId });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                         this.runtimeBus.send(...formatStatusMessage(jobState));
                     });
 
                     this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ jobId, first_line: 0 });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, first_line: 0 });
                         this.runtimeBus.send(...formatLogMessage(jobId, logLines));
                     });
 
@@ -768,12 +768,12 @@ define([
                     const jobId = jobState.job_id;
 
                     this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ jobId });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
                         this.runtimeBus.send(...formatStatusMessage(jobState));
                     });
 
                     this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ jobId, first_line: 0 });
+                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, first_line: 0 });
                         this.runtimeBus.send(
                             ...formatMessage(jobId, 'logs', {
                                 error: 'DANGER!',


### PR DESCRIPTION
# Description of PR purpose/changes

Another search and replace ticket, plus a bit more standardising of query names.

Added the parameters used for job-related requests to the `jcm` object as `jcm.PARAMS` and substituted any param strings found in the code with the appropriate `jcm.PARAMS.*` entry, e.g.

```js
bus.emit(jcm.REQUESTS.STATUS, { batchId: 'some-batch-id' })
```
is now
```js
bus.emit(jcm.REQUESTS.STATUS, { [jcm.PARAMS.BATCH_ID]: 'some-batch-id' })
```

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
