### PR TITLE
DATAUP-636 xSV happy path setup

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -51,17 +51,27 @@ define(['bluebird', 'base/js/namespace', 'narrativeConfig', 'util/kbaseApiUtil',
         return Promise.all(uploadCellProms);
     }
 
+    /**
+     * This creates a single app cell initialized with the web uploader app.
+     * @returns Promise that resolves when the web upload app cell is created
+     */
     function setupWebUploadCell() {
         return initSingleFileUploads([{ name: null, type: 'web_upload' }]);
     }
 
     /**
-     *
-     * @param {Array[object]} fileInfo :
+     * This does the work of taking a list of file and their types and converting them into one
+     * or more import app cells. It does so in 3 phases.
+     * 1. Filter the file infos into bins based on their given type - single upload, bulk upload, or xsv (that's CSV, TSV, Excel)
+     * 2. Get all the extended file info from the xsv files to push into the bulk uploader section
+     * 3. Make the bulk import and other singleton import cells.
+     * This returns a Promise that resolves once the cells are made.
+     * @param {Array[object]} fileInfo an array of file infos composed of these objects:
      * {
      *   name: filename (might be a path),
      *   type: data type id
      * }
+     * @returns a Promise that resolves when all cells are made
      */
     function setupImportCells(fileInfo) {
         /* Bin the files based on import stuff

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -1,0 +1,106 @@
+define(['bluebird', 'base/js/namespace', 'narrativeConfig', 'util/kbaseApiUtil', 'util/string'], (
+    Promise,
+    Jupyter,
+    Config,
+    APIUtil,
+    StringUtil
+) => {
+    'use strict';
+
+    function getSpreadsheetFileInfo(fileName) {
+        return Promise.resolve(fileName);
+    }
+
+    function initSingleFileUploads(fileInfo, appInfos) {
+        const tag = APIUtil.getAppVersionTag();
+        const uploadCellProms = fileInfo.map((file) => {
+            let fileParam = file.name;
+            const inputs = {};
+            const appInfo = appInfos[file.type];
+
+            if (appInfo.app_input_param_type && appInfo.app_input_param_type === 'list') {
+                fileParam = [fileParam];
+            }
+
+            if (appInfo.app_input_param) {
+                inputs[appInfo.app_input_param] = fileParam;
+            }
+
+            if (appInfo.app_output_param) {
+                inputs[appInfo.app_output_param] = StringUtil.sanitizeWorkspaceObjectName(
+                    file.name,
+                    true
+                );
+                if (appInfo.app_output_suffix) {
+                    inputs[appInfo.app_output_param] += appInfo.app_output_suffix;
+                }
+            }
+
+            if (appInfo.app_static_params) {
+                for (const p of Object.keys(appInfo.app_static_params)) {
+                    inputs[p] = appInfo.app_static_params[p];
+                }
+            }
+            return Promise.try(() => {
+                Jupyter.narrative.addAndPopulateApp(appInfo.app_id, tag, inputs);
+            });
+        });
+        return Promise.all(uploadCellProms);
+    }
+
+    /**
+     *
+     * @param {Array[object]} fileInfo :
+     * {
+     *   name: filename (might be a path),
+     *   type: data type id
+     * }
+     */
+    function setupImportCells(fileInfo) {
+        const uploaders = Config.get('uploaders');
+        const bulkIds = new Set(uploaders.bulkImportTypes);
+
+        /* Bin the files based on import stuff
+         * 1. format and put in bulkFiles if the type is in the bulkIds set
+         * 2. put in the queue to fetch spreadsheet info from the staging service if it's that type (TBD)
+         * 3. put it in the array of single-app uploaders otherwise
+         */
+        const bulkFiles = {};
+        const singleFiles = [];
+        const xsvFiles = [];
+        fileInfo.forEach((file) => {
+            const importType = file.type;
+            const appInfo = uploaders.app_info[importType];
+            if (bulkIds.has(importType)) {
+                if (!(importType in bulkFiles)) {
+                    bulkFiles[importType] = {
+                        appId: appInfo.app_id,
+                        files: [],
+                        outputSuffix: appInfo.app_output_suffix,
+                    };
+                }
+                bulkFiles[importType].push(file.name);
+            } else if (importType === 'csv/tsv/spreadsheet/whatever') {
+                xsvFiles.push(file.name);
+            } else {
+                singleFiles.push(file);
+            }
+        });
+        return getSpreadsheetFileInfo(xsvFiles)
+            .then(() => {
+                // TODO: merge xsvFileInfo with bulkFiles
+                if (Object.keys(bulkFiles).length) {
+                    return Jupyter.narrative.insertBulkImportCell(bulkFiles);
+                } else {
+                    return Promise.resolve();
+                }
+            })
+            .then(() => {
+                return initSingleFileUploads(singleFiles, uploaders.app_info);
+            });
+    }
+
+    return {
+        setupImportCells,
+    };
+});

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -1129,13 +1129,11 @@ define([
          * Creating a new bulk import cell returns a Promise, so this returns a Promise.
          */
         initImport: function () {
-            const stagingAreaViewer = this;
-
-            if (!stagingAreaViewer.fullDataTable) {
+            if (!this.fullDataTable) {
                 return Promise.resolve();
             }
             const checkedBoxSelector = `input.${cssBaseClass}-body__checkbox-input:checked`;
-            const selectedRows = stagingAreaViewer.fullDataTable.rows((_idx, _data, node) => {
+            const selectedRows = this.fullDataTable.rows((_idx, _data, node) => {
                 return !!node.querySelector(checkedBoxSelector);
             });
             const fileInfo = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2392,9 +2392,15 @@
         "node_modules/caniuse-lite": {
 <<<<<<< Updated upstream
 <<<<<<< Updated upstream
+<<<<<<< Updated upstream
             "version": "1.0.30001285",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
             "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
+=======
+            "version": "1.0.30001291",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
+            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
+>>>>>>> Stashed changes
 =======
             "version": "1.0.30001291",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
@@ -18014,9 +18020,15 @@
         "caniuse-lite": {
 <<<<<<< Updated upstream
 <<<<<<< Updated upstream
+<<<<<<< Updated upstream
             "version": "1.0.30001285",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
             "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
+=======
+            "version": "1.0.30001291",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
+            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
+>>>>>>> Stashed changes
 =======
             "version": "1.0.30001291",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,21 @@
             }
         },
         "node_modules/caniuse-lite": {
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
             "version": "1.0.30001285",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
             "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
+=======
+            "version": "1.0.30001291",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
+            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
+>>>>>>> Stashed changes
+=======
+            "version": "1.0.30001291",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
+            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
+>>>>>>> Stashed changes
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18012,21 @@
             }
         },
         "caniuse-lite": {
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
             "version": "1.0.30001285",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
             "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
+=======
+            "version": "1.0.30001291",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
+            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
+>>>>>>> Stashed changes
+=======
+            "version": "1.0.30001291",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
+            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
+>>>>>>> Stashed changes
             "dev": true
         },
         "center-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001287",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001287.tgz",
-            "integrity": "sha512-4udbs9bc0hfNrcje++AxBuc6PfLNHwh3PO9kbwnfCQWyqtlzg3py0YgFu8jyRTTo85VAz4U+VLxSlID09vNtWA==",
+            "version": "1.0.30001292",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+            "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001287",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001287.tgz",
-            "integrity": "sha512-4udbs9bc0hfNrcje++AxBuc6PfLNHwh3PO9kbwnfCQWyqtlzg3py0YgFu8jyRTTo85VAz4U+VLxSlID09vNtWA==",
+            "version": "1.0.30001292",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+            "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
             "dev": true
         },
         "center-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,27 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-            "version": "1.0.30001285",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
-            "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
-=======
             "version": "1.0.30001291",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
             "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
->>>>>>> Stashed changes
-=======
-            "version": "1.0.30001291",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
->>>>>>> Stashed changes
-=======
-            "version": "1.0.30001291",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
->>>>>>> Stashed changes
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18018,27 +18000,9 @@
             }
         },
         "caniuse-lite": {
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-            "version": "1.0.30001285",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
-            "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
-=======
             "version": "1.0.30001291",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
             "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
->>>>>>> Stashed changes
-=======
-            "version": "1.0.30001291",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
->>>>>>> Stashed changes
-=======
-            "version": "1.0.30001291",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-            "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
->>>>>>> Stashed changes
             "dev": true
         },
         "center-align": {

--- a/test/unit/spec/narrative_core/upload/importSetup-spec.js
+++ b/test/unit/spec/narrative_core/upload/importSetup-spec.js
@@ -1,0 +1,55 @@
+define([
+    'kbase/js/widgets/narrative_core/upload/importSetup',
+    'base/js/namespace',
+    'narrativeConfig',
+    'testUtil',
+], (ImportSetup, Jupyter, Config, TestUtil) => {
+    'use strict';
+
+    fdescribe('ImportSetup module tests', () => {
+        beforeAll(() => {
+            Jupyter.narrative = {
+                sidePanel: {
+                    $methodsWidget: {
+                        currentTag: 'release',
+                    },
+                },
+                addAndPopulateApp: () => {},
+                insertBulkImportCell: () => {},
+            };
+        });
+
+        beforeEach(() => {
+            jasmine.Ajax.install();
+        });
+
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+        });
+
+        afterAll(() => {
+            Jupyter.narrative = null;
+            TestUtil.clearRuntime();
+        });
+
+        it('should have expected functions', () => {
+            ['setupImportCells', 'setupWebUploadCell'].forEach((fn) => {
+                expect(ImportSetup[fn]).toEqual(jasmine.any(Function));
+            });
+        });
+
+        xdescribe('setupImportCells tests', () => {});
+
+        describe('setupWebUploadCell tests', () => {
+            it('should create a web upload app cell', () => {
+                spyOn(Jupyter.narrative, 'addAndPopulateApp');
+                ImportSetup.setupWebUploadCell();
+                expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledWith(
+                    'kb_uploadmethods/upload_web_file',
+                    'release',
+                    {}
+                );
+            });
+        });
+    });
+});

--- a/test/unit/spec/narrative_core/upload/importSetup-spec.js
+++ b/test/unit/spec/narrative_core/upload/importSetup-spec.js
@@ -6,12 +6,15 @@ define([
 ], (ImportSetup, Jupyter, Config, TestUtil) => {
     'use strict';
 
-    fdescribe('ImportSetup module tests', () => {
+    const uploaders = Config.get('uploaders');
+    const RELEASE_TAG = 'release';
+
+    describe('ImportSetup module tests', () => {
         beforeAll(() => {
             Jupyter.narrative = {
                 sidePanel: {
                     $methodsWidget: {
-                        currentTag: 'release',
+                        currentTag: RELEASE_TAG,
                     },
                 },
                 addAndPopulateApp: () => {},
@@ -20,6 +23,8 @@ define([
         });
 
         beforeEach(() => {
+            spyOn(Jupyter.narrative, 'addAndPopulateApp');
+            spyOn(Jupyter.narrative, 'insertBulkImportCell');
             jasmine.Ajax.install();
         });
 
@@ -38,12 +43,142 @@ define([
             });
         });
 
-        xdescribe('setupImportCells tests', () => {});
+        describe('setupImportCells tests', () => {
+            const TYPE = {
+                FASTQ: 'fastq_reads_interleaved', // bulk
+                SRA: 'sra_reads', // bulk
+                MATRIX: 'expression_matrix', // not bulk
+                MEDIA: 'media', // not bulk
+            };
+
+            const appIds = Object.values(TYPE).reduce((acc, appType) => {
+                acc[appType] = uploaders.app_info[appType].app_id;
+                return acc;
+            }, {});
+
+            const BULK = new Set([TYPE.FASTQ, TYPE.SRA]);
+            const fileCounts = [1, 2, 5];
+
+            /**
+             * Builds the fileInfo array with the given number of files of each data type.
+             * Returns an object with:
+             * {
+             *   fileInfo: array of file information (inputs to setupImportCells)
+             *   biCell: boolean - if true, then a single BI cell should get made
+             * }
+             */
+            function setupImportCellsInputs(numFiles, dataTypes) {
+                let biCell = false;
+                const fileInfo = [],
+                    bulkFiles = new Set(),
+                    nonBulkFiles = new Set();
+                for (let i = 0; i < dataTypes.length; i++) {
+                    for (let j = 0; j < numFiles; j++) {
+                        const fileName = `file${i * numFiles + j + 1}`;
+                        fileInfo.push({
+                            name: fileName,
+                            type: dataTypes[i],
+                        });
+                        if (BULK.has(dataTypes[i])) {
+                            biCell = true;
+                            bulkFiles.add(fileName);
+                        } else {
+                            nonBulkFiles.add(fileName);
+                        }
+                    }
+                }
+                return {
+                    fileInfo,
+                    biCell,
+                    bulkFiles,
+                    nonBulkFiles,
+                };
+            }
+
+            // multiple file types, multiple of each
+            // not gonna make a permuter because that's just overkill.
+            const typeCombos = [
+                ['FASTQ', 'SRA'],
+                ['FASTQ', 'MATRIX'],
+                ['FASTQ', 'SRA', 'MATRIX'],
+                ['FASTQ', 'MATRIX', 'MEDIA'],
+                ['FASTQ', 'SRA', 'MATRIX', 'MEDIA'],
+            ].concat(Object.keys(TYPE).map((singleType) => [singleType]));
+            fileCounts.forEach((numFiles) => {
+                typeCombos.forEach((typeCombo) => {
+                    const types = typeCombo.map((type) => TYPE[type]);
+                    const nonBulkAppIds = new Set();
+                    types.forEach((type) => {
+                        if (!BULK.has(type)) {
+                            nonBulkAppIds.add(appIds[type]);
+                        }
+                    });
+                    const { fileInfo, biCell, bulkFiles, nonBulkFiles } = setupImportCellsInputs(
+                        numFiles,
+                        types
+                    );
+                    const totalFiles = fileInfo.length;
+
+                    const numExpectedCells = (biCell ? 1 : 0) + nonBulkFiles.size;
+                    const label = [
+                        `should make ${numExpectedCells} cell${numExpectedCells > 1 ? 's' : ''} `,
+                        biCell ? '(with a BI cell) ' : '',
+                        `from ${totalFiles} file${totalFiles > 1 ? 's' : ''} `,
+                        `distributed over ${types.length} type${types.length > 1 ? 's' : ''}: `,
+                        types.join(', '),
+                    ].join('');
+                    it(label, async () => {
+                        await ImportSetup.setupImportCells(fileInfo);
+                        expect(Jupyter.narrative.insertBulkImportCell).toHaveBeenCalledTimes(
+                            biCell ? 1 : 0
+                        );
+                        if (biCell) {
+                            const callArgs =
+                                Jupyter.narrative.insertBulkImportCell.calls.mostRecent().args[0];
+                            // just spot check here that the right types are invoked and the structure's right.
+                            types.forEach((type) => {
+                                if (BULK.has(type)) {
+                                    const typeInfo = callArgs[type];
+                                    expect(typeInfo).toEqual(jasmine.any(Object));
+                                    expect(typeInfo.appId).toEqual(appIds[type]);
+                                    expect(typeInfo.files).toEqual(jasmine.any(Array));
+                                    expect(typeInfo.files.length).toBeGreaterThan(0);
+                                    typeInfo.files.forEach((file) => {
+                                        expect(bulkFiles.has(file)).toBeTrue();
+                                    });
+                                }
+                            });
+                        }
+                        expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledTimes(
+                            nonBulkFiles.size
+                        );
+                        Jupyter.narrative.addAndPopulateApp.calls.all().forEach((usage) => {
+                            const callArgs = usage.args;
+                            // check for 3 things - the app id isn't one that's flagged bulk, it has a release tag,
+                            // and it has an object with at least one key who's value is a file that's been
+                            // pre-flagged as a nonBulk app
+                            expect(callArgs.length).toEqual(3);
+                            expect(nonBulkAppIds.has(callArgs[0])).toBeTrue();
+                            expect(callArgs[1]).toEqual(RELEASE_TAG);
+                            expect(callArgs[2]).toEqual(jasmine.any(Object));
+                            expect(
+                                Object.values(callArgs[2]).some((name) => nonBulkFiles.has(name))
+                            ).toBeTrue();
+                        });
+                    });
+                });
+            });
+
+            it('should silently not set up any cells with no files', async () => {
+                await ImportSetup.setupImportCells([]);
+                expect(Jupyter.narrative.addAndPopulateApp).not.toHaveBeenCalled();
+                expect(Jupyter.narrative.insertBulkImportCell).not.toHaveBeenCalled();
+            });
+        });
 
         describe('setupWebUploadCell tests', () => {
-            it('should create a web upload app cell', () => {
-                spyOn(Jupyter.narrative, 'addAndPopulateApp');
-                ImportSetup.setupWebUploadCell();
+            it('should create a web upload app cell', async () => {
+                await ImportSetup.setupWebUploadCell();
                 expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledWith(
                     'kb_uploadmethods/upload_web_file',
                     'release',

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -260,7 +260,7 @@ define([
             const placeholder = $container.find('span.select2-selection__placeholder').html();
             expect(placeholder).toContain('Select a type');
 
-            //The options that should be in the import as dropdown
+            // The options that should be in the import as dropdown
             const menuOptions = [
                 'SRA Reads',
                 'GenBank Genome',
@@ -283,7 +283,7 @@ define([
         it('renders the dropdown correctly when a type is selected', async () => {
             await stagingViewer.render();
 
-            //find the fake sra reads row specifically (via the download button, then chaining back up to the select dropdown above - since we don't have a unique ID for these select drodpowns it's the best mehtod for now)
+            // find the fake sra reads row specifically (via the download button, then chaining back up to the select dropdown above - since we don't have a unique ID for these select drodpowns it's the best mehtod for now)
             const selectDropdown = $container
                 .find('[data-download="fake_sra_reads.sra"]')
                 .siblings('select');
@@ -425,109 +425,122 @@ define([
             expect(importButton.disabled).toBeTrue();
         });
 
-        describe('Should initialize an import app', () => {
+        describe('Should initialize uploader cells', () => {
+            const bulkAppId = 'kb_uploadmethods/import_sra_as_reads_from_staging',
+                bulkImportType = 'sra_reads',
+                bulkOutputSuffix = '_reads',
+                nonBulkAppId = 'kb_uploadmethods/import_tsv_as_expression_matrix_from_staging',
+                nonBulkType = 'expression_matrix',
+                nonBulkSuffix = '_matrix';
+
             let tag;
 
             beforeEach(() => {
                 tag = Jupyter.narrative.sidePanel.$methodsWidget.currentTag;
             });
 
-            const fileType = 'fastq_reads_interleaved',
-                fileName = 'foobar.txt',
-                appId = 'kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging',
-                importType = 'FASTQ/FASTA';
+            it('Should run the import app init function when the import button is clicked', async () => {
+                await stagingViewer.render();
+                const fileName = 'fake_sra_reads.sra';
 
-            it('Should initialize an import app with the expected inputs', () => {
-                const inputs = {
-                    fastq_fwd_staging_file_name: fileName,
-                    name: fileName + '_reads',
-                    import_type: importType,
-                };
-                spyOn(Jupyter.narrative, 'addAndPopulateApp');
-                spyOn(Jupyter.narrative, 'hideOverlay');
-                stagingViewer.initImportApp(fileType, fileName);
-                expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledWith(
-                    appId,
-                    tag,
-                    inputs
-                );
-                expect(Jupyter.narrative.hideOverlay).toHaveBeenCalled();
+                // find the fake sra reads dropdown
+                const selectDropdown = $container
+                    .find(`[data-download='${fileName}']`)
+                    .siblings('select');
+
+                // this auto-checks the checkbox
+                selectDropdown.val('sra_reads').trigger('change').trigger('select2:select');
+                const button = container.querySelector('.kb-staging-table-import__button');
+                expect(button.disabled).toBeFalse();
+
+                spyOn(stagingViewer, 'initImport');
+                $(button).click();
+                expect(stagingViewer.initImport).toHaveBeenCalled();
             });
 
-            it('Should initialize an import app with files in subdirectories', () => {
-                const subDir = 'a_subdirectory',
-                    inputs = {
-                        fastq_fwd_staging_file_name: subDir + '/' + fileName,
-                        name: fileName + '_reads',
-                        import_type: 'FASTQ/FASTA',
-                    };
+            it('Should initialize an import app with unselected files', async () => {
                 spyOn(Jupyter.narrative, 'addAndPopulateApp');
+                spyOn(Jupyter.narrative, 'insertBulkImportCell');
                 spyOn(Jupyter.narrative, 'hideOverlay');
-
-                stagingViewer.initImportApp(fileType, subDir + '/' + fileName);
-                expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledWith(
-                    appId,
-                    tag,
-                    inputs
-                );
-                expect(Jupyter.narrative.hideOverlay).toHaveBeenCalled();
-            });
-
-            it('Should NOT initialize an import app with an unknown type', () => {
-                spyOn(Jupyter.narrative, 'addAndPopulateApp');
-                spyOn(Jupyter.narrative, 'hideOverlay');
-                stagingViewer.initImportApp('some_unknown_type', 'foobar.txt');
+                await stagingViewer.initImport();
                 expect(Jupyter.narrative.addAndPopulateApp).not.toHaveBeenCalled();
+                expect(Jupyter.narrative.insertBulkImportCell).not.toHaveBeenCalled();
                 expect(Jupyter.narrative.hideOverlay).not.toHaveBeenCalled();
             });
-        });
-
-        describe('Should initialize a bulk import cell', () => {
-            const appId = 'kb_uploadmethods/import_sra_as_reads_from_staging',
-                importType = 'sra_reads',
-                outputSuffix = '_reads';
 
             [
                 {
                     subdir: null,
                     filename: 'fake_sra_reads.sra',
+                    isBulk: true,
                 },
                 {
                     subdir: 'test_folder',
                     filename: 'some_reads.fq',
+                    isBulk: true,
+                },
+                {
+                    subdir: null,
+                    filename: 'unknown_file.txt',
+                    isBulk: false,
+                },
+                {
+                    subdir: 'test_folder',
+                    filename: 'some_reads.fq',
+                    isBulk: false,
                 },
             ].forEach((testCase) => {
                 const filePath = (testCase.subdir ? testCase.subdir + '/' : '') + testCase.filename;
-                it(`Should initialize a bulk import cell with the expected input file ${filePath}`, async () => {
+                const isBulk = testCase.isBulk;
+                const dataType = isBulk ? bulkImportType : nonBulkType;
+                it(`Should initialize a${
+                    testCase.isBulk ? ' bulk' : 'n'
+                } import cell with the expected single input file ${filePath} and type ${dataType}`, async () => {
                     await stagingViewer.render();
                     if (testCase.subdir) {
                         stagingViewer.$elem.find(`button[data-name="${testCase.subdir}"]`).click();
                     }
 
-                    //find the fake sra reads one specifically
+                    // find the given file specifically
                     const selectDropdown = $container
                         .find(`[data-download='${filePath}']`)
                         .siblings('select');
 
-                    //this auto-checks the checkbox
-                    selectDropdown.val('sra_reads').trigger('change').trigger('select2:select');
+                    // this auto-checks the checkbox
+                    selectDropdown.val(dataType).trigger('change').trigger('select2:select');
 
                     const button = container.querySelector('.kb-staging-table-import__button');
                     expect(button.disabled).toBeFalse();
 
-                    const expectedInputs = {};
-                    expectedInputs[importType] = {
-                        appId,
-                        files: [filePath],
-                        outputSuffix,
-                    };
-
                     spyOn(Jupyter.narrative, 'insertBulkImportCell');
+                    spyOn(Jupyter.narrative, 'addAndPopulateApp');
                     spyOn(Jupyter.narrative, 'hideOverlay');
-                    $(button).click();
-                    expect(Jupyter.narrative.insertBulkImportCell).toHaveBeenCalledWith(
-                        expectedInputs
-                    );
+
+                    await stagingViewer.initImport();
+
+                    if (isBulk) {
+                        const expectedInputs = {};
+                        expectedInputs[dataType] = {
+                            appId: bulkAppId,
+                            files: [filePath],
+                            outputSuffix: isBulk ? bulkOutputSuffix : nonBulkSuffix,
+                        };
+                        expect(Jupyter.narrative.insertBulkImportCell).toHaveBeenCalledWith(
+                            expectedInputs
+                        );
+                        expect(Jupyter.narrative.addAndPopulateApp).not.toHaveBeenCalled();
+                    } else {
+                        const fileInputs = {
+                            staging_file_subdir_path: filePath,
+                            matrix_name: testCase.filename + '_matrix',
+                        };
+                        expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledWith(
+                            nonBulkAppId,
+                            tag,
+                            fileInputs
+                        );
+                        expect(Jupyter.narrative.insertBulkImportCell).not.toHaveBeenCalled();
+                    }
                     expect(Jupyter.narrative.hideOverlay).toHaveBeenCalled();
                 });
             });

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -432,11 +432,19 @@ define([
                 nonBulkAppId = 'kb_uploadmethods/import_tsv_as_expression_matrix_from_staging',
                 nonBulkType = 'expression_matrix',
                 nonBulkSuffix = '_matrix';
-
             let tag;
 
             beforeEach(() => {
                 tag = Jupyter.narrative.sidePanel.$methodsWidget.currentTag;
+            });
+
+            it('Should initialize a web upload app cell', async () => {
+                await stagingViewer.render();
+                spyOn(Jupyter.narrative, 'addAndPopulateApp');
+                const $urlButton = $container.find('.web_upload_div');
+
+                $urlButton.click();
+                expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalled();
             });
 
             it('Should run the import app init function when the import button is clicked', async () => {


### PR DESCRIPTION
# Description of PR purpose/changes

The first step for setting up the xSV stuff is, in my opinion, factoring out the code that sets up data import app cells (both standard and bulk import). This PR does that, creating a new `importSetup.js` module. 

This is really just a refactor at this point with stubs for the flow of how the xSV integration will work. It takes the separate `initBulkImport` and `initImportApp` functions in the `stagingAreaViewer` module and combines them into a single `initImport` function. This then calls out to the new module that does all the logic around what file gets uploaded in which cell and how.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-636
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* there should be no visual change
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
