### PR TITLE
DATAUP-680: cut down on new job messages

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -39,6 +39,10 @@ BATCH_APP = {
 }
 
 
+def timestamp() -> str:
+    return datetime.datetime.utcnow().isoformat() + "Z"
+
+
 def _app_error_wrapper(app_func: Callable) -> any:
     """
     This is a decorator meant to wrap any of the `run_app*` methods here.
@@ -61,7 +65,7 @@ def _app_error_wrapper(app_func: Callable) -> any:
             e_source = getattr(e, "source", "appmanager")
             msg_info = {
                 "event": "error",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "error_message": e_message,
                 "error_type": e_type,
                 "error_stacktrace": e_trace,
@@ -302,13 +306,14 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "launched_job",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
                 "job_id": job_id,
             },
         )
         self.register_new_job(new_job)
+        self._send_comm_message(NEW, {"job_id": job_id})
         if cell_id is None:
             return new_job
 
@@ -391,13 +396,14 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "launched_job",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
                 "job_id": job_id,
             },
         )
         self.register_new_job(new_job)
+        self._send_comm_message(NEW, {"job_id": job_id})
         if cell_id is not None:
             return
         else:
@@ -529,7 +535,7 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "launched_job_batch",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
                 "batch_id": batch_id,
@@ -548,6 +554,7 @@ class AppManager(object):
         for new_job in child_jobs:
             self.register_new_job(new_job)
         self.register_new_job(parent_job)
+        self._send_comm_message(NEW, {"job_id_list": [batch_id] + child_ids})
 
         if cell_id is None:
             return {"parent_job": parent_job, "child_jobs": child_jobs}
@@ -747,7 +754,7 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "success",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
             },
@@ -978,7 +985,6 @@ class AppManager(object):
 
     def register_new_job(self, job: Job) -> None:
         JobManager().register_new_job(job)
-        self._send_comm_message(NEW, {"job_id": job.job_id})
         with exc_to_msg("appmanager"):
             JobComm().lookup_job_state(job.job_id)
             JobComm().start_job_status_loop()

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -777,15 +777,12 @@ class AppManagerTestCase(unittest.TestCase):
         run_ids = [None, "a_run_id"]
         # test with / w/o run_id
         # should return None, fire a couple of messages
-
         for run_id in run_ids:
             self.assertIsNone(
                 self.am.run_app_bulk(
                     self.bulk_run_good_inputs, cell_id=cell_id, run_id=run_id
                 )
             )
-            print("bulk messages output")
-            print(self._bulk_messages(run_id=run_id, cell_id=cell_id, num_jobs=4))
 
             self._verify_comm_success(
                 c.return_value.send_comm_message,


### PR DESCRIPTION
# Description of PR purpose/changes

Only one `NEW_JOB` message is emitted when bulk jobs are kicked off, rather than a message for every job initiated.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-680
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions -- note: the test failure is a flaky frontend test

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
