### PR TITLE
DATAUP-497: retrieve job logs for a list of job IDs

### DIFF
--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -39,6 +39,10 @@ BATCH_APP = {
 }
 
 
+def timestamp() -> str:
+    return datetime.datetime.utcnow().isoformat() + "Z"
+
+
 def _app_error_wrapper(app_func: Callable) -> any:
     """
     This is a decorator meant to wrap any of the `run_app*` methods here.
@@ -61,7 +65,7 @@ def _app_error_wrapper(app_func: Callable) -> any:
             e_source = getattr(e, "source", "appmanager")
             msg_info = {
                 "event": "error",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "error_message": e_message,
                 "error_type": e_type,
                 "error_stacktrace": e_trace,
@@ -302,13 +306,14 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "launched_job",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
                 "job_id": job_id,
             },
         )
         self.register_new_job(new_job)
+        self._send_comm_message(NEW, {"job_id": job_id})
         if cell_id is None:
             return new_job
 
@@ -391,13 +396,14 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "launched_job",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
                 "job_id": job_id,
             },
         )
         self.register_new_job(new_job)
+        self._send_comm_message(NEW, {"job_id": job_id})
         if cell_id is not None:
             return
         else:
@@ -529,7 +535,7 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "launched_job_batch",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
                 "batch_id": batch_id,
@@ -548,6 +554,7 @@ class AppManager(object):
         for new_job in child_jobs:
             self.register_new_job(new_job)
         self.register_new_job(parent_job)
+        self._send_comm_message(NEW, {"job_id_list": [batch_id] + child_ids})
 
         if cell_id is None:
             return {"parent_job": parent_job, "child_jobs": child_jobs}
@@ -747,7 +754,7 @@ class AppManager(object):
             RUN_STATUS,
             {
                 "event": "success",
-                "event_at": datetime.datetime.utcnow().isoformat() + "Z",
+                "event_at": timestamp(),
                 "cell_id": cell_id,
                 "run_id": run_id,
             },
@@ -978,7 +985,6 @@ class AppManager(object):
 
     def register_new_job(self, job: Job) -> None:
         JobManager().register_new_job(job)
-        self._send_comm_message(NEW, {"job_id": job.job_id})
         with exc_to_msg("appmanager"):
             JobComm().lookup_job_state(job.job_id)
             JobComm().start_job_status_loop()

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -11,6 +11,8 @@ WSID_STANDARD = 12345
 NARR_DATE = "2017-03-31T23:42:59+0000"
 NARR_WS = "wjriehl:1490995018528"
 NARR_HASH = "278abf8f0dbf8ab5ce349598a8674a6e"
+JOB_CREATED = "5d64935cb215ad4128de94d7"
+JOB_NOT_FOUND = "job_not_found"
 
 
 def get_nar_obj(i):
@@ -296,6 +298,15 @@ class MockClients:
         }
         there are only 100 "log lines" in total.
         """
+        if params["job_id"] == JOB_CREATED:
+            raise ServerError(
+                "JSONRPCError", 2, "Cannot find job log with id: " + JOB_CREATED
+            )
+        if params["job_id"] == JOB_NOT_FOUND:
+            raise ServerError(
+                "JSONRPCError", 99, "Job ID is not registered: " + JOB_NOT_FOUND
+            )
+
         total_lines = 100
         skip = params.get("skip_lines", 0)
         lines = list()

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -777,15 +777,12 @@ class AppManagerTestCase(unittest.TestCase):
         run_ids = [None, "a_run_id"]
         # test with / w/o run_id
         # should return None, fire a couple of messages
-
         for run_id in run_ids:
             self.assertIsNone(
                 self.am.run_app_bulk(
                     self.bulk_run_good_inputs, cell_id=cell_id, run_id=run_id
                 )
             )
-            print("bulk messages output")
-            print(self._bulk_messages(run_id=run_id, cell_id=cell_id, num_jobs=4))
 
             self._verify_comm_success(
                 c.return_value.send_comm_message,

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -95,7 +95,7 @@ JOBS_BY_CELL_ID = {
     TEST_CELL_ID_LIST[3]: {BATCH_PARENT, BATCH_RETRY_RUNNING, BATCH_RETRY_ERROR},
 }
 
-# mapping expected as output from lookup_jobs_by_cell_id
+# mapping expected as output from lookup_job_states_by_cell_id
 TEST_CELL_IDs = {id: list(JOBS_BY_CELL_ID[id]) for id in JOBS_BY_CELL_ID.keys()}
 TEST_CELL_IDs[TEST_CELL_ID_LIST[4]] = []
 

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -45,6 +45,8 @@ from biokbase.narrative.exception_util import (
     JobIDException,
 )
 
+from src.biokbase.narrative.jobs.jobmanager import DOES_NOT_EXIST
+
 from .util import ConfigTests, validate_job_state
 from .narrative_mock.mockcomm import MockComm
 from .narrative_mock.mockclients import (
@@ -101,13 +103,17 @@ NO_JOBS_MAPPING = {
 def make_comm_msg(
     msg_type: str, job_id_like, as_job_request: bool, content: dict = None
 ):
-    if type(job_id_like) is list:
-        job_id_key = JOB_ID_LIST
+    job_arguments = {}
+    if type(job_id_like) is dict:
+        job_arguments = job_id_like
+    elif type(job_id_like) is list:
+        job_arguments[JOB_ID_LIST] = job_id_like
     else:
-        job_id_key = JOB_ID
+        job_arguments[JOB_ID] = job_id_like
+
     msg = {
         "msg_id": "some_id",
-        "content": {"data": {"request_type": msg_type, job_id_key: job_id_like}},
+        "content": {"data": {"request_type": msg_type, **job_arguments}},
     }
     if content is not None:
         msg["content"]["data"].update(content)
@@ -291,7 +297,7 @@ class JobCommTestCase(unittest.TestCase):
         expected = {
             STATUS_BATCH: JOB_NOT_PROVIDED_ERR,
             RETRY: JOBS_NOT_PROVIDED_ERR,
-            LOGS: JOB_NOT_PROVIDED_ERR,
+            LOGS: JOBS_NOT_PROVIDED_ERR,
         }
 
         for msg_type, err_type in expected.items():
@@ -638,7 +644,10 @@ class JobCommTestCase(unittest.TestCase):
                 "msg_type": INFO,
                 "content": {
                     JOB_COMPLETED: get_test_job_info(JOB_COMPLETED),
-                    JOB_NOT_FOUND: "does_not_exist",
+                    JOB_NOT_FOUND: {
+                        "job_id": JOB_NOT_FOUND,
+                        "error": "does_not_exist",
+                    },
                 },
             },
             msg["data"],
@@ -879,7 +888,7 @@ class JobCommTestCase(unittest.TestCase):
         ]
         for c in cases:
             content = {"first_line": c[0], "num_lines": c[1], "latest": c[2]}
-            req = make_comm_msg(LOGS, job_id, True, content)
+            req = make_comm_msg(LOGS, [job_id], True, content)
             self.jc._get_job_logs(req)
             msg = self.jc._comm.last_message
             self.assertEqual(LOGS, msg["data"]["msg_type"])
@@ -901,32 +910,98 @@ class JobCommTestCase(unittest.TestCase):
                 self.assertIn(str(first + idx), line["line"])
                 self.assertEqual(0, line["is_error"])
 
-    @mock.patch(CLIENTS, get_failing_mock_client)
+    @mock.patch(CLIENTS, get_mock_client)
     def test_get_job_logs_failure(self):
-        job_id = JOB_COMPLETED
+        job_id = JOB_CREATED
         req = make_comm_msg(LOGS, job_id, False)
-        with self.assertRaises(NarrativeException) as e:
-            self.jc._handle_comm_message(req)
-        self.assertIn("Can't get job logs", str(e.exception))
+        self.jc._handle_comm_message(req)
         msg = self.jc._comm.last_message
-        self.assertEqual(ERROR, msg["data"]["msg_type"])
-        self.assertEqual("Unable to retrieve job logs", msg["data"]["content"]["error"])
+        print(msg)
+        self.assertEqual(
+            msg["data"],
+            {
+                "msg_type": LOGS,
+                "content": {
+                    JOB_CREATED: {
+                        "job_id": JOB_CREATED,
+                        "batch_id": None,
+                        "error": "Cannot find job log with id: " + JOB_CREATED,
+                    }
+                },
+            },
+        )
 
     def test_get_job_logs_no_job(self):
         job_id = None
         req = make_comm_msg(LOGS, job_id, False)
-        err = JobIDException(JOB_NOT_REG_ERR, job_id)
-        with self.assertRaisesRegex(type(err), str(err)):
+        err = JobIDException(JOBS_MISSING_FALSY_ERR, [job_id])
+        with self.assertRaisesRegex(type(err), re.escape(str(err))):
             self.jc._handle_comm_message(req)
-        self.check_error_message(LOGS, {JOB_ID: job_id}, err)
+        self.check_error_message(LOGS, {JOB_ID_LIST: [job_id]}, err)
 
+    @mock.patch(CLIENTS, get_mock_client)
     def test_get_job_logs_bad_job(self):
         job_id = "bad_job"
         req = make_comm_msg(LOGS, job_id, False)
-        err = JobIDException(JOB_NOT_REG_ERR, job_id)
-        with self.assertRaisesRegex(type(err), str(err)):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(LOGS, {JOB_ID: job_id}, err)
+        self.jc._handle_comm_message(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            msg["data"],
+            {
+                "msg_type": LOGS,
+                "content": {
+                    job_id: {
+                        "job_id": job_id,
+                        "error": DOES_NOT_EXIST,
+                    }
+                },
+            },
+        )
+
+    @mock.patch(CLIENTS, get_mock_client)
+    def test_get_job_logs_job_dne(self):
+        req = make_comm_msg(LOGS, JOB_NOT_FOUND, False)
+        self.jc._handle_comm_message(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            msg["data"],
+            {
+                "msg_type": LOGS,
+                "content": {
+                    JOB_NOT_FOUND: {
+                        "job_id": JOB_NOT_FOUND,
+                        "error": DOES_NOT_EXIST,
+                    }
+                },
+            },
+        )
+
+    @mock.patch(CLIENTS, get_mock_client)
+    def test_get_job_logs__one_ok_one_bad_one_fetch_fail(self):
+        req = make_comm_msg(LOGS, [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND], False)
+        self.jc._handle_comm_message(req)
+        msg = self.jc._comm.last_message
+        self.assertEqual(LOGS, msg["data"]["msg_type"])
+
+        self.assertEqual(
+            set(list(msg["data"]["content"][JOB_COMPLETED].keys())),
+            set(["job_id", "batch_id", "first", "latest", "max_lines", "lines"]),
+        )
+        self.assertEqual(
+            {
+                "job_id": JOB_CREATED,
+                "batch_id": None,
+                "error": "Cannot find job log with id: " + JOB_CREATED,
+            },
+            msg["data"]["content"][JOB_CREATED],
+        )
+        self.assertEqual(
+            {
+                "job_id": JOB_NOT_FOUND,
+                "error": DOES_NOT_EXIST,
+            },
+            msg["data"]["content"][JOB_NOT_FOUND],
+        )
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_get_job_logs__latest(self):

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -144,6 +144,15 @@ class JobManagerTest(unittest.TestCase):
         self.jm.initialize_jobs()
         self.job_states = get_test_job_states()
 
+    def reset_job_manager(self):
+        # all jobs have been removed from the JobManager
+        self.jm._running_jobs = {}
+        self.jm._jobs_by_cell_id = {}
+        self.jm = biokbase.narrative.jobs.jobmanager.JobManager()
+
+        self.assertEqual(self.jm._running_jobs, {})
+        self.assertEqual(self.jm._jobs_by_cell_id, {})
+
     @mock.patch(CLIENTS, get_failing_mock_client)
     def test_initialize_jobs_ee2_fail(self):
         # init jobs should fail. specifically, ee2.check_workspace_jobs should error.
@@ -153,13 +162,7 @@ class JobManagerTest(unittest.TestCase):
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_initialize_jobs(self):
-        # all jobs have been removed from the JobManager
-        self.jm._running_jobs = {}
-        self.jm._jobs_by_cell_id = {}
-        self.jm = biokbase.narrative.jobs.jobmanager.JobManager()
-
-        self.assertEqual(self.jm._running_jobs, {})
-        self.assertEqual(self.jm._jobs_by_cell_id, {})
+        self.reset_job_manager()
 
         # redo the initialise to make sure it worked correctly
         self.jm.initialize_jobs()
@@ -199,7 +202,7 @@ class JobManagerTest(unittest.TestCase):
                     for job_id in job_ids
                     if cell_id in combo
                 ]
-                self.jm._running_jobs = {}
+                self.reset_job_manager()
                 self.jm.initialize_jobs(cell_ids=combo)
 
                 for job_id, d in self.jm._running_jobs.items():
@@ -630,31 +633,31 @@ class JobManagerTest(unittest.TestCase):
         self.assertEqual(set(self.job_ids), set(states.keys()))
         self.assertEqual(self.job_states, states)
 
-    ## lookup_jobs_by_cell_id
+    ## lookup_job_states_by_cell_id
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list_None(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list_None(self):
         with self.assertRaisesRegex(ValueError, CELLS_NOT_PROVIDED_ERR):
-            self.jm.lookup_jobs_by_cell_id(cell_id_list=None)
+            self.jm.lookup_job_states_by_cell_id(cell_id_list=None)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list_empty(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list_empty(self):
         with self.assertRaisesRegex(ValueError, CELLS_NOT_PROVIDED_ERR):
-            self.jm.lookup_jobs_by_cell_id(cell_id_list=[])
+            self.jm.lookup_job_states_by_cell_id(cell_id_list=[])
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list_no_results(self):
-        result = self.jm.lookup_jobs_by_cell_id(cell_id_list=["a", "b", "c"])
+    def test_lookup_job_states_by_cell_id__cell_id_list_no_results(self):
+        result = self.jm.lookup_job_states_by_cell_id(cell_id_list=["a", "b", "c"])
         self.assertEqual(
             {"jobs": {}, "mapping": {"a": set(), "b": set(), "c": set()}}, result
         )
 
-    def check_lookup_jobs_by_cell_id_results(self, cell_ids, expected_ids):
+    def check_lookup_job_states_by_cell_id_results(self, cell_ids, expected_ids):
         expected_states = {
             id: self.job_states[id]
             for id in self.job_states.keys()
             if id in expected_ids
         }
-        result = self.jm.lookup_jobs_by_cell_id(cell_id_list=cell_ids)
+        result = self.jm.lookup_job_states_by_cell_id(cell_id_list=cell_ids)
         self.assertEqual(set(expected_ids), set(result["jobs"].keys()))
         self.assertEqual(expected_states, result["jobs"])
         self.assertEqual(set(cell_ids), set(result["mapping"].keys()))
@@ -662,48 +665,50 @@ class JobManagerTest(unittest.TestCase):
             self.assertEqual(set(TEST_CELL_IDs[key]), set(result["mapping"][key]))
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list_all_results(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list_all_results(self):
         cell_ids = TEST_CELL_ID_LIST
         expected_ids = self.job_ids
-        self.check_lookup_jobs_by_cell_id_results(cell_ids, expected_ids)
+        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list__batch_job__one_cell(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list__batch_job__one_cell(self):
         cell_ids = [TEST_CELL_ID_LIST[2]]
         expected_ids = TEST_CELL_IDs[TEST_CELL_ID_LIST[2]]
-        self.check_lookup_jobs_by_cell_id_results(cell_ids, expected_ids)
+        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list__batch_job__two_cells(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list__batch_job__two_cells(self):
         cell_ids = [TEST_CELL_ID_LIST[2], TEST_CELL_ID_LIST[3]]
         expected_ids = (
             TEST_CELL_IDs[TEST_CELL_ID_LIST[2]] + TEST_CELL_IDs[TEST_CELL_ID_LIST[3]]
         )
-        self.check_lookup_jobs_by_cell_id_results(cell_ids, expected_ids)
+        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list__batch_job__one_ok_one_invalid(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list__batch_job__one_ok_one_invalid(
+        self,
+    ):
         cell_ids = [TEST_CELL_ID_LIST[1], TEST_CELL_ID_LIST[4]]
         expected_ids = TEST_CELL_IDs[TEST_CELL_ID_LIST[1]]
-        self.check_lookup_jobs_by_cell_id_results(cell_ids, expected_ids)
+        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list__batch_and_other_job(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list__batch_and_other_job(self):
         cell_ids = [TEST_CELL_ID_LIST[0], TEST_CELL_ID_LIST[2]]
         expected_ids = (
             TEST_CELL_IDs[TEST_CELL_ID_LIST[0]] + TEST_CELL_IDs[TEST_CELL_ID_LIST[2]]
         )
-        self.check_lookup_jobs_by_cell_id_results(cell_ids, expected_ids)
+        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_jobs_by_cell_id__cell_id_list__batch_in_many_cells(self):
+    def test_lookup_job_states_by_cell_id__cell_id_list__batch_in_many_cells(self):
         cell_ids = [TEST_CELL_ID_LIST[0], TEST_CELL_ID_LIST[2], TEST_CELL_ID_LIST[3]]
         expected_ids = (
             TEST_CELL_IDs[TEST_CELL_ID_LIST[0]]
             + TEST_CELL_IDs[TEST_CELL_ID_LIST[2]]
             + TEST_CELL_IDs[TEST_CELL_ID_LIST[3]]
         )
-        self.check_lookup_jobs_by_cell_id_results(cell_ids, expected_ids)
+        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_get_job_states(self):


### PR DESCRIPTION
# Description of PR purpose/changes

Alter the job logs retrieval commands to take a list, rather than a single job ID

The main purpose of this PR is to unify the job manager interface so all methods deal with lists of job IDs (instead of having a miso-mash of different interfaces) and emit errors as part of a set of results.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions -- flaky FE test has failed; will disabled in an upcoming PR if necessary.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
