### PR TITLE
Fix PTV-1717/-1839 - landing page link with functional-site prefix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 ### Unreleased
 - DATAUP-570 - Only use the Narrative configuration to set available import types in the Import area dropdowns
 - DATAUP-577 - Sanitize suggested output object names for bulk import jobs so they follow the rules
+- PTV-1717 - fix landing page links for modeling widgets
 
 ### Version 5.0.0
 This new major version of the KBase Narrative Interface introduces a way to import data from your data staging area in large batches using a single Bulk Import cell. See more details about the new workflows here: [Bulk Import Guide](https://docs.kbase.us/data/upload-download-guide/bulk-import-guide)

--- a/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbaseTabTable.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbaseTabTable.js
@@ -25,8 +25,6 @@ define([
             // root url path for landing pages
             const DATAVIEW_URL = '/#dataview/';
 
-            const type = input.type;
-
             // eslint-disable-next-line no-undef
             const kbModeling = new KBModeling(self.authToken());
 
@@ -36,7 +34,7 @@ define([
             //
             // 1) Use type (periods replaced with underscores) to instantiate a modeling object
             //
-            this.obj = new kbModeling[type.replace(/\./g, '_')](self);
+            this.obj = new kbModeling[input.type.replace(/\./g, '_')](self);
 
             //
             // 2) add the tabs (at page load)

--- a/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbaseTabTable.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbaseTabTable.js
@@ -1,14 +1,14 @@
-'use strict';
-
 define([
     'kbwidget',
     'jquery',
-    'bootstrap',
     'kbaseAuthenticatedWidget',
     'kbaseTabTableTabs',
-    'kbasePathways',
     'narrativeConfig',
-], (KBWidget, $, bootstrap, kbaseAuthenticatedWidget, kbaseTabTableTabs, kbasePathways, Config) => {
+
+    // For effect
+    'bootstrap',
+    'kbasePathways',
+], (KBWidget, $, kbaseAuthenticatedWidget, kbaseTabTableTabs, Config) => {
     'use strict';
     return KBWidget({
         name: 'kbaseTabTable',
@@ -23,13 +23,11 @@ define([
             this.$elem.append($tableContainer);
 
             // root url path for landing pages
-            const DATAVIEW_URL = '/functional-site/#/dataview/';
+            const DATAVIEW_URL = '/#dataview/';
 
             const type = input.type;
 
-            // tab widget
-            let tabs;
-
+            // eslint-disable-next-line no-undef
             const kbModeling = new KBModeling(self.authToken());
 
             // kbase api helper
@@ -47,8 +45,6 @@ define([
 
             const uiTabs = [];
             for (let i = 0; i < tabList.length; i++) {
-                const tab = tabList[i];
-
                 // add loading status
                 const placeholder = $('<div>');
                 placeholder.loading();
@@ -58,15 +54,16 @@ define([
 
             uiTabs[0].active = true;
             //tabs = self.$elem.kbaseTabTableTabs({tabs: uiTabs});
-            tabs = new kbaseTabTableTabs($tableContainer, { tabs: uiTabs });
+            const tabs = new kbaseTabTableTabs($tableContainer, { tabs: uiTabs });
 
             //
             // 3) get meta data, add any metadata tables
             //
+            let param;
             if (isNaN(input.ws) && isNaN(input.obj))
-                var param = { workspace: input.ws, name: input.obj };
+                param = { workspace: input.ws, name: input.obj };
             else if (!isNaN(input.ws) && !isNaN(input.obj))
-                var param = { ref: input.ws + '/' + input.obj };
+                param = { ref: input.ws + '/' + input.obj };
 
             self.kbapi('ws', 'get_object_info_new', { objects: [param], includeMetadata: 1 }).done(
                 (res) => {
@@ -75,7 +72,7 @@ define([
                     for (let i = 0; i < tabList.length; i++) {
                         const spec = tabList[i];
 
-                        if (spec.type == 'verticaltbl') {
+                        if (spec.type === 'verticaltbl') {
                             const key = spec.key,
                                 data = self.obj[key],
                                 tabPane = tabs.tabContent(spec.name);
@@ -92,9 +89,9 @@ define([
             // 4) get object data, create tabs
             //
             if (isNaN(input.ws) && isNaN(input.obj))
-                var param = { workspace: input.ws, name: input.obj };
+                param = { workspace: input.ws, name: input.obj };
             else if (!isNaN(input.ws) && !isNaN(input.obj))
-                var param = { ref: input.ws + '/' + input.obj };
+                param = { ref: input.ws + '/' + input.obj };
 
             self.kbapi('ws', 'get_objects', [param]).done((data) => {
                 const setMethod = self.obj.setData(data[0].data, tabs);
@@ -110,6 +107,7 @@ define([
             });
 
             const refLookup = {};
+
             function preProcessDataTable(tabSpec, tabPane) {
                 // get refs
                 const refs = [];
@@ -145,14 +143,14 @@ define([
                 });
             }
 
-            function buildContent(data) {
+            function buildContent() {
                 //5) Iterates over the entries in the spec and instantiate things
                 for (let i = 0; i < tabList.length; i++) {
                     const tabSpec = tabList[i];
                     const tabPane = tabs.tabContent(tabSpec.name);
 
                     // skip any vertical tables for now
-                    if (tabSpec.type == 'verticaltbl') continue;
+                    if (tabSpec.type === 'verticaltbl') continue;
 
                     // if widget, invoke widget with arguments
 
@@ -185,7 +183,7 @@ define([
             }
 
             // takes table spec and prepared data, returns datatables settings object
-            this.getTableSettings = function (tab, data) {
+            this.getTableSettings = function (tab) {
                 const tableColumns = getColSettings(tab);
 
                 const settings = {
@@ -195,13 +193,13 @@ define([
                     language: { search: '_INPUT_', searchPlaceholder: 'Search ' + tab.name },
                 };
 
+                const fnDrawCallback = () => {
+                    newTabEvents(tab.name);
+                };
+
                 // add any events
                 for (let i = 0; i < tab.columns.length; i++) {
-                    const col = tab.columns[i];
-
-                    settings.fnDrawCallback = function () {
-                        newTabEvents(tab.name);
-                    };
+                    settings.fnDrawCallback = fnDrawCallback;
                 }
 
                 return settings;
@@ -224,7 +222,7 @@ define([
 
                     let content = $('<div>');
 
-                    if (info.method && info.method != 'undefined') {
+                    if (info.method && info.method !== 'undefined') {
                         const res = self.obj[info.method](info);
 
                         if (res && 'done' in res) {
@@ -234,7 +232,7 @@ define([
                                 const table = self.verticalTable({ rows: rows });
                                 content.append(table);
                             });
-                        } else if (res == undefined) {
+                        } else if (res === undefined) {
                             content.append('<br>No data found for ' + info.id);
                         } else {
                             const table = self.verticalTable({ rows: res });
@@ -244,7 +242,8 @@ define([
                         tabs.addTab({ name: info.id, content: content, removable: true });
                         tabs.showTab(info.id);
                         newTabEvents(info.id);
-                    } else if (info.action == 'openWidget') {
+                    } else if (info.action === 'openWidget') {
+                        // eslint-disable-next-line no-undef
                         new kbaseTabTable(content, {
                             ws: info.ws,
                             type: info.type,
@@ -285,9 +284,9 @@ define([
                 return settings;
             }
 
-            function ref(key, type, format, method, action) {
+            function ref(key, type, format, method) {
                 return function (d) {
-                    if (type == 'tabLink' && format == 'dispIDCompart') {
+                    if (type === 'tabLink' && format === 'dispIDCompart') {
                         let dispid = d[key];
                         if ('dispid' in d) {
                             dispid = d.dispid;
@@ -301,7 +300,7 @@ define([
                             dispid +
                             '</a>'
                         );
-                    } else if (type == 'tabLink' && format == 'dispID') {
+                    } else if (type === 'tabLink' && format === 'dispID') {
                         const id = d[key];
                         return (
                             '<a class="id-click" data-id="' +
@@ -312,7 +311,7 @@ define([
                             id +
                             '</a>'
                         );
-                    } else if (type == 'wstype' && format == 'dispWSRef') {
+                    } else if (type === 'wstype' && format === 'dispWSRef') {
                         const ws = refLookup[d[key]].ws,
                             name = refLookup[d[key]].name,
                             wstype = refLookup[d[key]].type,
@@ -345,7 +344,7 @@ define([
                     const value = d[key];
 
                     if ($.isArray(value)) {
-                        if (type == 'tabLinkArray') return tabLinkArray(value, method);
+                        if (type === 'tabLinkArray') return tabLinkArray(value, method);
                         return d[key].join(', ');
                     }
 
@@ -387,8 +386,8 @@ define([
 
                     // don't display undefined things in vertical table
                     if (
-                        ('data' in row && typeof row.data == 'undefined') ||
-                        ('key' in row && typeof data[row.key] == 'undefined')
+                        ('data' in row && typeof row.data === 'undefined') ||
+                        ('key' in row && typeof data[row.key] === 'undefined')
                     )
                         continue;
 
@@ -397,10 +396,10 @@ define([
 
                     // if the data is in the row definition, use it
                     if ('data' in row) {
-                        var value;
-                        if (type == 'tabLinkArray') {
+                        let value;
+                        if (type === 'tabLinkArray') {
                             value = tabLinkArray(row.data, row.method);
-                        } else if (type == 'tabLink') {
+                        } else if (type === 'tabLink') {
                             value =
                                 '<a class="id-click" data-id="' +
                                 row.data +
@@ -414,7 +413,7 @@ define([
                         }
                         r.append('<td>' + value + '</td>');
                     } else if ('key' in row) {
-                        if (row.type == 'wstype') {
+                        if (row.type === 'wstype') {
                             const ref = data[row.key];
 
                             const cell = $('<td data-ref="' + ref + '">loading...</td>');
@@ -437,26 +436,13 @@ define([
                         } else {
                             r.append('<td>' + data[row.key] + '</td>');
                         }
-                    } else if (row.type == 'pictureEquation')
-                        r.append('<td>' + pictureEquation(row.data) + '</td>');
+                    } else if (row.type === 'pictureEquation')
+                        r.append('<td>' + this.pictureEquation(row.data) + '</td>');
 
                     table.append(r);
                 }
 
                 return table;
-            };
-
-            this.getBiochemReaction = function (id) {
-                const input = { reactions: [id] };
-                return self.kbapi('biochem', 'get_reactions', { reactions: [id] }).then((data) => {
-                    return data[0];
-                });
-            };
-
-            this.getBiochemCompound = function (id) {
-                return self.kbapi('biochem', 'get_compounds', { compounds: [id] }).then((data) => {
-                    return data[0];
-                });
             };
 
             this.getBiochemCompounds = function (ids) {
@@ -473,59 +459,51 @@ define([
             };
 
             this.pictureEquation = function (eq) {
+                let img_url;
                 const cpds = get_cpds(eq);
+                const $panel = $('<div>');
 
-                for (var i = 0; i < cpds.left.length; i++) {
-                    var cpd = cpds.left[i];
-                    var img_url = imageURL + cpd + '.png';
-                    panel.append(
-                        '<div class="pull-left text-center">\
-                                    <img src="' +
-                            img_url +
-                            '" width=150 ><br>\
-                                    <div class="cpd-id" data-cpd="' +
-                            cpd +
-                            '">' +
-                            cpd +
-                            '</div>\
-                                </div>'
-                    );
+                for (let i = 0; i < cpds.left.length; i++) {
+                    const cpd = cpds.left[i];
+                    img_url = imageURL + cpd + '.png';
+                    $panel.append(`
+                        <div class="pull-left text-center">
+                            <img src="${img_url}" width=150 ><br>
+                            <div class="cpd-id" data-cpd="${cpd}">
+                            ${cpd}
+                            </div>
+                        </div>
+                    `);
 
-                    var plus = $('<div class="pull-left text-center">+</div>');
+                    const plus = $('<div class="pull-left text-center">+</div>');
                     plus.css('margin', '30px 0 0 0');
 
                     if (i < cpds.left.length - 1) {
-                        panel.append(plus);
+                        $panel.append(plus);
                     }
                 }
 
                 const direction = $('<div class="pull-left text-center">' + '<=>' + '</div>');
                 direction.css('margin', '25px 0 0 0');
-                panel.append(direction);
+                $panel.append(direction);
 
-                for (var i = 0; i < cpds.right.length; i++) {
-                    var cpd = cpds.right[i];
-                    var img_url = imageURL + cpd + '.jpeg';
-                    panel.append(
-                        '<div class="pull-left text-center">\
-                                    <img src="' +
-                            img_url +
-                            '" data-cpd="' +
-                            cpd +
-                            '" width=150 ><br>\
-                                    <div class="cpd-id" data-cpd="' +
-                            cpd +
-                            '">' +
-                            cpd +
-                            '</div>\
-                                </div>'
-                    );
+                for (let i = 0; i < cpds.right.length; i++) {
+                    const cpd = cpds.right[i];
+                    img_url = imageURL + cpd + '.jpeg';
+                    $panel.append(`
+                        <div class="pull-left text-center">
+                            <img src="${img_url}" data-cpd="${cpd}" width=150 ><br>
+                            <div class="cpd-id" data-cpd="${cpd}">
+                                ${cpd}
+                            </div>
+                        </div>
+                    `);
 
-                    var plus = $('<div class="pull-left text-center">+</div>');
+                    const plus = $('<div class="pull-left text-center">+</div>');
                     plus.css('margin', '25px 0 0 0');
 
                     if (i < cpds.right.length - 1) {
-                        panel.append(plus);
+                        $panel.append(plus);
                     }
                 }
 
@@ -542,7 +520,7 @@ define([
                     });
                 });
 
-                return panel;
+                return $panel;
             };
 
             function get_cpds(equation) {

--- a/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbaseTabTable.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/modeling/kbaseTabTable.js
@@ -267,13 +267,12 @@ define([
                     const key = col.key,
                         type = col.type,
                         format = col.linkformat,
-                        method = col.method,
-                        action = col.action;
+                        method = col.method;
 
                     const config = {
                         sTitle: col.label,
                         sDefaultContent: '-',
-                        mData: ref(key, type, format, method, action),
+                        mData: ref(key, type, format, method),
                     };
 
                     if (col.width) config.sWidth = col.width;
@@ -381,8 +380,7 @@ define([
                 );
 
                 for (let i = 0; i < rows.length; i++) {
-                    const row = rows[i],
-                        type = row.type;
+                    const row = rows[i];
 
                     // don't display undefined things in vertical table
                     if (
@@ -397,9 +395,9 @@ define([
                     // if the data is in the row definition, use it
                     if ('data' in row) {
                         let value;
-                        if (type === 'tabLinkArray') {
+                        if (row.type === 'tabLinkArray') {
                             value = tabLinkArray(row.data, row.method);
-                        } else if (type === 'tabLink') {
+                        } else if (row.type === 'tabLink') {
                             value =
                                 '<a class="id-click" data-id="' +
                                 row.data +


### PR DESCRIPTION
# Description of PR purpose/changes

Some modeling widgets, such as the FBAModel viewer, were reported to have broken landing page links. The user reported that the link included "functional-site" in the path, and that removing it resulted in a working link for the landing page. "functional-site" was the name of the precursor to kbase-ui, which was in use about 5 years ago ... so this link has been broken for a long time!

The fix was very simple - just an edit of one line. The overall change required a tad more work, as the modeling widget source (kbase-extension/static/kbase/js/widgets/function_output/modeling) required some repair to be compliant with current practices in the codebase. To wit, it required fixes to satisfy eslint, including two overrides for global modules.

Two major flaws were left in the file, though, in order to avoid the need to refactor all of the modeling widgets - to wit, this code tends to use global modules, a practice which was superseded by AMD modules many years ago. The code does work, and converting all of the widgets to use or become good AMD citizens would require changing over 20 files, and involve hundreds if not thousands of edits.

Other caveats and notes:
- no additional tests were added; there is just one test for this file, loading the module; any functional tests would require much more work and surely some refactoring.

# Jira Ticket / Issue #
e.g. https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_
 - screenshots included

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [-] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
