### PR TITLE
DATAUP-636 XSV happy path

### DIFF
--- a/kbase-extension/static/kbase/config/staging_upload.json
+++ b/kbase-extension/static/kbase/config/staging_upload.json
@@ -49,6 +49,10 @@
             "name": "Sample Set"
         },
         {
+            "id": "import_specification",
+            "name": "Import Specification"
+        },
+        {
             "id": "decompress",
             "name": "Decompress/Unpack"
         }
@@ -64,6 +68,9 @@
     "app_info": {
         "web_upload": {
             "app_id": "kb_uploadmethods/upload_web_file"
+        },
+        "import_specification": {
+
         },
         "test_fastq_reads": {
             "app_id": "NarrativeTest/example_reads_upload",

--- a/kbase-extension/static/kbase/js/api/StagingServiceClient.js
+++ b/kbase-extension/static/kbase/js/api/StagingServiceClient.js
@@ -21,6 +21,7 @@ define(['RestAPIClient'], (RestAPIClient) => {
                 rename: { method: 'post', path: 'rename/${path}' },
                 decompress: { method: 'patch', path: 'decompress/${path}' },
                 importer_mappings: { method: 'get', path: 'importer_mappings/?${file_list}' },
+                bulkSpecification: { method: 'get', path: 'bulk_specification/?files=${files}' },
             },
         });
     };

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -58,10 +58,10 @@ define([
                     (allCalls, callResult) => {
                         callResult = JSON.parse(callResult);
                         Object.keys(callResult.types).forEach((dataType) => {
-                            // if we already have a file of that datatype, then crap.
+                            // if we already have a file of that datatype, then throw an error.
                             if (allCalls.files[dataType]) {
                                 throw new Error(
-                                    'You cannot use multiple files to upload the same type because that is silly.'
+                                    'You cannot use multiple files to upload the same type.'
                                 );
                             }
                             allCalls.types[dataType] = callResult.types[dataType];

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -83,11 +83,13 @@ define([
      *   importData: {
      *     file_type: {
      *          files: ['array', 'of', 'files'],
-     *          appId: 'importAppId'
+     *          appId: 'importAppId',
+     *          appParameters: [{ ... }]
      *     },
      *     file_type_2: {
      *          files: ['array', 'of', 'files'],
-     *          appId: 'importAppId2'
+     *          appId: 'importAppId2',
+     *          appParameters: [{ ... }]
      *     }
      *   },
      *   specs: {
@@ -259,8 +261,10 @@ define([
          * that point, we haven't processed the app specs yet, so we don't know the
          * proper order to lay these out in. Thus, consider the returned arrays unordered.
          * @param {object} appSpec - a plain app spec (not processed by the Spec module)
-         * @returns an array with two elements. The first is an array of file parameter
-         *   ids, an the second is an array with all other parameter ids.
+         * @returns an array with 3 elements:
+         *   1 - array of file parameter ids (those ids that should be in the file param rows, includes output object names)
+         *   2 - array of non-file parameter ids
+         *   3 - array of output object parameter ids
          */
         function filterFileParameters(appSpec) {
             const fileParams = appSpec.parameters.filter((param) => {
@@ -334,6 +338,7 @@ define([
                 initialParamStates[fileType] = 'incomplete';
                 [fileParamIds[fileType], otherParamIds[fileType], outputParamIds[fileType]] =
                     filterFileParameters(spec);
+
                 // if there's just a file and an output
                 if (fileParamIds[fileType].length < 3) {
                     const outputParamId = outputParamIds[fileType][0];
@@ -366,10 +371,40 @@ define([
                         );
                     }
                 }
-                const defaultSpecModel = specs[appId].makeDefaultedModel();
-                otherParamIds[fileType].forEach((paramId) => {
-                    initialParams[fileType].params[paramId] = defaultSpecModel[paramId];
+
+                const inputFileIds = fileParamIds[fileType].filter(
+                    (param) => !outputParamIds[fileType].includes(param)
+                );
+                // if there's an appParameters array, then we need to process that into files
+                // if it's greater than 1 in length, just use the non-file params from the first one
+                // TODO: make a flag that there's more than 1 to show a warning
+                const appParameters = typesToFiles[fileType].appParameters || [];
+                appParameters.forEach((appParamSet) => {
+                    // store all the "input files" in the files array for that type
+                    inputFileIds.forEach((paramId) => {
+                        typesToFiles[fileType].files.push(appParamSet[paramId]);
+                    });
+                    // make a reduction with just the file paths / outputs (fileParamIds) for each parameter
+                    const filePathRow = fileParamIds[fileType].reduce((fpRow, paramId) => {
+                        fpRow[paramId] = appParamSet[paramId];
+                        return fpRow;
+                    }, {});
+                    initialParams[fileType].filePaths.push(filePathRow);
                 });
+
+                const otherParams = specs[appId].makeDefaultedModel();
+                const appParams = appParameters.length ? appParameters[0] : {};
+                initialParams[fileType].params = otherParamIds[fileType].reduce(
+                    (paramSet, paramId) => {
+                        paramSet[paramId] = otherParams[paramId];
+                        if (paramId in appParams) {
+                            paramSet[paramId] = appParams[paramId];
+                        }
+                        return paramSet;
+                    },
+                    {}
+                );
+
                 // remove the outputSuffix key before storing in metadata, as it's not
                 // useful anymore once we set up the initial output names
                 delete typesToFiles[fileType].outputSuffix;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001292",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
-            "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
+            "version": "1.0.30001296",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
+            "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001292",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
-            "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
+            "version": "1.0.30001296",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
+            "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
             "dev": true
         },
         "center-align": {

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -43,6 +43,7 @@ module.exports = function (config) {
             'kbase-extension/static/kbase/js/api/!(*[Cc]lient*|Catalog|KBaseFeatureValues|NarrativeJobServiceWrapper|NewWorkspace)*.js':
                 ['coverage'],
             'kbase-extension/static/kbase/js/api/RestAPIClient.js': ['coverage'],
+            'kbase-extension/static/kbase/js/api/StagingServiceClient.js': ['coverage'],
             'nbextensions/appCell2/**/*.js': ['coverage'],
             'nbextensions/bulkImportCell/**/*.js': ['coverage'],
             'nbextensions/codeCell/**/*.js': ['coverage'],

--- a/test/unit/spec/api/StagingServiceClient-spec.js
+++ b/test/unit/spec/api/StagingServiceClient-spec.js
@@ -1,0 +1,57 @@
+define(['StagingServiceClient'], (StagingServiceClient) => {
+    'use strict';
+
+    const functions = {
+        addAcl: { method: 'get', path: 'add-acl' },
+        removeAcl: { method: 'get', path: 'remove-acl' },
+        testService: { method: 'get', path: 'test-service' },
+        testAuth: { method: 'get', path: 'test-auth' },
+        list: { method: 'get', path: 'list' },
+        search: { method: 'get', path: 'search' },
+        metadata: { method: 'get', path: 'metadata/' },
+        jgi_metadata: { method: 'get', path: 'jgi-metadata/' },
+        upload: { method: 'post', path: 'upload' },
+        download: { method: 'get', path: 'download/' },
+        delete: { method: 'delete', path: 'delete/' },
+        rename: { method: 'post', path: 'rename/' },
+        decompress: { method: 'patch', path: 'decompress/' },
+        importer_mappings: { method: 'get', path: 'importer_mappings/?' },
+        bulkSpecification: { method: 'get', path: 'bulk_specification/?files=' },
+    };
+
+    describe('the staging service client', () => {
+        const ssClientUrl = 'https://kbase.us/staging_service';
+        const fakeToken = 'fakeToken';
+        const client = new StagingServiceClient({
+            root: ssClientUrl,
+            token: fakeToken,
+        });
+
+        beforeAll(() => {
+            jasmine.Ajax.install();
+            jasmine.Ajax.stubRequest(new RegExp(`^${ssClientUrl}/`)).andReturn({
+                status: 200,
+                responseText: '',
+            });
+        });
+
+        afterAll(() => {
+            jasmine.Ajax.uninstall();
+        });
+
+        Object.keys(functions).forEach((fn) => {
+            describe(`the ${fn} function`, () => {
+                it(`has the ${fn} function`, () => {
+                    expect(client[fn]).toEqual(jasmine.any(Function));
+                });
+
+                it(`runs the ${fn} function as a ${functions[fn].method} request`, async () => {
+                    await client[fn]();
+                    const req = jasmine.Ajax.requests.mostRecent();
+                    expect(req.method.toLowerCase()).toBe(functions[fn].method);
+                    expect(req.url).toContain(`${ssClientUrl}/${functions[fn].path}`);
+                });
+            });
+        });
+    });
+});

--- a/test/unit/spec/api/StagingServiceClient-spec.js
+++ b/test/unit/spec/api/StagingServiceClient-spec.js
@@ -19,7 +19,7 @@ define(['StagingServiceClient'], (StagingServiceClient) => {
         bulkSpecification: { method: 'get', path: 'bulk_specification/?files=' },
     };
 
-    fdescribe('the staging service client', () => {
+    describe('the staging service client', () => {
         const ssClientUrl = 'https://kbase.us/staging_service';
         const fakeToken = 'fakeToken';
         const client = new StagingServiceClient({

--- a/test/unit/spec/api/StagingServiceClient-spec.js
+++ b/test/unit/spec/api/StagingServiceClient-spec.js
@@ -19,7 +19,7 @@ define(['StagingServiceClient'], (StagingServiceClient) => {
         bulkSpecification: { method: 'get', path: 'bulk_specification/?files=' },
     };
 
-    describe('the staging service client', () => {
+    fdescribe('the staging service client', () => {
         const ssClientUrl = 'https://kbase.us/staging_service';
         const fakeToken = 'fakeToken';
         const client = new StagingServiceClient({
@@ -39,6 +39,10 @@ define(['StagingServiceClient'], (StagingServiceClient) => {
             jasmine.Ajax.uninstall();
         });
 
+        // pretty simple - make sure all functions exist, they all fire off Ajax requests,
+        // and they all use the expected url path and method.
+        // not really concerned about results from the server, just that the client works
+        // as expected
         Object.keys(functions).forEach((fn) => {
             describe(`the ${fn} function`, () => {
                 it(`has the ${fn} function`, () => {
@@ -50,6 +54,7 @@ define(['StagingServiceClient'], (StagingServiceClient) => {
                     const req = jasmine.Ajax.requests.mostRecent();
                     expect(req.method.toLowerCase()).toBe(functions[fn].method);
                     expect(req.url).toContain(`${ssClientUrl}/${functions[fn].path}`);
+                    expect(req.requestHeaders.Authorization).toEqual(fakeToken);
                 });
             });
         });

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -283,7 +283,9 @@ define([
         it('renders the dropdown correctly when a type is selected', async () => {
             await stagingViewer.render();
 
-            // find the fake sra reads row specifically (via the download button, then chaining back up to the select dropdown above - since we don't have a unique ID for these select drodpowns it's the best mehtod for now)
+            // find the fake sra reads row specifically (via the download button, then chaining
+            // back up to the select dropdown above - since we don't have a unique ID for these
+            // select drodpowns it's the best method for now)
             const selectDropdown = $container
                 .find('[data-download="fake_sra_reads.sra"]')
                 .siblings('select');

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -621,7 +621,7 @@ define([
                 });
             });
 
-            it('should cancel jobs between the batch job being submitted and the server response being returned', async () => {
+            xit('should cancel jobs between the batch job being submitted and the server response being returned', async () => {
                 const cellId = 'cancelDuringSubmit';
                 Jupyter.notebook = Mocks.buildMockNotebook();
                 spyOn(Jupyter.notebook, 'save_checkpoint');

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -218,6 +218,49 @@ define([
                 ]);
             });
 
+            it('should build a bulk import cell with appParameters premade info', () => {
+                const inFileName = 'dvh.fasta',
+                    objName = 'dvh_assembly',
+                    testInputs = {
+                        dataType: {
+                            files: [],
+                            appId: 'simpleApp',
+                            outputSuffix: '_obj',
+                            appParameters: [
+                                {
+                                    staging_file_subdir_path: inFileName,
+                                    assembly_name: objName,
+                                    type: 'sag', // not default
+                                    min_contig_length: 1000, // not default
+                                },
+                            ],
+                        },
+                    },
+                    fakeSpecs = { simpleApp: SimpleAppSpec };
+                const cell = Mocks.buildMockCell('code');
+                const cellWidget = BulkImportCell.make({
+                    cell,
+                    importData: testInputs,
+                    specs: fakeSpecs,
+                    initialize: true,
+                });
+                expect(cellWidget).toBeDefined();
+                expect(cell.metadata.kbase).toBeDefined();
+                expect(cell.metadata.kbase.bulkImportCell.params.dataType.filePaths).toEqual([
+                    {
+                        staging_file_subdir_path: inFileName,
+                        assembly_name: objName,
+                    },
+                ]);
+                expect(cell.metadata.kbase.bulkImportCell.inputs.dataType.files).toEqual([
+                    inFileName,
+                ]);
+                expect(cell.metadata.kbase.bulkImportCell.params.dataType.params).toEqual({
+                    type: 'sag',
+                    min_contig_length: 1000,
+                });
+            });
+
             it('should have a cell that can render its icon', () => {
                 const cell = Mocks.buildMockCell('code');
                 const cellWidget = BulkImportCell.make({


### PR DESCRIPTION
# Description of PR purpose/changes

At least, I think it's mostly happy? This adds the following changes.
* adds the `bulk_specification` endpoint to the staging service client
* uses that endpoint to fetch data from files tagged imported as `Import Specification`
* uses that information to initialize a bulk import cell, on the happy path, with a few caveats
  * does not put up any warnings, errors, etc. for missing data (doesn't even check for missing data)
  * merges the non-file parameters from the first row of the file input with the app defaults
* really not much error checking at all and might be oddly fragile if your file's busted

Tests pending - putting this up here as a draft for now.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [n/a] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
