### PR TITLE
DATAUP-497: a mess o' trouble

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -325,11 +325,6 @@ class JobManager(object):
         (jobs_to_lookup, cell_to_job_mapping) = self._get_job_ids_by_cell_id(
             cell_id_list
         )
-
-        import json
-
-        print(cell_to_job_mapping)
-
         job_states = {}
         if len(jobs_to_lookup) > 0:
             job_states = self._construct_job_output_state_set(list(jobs_to_lookup))

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -261,7 +261,6 @@ class MockClients:
         return {"batch_id": self.test_job_id, "child_job_ids": child_job_ids}
 
     def cancel_job(self, params):
-        print({"cancel_job input": params})
         if params["job_id"] == BATCH_RETRY_RUNNING:
             raise generate_ee2_error(CANCEL)
         return {}

--- a/src/biokbase/narrative/tests/narrative_mock/mockcomm.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockcomm.py
@@ -15,15 +15,20 @@ class MockComm(object):
             return None
         return self.messages[-1]
 
+    def pop_message(self):
+        if len(self.messages) == 0:
+            return None
+        return self.messages.pop()
+
     def peek_message(self, i):
         return self.messages[i]
 
     def on_msg(self, *args, **kwargs):
         """Mock the msg router"""
 
-    def send(self, data=None, content=None):
+    def send(self, message=None):
         """Mock sending a msg"""
-        self.messages.append({"data": data, "content": content})
+        self.messages.append(message)
 
     def clear_message_cache(self):
         self.messages = []

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -95,7 +95,7 @@ JOBS_BY_CELL_ID = {
     TEST_CELL_ID_LIST[3]: {BATCH_PARENT, BATCH_RETRY_RUNNING, BATCH_RETRY_ERROR},
 }
 
-# mapping expected as output from lookup_job_states_by_cell_id
+# mapping expected as output from get_job_states_by_cell_id
 TEST_CELL_IDs = {id: list(JOBS_BY_CELL_ID[id]) for id in JOBS_BY_CELL_ID.keys()}
 TEST_CELL_IDs[TEST_CELL_ID_LIST[4]] = []
 

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -3,7 +3,6 @@ from unittest import mock
 import os
 import itertools
 import re
-import json
 
 from biokbase.narrative.exception_util import transform_job_exception
 from biokbase.narrative.jobs.jobcomm import exc_to_msg
@@ -83,9 +82,6 @@ from .test_job import (
     TERMINAL_JOBS,
     ACTIVE_JOBS,
     BATCH_CHILDREN,
-    get_test_job,
-    get_test_spec,
-    TEST_SPECS,
     TEST_JOBS,
     get_test_job_states,
     get_cell_2_jobs,

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -3,6 +3,7 @@ from unittest import mock
 import os
 import itertools
 import re
+import json
 
 from biokbase.narrative.exception_util import transform_job_exception
 from biokbase.narrative.jobs.jobcomm import exc_to_msg
@@ -12,7 +13,7 @@ from biokbase.narrative.jobs.jobmanager import (
     JOB_NOT_REG_ERR,
     JOB_NOT_BATCH_ERR,
     JOBS_TYPE_ERR,
-    JOBS_MISSING_FALSY_ERR,
+    JOBS_MISSING_ERR,
     get_error_output_state,
 )
 from biokbase.narrative.jobs.jobcomm import (
@@ -20,7 +21,12 @@ from biokbase.narrative.jobs.jobcomm import (
     JobComm,
     JOB_NOT_PROVIDED_ERR,
     JOBS_NOT_PROVIDED_ERR,
+    BATCH_NOT_PROVIDED_ERR,
     CELLS_NOT_PROVIDED_ERR,
+    ONE_INPUT_TYPE_ONLY_ERR,
+    INVALID_REQUEST_ERR,
+    MISSING_REQUEST_TYPE_ERR,
+    BATCH_ID,
     JOB_ID,
     JOB_ID_LIST,
     CELL_ID_LIST,
@@ -52,6 +58,7 @@ from .narrative_mock.mockcomm import MockComm
 from .narrative_mock.mockclients import (
     get_mock_client,
     get_failing_mock_client,
+    generate_ee2_error,
     MockClients,
 )
 from .test_job import (
@@ -83,10 +90,13 @@ from .test_job import (
     get_test_job_states,
     get_cell_2_jobs,
 )
+
 from .test_jobmanager import get_test_job_info, get_test_job_infos
 
-
+BATCH_PARENT_CHILDREN = [BATCH_PARENT] + BATCH_CHILDREN
 APP_NAME = "The Best App in the World"
+BAD_JOB_ID = "a_bad_job_id"
+BAD_JOB_ID_2 = "another_bad_job_id"
 EXP_ALL_STATE_IDS = ALL_JOBS  # or ACTIVE_JOBS
 CLIENTS = "biokbase.narrative.clients.get"
 
@@ -127,6 +137,21 @@ def get_app_data(*args):
     return {"info": {"name": APP_NAME}}
 
 
+def get_retried_job(job_id):
+    return {
+        "jobState": {
+            "job_id": job_id[::-1],
+            "status": "unmocked",
+            "job_output": {},
+            "batch_id": None,
+            "cell_id": None,
+            "run_id": None,
+            "child_jobs": [],
+        },
+        "outputWidgetInfo": None,
+    }
+
+
 class JobCommTestCase(unittest.TestCase):
     maxDiff = None
 
@@ -148,86 +173,121 @@ class JobCommTestCase(unittest.TestCase):
         self.jc.stop_job_status_loop()
         self.job_states = get_test_job_states()
 
-    def check_error_message(self, req, source, input_, err):
+    def check_error_message(self, req, err, extra_params={}):
         """
         response when no input was submitted with a query
         args:
             req: the JobRequest, dictionary, or string passed when throwing the error
+            extra_params: any extra content
+            err: the error object produced
+
+        error message produced will contain:
+            raw_request: the input that generated the error
             source: the request that was called
-            input: the dict with job_id/job_id_list key and value
+            extra_params
             name: the type of exception
             message: the error message
         """
-        if isinstance(req, dict):
-            raw_request = req["content"]["data"]
-        elif isinstance(req, JobRequest):
+        if isinstance(req, JobRequest):
             raw_request = req.raw_request
+            source = req.request_type
+        elif isinstance(req, dict):
+            raw_request = req
+            source = req["content"]["data"]["request_type"]
         elif isinstance(req, str):
             raw_request = req
+            source = req
 
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
                 "msg_type": ERROR,
                 "content": {
+                    "raw_request": raw_request,
                     "source": source,
-                    **input_,
+                    **extra_params,
                     "name": type(err).__name__,
                     "message": str(err),
-                    "raw_request": raw_request,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def check_job_id_list__no_jobs(self, request_type):
         job_id_list = [None, ""]
-        req = make_comm_msg(request_type, job_id_list, False)
-        err = JobIDException(JOBS_MISSING_FALSY_ERR, job_id_list)
+        req_dict = make_comm_msg(request_type, job_id_list, False)
+        req = make_comm_msg(request_type, job_id_list, True)
+        err = JobIDException(JOBS_MISSING_ERR, job_id_list)
+
+        # using handler
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(req, request_type, {JOB_ID_LIST: job_id_list}, err)
+            self.jc._handle_comm_message(req_dict)
+        self.check_error_message(req_dict, err)
+
+        # run directly
+        with self.assertRaisesRegex(type(err), re.escape(str(err))):
+            self.jc._msg_map[request_type](req)
 
     def check_job_id_list__dne_jobs(self, request_type, response_type=None):
-        FAKE_JOB = "fake_job_id"
-        job_id_list = [None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, FAKE_JOB]
-        req = make_comm_msg(request_type, job_id_list, True)
-        self.jc._handle_comm_message(req)
+        job_id_list = [None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, BAD_JOB_ID]
+        expected_output = {
+            JOB_NOT_FOUND: get_error_output_state(JOB_NOT_FOUND),
+            BAD_JOB_ID: get_error_output_state(BAD_JOB_ID),
+        }
+        req_dict = make_comm_msg(request_type, job_id_list, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
                 "msg_type": response_type if response_type else request_type,
-                "content": {
-                    JOB_NOT_FOUND: get_error_output_state(JOB_NOT_FOUND),
-                    FAKE_JOB: get_error_output_state(FAKE_JOB),
-                },
+                "content": expected_output,
             },
-            msg["data"],
+            msg,
         )
 
-    def check_batch_job__no_job_test(self, request_type):
-        for job_id in ["", None]:
-            req = make_comm_msg(request_type, {JOB_ID: job_id}, False)
+    def check_id_error(self, req_dict, err):
+        self.jc._comm.clear_message_cache()
+        with self.assertRaisesRegex(type(err), re.escape(str(err))):
+            self.jc._handle_comm_message(req_dict)
+        self.check_error_message(req_dict, err)
+
+    def check_job_id__no_job_test(self, request_type):
+        for job_id in [None, ""]:
+            self.jc._comm.clear_message_cache()
+            req_dict = make_comm_msg(request_type, {JOB_ID: job_id}, False)
+            req = make_comm_msg(request_type, {JOB_ID: job_id}, True)
+            err = JobIDException(JOBS_MISSING_ERR, [job_id])
+            self.check_id_error(req_dict, err)
+
+            # run directly -- returns
+            err = JobIDException(ONE_INPUT_TYPE_ONLY_ERR)
+            with self.assertRaisesRegex(type(err), re.escape(str(err))):
+                self.jc._msg_map[request_type](req)
+
+    def check_job_id__dne_test(self, request_type):
+        req_dict = make_comm_msg(request_type, {JOB_ID: JOB_NOT_FOUND}, False)
+        err = JobIDException(JOB_NOT_REG_ERR, JOB_NOT_FOUND)
+        self.check_id_error(req_dict, err)
+
+    def check_batch_id__no_job_test(self, request_type):
+        for job_id in [None, ""]:
+            req_dict = make_comm_msg(request_type + "_batch", {JOB_ID: job_id}, False)
             err = JobIDException(JOB_NOT_REG_ERR, job_id)
-            with self.assertRaisesRegex(type(err), str(err)):
-                self.jc._handle_comm_message(req)
-            self.check_error_message(req, request_type, {JOB_ID: job_id}, err)
+            self.check_id_error(req_dict, err)
 
-    def check_batch_job__dne_test(self, request_type):
-        job_id = JOB_NOT_FOUND
-        req = make_comm_msg(request_type, job_id, False)
-        err = JobIDException(JOB_NOT_REG_ERR, job_id)
-        with self.assertRaisesRegex(type(err), str(err)):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(req, request_type, {JOB_ID: job_id}, err)
+    def check_batch_id__dne_test(self, request_type):
+        req_dict = make_comm_msg(
+            request_type + "_batch", {JOB_ID: JOB_NOT_FOUND}, False
+        )
+        err = JobIDException(JOB_NOT_REG_ERR, JOB_NOT_FOUND)
+        self.check_id_error(req_dict, err)
 
-    def check_batch_job__not_batch_test(self, request_type):
-        job_id = BATCH_COMPLETED
-        req = make_comm_msg(request_type, job_id, False)
-        err = JobIDException(JOB_NOT_BATCH_ERR, job_id)
-        with self.assertRaisesRegex(type(err), str(err)):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(req, request_type, {JOB_ID: job_id}, err)
+    def check_batch_id__not_batch_test(self, request_type):
+        req_dict = make_comm_msg(
+            request_type + "_batch", {JOB_ID: BATCH_COMPLETED}, False
+        )
+        err = JobIDException(JOB_NOT_BATCH_ERR, BATCH_COMPLETED)
+        self.check_id_error(req_dict, err)
 
     # ---------------------
     # Send comms methods
@@ -235,78 +295,76 @@ class JobCommTestCase(unittest.TestCase):
     def test_send_comm_msg_ok(self):
         self.jc.send_comm_message("some_msg", {"foo": "bar"})
         msg = self.jc._comm.last_message
-        self.assertDictEqual(
+        self.assertEqual(
             msg,
             {
-                "content": None,
-                "data": {"content": {"foo": "bar"}, "msg_type": "some_msg"},
+                "msg_type": "some_msg",
+                "content": {"foo": "bar"},
             },
         )
         self.jc._comm.clear_message_cache()
 
     def test_send_error_msg__JobRequest(self):
         req = make_comm_msg("bar", "aeaeae", True)
-        self.jc.send_error_message("foo", req, {"extra": "field"})
+        self.jc.send_error_message(req, {"extra": "field"})
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": "foo",
+                "msg_type": ERROR,
                 "content": {
                     "source": "bar",
-                    JOB_ID: "aeaeae",
                     "extra": "field",
                     "raw_request": req.raw_request,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_send_error_msg__dict(self):
-        req = make_comm_msg("bar", "aeaeae", False)
-        self.jc.send_error_message("foo", req, {"extra": "field"})
+        req_dict = make_comm_msg("bar", "aeaeae", False)
+        self.jc.send_error_message(req_dict, {"extra": "field"})
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": "foo",
+                "msg_type": ERROR,
                 "content": {
                     "source": "bar",
-                    JOB_ID: "aeaeae",
                     "extra": "field",
-                    "raw_request": req["content"]["data"],
+                    "raw_request": req_dict,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_send_error_msg__None(self):
-        self.jc.send_error_message("foo", None, {"extra": "field"})
+        self.jc.send_error_message(None, {"extra": "field"})
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": "foo",
+                "msg_type": ERROR,
                 "content": {
                     "source": None,
                     "extra": "field",
                     "raw_request": None,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_send_error_msg__str(self):
         source = "test_jobcomm"
-        self.jc.send_error_message("foo", source, {"extra": "field"})
+        self.jc.send_error_message(source, {"extra": "field"})
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": "foo",
+                "msg_type": ERROR,
                 "content": {
                     "source": source,
                     "extra": "field",
                     "raw_request": source,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     # ---------------------
@@ -314,24 +372,32 @@ class JobCommTestCase(unittest.TestCase):
     # ---------------------
     @mock.patch(CLIENTS, get_mock_client)
     def test_req_no_inputs__succeed(self):
-        req = make_comm_msg(STATUS_ALL, None, False)
-        self.jc._handle_comm_message(req)
+        req_dict = make_comm_msg(STATUS_ALL, None, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
-        self.assertEqual(STATUS_ALL, msg["data"]["msg_type"])
+        self.assertEqual(STATUS_ALL, msg["msg_type"])
 
     def test_req_no_inputs__fail(self):
         expected = {
             STATUS_BATCH: JOB_NOT_PROVIDED_ERR,
-            RETRY: JOBS_NOT_PROVIDED_ERR,
-            LOGS: JOBS_NOT_PROVIDED_ERR,
+            INFO_BATCH: JOB_NOT_PROVIDED_ERR,
+            START_UPDATE_BATCH: JOB_NOT_PROVIDED_ERR,
+            STOP_UPDATE_BATCH: JOB_NOT_PROVIDED_ERR,
+            CANCEL: ONE_INPUT_TYPE_ONLY_ERR,
+            INFO: ONE_INPUT_TYPE_ONLY_ERR,
+            LOGS: ONE_INPUT_TYPE_ONLY_ERR,
+            RETRY: ONE_INPUT_TYPE_ONLY_ERR,
+            START_UPDATE: ONE_INPUT_TYPE_ONLY_ERR,
+            STATUS: ONE_INPUT_TYPE_ONLY_ERR,
+            STOP_UPDATE: ONE_INPUT_TYPE_ONLY_ERR,
         }
 
         for msg_type, err_type in expected.items():
-            req = make_comm_msg(msg_type, None, False)
+            req_dict = make_comm_msg(msg_type, None, False)
             err = JobIDException(err_type)
             with self.assertRaisesRegex(type(err), str(err)):
-                self.jc._handle_comm_message(req)
-            self.check_error_message(req, msg_type, {}, err)
+                self.jc._handle_comm_message(req_dict)
+            self.check_error_message(req_dict, err)
 
     # ---------------------
     # Start job status loop
@@ -348,7 +414,7 @@ class JobCommTestCase(unittest.TestCase):
                 "msg_type": STATUS_ALL,
                 "content": get_test_job_states(EXP_ALL_STATE_IDS),
             },
-            msg["data"],
+            msg,
         )
         self.assertTrue(self.jc._running_lookup_loop)
         self.assertIsNotNone(self.jc._lookup_timer)
@@ -375,11 +441,9 @@ class JobCommTestCase(unittest.TestCase):
                 self.assertEqual(
                     {
                         "msg_type": STATUS_ALL,
-                        "content": get_test_job_states(
-                            EXP_ALL_STATE_IDS
-                        ),
+                        "content": get_test_job_states(EXP_ALL_STATE_IDS),
                     },
-                    msg["data"],
+                    msg,
                 )
 
                 self.assertTrue(self.jc._running_lookup_loop)
@@ -393,51 +457,71 @@ class JobCommTestCase(unittest.TestCase):
     # Lookup all job states
     # ---------------------
 
-    def check_lookup_job_states(self, output_states=None, job_id_list=[]):
+    @mock.patch(CLIENTS, get_mock_client)
+    def check_job_output_states(
+        self,
+        output_states=None,
+        params={},
+        request_type=STATUS,
+        response_type=STATUS,
+        ok_states=[],
+        error_states=[],
+    ):
+        """
+        Handle any request that returns a dictionary of job state objects; this
+        includes STATUS, CANCEL, START_UPDATE, STOP_UPDATE, and more.
+        The output of the query is verified against the stored job states.
+
+        :param output_states: output [if query has already been run] (opt)
+        :param request_type: (opt) defaults to STATUS
+        :param response_type: (opt) defaults to STATUS
+        :param params: params for the comm message (opt)
+        :param ok_states: list of job IDs expected to be in the output
+        :param error_states: list of job IDs expected to return a not found error
+        """
         if output_states is None:
-            req = make_comm_msg(STATUS, job_id_list, True)
-            output_states = self.jc._lookup_job_states(req)
+            req_dict = make_comm_msg(request_type, params, False)
+            output_states = self.jc._handle_comm_message(req_dict)
+
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
-                "msg_type": STATUS,
+                "msg_type": response_type,
                 "content": output_states,
             },
-            msg["data"],
+            msg,
         )
+
         for job_id, state in output_states.items():
-            if job_id in self.job_states:
+            if job_id in ok_states:
                 self.assertEqual(self.job_states[job_id], state)
                 validate_job_state(state)
-            else:
+            elif job_id in error_states:
                 self.assertEqual(get_error_output_state(job_id), state)
+            else:
+                # every valid job ID should be in either error_states or ok_states
+                self.assertIn(job_id, error_states + ok_states)
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_all_job_states__ok(self):
-        req = make_comm_msg(STATUS_ALL, None, True)
-        output_states = self.jc._lookup_all_job_states(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS_ALL,
-                "content": get_test_job_states(EXP_ALL_STATE_IDS),
-            },
-            msg["data"],
+        self.check_job_output_states(
+            request_type=STATUS_ALL,
+            response_type=STATUS_ALL,
+            ok_states=EXP_ALL_STATE_IDS,
         )
-        for job_id, state in output_states.items():
-            self.assertIsInstance(job_id, str)
-            validate_job_state(state)
 
     # -----------------------
     # Lookup single job state
     # -----------------------
     def test_lookup_job_state__1_ok(self):
         output_states = self.jc.lookup_job_state(JOB_COMPLETED)
-        self.check_lookup_job_states(output_states)
+        self.check_job_output_states(
+            output_states=output_states, ok_states=[JOB_COMPLETED]
+        )
 
     def test_lookup_job_state__no_job(self):
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[None]}")
+            JobIDException, re.escape(f"{JOBS_MISSING_ERR}: {[None]}")
         ):
             self.jc.lookup_job_state(None)
 
@@ -445,29 +529,65 @@ class JobCommTestCase(unittest.TestCase):
     # Lookup select job states
     # -----------------------
 
-    def test_lookup_job_states__1_ok(self):
+    def test_lookup_job_states__job_id__ok(self):
+        self.check_job_output_states(
+            params={JOB_ID: JOB_COMPLETED}, ok_states=[JOB_COMPLETED]
+        )
+
+    def test_lookup_job_states__job_id__dne(self):
+        self.check_job_output_states(
+            params={JOB_ID: JOB_NOT_FOUND}, error_states=[JOB_NOT_FOUND]
+        )
+
+    def test_lookup_job_states__job_id__invalid(self):
+        self.check_job_id__no_job_test(STATUS)
+
+    def test_lookup_job_states__job_id_list__1_ok(self):
         job_id_list = [JOB_COMPLETED]
-        self.check_lookup_job_states(None, job_id_list)
+        self.check_job_output_states(
+            params={JOB_ID_LIST: job_id_list}, ok_states=job_id_list
+        )
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states__2_ok(self):
+    def test_lookup_job_states__job_id_list__2_ok(self):
         job_id_list = [JOB_COMPLETED, BATCH_PARENT]
-        self.check_lookup_job_states(None, job_id_list)
+        self.check_job_output_states(
+            params={JOB_ID_LIST: job_id_list}, ok_states=job_id_list
+        )
 
-    def test_lookup_job_states__ok_bad(self):
-        job_id_list = ["nope", JOB_COMPLETED]
-        self.check_lookup_job_states(None, job_id_list)
+    def test_lookup_job_states__job_id_list__ok_bad(self):
+        job_id_list = [BAD_JOB_ID, JOB_COMPLETED]
+        self.check_job_output_states(
+            params={JOB_ID_LIST: job_id_list},
+            ok_states=[JOB_COMPLETED],
+            error_states=[BAD_JOB_ID],
+        )
 
-    def test_lookup_job_states__no_jobs(self):
+    def test_lookup_job_states__job_id_list__no_jobs(self):
         self.check_job_id_list__no_jobs(STATUS)
 
+    def test_lookup_job_states__batch_id__ok(self):
+        self.check_job_output_states(
+            request_type=STATUS_BATCH,
+            params={JOB_ID: BATCH_PARENT},
+            ok_states=BATCH_PARENT_CHILDREN,
+        )
+
+    def test_lookup_job_states__batch_id__dne(self):
+        self.check_batch_id__dne_test(STATUS)
+
+    def test_lookup_job_states__batch_id__no_job(self):
+        self.check_batch_id__no_job_test(STATUS)
+
+    def test_lookup_job_states__batch_id__not_batch(self):
+        self.check_batch_id__not_batch_test(STATUS)
+
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states__ee2_error(self):
+    def test_lookup_job_states__job_id_list__ee2_error(self):
         def mock_check_jobs(self, params):
             raise Exception("Test exception")
 
         job_id_list = ALL_JOBS
-        req = make_comm_msg(STATUS, job_id_list, True)
+        req_dict = make_comm_msg(STATUS, job_id_list, False)
 
         TIME_NOW = 987654321
         with mock.patch("time.time") as fake_time:
@@ -475,7 +595,7 @@ class JobCommTestCase(unittest.TestCase):
             with mock.patch.object(
                 MockClients, "check_jobs", side_effect=mock_check_jobs
             ):
-                self.jc._lookup_job_states(req)
+                self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
 
         expected = get_test_job_states(ALL_JOBS)
@@ -489,37 +609,8 @@ class JobCommTestCase(unittest.TestCase):
                 "msg_type": STATUS,
                 "content": expected,
             },
-            msg["data"],
+            msg,
         )
-
-    # -----------------------
-    # Lookup batch job states
-    # -----------------------
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_batch__ok(self):
-        job_id = BATCH_PARENT
-        req = make_comm_msg(STATUS_BATCH, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS,
-                "content": {
-                    job_id: self.job_states[job_id]
-                    for job_id in [BATCH_PARENT] + BATCH_CHILDREN
-                },
-            },
-            msg["data"],
-        )
-
-    def test_lookup_job_states_batch__dne(self):
-        self.check_batch_job__dne_test(STATUS_BATCH)
-
-    def test_lookup_job_states_batch__no_job(self):
-        self.check_batch_job__no_job_test(STATUS_BATCH)
-
-    def test_lookup_job_states_batch__not_batch(self):
-        self.check_batch_job__not_batch_test(STATUS_BATCH)
 
     # -----------------------
     # lookup cell job states
@@ -527,43 +618,39 @@ class JobCommTestCase(unittest.TestCase):
 
     def test_lookup_job_states_by_cell_id__job_req_none(self):
         cell_id_list = None
-        req = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
+        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
         err = ValueError(CELLS_NOT_PROVIDED_ERR)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(
-            req, CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, err
-        )
+            self.jc._handle_comm_message(req_dict)
+        self.check_error_message(req_dict, err)
 
     def test_lookup_job_states_by_cell_id__empty_cell_id_list(self):
         cell_id_list = []
-        req = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
+        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
         err = ValueError(CELLS_NOT_PROVIDED_ERR)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(
-            req, CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, err
-        )
+            self.jc._handle_comm_message(req_dict)
+        self.check_error_message(req_dict, err)
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_job_states_by_cell_id__invalid_cell_id_list(self):
         cell_id_list = ["a", "b", "c"]
-        req = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
-        self.jc._handle_comm_message(req)
+        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
                 "msg_type": CELL_JOB_STATUS,
                 "content": NO_JOBS_MAPPING,
             },
-            msg["data"],
+            msg,
         )
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_job_states_by_cell_id__invalid_cell_id_list_req(self):
         cell_id_list = ["a", "b", "c"]
-        req = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, True)
-        result = self.jc._lookup_job_states_by_cell_id(req)
+        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
+        result = self.jc._handle_comm_message(req_dict)
         self.assertEqual(result, NO_JOBS_MAPPING)
         msg = self.jc._comm.last_message
         self.assertEqual(
@@ -571,7 +658,7 @@ class JobCommTestCase(unittest.TestCase):
                 "msg_type": CELL_JOB_STATUS,
                 "content": NO_JOBS_MAPPING,
             },
-            msg["data"],
+            msg,
         )
 
     @mock.patch(CLIENTS, get_mock_client)
@@ -583,43 +670,75 @@ class JobCommTestCase(unittest.TestCase):
             id: job_states[id] for id in job_states.keys() if id in expected_ids
         }
 
-        req = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
-        self.jc._handle_comm_message(req)
+        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
-        self.assertEqual(set(msg["data"].keys()), set(["msg_type", "content"]))
-        self.assertEqual(msg["data"]["msg_type"], CELL_JOB_STATUS)
-        self.assertEqual(msg["data"]["content"]["jobs"], expected_states)
-        self.assertEqual(
-            set(cell_id_list), set(msg["data"]["content"]["mapping"].keys())
-        )
-        for key in msg["data"]["content"]["mapping"].keys():
+        self.assertEqual(set(msg.keys()), set(["msg_type", "content"]))
+        self.assertEqual(msg["msg_type"], CELL_JOB_STATUS)
+        self.assertEqual(msg["content"]["jobs"], expected_states)
+        self.assertEqual(set(cell_id_list), set(msg["content"]["mapping"].keys()))
+        for key in msg["content"]["mapping"].keys():
             self.assertEqual(
-                set(TEST_CELL_IDs[key]), set(msg["data"]["content"]["mapping"][key])
+                set(TEST_CELL_IDs[key]), set(msg["content"]["mapping"][key])
             )
 
     # -----------------------
     # Lookup job info
     # -----------------------
-    def test_lookup_job_info__ok(self):
+    @mock.patch(CLIENTS, get_mock_client)
+    def test_lookup_job_info__job_id__ok(self):
+        req_dict = make_comm_msg(INFO, {JOB_ID: JOB_COMPLETED}, False)
+        self.jc._handle_comm_message(req_dict)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": INFO,
+                "content": {
+                    JOB_COMPLETED: get_test_job_info(JOB_COMPLETED),
+                },
+            },
+            msg,
+        )
+
+    @mock.patch(CLIENTS, get_mock_client)
+    def test_lookup_job_info__job_id__dne(self):
+        req_dict = make_comm_msg(INFO, {JOB_ID: JOB_NOT_FOUND}, False)
+        self.jc._handle_comm_message(req_dict)
+        msg = self.jc._comm.last_message
+        self.assertEqual(
+            {
+                "msg_type": INFO,
+                "content": {
+                    JOB_NOT_FOUND: {
+                        "job_id": JOB_NOT_FOUND,
+                        "error": "does_not_exist",
+                    },
+                },
+            },
+            msg,
+        )
+
+    @mock.patch(CLIENTS, get_mock_client)
+    def test_lookup_job_info__job_id_list__ok(self):
         job_id_list = ALL_JOBS
-        req = make_comm_msg(INFO, job_id_list, True)
-        self.jc._lookup_job_info(req)
+        req_dict = make_comm_msg(INFO, job_id_list, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
                 "msg_type": INFO,
                 "content": get_test_job_infos(job_id_list),
             },
-            msg["data"],
+            msg,
         )
 
-    def test_lookup_job_info__no_job(self):
+    def test_lookup_job_info__job_id_list__no_jobs(self):
         self.check_job_id_list__no_jobs(INFO)
 
-    def test_lookup_job_info__ok_bad(self):
+    def test_lookup_job_info__job_id_list__ok_bad(self):
         job_id_list = [JOB_COMPLETED, JOB_NOT_FOUND]
-        req = make_comm_msg(INFO, job_id_list, True)
-        self.jc._lookup_job_info(req)
+        req_dict = make_comm_msg(INFO, job_id_list, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
@@ -632,104 +751,71 @@ class JobCommTestCase(unittest.TestCase):
                     },
                 },
             },
-            msg["data"],
+            msg,
         )
 
-    # ------------
-    # Lookup batch job infos
-    # ------------
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_info_batch__ok(self):
+    def test_lookup_job_info__batch_id__ok(self):
         job_id = BATCH_PARENT
-        req = make_comm_msg(INFO_BATCH, job_id, True)
-        self.jc._lookup_job_info_batch(req)
+        req_dict = make_comm_msg(INFO_BATCH, {JOB_ID: job_id}, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
                 "msg_type": INFO,
-                "content": get_test_job_infos([BATCH_PARENT] + BATCH_CHILDREN),
+                "content": get_test_job_infos(BATCH_PARENT_CHILDREN),
             },
-            msg["data"],
+            msg,
         )
 
-    def test_lookup_job_info_batch__no_job(self):
-        self.check_batch_job__no_job_test(INFO_BATCH)
+    def test_lookup_job_info__batch_id__no_job(self):
+        self.check_batch_id__no_job_test(INFO)
 
-    def test_lookup_job_info_batch__dne(self):
-        self.check_batch_job__dne_test(INFO_BATCH)
+    def test_lookup_job_info__batch_id__dne(self):
+        self.check_batch_id__dne_test(INFO)
 
-    def test_lookup_job_info_batch__not_batch(self):
-        self.check_batch_job__not_batch_test(INFO_BATCH)
+    def test_lookup_job_info__batch_id__not_batch(self):
+        self.check_batch_id__not_batch_test(INFO)
 
     # ------------
     # Cancel list of jobs
     # ------------
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_cancel_jobs__single_job_id_in(self):
-        job_id = JOB_RUNNING
-        req = make_comm_msg(CANCEL, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS,
-                "content": {
-                    JOB_RUNNING: self.job_states[JOB_RUNNING],
-                },
-            },
-            msg["data"],
+    def test_cancel_jobs__job_id__ok(self):
+        self.check_job_output_states(
+            request_type=CANCEL, params={JOB_ID: JOB_RUNNING}, ok_states=[JOB_RUNNING]
         )
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_cancel_jobs__1_ok(self):
+    def test_cancel_jobs__job_id_list__1_ok(self):
         job_id_list = [JOB_RUNNING]
-        req = make_comm_msg(CANCEL, job_id_list, True)
-        self.jc._cancel_jobs(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS,
-                "content": {
-                    JOB_RUNNING: self.job_states[JOB_RUNNING],
-                },
-            },
-            msg["data"],
+        self.check_job_output_states(
+            request_type=CANCEL,
+            params={JOB_ID_LIST: job_id_list},
+            ok_states=job_id_list,
         )
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_cancel_jobs__2_ok(self):
+    def test_cancel_jobs__job_id_list__2_ok(self):
         job_id_list = [JOB_CREATED, JOB_RUNNING, None]
-        req = make_comm_msg(CANCEL, job_id_list, True)
-        self.jc._cancel_jobs(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS,
-                "content": {
-                    JOB_CREATED: self.job_states[JOB_CREATED],
-                    JOB_RUNNING: self.job_states[JOB_RUNNING],
-                },
-            },
-            msg["data"],
+        self.check_job_output_states(
+            request_type=CANCEL,
+            params={JOB_ID_LIST: job_id_list},
+            ok_states=[JOB_CREATED, JOB_RUNNING],
         )
 
-    def test_cancel_jobs__no_job(self):
+    def test_cancel_jobs__job_id_list__no_jobs(self):
         job_id_list = None
-        req = make_comm_msg(CANCEL, {JOB_ID_LIST: job_id_list}, False)
+        req_dict = make_comm_msg(CANCEL, {JOB_ID_LIST: job_id_list}, False)
         err = TypeError(JOBS_TYPE_ERR)
         with self.assertRaisesRegex(type(err), str(err)):
-            self.jc._handle_comm_message(req)
+            self.jc._handle_comm_message(req_dict)
 
         job_id_list = [None, ""]
-        req = make_comm_msg(CANCEL, job_id_list, False)
-        err = JobIDException(JOBS_MISSING_FALSY_ERR, job_id_list)
+        req_dict = make_comm_msg(CANCEL, job_id_list, False)
+        err = JobIDException(JOBS_MISSING_ERR, job_id_list)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(req, CANCEL, {JOB_ID_LIST: job_id_list}, err)
+            self.jc._handle_comm_message(req_dict)
+        self.check_error_message(req_dict, err)
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_cancel_jobs__some_bad_jobs(self):
-        FAKE_JOB = "fake_job_id"
+    def test_cancel_jobs__job_id_list__ok_bad(self):
         job_id_list = [
             None,
             JOB_NOT_FOUND,
@@ -737,116 +823,210 @@ class JobCommTestCase(unittest.TestCase):
             "",
             JOB_RUNNING,
             JOB_CREATED,
-            FAKE_JOB,
+            BAD_JOB_ID,
         ]
-        req = make_comm_msg(CANCEL, job_id_list, True)
-        self.jc._cancel_jobs(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS,
-                "content": {
-                    JOB_RUNNING: self.job_states[JOB_RUNNING],
-                    JOB_CREATED: self.job_states[JOB_CREATED],
-                    JOB_NOT_FOUND: get_error_output_state(JOB_NOT_FOUND),
-                    FAKE_JOB: get_error_output_state(FAKE_JOB),
-                },
-            },
-            msg["data"],
+        self.check_job_output_states(
+            request_type=CANCEL,
+            params={JOB_ID_LIST: job_id_list},
+            ok_states=[JOB_CREATED, JOB_RUNNING],
+            error_states=[JOB_NOT_FOUND, BAD_JOB_ID],
         )
 
-    def test_cancel_jobs__all_bad_jobs(self):
-        FAKE_JOB = "fake_job_id"
-        job_id_list = [None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, FAKE_JOB]
-        req = make_comm_msg(CANCEL, job_id_list, True)
-        self.jc._cancel_jobs(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS,
-                "content": {
-                    JOB_NOT_FOUND: get_error_output_state(JOB_NOT_FOUND),
-                    FAKE_JOB: get_error_output_state(FAKE_JOB),
-                },
-            },
-            msg["data"],
+    def test_cancel_jobs__job_id_list__all_bad_jobs(self):
+        job_id_list = [None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, BAD_JOB_ID]
+        self.check_job_output_states(
+            request_type=CANCEL,
+            params={JOB_ID_LIST: job_id_list},
+            error_states=[JOB_NOT_FOUND, BAD_JOB_ID],
         )
 
-    @mock.patch(CLIENTS, get_failing_mock_client)
-    def test_cancel_jobs__failure(self):
-        job_id_list = [JOB_RUNNING]
-        req = make_comm_msg(CANCEL, job_id_list, False)
-        with self.assertRaises(NarrativeException) as e:
-            self.jc._handle_comm_message(req)
-        self.assertIn("Can't cancel job", str(e.exception))
-        msg = self.jc._comm.last_message
-        self.assertEqual(ERROR, msg["data"]["msg_type"])
-        self.assertEqual(CANCEL, msg["data"]["content"]["source"])
-        self.assertEqual(job_id_list, msg["data"]["content"][JOB_ID_LIST])
-        self.assertEqual("Unable to cancel job", msg["data"]["content"]["error"])
+    @mock.patch(CLIENTS, get_mock_client)
+    def test_cancel_jobs__job_id_list__failure(self):
+        # the mock client will throw an error with BATCH_RETRY_RUNNING
+        job_id_list = [JOB_RUNNING, BATCH_RETRY_RUNNING]
+        req_dict = make_comm_msg(CANCEL, job_id_list, False)
+        output = self.jc._handle_comm_message(req_dict)
+        expected = {
+            JOB_RUNNING: self.job_states[JOB_RUNNING],
+            BATCH_RETRY_RUNNING: {
+                **self.job_states[BATCH_RETRY_RUNNING],
+                "error": {
+                    "name": "JSONRPCError",
+                    "message": CANCEL + " failed",
+                    "code": -32000,
+                    "error": "Unable to cancel job",
+                },
+            },
+        }
+
+        self.assertEqual(output, expected)
+        self.assertEqual(
+            self.jc._comm.last_message,
+            {
+                "msg_type": STATUS,
+                "content": expected,
+            },
+        )
 
     # ------------
     # Retry list of jobs
     # ------------
     @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs_1_ok(self):
-        job_id_list = [JOB_TERMINATED]
-        req = make_comm_msg(RETRY, job_id_list, True)
-        self.jc._retry_jobs(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual({JOB_ID_LIST: [JOB_TERMINATED[::-1]]}, msg["data"]["content"])
-        self.assertEqual(NEW, msg["data"]["msg_type"])
+    def test_retry_jobs__job_id__ok(self):
+        req_dict = make_comm_msg(RETRY, {JOB_ID: JOB_TERMINATED}, False)
+        expected = {
+            JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
+                "job": self.job_states[JOB_TERMINATED],
+                "retry": get_retried_job(JOB_TERMINATED),
+            },
+        }
+        retry_data = self.jc._handle_comm_message(req_dict)
+        self.assertEqual(expected, retry_data)
+        new_msg = self.jc._comm.pop_message()
+        self.assertEqual(
+            {"msg_type": NEW, "content": {JOB_ID_LIST: [JOB_TERMINATED[::-1]]}},
+            new_msg,
+        )
+        retry_msg = self.jc._comm.pop_message()
+        self.assertEqual(
+            {
+                "msg_type": RETRY,
+                "content": expected,
+            },
+            retry_msg,
+        )
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs_2_ok(self):
+    def test_retry_jobs__job_id_list__2_ok(self):
         job_id_list = [JOB_TERMINATED, JOB_ERROR, None]
-        req = make_comm_msg(RETRY, job_id_list, True)
-        self.jc._retry_jobs(req)
-        msg = self.jc._comm.last_message
+        req_dict = make_comm_msg(RETRY, job_id_list, False)
+        expected = {
+            JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
+                "job": self.job_states[JOB_TERMINATED],
+                "retry": get_retried_job(JOB_TERMINATED),
+            },
+            JOB_ERROR: {
+                "job_id": JOB_ERROR,
+                "job": self.job_states[JOB_ERROR],
+                "retry": get_retried_job(JOB_ERROR),
+            },
+        }
+        retry_data = self.jc._handle_comm_message(req_dict)
+        self.assertEqual(expected, retry_data)
+        new_msg = self.jc._comm.pop_message()
         self.assertEqual(
-            {JOB_ID_LIST: [JOB_TERMINATED[::-1], JOB_ERROR[::-1]]},
-            msg["data"]["content"],
+            {
+                "msg_type": NEW,
+                "content": {JOB_ID_LIST: [JOB_TERMINATED[::-1], JOB_ERROR[::-1]]},
+            },
+            new_msg,
         )
-        self.assertEqual(NEW, msg["data"]["msg_type"])
+        retry_msg = self.jc._comm.pop_message()
+        self.assertEqual(
+            {"msg_type": RETRY, "content": expected},
+            retry_msg,
+        )
 
-    def test_retry_jobs_no_job(self):
+    def test_retry_jobs__job_id_list__no_jobs(self):
         self.check_job_id_list__no_jobs(RETRY)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs_some_bad_jobs(self):
-        job_id_list = [JOB_TERMINATED, "nope", "no"]
-        req = make_comm_msg(RETRY, job_id_list, True)
-        self.jc._retry_jobs(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual({JOB_ID_LIST: [JOB_TERMINATED[::-1]]}, msg["data"]["content"])
-        self.assertEqual(NEW, msg["data"]["msg_type"])
+    def test_retry_jobs__job_id_list__ok_bad(self):
+        job_id_list = [JOB_TERMINATED, BAD_JOB_ID, BAD_JOB_ID_2]
+        req_dict = make_comm_msg(RETRY, job_id_list, False)
+        expected = {
+            JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
+                "job": self.job_states[JOB_TERMINATED],
+                "retry": get_retried_job(JOB_TERMINATED),
+            },
+            BAD_JOB_ID: {
+                "job_id": BAD_JOB_ID,
+                "job": get_error_output_state(BAD_JOB_ID),
+                "error": DOES_NOT_EXIST,
+            },
+            BAD_JOB_ID_2: {
+                "job_id": BAD_JOB_ID_2,
+                "job": get_error_output_state(BAD_JOB_ID_2),
+                "error": DOES_NOT_EXIST,
+            },
+        }
+        retry_data = self.jc._handle_comm_message(req_dict)
+        self.assertEqual(expected, retry_data)
+        new_msg = self.jc._comm.pop_message()
+        self.assertEqual(
+            {"msg_type": NEW, "content": {JOB_ID_LIST: [JOB_TERMINATED[::-1]]}},
+            new_msg,
+        )
+        retry_msg = self.jc._comm.pop_message()
+        self.assertEqual(
+            {
+                "msg_type": RETRY,
+                "content": expected,
+            },
+            retry_msg,
+        )
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs_all_bad_jobs(self):
-        job_id_list = ["nope", "no"]
-        req = make_comm_msg(RETRY, job_id_list, True)
-        self.jc._retry_jobs(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual({JOB_ID_LIST: []}, msg["data"]["content"])
-        self.assertEqual(NEW, msg["data"]["msg_type"])
+    def test_retry_jobs__job_id_list__all_bad_jobs(self):
+        job_id_list = [BAD_JOB_ID, BAD_JOB_ID_2]
+        req_dict = make_comm_msg(RETRY, job_id_list, False)
+        expected = {
+            BAD_JOB_ID: {
+                "job_id": BAD_JOB_ID,
+                "job": get_error_output_state(BAD_JOB_ID),
+                "error": DOES_NOT_EXIST,
+            },
+            BAD_JOB_ID_2: {
+                "job_id": BAD_JOB_ID_2,
+                "job": get_error_output_state(BAD_JOB_ID_2),
+                "error": DOES_NOT_EXIST,
+            },
+        }
+        retry_data = self.jc._handle_comm_message(req_dict)
+        self.assertEqual(expected, retry_data)
+        new_msg = self.jc._comm.pop_message()
+        self.assertEqual({"msg_type": NEW, "content": {JOB_ID_LIST: []}}, new_msg)
+        retry_msg = self.jc._comm.pop_message()
+        self.assertEqual(
+            {"msg_type": RETRY, "content": expected},
+            retry_msg,
+        )
 
     @mock.patch(CLIENTS, get_failing_mock_client)
-    def test_retry_jobs_failure(self):
+    def test_retry_jobs__job_id_list__failure(self):
         job_id_list = [JOB_COMPLETED, JOB_CREATED, JOB_TERMINATED]
-        req = make_comm_msg(RETRY, job_id_list, False)
-        with self.assertRaises(NarrativeException) as e:
-            self.jc._handle_comm_message(req)
-        self.assertIn("Jobs retry failed", str(e.exception))
+        req_dict = make_comm_msg(RETRY, job_id_list, False)
+        err = transform_job_exception(
+            generate_ee2_error(RETRY), "Unable to retry job(s)"
+        )
+
+        with self.assertRaisesRegex(type(err), re.escape(str(err))):
+            self.jc._handle_comm_message(req_dict)
+
         msg = self.jc._comm.last_message
-        self.assertEqual(ERROR, msg["data"]["msg_type"])
-        self.assertEqual(job_id_list, msg["data"]["content"][JOB_ID_LIST])
-        self.assertEqual("Unable to retry job(s)", msg["data"]["content"]["error"])
+        self.assertEqual(
+            msg,
+            {
+                "msg_type": ERROR,
+                "content": {
+                    "raw_request": req_dict,
+                    "source": RETRY,
+                    "name": "JSONRPCError",
+                    "error": "Unable to retry job(s)",
+                    "code": -32000,
+                    "message": RETRY + " failed",
+                },
+            },
+        )
 
     # -----------------
     # Fetching job logs
     # -----------------
     @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs_ok(self):
+    def test_get_job_logs__job_id__ok(self):
         job_id = JOB_COMPLETED
         lines_available = 100  # just for convenience if the mock changes
         # first_line, num_lines, latest, number of lines in output
@@ -866,11 +1046,11 @@ class JobCommTestCase(unittest.TestCase):
         ]
         for c in cases:
             content = {"first_line": c[0], "num_lines": c[1], "latest": c[2]}
-            req = make_comm_msg(LOGS, [job_id], True, content)
-            self.jc._get_job_logs(req)
+            req_dict = make_comm_msg(LOGS, [job_id], False, content)
+            self.jc._handle_comm_message(req_dict)
             msg = self.jc._comm.last_message
-            self.assertEqual(LOGS, msg["data"]["msg_type"])
-            msg_content = msg["data"]["content"][job_id]
+            self.assertEqual(LOGS, msg["msg_type"])
+            msg_content = msg["content"][job_id]
             self.assertEqual(job_id, msg_content["job_id"])
             self.assertEqual(None, msg_content["batch_id"])
             self.assertEqual(lines_available, msg_content["max_lines"])
@@ -889,14 +1069,13 @@ class JobCommTestCase(unittest.TestCase):
                 self.assertEqual(0, line["is_error"])
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs_failure(self):
+    def test_get_job_logs__job_id__failure(self):
         job_id = JOB_CREATED
-        req = make_comm_msg(LOGS, job_id, False)
-        self.jc._handle_comm_message(req)
+        req_dict = make_comm_msg(LOGS, job_id, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
-        print(msg)
         self.assertEqual(
-            msg["data"],
+            msg,
             {
                 "msg_type": LOGS,
                 "content": {
@@ -909,22 +1088,22 @@ class JobCommTestCase(unittest.TestCase):
             },
         )
 
-    def test_get_job_logs_no_job(self):
+    def test_get_job_logs__job_id__no_job(self):
         job_id = None
-        req = make_comm_msg(LOGS, {JOB_ID: job_id}, False)
-        err = JobIDException(JOBS_MISSING_FALSY_ERR, [job_id])
+        req_dict = make_comm_msg(LOGS, {JOB_ID: job_id}, False)
+        err = JobIDException(JOBS_MISSING_ERR, [job_id])
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(req, LOGS, {JOB_ID_LIST: [job_id]}, err)
+            self.jc._handle_comm_message(req_dict)
+        self.check_error_message(req_dict, err)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs_bad_job(self):
+    def test_get_job_logs__job_id__bad_job(self):
         job_id = "bad_job"
-        req = make_comm_msg(LOGS, job_id, False)
-        self.jc._handle_comm_message(req)
+        req_dict = make_comm_msg(LOGS, job_id, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
         self.assertEqual(
-            msg["data"],
+            msg,
             {
                 "msg_type": LOGS,
                 "content": {
@@ -937,12 +1116,12 @@ class JobCommTestCase(unittest.TestCase):
         )
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs_job_dne(self):
-        req = make_comm_msg(LOGS, JOB_NOT_FOUND, False)
-        self.jc._handle_comm_message(req)
+    def test_get_job_logs__job_id__job_dne(self):
+        req_dict = make_comm_msg(LOGS, JOB_NOT_FOUND, False)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
         self.assertEqual(
-            msg["data"],
+            msg,
             {
                 "msg_type": LOGS,
                 "content": {
@@ -955,14 +1134,16 @@ class JobCommTestCase(unittest.TestCase):
         )
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs__one_ok_one_bad_one_fetch_fail(self):
-        req = make_comm_msg(LOGS, [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND], False)
-        self.jc._handle_comm_message(req)
+    def test_get_job_logs__job_id_list__one_ok_one_bad_one_fetch_fail(self):
+        req_dict = make_comm_msg(
+            LOGS, [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND], False
+        )
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
-        self.assertEqual(LOGS, msg["data"]["msg_type"])
+        self.assertEqual(LOGS, msg["msg_type"])
 
         self.assertEqual(
-            set(list(msg["data"]["content"][JOB_COMPLETED].keys())),
+            set(list(msg["content"][JOB_COMPLETED].keys())),
             set(["job_id", "batch_id", "first", "latest", "max_lines", "lines"]),
         )
         self.assertEqual(
@@ -971,26 +1152,26 @@ class JobCommTestCase(unittest.TestCase):
                 "batch_id": None,
                 "error": "Cannot find job log with id: " + JOB_CREATED,
             },
-            msg["data"]["content"][JOB_CREATED],
+            msg["content"][JOB_CREATED],
         )
         self.assertEqual(
             {
                 "job_id": JOB_NOT_FOUND,
                 "error": DOES_NOT_EXIST,
             },
-            msg["data"]["content"][JOB_NOT_FOUND],
+            msg["content"][JOB_NOT_FOUND],
         )
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs__latest(self):
+    def test_get_job_logs__job_id__latest(self):
         job_id = JOB_COMPLETED
-        req = make_comm_msg(
+        req_dict = make_comm_msg(
             LOGS, job_id, False, content={"num_lines": 10, "latest": True}
         )
-        self.jc._handle_comm_message(req)
+        self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
-        msg_content = msg["data"]["content"][job_id]
-        self.assertEqual(msg["data"]["msg_type"], LOGS)
+        msg_content = msg["content"][job_id]
+        self.assertEqual(msg["msg_type"], LOGS)
         self.assertEqual(msg_content["job_id"], job_id)
         self.assertTrue(msg_content["latest"])
         self.assertEqual(msg_content["first"], 90)
@@ -1001,14 +1182,12 @@ class JobCommTestCase(unittest.TestCase):
     # Modify job update
     # ------------------------
     @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__start__ok(self):
+    def test_modify_job_update__job_id_list__start__ok(self):
         job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
-        req = make_comm_msg(START_UPDATE, job_id_list, True)
-        self.jc._modify_job_updates(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {"msg_type": STATUS, "content": get_test_job_states(job_id_list)},
-            msg["data"],
+        self.check_job_output_states(
+            request_type=START_UPDATE,
+            params={JOB_ID_LIST: job_id_list},
+            ok_states=[JOB_COMPLETED, JOB_CREATED, BATCH_PARENT],
         )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
@@ -1025,10 +1204,13 @@ class JobCommTestCase(unittest.TestCase):
         self.assertTrue(self.jc._running_lookup_loop)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__stop__ok(self):
+    def test_modify_job_update__job_id_list__stop__ok(self):
         job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
-        req = make_comm_msg(STOP_UPDATE, job_id_list, True)
-        self.jc._modify_job_updates(req)
+        self.check_job_output_states(
+            request_type=STOP_UPDATE,
+            params={JOB_ID_LIST: job_id_list},
+            ok_states=[JOB_COMPLETED, JOB_CREATED, BATCH_PARENT],
+        )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
                 self.assertEqual(
@@ -1043,18 +1225,23 @@ class JobCommTestCase(unittest.TestCase):
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
 
-    def test_modify_job_update__no_job(self):
+    def test_modify_job_update__job_id_list__no_jobs(self):
         job_id_list = [None]
-        req = make_comm_msg(START_UPDATE, job_id_list, False)
-        err = JobIDException(JOBS_MISSING_FALSY_ERR, job_id_list)
+        req_dict = make_comm_msg(START_UPDATE, job_id_list, False)
+        err = JobIDException(JOBS_MISSING_ERR, job_id_list)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
-            self.jc._handle_comm_message(req)
-        self.check_error_message(req, START_UPDATE, {JOB_ID_LIST: job_id_list}, err)
+            self.jc._handle_comm_message(req_dict)
+        self.check_error_message(req_dict, err)
 
-    def test_modify_job_update__stop__ok_bad_job(self):
-        job_id_list = [JOB_COMPLETED]
-        req = make_comm_msg(STOP_UPDATE, job_id_list + [JOB_NOT_FOUND], True)
-        self.jc._modify_job_updates(req)
+    def test_modify_job_update__job_id_list__stop__ok_bad_job(self):
+        job_id_list = [JOB_COMPLETED, JOB_CREATED]
+        self.check_job_output_states(
+            request_type=STOP_UPDATE,
+            params={JOB_ID_LIST: [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND]},
+            ok_states=[JOB_COMPLETED, JOB_CREATED],
+            error_states=[JOB_NOT_FOUND],
+        )
+
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
                 self.assertEqual(
@@ -1070,13 +1257,16 @@ class JobCommTestCase(unittest.TestCase):
         self.assertFalse(self.jc._running_lookup_loop)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__stop__loop_still_running(self):
+    def test_modify_job_update__job_id_list__stop__loop_still_running(self):
         """Lookup loop should not get stopped"""
         self.jc.start_job_status_loop()
 
         job_id_list = [JOB_COMPLETED, BATCH_PARENT, JOB_RUNNING]
-        req = make_comm_msg(STOP_UPDATE, job_id_list, True)
-        self.jc._modify_job_updates(req)
+        self.check_job_output_states(
+            request_type=STOP_UPDATE,
+            params={JOB_ID_LIST: job_id_list},
+            ok_states=job_id_list,
+        )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
                 self.assertEqual(
@@ -1095,15 +1285,13 @@ class JobCommTestCase(unittest.TestCase):
     # Modify job update batch
     # ------------------------
     @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update_batch__start__ok(self):
-        job_id = BATCH_PARENT
-        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
-        req = make_comm_msg(START_UPDATE_BATCH, job_id, True)
-        self.jc._modify_job_updates_batch(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {"msg_type": STATUS, "content": get_test_job_states(job_id_list)},
-            msg["data"],
+    def test_modify_job_update__batch_id__start__ok(self):
+        batch_id = BATCH_PARENT
+        job_id_list = BATCH_PARENT_CHILDREN
+        self.check_job_output_states(
+            request_type=START_UPDATE_BATCH,
+            params={JOB_ID: batch_id},
+            ok_states=job_id_list,
         )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
@@ -1120,11 +1308,14 @@ class JobCommTestCase(unittest.TestCase):
         self.assertTrue(self.jc._running_lookup_loop)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update_batch__stop__ok(self):
-        job_id = BATCH_PARENT
-        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
-        req = make_comm_msg(STOP_UPDATE_BATCH, job_id, True)
-        self.jc._modify_job_updates_batch(req)
+    def test_modify_job_update__batch_id__stop__ok(self):
+        batch_id = BATCH_PARENT
+        job_id_list = BATCH_PARENT_CHILDREN
+        self.check_job_output_states(
+            request_type=STOP_UPDATE_BATCH,
+            params={JOB_ID: batch_id},
+            ok_states=job_id_list,
+        )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
                 self.assertEqual(
@@ -1139,17 +1330,17 @@ class JobCommTestCase(unittest.TestCase):
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
 
-    def test_modify_job_update_batch__no_job(self):
-        self.check_batch_job__no_job_test(START_UPDATE_BATCH)
-        self.check_batch_job__no_job_test(STOP_UPDATE_BATCH)
+    def test_modify_job_update__batch_id__no_job(self):
+        self.check_batch_id__no_job_test(START_UPDATE)
+        self.check_batch_id__no_job_test(STOP_UPDATE)
 
-    def test_modify_job_update_batch__bad_job(self):
-        self.check_batch_job__dne_test(START_UPDATE_BATCH)
-        self.check_batch_job__dne_test(STOP_UPDATE_BATCH)
+    def test_modify_job_update__batch_id__bad_job(self):
+        self.check_batch_id__dne_test(START_UPDATE)
+        self.check_batch_id__dne_test(STOP_UPDATE)
 
-    def test_modify_job_update_batch__not_batch(self):
-        self.check_batch_job__not_batch_test(START_UPDATE_BATCH)
-        self.check_batch_job__not_batch_test(STOP_UPDATE_BATCH)
+    def test_modify_job_update__batch_id__not_batch(self):
+        self.check_batch_id__not_batch_test(START_UPDATE)
+        self.check_batch_id__not_batch_test(STOP_UPDATE)
 
     # ------------------------
     # Handle bad comm messages
@@ -1170,172 +1361,6 @@ class JobCommTestCase(unittest.TestCase):
             )
         self.assertIn(f"Unknown KBaseJobs message '{unknown}'", str(e.exception))
 
-    # From here, this test the ability for the _handle_comm_message function to
-    # deal with the various types of messages that will get passed to it. While
-    # the majority of the tests above are sent directly to the function to be
-    # tested, these just craft the message and pass it to the message handler.
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_all_states_msg(self):
-        req = make_comm_msg(STATUS_ALL, None, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(msg["data"]["msg_type"], STATUS_ALL)
-        states = msg["data"]["content"]
-        self.assertIsInstance(states, dict)
-        for job_id in states:
-            validate_job_state(states[job_id])
-
-    def test_handle_job_status_msg(self):
-        job_id = JOB_COMPLETED
-        req = make_comm_msg(STATUS, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(msg["data"]["msg_type"], STATUS)
-        validate_job_state(msg["data"]["content"][JOB_COMPLETED])
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_job_info_msg(self):
-        job_id = JOB_COMPLETED
-        req = make_comm_msg(INFO, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {"msg_type": INFO, "content": {job_id: get_test_job_info(job_id)}},
-            msg["data"],
-        )
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_job_status_batch_msg(self):
-        job_id = BATCH_PARENT
-        req = make_comm_msg(STATUS_BATCH, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": STATUS,
-                "content": get_test_job_states([BATCH_PARENT] + BATCH_CHILDREN),
-            },
-            msg["data"],
-        )
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_job_info_batch_msg(self):
-        job_id = BATCH_PARENT
-        req = make_comm_msg(INFO_BATCH, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {
-                "msg_type": INFO,
-                "content": get_test_job_infos([BATCH_PARENT] + BATCH_CHILDREN),
-            },
-            msg["data"],
-        )
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_cancel_job_msg(self):
-        job_id = JOB_COMPLETED
-        req = make_comm_msg(CANCEL, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(msg["data"]["msg_type"], STATUS)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_start_job_update_msg(self):
-        job_id_list = [JOB_CREATED, JOB_COMPLETED, BATCH_PARENT]
-        req = make_comm_msg(START_UPDATE, job_id_list, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {"msg_type": STATUS, "content": get_test_job_states(job_id_list)},
-            msg["data"],
-        )
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]) + 1,
-                )
-            else:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
-                )
-        self.assertTrue(self.jc._lookup_timer)
-        self.assertTrue(self.jc._running_lookup_loop)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_stop_job_update_msg(self):
-        job_id_list = [JOB_CREATED, JOB_COMPLETED, BATCH_PARENT]
-        req = make_comm_msg(STOP_UPDATE, job_id_list, False)
-        self.jc._handle_comm_message(req)
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0),
-                )
-            else:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
-                )
-        self.assertIsNone(self.jc._lookup_timer)
-        self.assertFalse(self.jc._running_lookup_loop)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_start_job_update_batch_msg(self):
-        job_id = BATCH_PARENT
-        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
-        req = make_comm_msg(START_UPDATE_BATCH, job_id, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(
-            {"msg_type": STATUS, "content": get_test_job_states(job_id_list)},
-            msg["data"],
-        )
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]) + 1,
-                )
-            else:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
-                )
-        self.assertTrue(self.jc._lookup_timer)
-        self.assertTrue(self.jc._running_lookup_loop)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_stop_job_update_batch_msg(self):
-        job_id = BATCH_PARENT
-        job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
-        req = make_comm_msg(STOP_UPDATE_BATCH, job_id, False)
-        self.jc._handle_comm_message(req)
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0),
-                )
-            else:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
-                )
-        self.assertIsNone(self.jc._lookup_timer)
-        self.assertFalse(self.jc._running_lookup_loop)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_handle_cancel_job_msg_with_job_id_list(self):
-        job_id_list = [JOB_COMPLETED]
-        req = make_comm_msg(CANCEL, job_id_list, False)
-        self.jc._handle_comm_message(req)
-        msg = self.jc._comm.last_message
-        self.assertEqual(msg["data"]["msg_type"], STATUS)
-
 
 class JobRequestTestCase(unittest.TestCase):
     """
@@ -1352,6 +1377,8 @@ class JobRequestTestCase(unittest.TestCase):
         rq = JobRequest(rq_msg)
         self.assertEqual(rq.msg_id, "some_id")
         self.assertEqual(rq.request_type, "a_request")
+        self.assertEqual(rq.raw_request, rq_msg)
+        self.assertEqual(rq.rq_data, {"request_type": "a_request"})
         with self.assertRaisesRegex(JobIDException, JOB_NOT_PROVIDED_ERR):
             rq.job_id
         with self.assertRaisesRegex(JobIDException, JOBS_NOT_PROVIDED_ERR):
@@ -1359,19 +1386,30 @@ class JobRequestTestCase(unittest.TestCase):
 
     def test_request_no_data(self):
         rq_msg = {"msg_id": "some_id", "content": {}}
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaisesRegex(ValueError, INVALID_REQUEST_ERR):
             JobRequest(rq_msg)
-        self.assertIn("Improperly formatted job channel message!", str(e.exception))
 
     def test_request_no_req(self):
         rq_msg = {"msg_id": "some_id", "content": {"data": {"request_type": None}}}
         rq_msg2 = {"msg_id": "some_other_id", "content": {"data": {}}}
         for msg in [rq_msg, rq_msg2]:
-            with self.assertRaises(ValueError) as e:
+            with self.assertRaisesRegex(ValueError, MISSING_REQUEST_TYPE_ERR):
                 JobRequest(msg)
-            self.assertIn(
-                "Missing request type in job channel message!", str(e.exception)
-            )
+
+    def test_request_more_than_one_input(self):
+        """Ensure that supplying more than one job ID-like input raises an error"""
+        combos = itertools.combinations(
+            [
+                {JOB_ID: "job_id"},
+                {JOB_ID_LIST: ["job_1_id", "job_2_id"]},
+                {BATCH_ID: "batch_id"},
+            ],
+            2,
+        )
+        for co in combos:
+            msg = make_comm_msg(STATUS, {**co[0], **co[1]}, False)
+            with self.assertRaisesRegex(ValueError, ONE_INPUT_TYPE_ONLY_ERR):
+                JobRequest(msg)
 
     def test_request_both_inputs(self):
         msg = {
@@ -1384,24 +1422,21 @@ class JobRequestTestCase(unittest.TestCase):
                 }
             },
         }
-        with self.assertRaisesRegex(ValueError, "Both job_id and job_id_list present"):
+        with self.assertRaisesRegex(ValueError, ONE_INPUT_TYPE_ONLY_ERR):
             JobRequest(msg)
 
     def test_request__no_input(self):
-        msg = {
-            "msg_id": "some_id",
-            "content": {
-                "data": {
-                    "request_type": STATUS,
-                }
-            },
-        }
+        msg = make_comm_msg(STATUS, {}, False)
         req = JobRequest(msg)
 
         with self.assertRaisesRegex(JobIDException, JOB_NOT_PROVIDED_ERR):
             req.job_id
         with self.assertRaisesRegex(JobIDException, JOBS_NOT_PROVIDED_ERR):
             req.job_id_list
+        with self.assertRaisesRegex(JobIDException, BATCH_NOT_PROVIDED_ERR):
+            req.batch_id
+        with self.assertRaisesRegex(ValueError, CELLS_NOT_PROVIDED_ERR):
+            req.cell_id_list
 
     def _check_rq_equal(self, rq0, rq1):
         self.assertEqual(rq0.msg_id, rq1.msg_id)
@@ -1476,7 +1511,7 @@ class JobRequestTestCase(unittest.TestCase):
                 }
             },
         }
-        with self.assertRaisesRegex(ValueError, "Both job_id and job_id_list present"):
+        with self.assertRaisesRegex(ValueError, ONE_INPUT_TYPE_ONLY_ERR):
             JobRequest.translate(msg)
 
 
@@ -1530,13 +1565,12 @@ class exc_to_msgTestCase(unittest.TestCase):
                 "msg_type": ERROR,
                 "content": {
                     "source": req_type,
-                    JOB_ID_LIST: job_id_list,
                     "name": "RuntimeError",
                     "message": message,
                     "raw_request": req.raw_request,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_with_nested_try__succeed(self):
@@ -1582,7 +1616,6 @@ class exc_to_msgTestCase(unittest.TestCase):
                 "content": {
                     "raw_request": req.raw_request,
                     "source": req_type,
-                    JOB_ID_LIST: job_id_list,
                     # Below are from transform_job_exception
                     "name": "Exception",
                     "message": message,
@@ -1590,7 +1623,7 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "code": -1,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_JobIDException(self):
@@ -1616,12 +1649,11 @@ class exc_to_msgTestCase(unittest.TestCase):
                 "content": {
                     "raw_request": req.raw_request,
                     "source": req_type,
-                    JOB_ID: job_id,
                     "name": "JobIDException",
                     "message": f"{message}: a0a0a0",
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_ValueError(self):
@@ -1647,18 +1679,17 @@ class exc_to_msgTestCase(unittest.TestCase):
                 "content": {
                     "raw_request": req.raw_request,
                     "source": req_type,
-                    JOB_ID_LIST: job_id_list,
                     "name": "ValueError",
                     "message": message,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_dict_req__no_err(self):
         job_id = JOB_ERROR
         req_type = RETRY
-        req = make_comm_msg(req_type, job_id, False)
+        req_dict = make_comm_msg(req_type, job_id, False)
         message = (
             "Casteism can mean seeking to keep those on your "
             "disfavored rung from gaining on you, to curry the "
@@ -1669,14 +1700,14 @@ class exc_to_msgTestCase(unittest.TestCase):
         def f():
             print(message)
 
-        self.foo(req, f)
+        self.foo(req_dict, f)
         msg = self.jc._comm.last_message
         self.assertIsNone(msg)
 
     def test_dict_req__error_down_the_stack(self):
         job_id = JOB_CREATED
         req_type = STATUS
-        req = make_comm_msg(req_type, job_id, False)
+        req_dict = make_comm_msg(req_type, job_id, False)
         message = (
             "Caste is the granting or witholding of "
             "respect, status, honor, attention, priveliges, "
@@ -1693,29 +1724,27 @@ class exc_to_msgTestCase(unittest.TestCase):
                 f(i - 1)
 
         with self.assertRaisesRegex(ValueError, message):
-            self.foo(req, f)
+            self.foo(req_dict, f)
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req["content"]["data"],
+                    "raw_request": req_dict,
                     "source": req_type,
-                    JOB_ID: job_id,
                     "name": "ValueError",
                     "message": message,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_dict_req__both_inputs(self):
-        job_id = JOB_CREATED
-        job_id_list = []
         req_type = STATUS
         # can give it both job_id and job_id_list since it's not a JobRequest
-        req = make_comm_msg(req_type, job_id, False)
-        req["content"]["data"][JOB_ID_LIST] = job_id_list
+        req_dict = make_comm_msg(
+            req_type, {JOB_ID: JOB_CREATED, JOB_ID_LIST: []}, False
+        )
         message = (
             "What some people call racism could be seen as merely "
             "one manifestation of the degree to which we have internalized "
@@ -1726,21 +1755,19 @@ class exc_to_msgTestCase(unittest.TestCase):
             raise ValueError(message)
 
         with self.assertRaisesRegex(ValueError, message):
-            self.foo(req, f)
+            self.foo(req_dict, f)
         msg = self.jc._comm.last_message
         self.assertEqual(
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req["content"]["data"],
+                    "raw_request": req_dict,
                     "source": req_type,
-                    JOB_ID: job_id,
-                    JOB_ID_LIST: job_id_list,
                     "name": "ValueError",
                     "message": message,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_None_req(self):
@@ -1764,7 +1791,7 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "raw_request": None,
                 },
             },
-            msg["data"],
+            msg,
         )
 
     def test_str_req(self):
@@ -1788,5 +1815,5 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "raw_request": source,
                 },
             },
-            msg["data"],
+            msg,
         )

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -13,7 +13,7 @@ import biokbase.narrative.jobs.jobmanager
 from biokbase.narrative.jobs.jobmanager import (
     JOB_NOT_REG_ERR,
     JOB_NOT_BATCH_ERR,
-    JOBS_MISSING_FALSY_ERR,
+    JOBS_MISSING_ERR,
     CELLS_NOT_PROVIDED_ERR,
     get_error_output_state,
 )
@@ -218,12 +218,12 @@ class JobManagerTest(unittest.TestCase):
             self.jm._check_job_list(None)
 
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+            JobIDException, re.escape(f"{JOBS_MISSING_ERR}: {[]}")
         ):
             self.jm._check_job_list([])
 
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')
+            JobIDException, re.escape(f'{JOBS_MISSING_ERR}: {["", "", None]}')
         ):
             self.jm._check_job_list(["", "", None])
 
@@ -360,12 +360,12 @@ class JobManagerTest(unittest.TestCase):
 
     def test_cancel_jobs__bad_inputs(self):
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+            JobIDException, re.escape(f"{JOBS_MISSING_ERR}: {[]}")
         ):
             self.jm.cancel_jobs([])
 
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')
+            JobIDException, re.escape(f'{JOBS_MISSING_ERR}: {["", "", None]}')
         ):
             self.jm.cancel_jobs(["", "", None])
 
@@ -436,10 +436,9 @@ class JobManagerTest(unittest.TestCase):
             mock.Mock(return_value={}, side_effect=check_state),
         ) as mock_cancel_job:
             results = self.jm.cancel_jobs(jobs)
-            self.assertNotIn("canceling", self.jm._running_jobs[JOB_RUNNING])
-            self.assertNotIn("canceling", self.jm._running_jobs[JOB_CREATED])
-            self.assertEqual(self.jm._running_jobs[JOB_RUNNING]["refresh"], 1)
-            self.assertEqual(self.jm._running_jobs[JOB_CREATED]["refresh"], 1)
+            for job in [JOB_RUNNING, JOB_CREATED]:
+                self.assertNotIn("canceling", self.jm._running_jobs[job])
+                self.assertEqual(self.jm._running_jobs[job]["refresh"], 1)
             self.assertEqual(results.keys(), expected.keys())
             self.assertEqual(results, expected)
             mock_cancel_job.assert_has_calls(
@@ -490,6 +489,7 @@ class JobManagerTest(unittest.TestCase):
         job_ids = [JOB_TERMINATED]
         expected = {
             JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
                 "job": self.job_states[JOB_TERMINATED],
                 "retry": get_retry_job_state(JOB_TERMINATED),
             }
@@ -503,10 +503,12 @@ class JobManagerTest(unittest.TestCase):
         job_ids = [JOB_TERMINATED, JOB_ERROR]
         expected = {
             JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
                 "job": self.job_states[JOB_TERMINATED],
                 "retry": get_retry_job_state(JOB_TERMINATED),
             },
             JOB_ERROR: {
+                "job_id": JOB_ERROR,
                 "job": self.job_states[JOB_ERROR],
                 "retry": get_retry_job_state(JOB_ERROR),
             },
@@ -520,14 +522,17 @@ class JobManagerTest(unittest.TestCase):
         job_ids = [JOB_NOT_FOUND, JOB_TERMINATED, JOB_COMPLETED]
         expected = {
             JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
                 "job": self.job_states[JOB_TERMINATED],
                 "retry": get_retry_job_state(JOB_TERMINATED),
             },
             JOB_COMPLETED: {
+                "job_id": JOB_COMPLETED,
                 "job": self.job_states[JOB_COMPLETED],
                 "error": ERR_STR,
             },
             JOB_NOT_FOUND: {
+                "job_id": JOB_NOT_FOUND,
                 "job": get_error_output_state(JOB_NOT_FOUND),
                 "error": "does_not_exist",
             },
@@ -550,9 +555,21 @@ class JobManagerTest(unittest.TestCase):
     def test_retry_jobs__all_error(self):
         job_ids = [JOB_TERMINATED, JOB_CREATED, JOB_RUNNING]
         expected = {
-            JOB_TERMINATED: {"job": self.job_states[JOB_TERMINATED], "error": ERR_STR},
-            JOB_CREATED: {"job": self.job_states[JOB_CREATED], "error": ERR_STR},
-            JOB_RUNNING: {"job": self.job_states[JOB_RUNNING], "error": ERR_STR},
+            JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
+                "job": self.job_states[JOB_TERMINATED],
+                "error": ERR_STR,
+            },
+            JOB_CREATED: {
+                "job_id": JOB_CREATED,
+                "job": self.job_states[JOB_CREATED],
+                "error": ERR_STR,
+            },
+            JOB_RUNNING: {
+                "job_id": JOB_RUNNING,
+                "job": self.job_states[JOB_RUNNING],
+                "error": ERR_STR,
+            },
         }
 
         ee2_ret = [
@@ -577,6 +594,7 @@ class JobManagerTest(unittest.TestCase):
 
         expected = {
             JOB_TERMINATED: {
+                "job_id": JOB_TERMINATED,
                 "job": self.job_states[JOB_TERMINATED],
                 "retry": get_retry_job_state(JOB_TERMINATED, status=retry_status),
             }
@@ -599,6 +617,7 @@ class JobManagerTest(unittest.TestCase):
         job_ids = ["", "", None, dne_id]
         expected = {
             dne_id: {
+                "job_id": dne_id,
                 "job": get_error_output_state(dne_id),
                 "error": "does_not_exist",
             }
@@ -609,12 +628,12 @@ class JobManagerTest(unittest.TestCase):
 
     def test_retry_jobs__bad_inputs(self):
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+            JobIDException, re.escape(f"{JOBS_MISSING_ERR}: {[]}")
         ):
             self.jm.retry_jobs([])
 
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')
+            JobIDException, re.escape(f'{JOBS_MISSING_ERR}: {["", "", None]}')
         ):
             self.jm.retry_jobs(["", "", None])
 
@@ -745,7 +764,7 @@ class JobManagerTest(unittest.TestCase):
 
     def test_get_job_states__empty(self):
         with self.assertRaisesRegex(
-            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+            JobIDException, re.escape(f"{JOBS_MISSING_ERR}: {[]}")
         ):
             self.jm.get_job_states([])
 


### PR DESCRIPTION
# Description of PR purpose/changes

This started off as a fairly benign search and replace and somehow... grew.

Lots of tidying and a bit of refactoring of jobcomm tests without much content change.

Comments inline.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [-] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
