### PR TITLE
PTV-1726 session version

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 - DATAUP-570 - Only use the Narrative configuration to set available import types in the Import area dropdowns
 - DATAUP-577 - Sanitize suggested output object names for bulk import jobs so they follow the rules
 - PTV-1717 - fix landing page links for modeling widgets
+- PTV-1726 - address issue where the "Narrative updated in another session" would appear with no other session open
 
 ### Version 5.0.0
 This new major version of the KBase Narrative Interface introduces a way to import data from your data staging area in large batches using a single Bulk Import cell. See more details about the new workflows here: [Bulk Import Guide](https://docs.kbase.us/data/upload-download-guide/bulk-import-guide)

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -325,7 +325,7 @@ define([
                     break;
 
                 case 'new_job':
-                    Jupyter.notebook.save_checkpoint();
+                    Jupyter.narrative.saveNarrative();
                     break;
 
                 // CELL messages

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -402,29 +402,25 @@ define([
     };
 
     /**
-     * Expects the usual workspace object info array. If that's present, it's captured. If not,
-     * we run get_object_info_new and fetch it ourselves. Note that it should have its metadata.
+     * Fetches the current narrative ref info from the Workspace.
+     * @returns Promise that resolves when the latest narrative object info has been
+     * retrieved.
      */
-    Narrative.prototype.updateDocumentVersion = function (docInfo) {
-        if (docInfo) {
-            this.documentVersionInfo = docInfo;
-            return Promise.resolve();
-        } else {
-            return this.getNarrativeRef()
-                .then((narrativeRef) => {
-                    return workspaceClient(this.getAuthToken()).get_object_info_new({
-                        objects: [{ ref: narrativeRef }],
-                        includeMetadata: 1,
-                    });
-                })
-                .then((info) => {
-                    this.documentVersionInfo = info[0];
-                })
-                .catch((error) => {
-                    // no op for now.
-                    console.error(error);
+    Narrative.prototype.updateDocumentVersion = function () {
+        return this.getNarrativeRef()
+            .then((narrativeRef) => {
+                return workspaceClient(this.getAuthToken()).get_object_info_new({
+                    objects: [{ ref: narrativeRef }],
+                    includeMetadata: 1,
                 });
-        }
+            })
+            .then((info) => {
+                this.documentVersionInfo = info[0];
+            })
+            .catch((error) => {
+                // no op for now.
+                console.error(error);
+            });
     };
 
     Narrative.prototype.showDocumentVersionDialog = function (newVerInfo) {

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -15,7 +15,6 @@ define([
     'narrativeConfig',
     'common/jobCommChannel',
     'kbaseNarrativeSidePanel',
-    'kbaseNarrativeOutputCell',
     'kbaseNarrativeWorkspace',
     'kbaseNarrativeMethodCell',
     'kbaseAccordion',
@@ -33,8 +32,6 @@ define([
     'text!kbase/templates/update_dialog_body.html',
     'text!kbase/templates/document_version_change.html',
     'narrativeLogin',
-    'common/ui',
-    'common/html',
     'common/runtime',
     'narrativeTour',
     'kb_service/utils',
@@ -49,7 +46,6 @@ define([
     Config,
     JobComms,
     KBaseNarrativeSidePanel,
-    KBaseNarrativeOutputCell,
     KBaseNarrativeWorkspace,
     KBaseNarrativeMethodCell,
     KBaseAccordion,
@@ -67,8 +63,6 @@ define([
     UpdateDialogBodyTemplate,
     DocumentVersionDialogBodyTemplate,
     NarrativeLogin,
-    UI,
-    html,
     Runtime,
     Tour,
     ServiceUtils,
@@ -139,6 +133,7 @@ define([
         this.workspaceRef = null;
         this.workspaceId = this.runtime.workspaceId();
         this.workspaceInfo = {};
+
         this.sidePanel = null;
 
         // The set of currently instantiated KBase Widgets.
@@ -151,6 +146,10 @@ define([
         });
         return this;
     };
+
+    function workspaceClient(token) {
+        return new Workspace(Config.url('workspace'), { token });
+    }
 
     Narrative.prototype.isLoaded = () => {
         return Jupyter.notebook._fully_loaded;
@@ -166,29 +165,24 @@ define([
     };
 
     Narrative.prototype.getNarrativeRef = function () {
-        return Promise.try(() => {
-            if (this.workspaceRef) {
+        if (this.workspaceRef) {
+            return Promise.resolve(this.workspaceRef);
+        }
+        return workspaceClient(this.getAuthToken())
+            .get_workspace_info({ id: this.workspaceId })
+            .then((wsInfo) => {
+                const narrId = wsInfo[8]['narrative'];
+                this.workspaceRef = this.workspaceId + '/' + narrId;
                 return this.workspaceRef;
-            }
-            return new Workspace(Config.url('workspace'), {
-                token: this.getAuthToken(),
-            })
-                .get_workspace_info({ id: this.workspaceId })
-                .then((wsInfo) => {
-                    const narrId = wsInfo[8]['narrative'];
-                    this.workspaceRef = this.workspaceId + '/' + narrId;
-                    return this.workspaceRef;
-                });
-        });
+            });
     };
 
     Narrative.prototype.getUserPermissions = function () {
-        const ws = new Workspace(Config.url('workspace'), {
-            token: this.getAuthToken(),
-        });
-        return ws.get_workspace_info({ id: this.workspaceId }).then((wsInfo) => {
-            return wsInfo[5];
-        });
+        return workspaceClient(this.getAuthToken())
+            .get_workspace_info({ id: this.workspaceId })
+            .then((wsInfo) => {
+                return wsInfo[5];
+            });
     };
 
     // Wrappers for the Jupyter/Jupyter function so we only maintain it in one place.
@@ -282,11 +276,14 @@ define([
         const self = this;
         $([Jupyter.events]).on('before_save.Notebook', () => {
             $('#kb-save-btn').find('div.fa-save').addClass('fa-spin');
+            $('#kb-save-btn').prop('disabled', true);
         });
         $([Jupyter.events]).on('notebook_saved.Notebook', () => {
-            $('#kb-save-btn').find('div.fa-save').removeClass('fa-spin');
-            self.stopVersionCheck = false;
-            self.updateDocumentVersion();
+            self.updateDocumentVersion().then(() => {
+                self.stopVersionCheck = false;
+                $('#kb-save-btn').find('div.fa-save').removeClass('fa-spin');
+                $('#kb-save-btn').prop('disabled', false);
+            });
         });
         $([Jupyter.events]).on('kernel_idle.Kernel', () => {
             $('#kb-kernel-icon').removeClass().addClass('fa fa-circle-o');
@@ -408,30 +405,25 @@ define([
      * we run get_object_info_new and fetch it ourselves. Note that it should have its metadata.
      */
     Narrative.prototype.updateDocumentVersion = function (docInfo) {
-        const self = this;
-        return Promise.try(() => {
-            if (docInfo) {
-                self.documentVersionInfo = docInfo;
-            } else {
-                const workspace = new Workspace(Config.url('workspace'), {
-                    token: self.getAuthToken(),
-                });
-                self.getNarrativeRef()
-                    .then((narrativeRef) => {
-                        return workspace.get_object_info_new({
-                            objects: [{ ref: narrativeRef }],
-                            includeMetadata: 1,
-                        });
-                    })
-                    .then((info) => {
-                        self.documentVersionInfo = info[0];
-                    })
-                    .catch((error) => {
-                        // no op for now.
-                        console.error(error);
+        if (docInfo) {
+            this.documentVersionInfo = docInfo;
+            return Promise.resolve();
+        } else {
+            return this.getNarrativeRef()
+                .then((narrativeRef) => {
+                    return workspaceClient(this.getAuthToken()).get_object_info_new({
+                        objects: [{ ref: narrativeRef }],
+                        includeMetadata: 1,
                     });
-            }
-        });
+                })
+                .then((info) => {
+                    this.documentVersionInfo = info[0];
+                })
+                .catch((error) => {
+                    // no op for now.
+                    console.error(error);
+                });
+        }
     };
 
     Narrative.prototype.showDocumentVersionDialog = function (newVerInfo) {
@@ -892,7 +884,12 @@ define([
     /**
      * @method
      * @public
-     * This triggers a save, but saves all cell states first.
+     * This is a wrapper around the Jupyter.notebook.save_checkpoint function. It also handles
+     * state management around checking Narrative versions. Mainly, it shuts off the version check.
+     * Once the `save_checkpoint` function finishes running, it triggers the notebook_saved.Notebook
+     * event, which is caught elsewhere, and used to reactivate the version check.
+     *
+     * This also disables the save button until the save completes to prevent spam and other issues.
      */
     Narrative.prototype.saveNarrative = function () {
         this.stopVersionCheck = true;

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -382,11 +382,12 @@ define([
     };
 
     /**
-     * Expects docInfo to be a workspace object info array, especially where the 4th element is
-     * an int > 0.
+     * This checks the loaded Narrative document version against the given value.
+     * If the loaded document version is not the same as the given version parameter,
+     * then the document version mismatch button should be shown.
      */
     Narrative.prototype.checkDocumentVersion = function (docInfo) {
-        if (docInfo.length < 5 || this.stopVersionCheck) {
+        if (this.stopVersionCheck || !docInfo || docInfo.length < 5) {
             return;
         }
         if (docInfo[4] !== this.documentVersionInfo[4]) {

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -926,7 +926,7 @@ define([
             cancelBatch = null;
             updateEditingState();
             switchToTab('configure');
-            Jupyter.notebook.save_checkpoint();
+            Jupyter.narrative.saveNarrative();
         }
 
         function resetRunStatusListener() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001298",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-            "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+            "version": "1.0.30001299",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001298",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
-            "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+            "version": "1.0.30001299",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
             "dev": true
         },
         "center-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001296",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-            "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
+            "version": "1.0.30001298",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+            "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001296",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-            "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
+            "version": "1.0.30001298",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+            "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
             "dev": true
         },
         "center-align": {

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -60,11 +60,15 @@ define([
         beforeEach(() => {
             testBus = Runtime.make().bus();
             Jupyter.notebook = makeMockNotebook();
+            Jupyter.narrative = {
+                saveNarrative: () => {},
+            };
         });
 
         afterEach(() => {
             TestUtil.clearRuntime();
             Jupyter.notebook = null;
+            Jupyter.narrative = null;
             testBus = null;
         });
 
@@ -454,10 +458,10 @@ define([
 
         it('Should respond to new_job by saving the Narrative', () => {
             const comm = new JobCommChannel();
-            spyOn(Jupyter.notebook, 'save_checkpoint');
+            spyOn(Jupyter.narrative, 'saveNarrative');
             return comm.initCommChannel().then(() => {
                 comm.handleCommMessages(makeCommMsg('new_job', {}));
-                expect(Jupyter.notebook.save_checkpoint).toHaveBeenCalled();
+                expect(Jupyter.narrative.saveNarrative).toHaveBeenCalled();
             });
         });
 

--- a/test/unit/spec/kbaseNarrativeSpec.js
+++ b/test/unit/spec/kbaseNarrativeSpec.js
@@ -14,7 +14,7 @@ define([
         TEST_TOKEN = 'foo',
         TEST_USER = 'some_user';
 
-    describe('Test the kbaseNarrative module', () => {
+    fdescribe('Test the kbaseNarrative module', () => {
         let container;
         let narr;
 
@@ -208,5 +208,81 @@ define([
                     expect(narr.insertAndSelectCell).toHaveBeenCalled();
                 });
         });
+
+        it('should compare the Narrative document version on request', () => {
+            // start by mocking a version button that doesn't really do much except exist.
+            const verButton = document.createElement('button');
+            verButton.setAttribute('id', 'kb-narr-version-btn');
+            verButton.classList.add('kb-nav-btn-upgrade');
+            document.body.appendChild(verButton);
+            expect(verButton).toBeDefined();
+            // first test, should do nothing (don't expose the button)
+            narr.checkDocumentVersion();
+            expect(getComputedStyle(verButton).display).toBe('none');
+
+            // second test, should be different and expose the button
+            const wsId = 5,
+                objId = 1,
+                version = 10;
+            const objInfo = [
+                objId,
+                'SomeNarrative',
+                'KBaseNarrative.Narrative-4.0',
+                '2022-01-12T16:03:21+0000',
+                version,
+                'wjriehl',
+                wsId,
+                'wjriehl:narrative_1634933593954',
+                'caa15e90e772c76159be4d0eaca89714',
+                12345,
+                null,
+            ];
+            narr.checkDocumentVersion(objInfo);
+            expect(getComputedStyle(verButton).display).not.toBe('none');
+        });
+
+        it('should not compare the document version if the flag is set to false', () => {
+            // start by mocking a version button that doesn't really do much except exist.
+            const verButton = document.createElement('button');
+            verButton.setAttribute('id', 'kb-narr-version-btn');
+            verButton.classList.add('kb-nav-btn-upgrade');
+            document.body.appendChild(verButton);
+            expect(verButton).toBeDefined();
+            // first test, should do nothing (don't expose the button)
+            narr.checkDocumentVersion();
+            expect(getComputedStyle(verButton).display).toBe('none');
+
+            narr.stopVersionCheck = true;
+
+            // second test, should be different and expose the button
+            const wsId = 5,
+                objId = 1,
+                version = 10;
+            const objInfo = [
+                objId,
+                'SomeNarrative',
+                'KBaseNarrative.Narrative-4.0',
+                '2022-01-12T16:03:21+0000',
+                version,
+                'wjriehl',
+                wsId,
+                'wjriehl:narrative_1634933593954',
+                'caa15e90e772c76159be4d0eaca89714',
+                12345,
+                null,
+            ];
+            narr.checkDocumentVersion(objInfo);
+            expect(getComputedStyle(verButton).display).toBe('none');
+        });
+
+        it('should save the narrative on request by calling out to Jupyter.notebook.save_notebook', () => {
+            spyOn(Jupyter.notebook, 'save_checkpoint');
+            narr.saveNarrative();
+            expect(Jupyter.notebook.save_checkpoint).toHaveBeenCalled();
+        });
+
+        it('should not check the document version while saving', () => {});
+
+        it('should update the document version after a successful save', () => {});
     });
 });

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -128,6 +128,7 @@ define([
         beforeAll(() => {
             Jupyter.narrative = {
                 getAuthToken: () => 'fakeToken',
+                saveNarrative: () => {},
             };
             jasmine.Ajax.install();
             jasmine.Ajax.stubRequest(Config.url('workspace')).andReturn({
@@ -590,7 +591,7 @@ define([
                     // wait for the cell to reset so the run button is visible
                     // expect the state to be editingComplete
                     Jupyter.notebook = Mocks.buildMockNotebook();
-                    spyOn(Jupyter.notebook, 'save_checkpoint');
+                    spyOn(Jupyter.narrative, 'saveNarrative');
                     spyOn(Date, 'now').and.returnValue(1234567890);
                     testCase.cellId = `${testCase.state}-${testCase.action}`;
                     const { cell, bulkImportCellInstance } = initCell(testCase);
@@ -646,7 +647,7 @@ define([
                                 undefined
                             );
                             expect(bulkImportCellInstance.jobManager.listeners).toEqual({});
-                            expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
+                            expect(Jupyter.narrative.saveNarrative.calls.allArgs()).toEqual([[]]);
                             if (testCase.action === 'reset') {
                                 const allEmissions =
                                     bulkImportCellInstance.jobManager.bus.emit.calls.allArgs();
@@ -667,7 +668,7 @@ define([
             xit('should cancel jobs between the batch job being submitted and the server response being returned', async () => {
                 const cellId = 'cancelDuringSubmit';
                 Jupyter.notebook = Mocks.buildMockNotebook();
-                spyOn(Jupyter.notebook, 'save_checkpoint');
+                spyOn(Jupyter.narrative, 'saveNarrative');
                 spyOn(Date, 'now').and.returnValue(1234567890);
                 const { cell, bulkImportCellInstance } = initCell({
                     cellId,
@@ -762,7 +763,7 @@ define([
                     ['request-job-updates-stop', { batchId }],
                     ['reset-cell', { cellId: `${cellId}-test-cell`, ts: 1234567890 }],
                 ];
-                expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
+                expect(Jupyter.narrative.saveNarrative.calls.allArgs()).toEqual([[]]);
                 expect(bulkImportCellInstance.jobManager.bus.emit.calls.allArgs()).toEqual(
                     jasmine.arrayWithExactContents(callArgs)
                 );


### PR DESCRIPTION
# Description of PR purpose/changes

This addresses an issue where the "Narrative updated in another session" button would occasionally show up for no apparent reason. The reason was that race conditions are no fun.

See ticket for details, but the short version is that it was possible for the narrative's known document version to get out of sync with what's in the Workspace. This would happen when a timer that updates the available Workspace data (including the Narrative object) would fire while the Narrative was saving, in just the right time to cause problems. Couple this with a few asynchronous functions that were handling things poorly, and you get this intermittent, hard to reproduce, problem.

No guarantees that this fixes it for sure, but I identified a few places to make improvements and put in a number of tests around it.

This also fixes a few places that were calling `Jupyter.notebook.save_narrative` directly instead of the `Jupyter.narrative.saveNarrative` wrapper.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1726
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Hard to test, but spamming saves and / or making a number of short-running apps that generate data were the most common triggers.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [x] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
