### PR TITLE
DATAUP-497: move all test result generation to a single file

### DIFF
--- a/src/biokbase/narrative/tests/generate_test_results.py
+++ b/src/biokbase/narrative/tests/generate_test_results.py
@@ -1,0 +1,219 @@
+import copy
+from biokbase.narrative.tests.util import ConfigTests
+from biokbase.narrative.app_util import app_version_tags
+
+from biokbase.narrative.jobs.jobcomm import (
+    INFO,
+    LOGS,
+    RETRY,
+    STATUS,
+)
+
+from biokbase.narrative.jobs.job import (
+    JOB_ATTR_DEFAULTS,
+    EXCLUDED_JOB_STATE_FIELDS,
+    COMPLETED_STATUS,
+)
+from biokbase.narrative.tests.job_test_constants import (
+    BAD_JOBS,
+    RETRIED_JOBS,
+    BATCH_PARENT,
+    JOB_COMPLETED,
+    BATCH_COMPLETED,
+    BATCH_RETRY_COMPLETED,
+    get_test_job,
+    generate_error,
+)
+
+config = ConfigTests()
+
+TEST_JOBS = config.load_json_file(config.get("jobs", "ee2_job_test_data_file"))
+spec_list = config.load_json_file(config.get("specs", "app_specs_file"))
+TEST_SPECS = {}
+
+for tag in app_version_tags:
+    spec_dict = dict()
+    for spec in spec_list:
+        spec_dict[spec["info"]["id"]] = spec
+    TEST_SPECS[tag] = spec_dict
+
+
+def get_test_spec(tag, app_id):
+    return copy.deepcopy(TEST_SPECS[tag][app_id])
+
+
+def _generate_job_output(job_id):
+    state = get_test_job(job_id)
+    job_input = state.get("job_input", {})
+    narr_cell_info = job_input.get("narrative_cell_info", {})
+
+    state.update(
+        {
+            "batch_id": state.get(
+                "batch_id", job_id if state.get("batch_job", False) else None
+            ),
+            "cell_id": narr_cell_info.get("cell_id", None),
+            "run_id": narr_cell_info.get("run_id", None),
+            "job_output": state.get("job_output", {}),
+            "child_jobs": state.get("child_jobs", []),
+        }
+    )
+    for f in EXCLUDED_JOB_STATE_FIELDS:
+        if f in state:
+            del state[f]
+
+    if state["status"] != COMPLETED_STATUS:
+        return {"jobState": state, "outputWidgetInfo": None}
+
+    widget_info = {
+        JOB_COMPLETED: {
+            "name": "kbaseDefaultNarrativeOutput",
+            "params": {"out_value": None, "report_name": None, "report_ref": None},
+            "tag": "dev",
+        },
+        BATCH_COMPLETED: {
+            "name": "no-display",
+            "params": {
+                "obj_ref": "18836/5/1",
+                "report_name": "kb_sra_upload_report_af468a02-4278-40af-9536-0bdef1f050db",
+                "report_ref": "62425/18/1",
+                "report_window_line_height": "16",
+                "wsName": "wjriehl:1475006266615",
+            },
+            "tag": "release",
+        },
+        BATCH_RETRY_COMPLETED: {
+            "name": "no-display",
+            "params": {
+                "obj_ref": "18836/5/1",
+                "report_name": "kb_sra_upload_report_4ffc6219-0260-4f1d-8b4d-5083e0595150",
+                "report_ref": "62425/19/1",
+                "report_window_line_height": "16",
+                "wsName": "wjriehl:1475006266615",
+            },
+            "tag": "release",
+        },
+    }
+    return {
+        "jobState": state,
+        "outputWidgetInfo": widget_info[job_id],
+    }
+
+
+def generate_bad_jobs():
+    bad_jobs = {
+        job_id: {"job_id": job_id, "error": generate_error(job_id, "not_found")}
+        for job_id in BAD_JOBS
+    }
+    return bad_jobs
+
+
+def generate_job_output_state():
+    """
+    Generate the expected output from a `job_status` request
+    """
+    job_status = generate_bad_jobs()
+    for job_id in TEST_JOBS:
+        job_status[job_id] = _generate_job_output(job_id)
+    return job_status
+
+
+def generate_job_info():
+    """
+    Expected output from a `job_info` request
+    """
+    job_info = generate_bad_jobs()
+    for job_id in TEST_JOBS:
+        test_job = get_test_job(job_id)
+        job_id = test_job.get("job_id")
+        app_id = test_job.get("job_input", {}).get("app_id", None)
+        tag = (
+            test_job.get("job_input", {})
+            .get("narrative_cell_info", {})
+            .get("tag", "release")
+        )
+        params = test_job.get("job_input", {}).get(
+            "params", JOB_ATTR_DEFAULTS["params"]
+        )
+        batch_job = test_job.get("batch_job", JOB_ATTR_DEFAULTS["batch_job"])
+        app_name = "batch" if batch_job else get_test_spec(tag, app_id)["info"]["name"]
+        batch_id = (
+            job_id
+            if batch_job
+            else test_job.get("batch_id", JOB_ATTR_DEFAULTS["batch_id"])
+        )
+
+        job_info[job_id] = {
+            "app_id": app_id,
+            "app_name": app_name,
+            "job_id": job_id,
+            "job_params": params,
+            "batch_id": batch_id,
+        }
+    return job_info
+
+
+def generate_job_retries():
+    """
+    Expected output from a `retry_job` request
+    """
+    job_retries = generate_bad_jobs()
+    for job_id in TEST_JOBS:
+        if job_id in RETRIED_JOBS:
+            job_retries[job_id] = {
+                "job_id": job_id,
+                "job": _generate_job_output(job_id),
+                "retry": _generate_job_output(RETRIED_JOBS[job_id]),
+            }
+        elif job_id == BATCH_PARENT:
+            job_retries[job_id] = {
+                "job_id": job_id,
+                "job": _generate_job_output(job_id),
+                "error": generate_error(job_id, "batch_parent_retry"),
+            }
+        else:
+            job_retries[job_id] = {
+                "job_id": job_id,
+                "job": _generate_job_output(job_id),
+                "error": generate_error(job_id, "retry_status"),
+            }
+    return job_retries
+
+
+def log_gen(n_lines):
+    lines = []
+    for i in range(n_lines):
+        lines.append({"is_error": 0, "line": f"This is line {str(i+1)}"})
+    return lines
+
+
+def generate_job_logs():
+    """
+    Expected output from a `job_logs` request. Note that only completed jobs have logs in this case.
+    """
+    job_logs = generate_bad_jobs()
+    for job_id in TEST_JOBS:
+        if job_id in [JOB_COMPLETED, BATCH_COMPLETED, BATCH_RETRY_COMPLETED]:
+            job_logs[job_id] = {
+                "job_id": job_id,
+                "batch_id": get_test_job(job_id).get("batch_id", None),
+                "first": 0,
+                "latest": False,
+                "max_lines": 50,
+                "lines": log_gen(5),
+            }
+        else:
+            job_logs[job_id] = {
+                "batch_id": get_test_job(job_id).get("batch_id", None),
+                "error": generate_error(job_id, "no_logs"),
+                "job_id": job_id,
+            }
+    return job_logs
+
+
+ALL_RESPONSE_DATA = {
+    STATUS: generate_job_output_state(),
+    INFO: generate_job_info(),
+    RETRY: generate_job_retries(),
+    LOGS: generate_job_logs(),
+}

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -11,6 +11,7 @@ from biokbase.narrative.jobs.jobmanager import (
     JOB_NOT_BATCH_ERR,
     JOBS_TYPE_ERR,
     JOBS_MISSING_ERR,
+    get_error_output_state,
 )
 from biokbase.narrative.jobs.jobcomm import (
     JobRequest,
@@ -44,6 +45,8 @@ from biokbase.narrative.exception_util import (
     JobRequestException,
     transform_job_exception,
 )
+
+from biokbase.narrative.tests.generate_test_results import ALL_RESPONSE_DATA
 from .util import ConfigTests, validate_job_state
 from biokbase.narrative.tests.job_test_constants import (
     CLIENTS,
@@ -82,12 +85,6 @@ from .narrative_mock.mockclients import (
     generate_ee2_error,
     MockClients,
 )
-
-from .test_job import (
-    get_test_job_states,
-)
-
-from .test_jobmanager import get_test_job_retries, get_test_job_infos
 
 APP_NAME = "The Best App in the World"
 
@@ -140,9 +137,6 @@ class JobCommTestCase(unittest.TestCase):
         cls.jm = JobManager()
         cls.jc = JobComm()
         cls.jc._comm = MockComm()
-        cls.job_states = get_test_job_states()
-        cls.retry_job = get_test_job_retries()
-        cls.job_info = get_test_job_infos()
 
     @mock.patch(CLIENTS, get_mock_client)
     def setUp(self):
@@ -381,7 +375,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": STATUS_ALL,
-                "content": {id: self.job_states[id] for id in ALL_JOBS},
+                "content": {id: ALL_RESPONSE_DATA[STATUS][id] for id in ALL_JOBS},
             },
             msg,
         )
@@ -409,7 +403,9 @@ class JobCommTestCase(unittest.TestCase):
                 self.assertEqual(
                     {
                         "msg_type": STATUS_ALL,
-                        "content": {id: self.job_states[id] for id in ALL_JOBS},
+                        "content": {
+                            id: ALL_RESPONSE_DATA[STATUS][id] for id in ALL_JOBS
+                        },
                     },
                     msg,
                 )
@@ -461,17 +457,12 @@ class JobCommTestCase(unittest.TestCase):
         )
 
         for job_id, state in output_states.items():
+            self.assertEqual(ALL_RESPONSE_DATA[STATUS][job_id], state)
             if job_id in ok_states:
-                self.assertEqual(self.job_states[job_id], state)
                 validate_job_state(state)
-            elif job_id in error_states:
-                self.assertEqual(
-                    state,
-                    {"job_id": job_id, "error": generate_error(job_id, "not_found")},
-                )
             else:
                 # every valid job ID should be in either error_states or ok_states
-                self.assertIn(job_id, error_states + ok_states)
+                self.assertIn(job_id, error_states)
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_all_job_states__ok(self):
@@ -567,7 +558,7 @@ class JobCommTestCase(unittest.TestCase):
                 self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
 
-        expected = {id: copy.deepcopy(self.job_states[id]) for id in ALL_JOBS}
+        expected = {id: copy.deepcopy(ALL_RESPONSE_DATA[STATUS][id]) for id in ALL_JOBS}
         for job_id in ACTIVE_JOBS:
             # add in the ee2_error status and updated timestamp
             expected[job_id]["jobState"]["status"] = "ee2_error"
@@ -634,7 +625,7 @@ class JobCommTestCase(unittest.TestCase):
     def test_lookup_job_states_by_cell_id__all_results(self):
         cell_id_list = TEST_CELL_ID_LIST
         expected_ids = TEST_JOB_IDS
-        expected_states = {id: self.job_states[id] for id in expected_ids}
+        expected_states = {id: ALL_RESPONSE_DATA[STATUS][id] for id in expected_ids}
 
         req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
         self.jc._handle_comm_message(req_dict)
@@ -657,7 +648,7 @@ class JobCommTestCase(unittest.TestCase):
         req_dict = make_comm_msg(INFO, job_args, False)
         self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
-        expected = {id: self.job_info[id] for id in job_id_list}
+        expected = {id: ALL_RESPONSE_DATA[INFO][id] for id in job_id_list}
         self.assertEqual(
             {
                 "msg_type": INFO,
@@ -790,9 +781,9 @@ class JobCommTestCase(unittest.TestCase):
         output = self.jc._handle_comm_message(req_dict)
         print(output)
         expected = {
-            JOB_RUNNING: self.job_states[JOB_RUNNING],
+            JOB_RUNNING: ALL_RESPONSE_DATA[STATUS][JOB_RUNNING],
             BATCH_RETRY_RUNNING: {
-                **self.job_states[BATCH_RETRY_RUNNING],
+                **ALL_RESPONSE_DATA[STATUS][BATCH_RETRY_RUNNING],
                 "error": CANCEL + " failed",
             },
         }
@@ -813,7 +804,7 @@ class JobCommTestCase(unittest.TestCase):
     @mock.patch(CLIENTS, get_mock_client)
     def check_retry_jobs(self, job_args, job_id_list):
         req_dict = make_comm_msg(RETRY, job_args, False)
-        expected = {id: self.retry_job[id] for id in job_id_list if id}
+        expected = {id: ALL_RESPONSE_DATA[RETRY][id] for id in job_id_list if id}
         retry_data = self.jc._handle_comm_message(req_dict)
         self.assertEqual(expected, retry_data)
         retry_msg = self.jc._comm.pop_message()

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -11,7 +11,6 @@ from biokbase.narrative.jobs.jobmanager import (
     JOB_NOT_BATCH_ERR,
     JOBS_TYPE_ERR,
     JOBS_MISSING_ERR,
-    get_error_output_state,
 )
 from biokbase.narrative.jobs.jobcomm import (
     JobRequest,


### PR DESCRIPTION
# Description of PR purpose/changes

Message generation for the major message types (job status, info, retry, and logs) is now centralised in a single file. Hurrah!

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
