### PR TITLE
DATAUP-636 XSV happy path parameter fixes

### DIFF
--- a/kbase-extension/static/kbase/js/util/kbaseApiUtil.js
+++ b/kbase-extension/static/kbase/js/util/kbaseApiUtil.js
@@ -41,6 +41,8 @@ define([
      * "get_method_full_info" from the Narrative Method Store service.
      * @param {Array} idList - a list of app ids
      * @param {String} tag - a tag, one of 'release', 'beta', 'dev'
+     * @returns Promise that resolves into a list of app specs matching the order given
+     *   by idList
      */
     function getAppSpecs(idList, tag) {
         if (!tag) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001296",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-            "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
+            "version": "1.0.30001299",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001296",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-            "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
+            "version": "1.0.30001299",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
             "dev": true
         },
         "center-align": {

--- a/test/data/kb_uploadmethods.import_fastq_interleaved_as_reads_from_staging.spec.json
+++ b/test/data/kb_uploadmethods.import_fastq_interleaved_as_reads_from_staging.spec.json
@@ -1,0 +1,287 @@
+{
+    "info": {
+        "id": "kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging",
+        "module_name": "kb_uploadmethods",
+        "git_commit_hash": "bcfe5e28883b83593893f5fe970b45fa4c0b5341",
+        "name": "Import Interleaved FASTQ file as Reads from Staging Area",
+        "ver": "1.0.51",
+        "subtitle": "Import a interleaved FASTQ file into your Narrative as a Reads data object",
+        "tooltip": "Import a interleaved FASTQ file into your Narrative as a Reads data object",
+        "icon": {
+            "url": "img?method_id=kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging&image_name=data-pink.png&tag=release"
+        },
+        "categories": [
+            "inactive",
+            "reads",
+            "upload"
+        ],
+        "authors": [
+            "tgu2"
+        ],
+        "input_types": [],
+        "output_types": [
+            "KBaseFile.PairedEndLibrary",
+            "KBaseFile.SingleEndLibrary"
+        ],
+        "app_type": "app",
+        "namespace": "kb_uploadmethods"
+    },
+    "widgets": {
+        "input": "null",
+        "output": "no-display"
+    },
+    "parameters": [
+        {
+            "id": "fastq_fwd_staging_file_name",
+            "ui_name": "Forward/Left FASTQ File Path",
+            "short_hint": "Short read file containing a paired end library in FASTQ format",
+            "description": "Valid file extensions for FASTQ: .fastq, .fnq, .fq;",
+            "field_type": "dynamic_dropdown",
+            "allow_multiple": 0,
+            "optional": 0,
+            "advanced": 0,
+            "disabled": 0,
+            "ui_class": "parameter",
+            "default_values": [
+                ""
+            ],
+            "dynamic_dropdown_options": {
+                "data_source": "ftp_staging",
+                "service_params": null,
+                "multiselection": 0,
+                "query_on_empty_input": 1,
+                "result_array_index": 0
+            }
+        },
+        {
+            "id": "sequencing_tech",
+            "ui_name": "Sequencing Technology",
+            "short_hint": "The name of the sequencing technology used to create the reads file",
+            "description": "The name of the sequencing technology used to create the reads file",
+            "field_type": "dropdown",
+            "allow_multiple": 0,
+            "optional": 0,
+            "advanced": 0,
+            "disabled": 0,
+            "ui_class": "parameter",
+            "default_values": [
+                "Illumina"
+            ],
+            "dropdown_options": {
+                "options": [
+                    {
+                        "value": "Illumina",
+                        "display": "Illumina"
+                    },
+                    {
+                        "value": "PacBio CLR",
+                        "display": "PacBio CLR"
+                    },
+                    {
+                        "value": "PacBio CCS",
+                        "display": "PacBio CCS"
+                    },
+                    {
+                        "value": "IonTorrent",
+                        "display": "IonTorrent"
+                    },
+                    {
+                        "value": "NanoPore",
+                        "display": "NanoPore"
+                    },
+                    {
+                        "value": "Unknown",
+                        "display": "Unknown"
+                    }
+                ],
+                "multiselection": 0
+            }
+        },
+        {
+            "id": "name",
+            "ui_name": "Reads Object Name",
+            "short_hint": "Provide a name for the Reads object that will be created by this importer",
+            "description": "Provide a name for the Reads object that will be created by this importer",
+            "field_type": "text",
+            "allow_multiple": 0,
+            "optional": 0,
+            "advanced": 0,
+            "disabled": 0,
+            "ui_class": "output",
+            "default_values": [
+                ""
+            ],
+            "text_options": {
+                "valid_ws_types": [
+                    "KBaseFile.SingleEndLibrary",
+                    "KBaseFile.PairedEndLibrary"
+                ],
+                "is_output_name": 1,
+                "placeholder": "",
+                "regex_constraint": []
+            }
+        },
+        {
+            "id": "single_genome",
+            "ui_name": "Single Genome",
+            "short_hint": "Select if the reads are from a single genome, leave blank if from a metagenome",
+            "description": "Select if the reads are from a single genome, leave blank if from a metagenome",
+            "field_type": "checkbox",
+            "allow_multiple": 0,
+            "optional": 0,
+            "advanced": 0,
+            "disabled": 0,
+            "ui_class": "parameter",
+            "default_values": [
+                "1"
+            ],
+            "checkbox_options": {
+                "checked_value": 1,
+                "unchecked_value": 0
+            }
+        },
+        {
+            "id": "read_orientation_outward",
+            "ui_name": "Reads Orientation Outward",
+            "short_hint": "Select if reads in a pair point outward",
+            "description": "Select if reads in a pair point outward",
+            "field_type": "checkbox",
+            "allow_multiple": 0,
+            "optional": 1,
+            "advanced": 1,
+            "disabled": 0,
+            "ui_class": "parameter",
+            "default_values": [
+                "0"
+            ],
+            "checkbox_options": {
+                "checked_value": 1,
+                "unchecked_value": 0
+            }
+        },
+        {
+            "id": "insert_size_std_dev",
+            "ui_name": "St. Dev. of Insert Size",
+            "short_hint": "The standard deviation of insert lengths",
+            "description": "The standard deviation of insert lengths",
+            "field_type": "text",
+            "allow_multiple": 0,
+            "optional": 1,
+            "advanced": 1,
+            "disabled": 0,
+            "ui_class": "parameter",
+            "default_values": [
+                ""
+            ],
+            "text_options": {
+                "validate_as": "float",
+                "is_output_name": 0,
+                "placeholder": "",
+                "regex_constraint": []
+            }
+        },
+        {
+            "id": "insert_size_mean",
+            "ui_name": "Mean Insert Size",
+            "short_hint": "The mean (average) insert length",
+            "description": "The mean (average) insert length",
+            "field_type": "text",
+            "allow_multiple": 0,
+            "optional": 1,
+            "advanced": 1,
+            "disabled": 0,
+            "ui_class": "parameter",
+            "default_values": [
+                ""
+            ],
+            "text_options": {
+                "validate_as": "float",
+                "is_output_name": 0,
+                "placeholder": "",
+                "regex_constraint": []
+            }
+        }
+    ],
+    "fixed_parameters": [],
+    "behavior": {
+        "kb_service_url": "",
+        "kb_service_name": "kb_uploadmethods",
+        "kb_service_version": "bcfe5e28883b83593893f5fe970b45fa4c0b5341",
+        "kb_service_method": "import_reads_from_staging",
+        "kb_service_input_mapping": [
+            {
+                "narrative_system_variable": "workspace",
+                "target_property": "workspace_name"
+            },
+            {
+                "constant_value": "FASTQ/FASTA",
+                "target_property": "import_type"
+            },
+            {
+                "input_parameter": "fastq_fwd_staging_file_name",
+                "target_property": "fastq_fwd_staging_file_name"
+            },
+            {
+                "input_parameter": "sequencing_tech",
+                "target_property": "sequencing_tech"
+            },
+            {
+                "input_parameter": "name",
+                "target_property": "name"
+            },
+            {
+                "input_parameter": "single_genome",
+                "target_property": "single_genome"
+            },
+            {
+                "constant_value": "1",
+                "target_property": "interleaved"
+            },
+            {
+                "input_parameter": "insert_size_mean",
+                "target_property": "insert_size_mean"
+            },
+            {
+                "input_parameter": "insert_size_std_dev",
+                "target_property": "insert_size_std_dev"
+            },
+            {
+                "input_parameter": "read_orientation_outward",
+                "target_property": "read_orientation_outward"
+            }
+        ],
+        "kb_service_output_mapping": [
+            {
+                "narrative_system_variable": "workspace",
+                "target_property": "wsName"
+            },
+            {
+                "service_method_output_path": [
+                    "0",
+                    "obj_ref"
+                ],
+                "target_property": "obj_ref",
+                "target_type_transform": "resolved-ref"
+            },
+            {
+                "service_method_output_path": [
+                    "0",
+                    "report_name"
+                ],
+                "target_property": "report_name"
+            },
+            {
+                "service_method_output_path": [
+                    "0",
+                    "report_ref"
+                ],
+                "target_property": "report_ref"
+            },
+            {
+                "constant_value": "16",
+                "target_property": "report_window_line_height"
+            }
+        ]
+    },
+    "job_id_output_field": "docker"
+}

--- a/test/unit/spec/narrative_core/upload/importSetup-spec.js
+++ b/test/unit/spec/narrative_core/upload/importSetup-spec.js
@@ -5,18 +5,8 @@ define([
     'narrativeMocks',
     'testUtil',
     'json!/test/data/kb_uploadmethods.import_fastq_interleaved_as_reads_from_staging.spec.json',
-    'json!/test/data/kb_uploadmethods.import_fastq_interleaved_as_reads_from_staging.info.json',
     'json!/test/data/kb_uploadmethods.import_fasta_as_assembly_from_staging.spec.json',
-], (
-    ImportSetup,
-    Jupyter,
-    Config,
-    Mocks,
-    TestUtil,
-    ImportFastqSpec,
-    ImportFastqInfo,
-    ImportAssemblySpec
-) => {
+], (ImportSetup, Jupyter, Config, Mocks, TestUtil, ImportFastqSpec, ImportAssemblySpec) => {
     'use strict';
 
     const uploaders = Config.get('uploaders');


### PR DESCRIPTION
# Description of PR purpose/changes

Not so much on error handling in this one, but fixes a parameter issue. Now, the static dropdown and checkbox values are more precise. This change expects that the user provides the "display" value for the dropdowns, and either a "1" or "0" for checkboxes, as per design decisions here: https://kbase-jira.atlassian.net/browse/DATAUP-408?focusedCommentId=84578 . These get translated into the proper "value" and "unchecked_value"/"checked_value" properties, respectively. All other parameters are more or less text field based and would be unchanged. Except for the scary dynamic dropdown thing which will get solved later.

Also introduces a minor issue where the app specs get fetched multiple times on the way to starting a BI cell. This will get streamlined in a future PR.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-636
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* I'd suggest using types that make use of checkboxes (like interleaved FASTQ reads) and types where the dropdown display names differ from their values (like assembly) for testing xSV uploads. See comments in https://kbase-jira.atlassian.net/browse/DATAUP-636 for an example.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a - fix to unreleased change] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
