### PR TITLE
DATAUP-497: PR V

### DIFF
--- a/src/biokbase/narrative/tests/data/app_specs.json
+++ b/src/biokbase/narrative/tests/data/app_specs.json
@@ -4113,5 +4113,279 @@
             "input": "null",
             "output": "no-display"
         }
+    },
+    {
+        "behavior": {
+            "kb_service_input_mapping": [
+                {
+                    "narrative_system_variable": "workspace",
+                    "target_property": "workspace_name"
+                },
+                {
+                    "input_parameter": "text_input",
+                    "target_property": "text_input"
+                },
+                {
+                    "input_parameter": "checkbox_input",
+                    "target_property": "checkbox_input"
+                }
+            ],
+            "kb_service_method": "example_report",
+            "kb_service_name": "NarrativeTest",
+            "kb_service_output_mapping": [
+                {
+                    "service_method_output_path": [
+                        "0",
+                        "report_name"
+                    ],
+                    "target_property": "report_name"
+                },
+                {
+                    "service_method_output_path": [
+                        "0",
+                        "report_ref"
+                    ],
+                    "target_property": "report_ref"
+                },
+                {
+                    "constant_value": "16",
+                    "target_property": "report_window_line_height"
+                }
+            ],
+            "kb_service_url": "",
+            "kb_service_version": "8d1f8480aee9852e9354cf723f0808fae53b2fcc"
+        },
+        "fixed_parameters": [],
+        "info": {
+            "app_type": "app",
+            "authors": [
+                "wjriehl"
+            ],
+            "categories": [],
+            "git_commit_hash": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "id": "NarrativeTest/report_example",
+            "input_types": [],
+            "module_name": "NarrativeTest",
+            "name": "Example HTML Report",
+            "namespace": "NarrativeTest",
+            "output_types": [],
+            "subtitle": "Show an example HTML Report",
+            "tooltip": "Show an example HTML Report",
+            "ver": "0.0.2"
+        },
+        "job_id_output_field": "docker",
+        "parameters": [
+            {
+                "advanced": 0,
+                "allow_multiple": 0,
+                "default_values": [
+                    ""
+                ],
+                "description": "Some input test goes here",
+                "disabled": 0,
+                "field_type": "text",
+                "id": "text_input",
+                "optional": 1,
+                "short_hint": "Add some text for your report",
+                "text_options": {
+                    "is_output_name": 0,
+                    "placeholder": "",
+                    "regex_constraint": []
+                },
+                "ui_class": "parameter",
+                "ui_name": "Text Input"
+            },
+            {
+                "advanced": 0,
+                "allow_multiple": 0,
+                "checkbox_options": {
+                    "checked_value": 1,
+                    "unchecked_value": 0
+                },
+                "default_values": [
+                    "1"
+                ],
+                "description": "Your report will show this being checked or not",
+                "disabled": 0,
+                "field_type": "checkbox",
+                "id": "checkbox_input",
+                "optional": 0,
+                "short_hint": "Show this off in your report",
+                "ui_class": "parameter",
+                "ui_name": "Checkbox Input"
+            }
+        ],
+        "widgets": {
+            "input": "null",
+            "output": "no-display"
+        }
+    },
+    {
+        "behavior": {
+            "kb_service_input_mapping": [
+                {
+                    "input_parameter": "naptime",
+                    "target_property": "naptime"
+                },
+                {
+                    "input_parameter": "fail",
+                    "target_property": "fail"
+                }
+            ],
+            "kb_service_method": "app_sleep",
+            "kb_service_name": "NarrativeTest",
+            "kb_service_output_mapping": [],
+            "kb_service_url": "",
+            "kb_service_version": "8d1f8480aee9852e9354cf723f0808fae53b2fcc"
+        },
+        "fixed_parameters": [],
+        "info": {
+            "app_type": "app",
+            "authors": [
+                "wjriehl"
+            ],
+            "categories": [
+                "active"
+            ],
+            "git_commit_hash": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "id": "NarrativeTest/app_sleep",
+            "input_types": [],
+            "module_name": "NarrativeTest",
+            "name": "App Sleep",
+            "namespace": "NarrativeTest",
+            "output_types": [],
+            "subtitle": "A simple test app that sleeps before succeeding or failing.",
+            "tooltip": "A simple test app that sleeps before succeeding or failing.",
+            "ver": "0.0.2"
+        },
+        "job_id_output_field": "docker",
+        "parameters": [
+            {
+                "advanced": 0,
+                "allow_multiple": 0,
+                "default_values": [
+                    "5"
+                ],
+                "description": "",
+                "disabled": 0,
+                "field_type": "text",
+                "id": "naptime",
+                "optional": 0,
+                "short_hint": "How long to sleep in seconds before returning",
+                "text_options": {
+                    "is_output_name": 0,
+                    "min_int": 0,
+                    "placeholder": "",
+                    "regex_constraint": [],
+                    "valid_ws_types": [],
+                    "validate_as": "int"
+                },
+                "ui_class": "parameter",
+                "ui_name": "Nap length (sec)"
+            },
+            {
+                "advanced": 0,
+                "allow_multiple": 0,
+                "checkbox_options": {
+                    "checked_value": 1,
+                    "unchecked_value": 0
+                },
+                "default_values": [
+                    ""
+                ],
+                "description": "",
+                "disabled": 0,
+                "field_type": "checkbox",
+                "id": "fail",
+                "optional": 0,
+                "short_hint": "If checked, this will raise on error after sleeping.",
+                "ui_class": "parameter",
+                "ui_name": "Fail on wake"
+            }
+        ],
+        "widgets": {
+            "input": "null",
+            "output": "no-display"
+        }
+    },
+    {
+        "behavior": {
+            "kb_service_input_mapping": [
+                {
+                    "input_parameter": "num_lines",
+                    "target_property": "num_lines"
+                }
+            ],
+            "kb_service_method": "app_logs",
+            "kb_service_name": "NarrativeTest",
+            "kb_service_output_mapping": [
+                {
+                    "service_method_output_path": [
+                        "0",
+                        "num_lines"
+                    ],
+                    "target_property": "num_lines"
+                },
+                {
+                    "service_method_output_path": [
+                        "0",
+                        "prefix"
+                    ],
+                    "target_property": "unique_string"
+                }
+            ],
+            "kb_service_url": "",
+            "kb_service_version": "8d1f8480aee9852e9354cf723f0808fae53b2fcc"
+        },
+        "fixed_parameters": [],
+        "info": {
+            "app_type": "app",
+            "authors": [
+                "wjriehl"
+            ],
+            "categories": [
+                "active"
+            ],
+            "git_commit_hash": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "id": "NarrativeTest/app_logs",
+            "input_types": [],
+            "module_name": "NarrativeTest",
+            "name": "App Logs",
+            "namespace": "NarrativeTest",
+            "output_types": [],
+            "subtitle": "A test app that generates a number of log lines with a unique string attached.",
+            "tooltip": "A test app that generates a number of log lines with a unique string attached.",
+            "ver": "0.0.2"
+        },
+        "job_id_output_field": "docker",
+        "parameters": [
+            {
+                "advanced": 0,
+                "allow_multiple": 0,
+                "default_values": [
+                    "100"
+                ],
+                "description": "",
+                "disabled": 0,
+                "field_type": "text",
+                "id": "num_lines",
+                "optional": 0,
+                "short_hint": "Number of log lines to generates",
+                "text_options": {
+                    "is_output_name": 0,
+                    "min_int": 0,
+                    "placeholder": "",
+                    "regex_constraint": [],
+                    "valid_ws_types": [],
+                    "validate_as": "int"
+                },
+                "ui_class": "parameter",
+                "ui_name": "Number of lines"
+            }
+        ],
+        "widgets": {
+            "input": "null",
+            "output": "null"
+        }
     }
 ]

--- a/src/biokbase/narrative/tests/data/ee2_job_test_data.json
+++ b/src/biokbase/narrative/tests/data/ee2_job_test_data.json
@@ -1,191 +1,213 @@
 {
     "JOB_COMPLETED": {
-        "job_id": "JOB_COMPLETED",
-        "user": "fake_test_user",
-        "authstrat": "kbaseworkspace",
         "batch_id": null,
         "batch_job": false,
         "child_jobs": [],
-        "wsid": 9999,
-        "status": "completed",
-        "updated": 1566860098000,
-        "created": 1566860088000,
-        "finished": 1566860098000,
+        "created": 1642431805000,
+        "finished": 1642431852079,
+        "job_id": "JOB_COMPLETED",
         "job_input": {
-            "wsid": 123,
-            "method": "method",
-            "requested_release": "requested_release",
-            "params": [
-                {
-                    "k_list": [],
-                    "k_max": null,
-                    "output_contigset_name": "MEGAHIT.contigs"
-                }
-            ],
-            "service_ver": "04a6fbf889a4e82a84a227e2d4770fae3fdd9f74",
-            "app_id": "NarrativeTest/test_editor",
-            "source_ws_objects": [],
+            "app_id": "NarrativeTest/report_example",
+            "method": "NarrativeTest.example_report",
             "narrative_cell_info": {
                 "cell_id": "NARRATIVE_CELL_1",
+                "run_id": "cd76b1cd-f6d7-438d-ac9c-121fa637cbdc",
                 "tag": "dev",
-                "run_id": "6546971e-757a-4a26-8439-325497c6d842"
-            }
+                "token_id": "8c10679f-0ae8-4487-bd6b-581e463f50c9"
+            },
+            "params": [
+                {
+                    "checkbox_input": 1,
+                    "text_input": "Some text",
+                    "workspace_name": "ialarmedalien:narrative_1638480919860"
+                }
+            ],
+            "service_ver": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "source_ws_objects": [],
+            "wsid": 65854
         },
         "job_output": {
-            "version": "1.1",
+            "id": "JOB_COMPLETED",
             "result": [
                 {
-                    "new_number": 200
+                    "report_name": "NarrativeTest.example_reportfd0250fa-5ec0-4914-88e7-5922b3047092",
+                    "report_ref": "54321/60/1"
                 }
             ],
-            "id": "5d7024304446f0da4ac7eac4"
+            "version": "1.1"
         },
+        "queued": 1642431805791,
+        "retry_count": 0,
         "retry_ids": [],
-        "retry_parent": null
+        "retry_saved_toggle": false,
+        "running": 1642431816870,
+        "status": "completed",
+        "updated": 1642431852275,
+        "user": "test_user",
+        "widget_info": {
+            "name": "no-display",
+            "params": {
+                "report_name": "NarrativeTest.example_reportfd0250fa-5ec0-4914-88e7-5922b3047092",
+                "report_ref": "54321/60/1",
+                "report_window_line_height": "16"
+            },
+            "tag": "dev"
+        },
+        "wsid": 54321
     },
     "JOB_CREATED": {
-        "job_id": "JOB_CREATED",
-        "user": "tgu2",
-        "authstrat": "kbaseworkspace",
         "batch_id": null,
         "batch_job": false,
         "child_jobs": [],
-        "wsid": 9999,
-        "status": "created",
-        "updated": 1572462965487,
-        "created": 1572462971988,
+        "created": 1642522053000,
+        "job_id": "JOB_CREATED",
         "job_input": {
-            "wsid": 9999,
-            "method": "AssemblyRAST.run_arast",
-            "params": [
-                {
-                    "k_list": [],
-                    "k_max": null,
-                    "output_contigset_name": "MEGAHIT.contigs"
-                }
-            ],
-            "service_ver": "1.2.3",
-            "app_id": "AssemblyRAST/run_arast",
-            "source_ws_objects": ["a/b/c", "e/d"],
-            "parent_job_id": "9998",
+            "app_id": "NarrativeTest/app_sleep",
+            "method": "NarrativeTest.app_sleep",
             "narrative_cell_info": {
                 "cell_id": "NARRATIVE_CELL_1",
+                "run_id": "45620f44-6045-482c-af54-d7c123854fe3",
                 "tag": "dev",
-                "run_id": "6546971e-757a-4a26-8439-325497c6d842"
-            }
-        },
-        "retry_ids": [],
-        "retry_parent": null
-    },
-    "JOB_RUNNING": {
-        "job_id": "JOB_RUNNING",
-        "user": "wjriehl",
-        "authstrat": "kbaseworkspace",
-        "batch_id": null,
-        "batch_job": false,
-        "child_jobs": [],
-        "wsid": 9999,
-        "status": "running",
-        "updated": 1572462965490,
-        "created": 1572462971990,
-        "running": 1572462965490,
-        "job_input": {
-            "wsid": 9999,
-            "method": "AssemblyRAST.run_arast",
+                "token_id": "d5f340b9-c087-49f2-95e8-2fdba700bf97"
+            },
             "params": [
                 {
-                    "k_list": [],
-                    "k_max": null,
-                    "output_contigset_name": "MEGAHIT.contigs"
+                    "fail": 1,
+                    "naptime": 50000
                 }
             ],
-            "service_ver": "2.0.0",
-            "app_id": "AssemblyRAST/run_arast",
-            "source_ws_objects": ["a/b/c", "e/d"],
-            "parent_job_id": null,
-            "narrative_cell_info": {
-                "cell_id": "NARRATIVE_CELL_2",
-                "tag": "dev",
-                "run_id": "6546971e-757a-4a26-8439-325497c6d843"
-            }
+            "service_ver": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "source_ws_objects": [],
+            "wsid": 55555
         },
+        "retry_count": 0,
         "retry_ids": [],
-        "retry_parent": null
+        "retry_saved_toggle": false,
+        "status": "created",
+        "updated": 1642522062069,
+        "user": "fake_test_user",
+        "wsid": 55555
     },
     "JOB_TERMINATED": {
-        "job_id": "JOB_TERMINATED",
-        "user": "fake_test_user",
-        "authstrat": "kbaseworkspace",
         "batch_id": null,
         "batch_job": false,
         "child_jobs": [],
-        "wsid": 9999,
-        "status": "terminated",
-        "updated": 1572462965495,
-        "created": 1572462971995,
-        "finished": 1572462965495,
+        "created": 1642521724000,
+        "finished": 1642521729372,
+        "job_id": "JOB_TERMINATED",
         "job_input": {
-            "wsid": 9999,
-            "method": "AssemblyRAST.run_arast",
-            "params": [
-                {
-                    "k_list": [],
-                    "k_max": null,
-                    "output_contigset_name": "MEGAHIT.contigs"
-                }
-            ],
-            "service_ver": "4.0.0",
-            "app_id": "AssemblyRAST/run_arast",
-            "source_ws_objects": ["a/b/c", "e/d"],
-            "parent_job_id": null,
+            "app_id": "NarrativeTest/app_logs",
+            "method": "NarrativeTest.app_logs",
             "narrative_cell_info": {
                 "cell_id": "NARRATIVE_CELL_2",
+                "run_id": "5f31a481-3ef6-45ff-b627-a5a0e90c212b",
                 "tag": "dev",
-                "run_id": "6546971e-757a-4a26-8439-325497c6d843"
-            }
+                "token_id": "a9f4cad3-1cde-4ac5-b3f8-615b47ce4ab4"
+            },
+            "params": [
+                {
+                    "num_lines": 100
+                }
+            ],
+            "service_ver": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "source_ws_objects": [],
+            "wsid": 54321
         },
+        "queued": 1642521724208,
+        "retry_count": 0,
         "retry_ids": [],
-        "retry_parent": null
+        "retry_saved_toggle": false,
+        "status": "terminated",
+        "terminated_code": 0,
+        "updated": 1642521729372,
+        "user": "test_user",
+        "wsid": 54321
+    },
+    "JOB_RUNNING": {
+        "batch_id": null,
+        "batch_job": false,
+        "child_jobs": [],
+        "created": 1642521765000,
+        "job_id": "JOB_RUNNING",
+        "job_input": {
+            "app_id": "NarrativeTest/app_logs",
+            "method": "NarrativeTest.app_logs",
+            "narrative_cell_info": {
+                "cell_id": "NARRATIVE_CELL_2",
+                "run_id": "b27bdcf3-98f8-4c62-8b5d-5b181cf46058",
+                "tag": "dev",
+                "token_id": "c5ce7f0c-0c13-447e-bed8-c69570f146c4"
+            },
+            "params": [
+                {
+                    "num_lines": 10000
+                }
+            ],
+            "service_ver": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "source_ws_objects": [],
+            "wsid": 54321
+        },
+        "queued": 1642521765842,
+        "retry_count": 0,
+        "retry_ids": [],
+        "retry_saved_toggle": false,
+        "running": 1642521775867,
+        "status": "running",
+        "updated": 1642521775870,
+        "user": "test_user",
+        "wsid": 54321
     },
     "JOB_ERROR": {
-        "job_id": "JOB_ERROR",
-        "user": "fake_test_user",
-        "authstrat": "kbaseworkspace",
         "batch_id": null,
         "batch_job": false,
         "child_jobs": [],
-        "wsid": 9999,
-        "status": "error",
-        "updated": 1572462965495,
-        "created": 1572462971995,
+        "created": 1642431841000,
+        "error": {
+            "code": -32000,
+            "error": "Traceback (most recent call last):\n  File \"/kb/module/bin/../lib/NarrativeTest/NarrativeTestServer.py\", line 101, in _call_method\n    result = method(ctx, *params)\n  File \"/kb/module/lib/NarrativeTest/NarrativeTestImpl.py\", line 345, in app_sleep\n    raise RuntimeError('App woke up from its nap very cranky!')\nRuntimeError: App woke up from its nap very cranky!\n",
+            "message": "'App woke up from its nap very cranky!'",
+            "name": "Server error"
+        },
+        "error_code": 1,
+        "errormsg": "Job output contains an error",
+        "finished": 1642431856245,
+        "job_id": "JOB_ERROR",
         "job_input": {
-            "wsid": 9999,
-            "method": "AssemblyRAST.run_arast",
-            "params": [
-                {
-                    "k_list": [],
-                    "k_max": null,
-                    "output_contigset_name": "MEGAHIT.contigs"
-                }
-            ],
-            "service_ver": "3.6.9",
-            "app_id": "AssemblyRAST/run_arast",
-            "source_ws_objects": [
-                "a/b/c",
-                "e/d"
-            ],
-            "parent_job_id": null,
+            "app_id": "NarrativeTest/app_sleep",
+            "method": "NarrativeTest.app_sleep",
             "narrative_cell_info": {
                 "cell_id": "NARRATIVE_CELL_2",
+                "run_id": "c2ed67e1-4457-4aa0-8f10-88d5f530cbc7",
                 "tag": "dev",
-                "run_id": "6546971e-757a-4a26-8439-325497c6d843"
-            }
+                "token_id": "5ecc946b-e716-41b4-9b1f-c0b61c889192"
+            },
+            "params": [
+                {
+                    "fail": 1,
+                    "naptime": 5
+                }
+            ],
+            "requirements": {
+                "clientgroup": "njs",
+                "cpu": 2,
+                "disk": 100,
+                "memory": 23000
+            },
+            "service_ver": "8d1f8480aee9852e9354cf723f0808fae53b2fcc",
+            "source_ws_objects": [],
+            "wsid": 65854
         },
+        "queued": 1642431841259,
+        "retry_count": 0,
         "retry_ids": [],
-        "retry_parent": null
+        "retry_saved_toggle": false,
+        "running": 1642431847689,
+        "status": "error",
+        "updated": 1642431856323,
+        "user": "ialarmedalien",
+        "wsid": 65854
     },
     "BATCH_PARENT": {
-        "authstrat": "kbaseworkspace",
         "batch_job": true,
         "child_jobs": [
             "BATCH_COMPLETED",
@@ -214,7 +236,6 @@
         "wsid": 10538
     },
     "BATCH_COMPLETED": {
-        "authstrat": "kbaseworkspace",
         "batch_id": "BATCH_PARENT",
         "batch_job": false,
         "child_jobs": [],
@@ -268,10 +289,20 @@
         "status": "completed",
         "updated": 1625756075071,
         "user": "alien_test_user",
+        "widget_info": {
+            "name": "no-display",
+            "params": {
+                "obj_ref": "18836/5/1",
+                "report_name": "kb_sra_upload_report_af468a02-4278-40af-9536-0bdef1f050db",
+                "report_ref": "62425/18/1",
+                "report_window_line_height": "16",
+                "wsName": "wjriehl:1475006266615"
+            },
+            "tag": "release"
+        },
         "wsid": 10538
     },
     "BATCH_TERMINATED": {
-        "authstrat": "kbaseworkspace",
         "batch_id": "BATCH_PARENT",
         "batch_job": false,
         "child_jobs": [],
@@ -318,7 +349,6 @@
         "wsid": 10538
     },
     "BATCH_TERMINATED_RETRIED": {
-        "authstrat": "kbaseworkspace",
         "batch_id": "BATCH_PARENT",
         "batch_job": false,
         "child_jobs": [],
@@ -356,7 +386,10 @@
         },
         "queued": 1625755944519,
         "retry_count": 2,
-        "retry_ids": ["BATCH_RETRY_COMPLETED", "BATCH_RETRY_RUNNING"],
+        "retry_ids": [
+            "BATCH_RETRY_COMPLETED",
+            "BATCH_RETRY_RUNNING"
+        ],
         "retry_saved_toggle": false,
         "running": 1625755952563,
         "status": "terminated",
@@ -366,7 +399,6 @@
         "wsid": 10538
     },
     "BATCH_ERROR_RETRIED": {
-        "authstrat": "kbaseworkspace",
         "batch_id": "BATCH_PARENT",
         "batch_job": false,
         "child_jobs": [],
@@ -411,7 +443,9 @@
         },
         "queued": 1625755944590,
         "retry_count": 1,
-        "retry_ids": ["BATCH_RETRY_ERROR"],
+        "retry_ids": [
+            "BATCH_RETRY_ERROR"
+        ],
         "retry_saved_toggle": false,
         "running": 1625755952628,
         "status": "error",
@@ -420,7 +454,6 @@
         "wsid": 10538
     },
     "BATCH_RETRY_COMPLETED": {
-        "authstrat": "kbaseworkspace",
         "batch_id": "BATCH_PARENT",
         "batch_job": false,
         "child_jobs": [],
@@ -476,10 +509,20 @@
         "status": "completed",
         "updated": 1625756123553,
         "user": "alien_test_user",
+        "widget_info": {
+            "name": "no-display",
+            "params": {
+                "obj_ref": "18836/5/1",
+                "report_name": "kb_sra_upload_report_4ffc6219-0260-4f1d-8b4d-5083e0595150",
+                "report_ref": "62425/19/1",
+                "report_window_line_height": "16",
+                "wsName": "wjriehl:1475006266615"
+            },
+            "tag": "release"
+        },
         "wsid": 10538
     },
     "BATCH_RETRY_RUNNING": {
-        "authstrat": "kbaseworkspace",
         "batch_id": "BATCH_PARENT",
         "batch_job": false,
         "child_jobs": [],
@@ -526,7 +569,6 @@
         "wsid": 10538
     },
     "BATCH_RETRY_ERROR": {
-        "authstrat": "kbaseworkspace",
         "batch_id": "BATCH_PARENT",
         "batch_job": false,
         "child_jobs": [],

--- a/src/biokbase/narrative/tests/job_test_constants.py
+++ b/src/biokbase/narrative/tests/job_test_constants.py
@@ -1,19 +1,10 @@
 from .util import ConfigTests
 import copy
+from biokbase.narrative.jobs.job import TERMINAL_STATUSES
 
 
 config = ConfigTests()
 TEST_JOBS = config.load_json_file(config.get("jobs", "ee2_job_test_data_file"))
-
-
-def get_retried_jobs(all_jobs):
-    # collect retried jobs
-    retried_jobs = {}
-    for job in all_jobs.values():
-        # save the first retry ID with the retried job
-        if "retry_ids" in job and len(job["retry_ids"]) > 0:
-            retried_jobs[job["job_id"]] = job["retry_ids"][0]
-    return retried_jobs
 
 
 def generate_error(job_id, err_type):
@@ -45,8 +36,6 @@ def get_test_job(job_id):
 
 
 CLIENTS = "biokbase.narrative.clients.get"
-TEST_JOB_IDS = list(TEST_JOBS.keys())
-RETRIED_JOBS = get_retried_jobs(TEST_JOBS)
 
 # test_jobs contains jobs in the following states
 JOB_COMPLETED = "JOB_COMPLETED"
@@ -62,6 +51,22 @@ BATCH_ERROR_RETRIED = "BATCH_ERROR_RETRIED"
 BATCH_RETRY_COMPLETED = "BATCH_RETRY_COMPLETED"
 BATCH_RETRY_RUNNING = "BATCH_RETRY_RUNNING"
 BATCH_RETRY_ERROR = "BATCH_RETRY_ERROR"
+
+ALL_JOBS = [
+    JOB_COMPLETED,
+    JOB_CREATED,
+    JOB_RUNNING,
+    JOB_TERMINATED,
+    JOB_ERROR,
+    BATCH_PARENT,
+    BATCH_COMPLETED,
+    BATCH_TERMINATED,
+    BATCH_TERMINATED_RETRIED,
+    BATCH_ERROR_RETRIED,
+    BATCH_RETRY_COMPLETED,
+    BATCH_RETRY_ERROR,
+    BATCH_RETRY_RUNNING
+]
 
 JOB_NOT_FOUND = "job_not_found"
 BAD_JOB_ID = "a_bad_job_id"
@@ -81,23 +86,8 @@ BATCH_CHILDREN = [
 
 BATCH_PARENT_CHILDREN = [BATCH_PARENT] + BATCH_CHILDREN
 
-JOBS_TERMINALITY = {
-    JOB_COMPLETED: True,
-    JOB_CREATED: False,
-    JOB_RUNNING: False,
-    JOB_TERMINATED: True,
-    JOB_ERROR: True,
-    BATCH_PARENT: False,
-    BATCH_COMPLETED: True,
-    BATCH_TERMINATED: True,
-    BATCH_TERMINATED_RETRIED: True,
-    BATCH_ERROR_RETRIED: True,
-    BATCH_RETRY_COMPLETED: True,
-    BATCH_RETRY_RUNNING: False,
-    BATCH_RETRY_ERROR: True,
-}
+JOBS_TERMINALITY = {id: TEST_JOBS[id]["status"] in TERMINAL_STATUSES for id in TEST_JOBS.keys()}
 
-ALL_JOBS = list(JOBS_TERMINALITY.keys())
 TERMINAL_JOBS = []
 ACTIVE_JOBS = []
 for key, value in JOBS_TERMINALITY.items():
@@ -106,37 +96,6 @@ for key, value in JOBS_TERMINALITY.items():
     else:
         ACTIVE_JOBS.append(key)
 
-TEST_CELL_ID_LIST = [
-    "NARRATIVE_CELL_1",
-    "NARRATIVE_CELL_2",
-    # batch cell
-    "NARRATIVE_BATCH_CELL_1",
-    # batch cell two
-    "NARRATIVE_BATCH_CELL_2",
-    "invalid_cell_id",
-]
-# expected _jobs_by_cell_id mapping in JobManager
-JOBS_BY_CELL_ID = {
-    TEST_CELL_ID_LIST[0]: {JOB_COMPLETED, JOB_CREATED},
-    TEST_CELL_ID_LIST[1]: {JOB_RUNNING, JOB_TERMINATED, JOB_ERROR},
-    TEST_CELL_ID_LIST[2]: {
-        BATCH_PARENT,
-        BATCH_COMPLETED,
-        BATCH_TERMINATED,
-        BATCH_TERMINATED_RETRIED,
-        BATCH_ERROR_RETRIED,
-    },
-    TEST_CELL_ID_LIST[3]: {
-        BATCH_PARENT,
-        BATCH_RETRY_COMPLETED,
-        BATCH_RETRY_RUNNING,
-        BATCH_RETRY_ERROR,
-    },
-}
-
-# mapping expected as output from get_job_states_by_cell_id
-TEST_CELL_IDs = {id: list(JOBS_BY_CELL_ID[id]) for id in JOBS_BY_CELL_ID.keys()}
-TEST_CELL_IDs[TEST_CELL_ID_LIST[4]] = []
 
 READS_OBJ_1 = "rhodobacterium.art.q20.int.PE.reads"
 READS_OBJ_2 = "rhodobacterium.art.q10.PE.reads"

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -16,11 +16,13 @@ from biokbase.narrative.tests.job_test_constants import (
     JOB_CREATED,
     BATCH_RETRY_RUNNING,
     JOB_NOT_FOUND,
-    RETRIED_JOBS,
     BATCH_PARENT,
     READS_OBJ_1,
     READS_OBJ_2,
     generate_error,
+)
+from biokbase.narrative.tests.generate_test_results import (
+    RETRIED_JOBS
 )
 
 RANDOM_DATE = "2018-08-10T16:47:36+0000"
@@ -92,10 +94,6 @@ class MockClients:
     @property
     def job_state_data(self):
         return copy.deepcopy(self._job_state_data)
-
-    @property
-    def initial_job_state_data(self):
-        return copy.deepcopy(self._initial_job_state_data)
 
     # ----- Narrative Method Store functions ------
 

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -45,7 +45,6 @@ from biokbase.narrative.exception_util import (
     transform_job_exception,
 )
 
-from biokbase.narrative.tests.generate_test_results import ALL_RESPONSE_DATA
 from .util import ConfigTests, validate_job_state
 from biokbase.narrative.tests.job_test_constants import (
     CLIENTS,
@@ -65,18 +64,22 @@ from biokbase.narrative.tests.job_test_constants import (
     JOB_NOT_FOUND,
     BAD_JOB_ID,
     BAD_JOB_ID_2,
-    TEST_CELL_ID_LIST,
-    TEST_CELL_IDs,
     JOBS_TERMINALITY,
     ALL_JOBS,
+    BAD_JOBS,
     ACTIVE_JOBS,
-    JOBS_BY_CELL_ID,
     BATCH_PARENT_CHILDREN,
     BATCH_CHILDREN,
-    TEST_JOB_IDS,
-    RETRIED_JOBS,
     generate_error,
 )
+from biokbase.narrative.tests.generate_test_results import (
+    ALL_RESPONSE_DATA,
+    RETRIED_JOBS,
+    TEST_CELL_ID_LIST,
+    TEST_CELL_IDs,
+    JOBS_BY_CELL_ID,
+)
+
 from .narrative_mock.mockcomm import MockComm
 from .narrative_mock.mockclients import (
     get_mock_client,
@@ -623,7 +626,7 @@ class JobCommTestCase(unittest.TestCase):
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_job_states_by_cell_id__all_results(self):
         cell_id_list = TEST_CELL_ID_LIST
-        expected_ids = TEST_JOB_IDS
+        expected_ids = ALL_JOBS
         expected_states = {id: ALL_RESPONSE_DATA[STATUS][id] for id in expected_ids}
 
         req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list}, False)
@@ -849,8 +852,10 @@ class JobCommTestCase(unittest.TestCase):
         self.check_retry_jobs(job_id_list, job_id_list)
 
     def test_retry_jobs__job_id_list__all_jobs(self):
-        for job_id in TEST_JOB_IDS:
+        job_id_list = ALL_JOBS + BAD_JOBS
+        for job_id in job_id_list:
             self.check_retry_jobs({JOB_ID: job_id}, [job_id])
+        self.check_retry_jobs(job_id_list, job_id_list)
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_retry_jobs__job_id_list__all_bad_jobs(self):

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -284,7 +284,6 @@ class JobManagerTest(unittest.TestCase):
             "app_id": {},
             "batch_id": {},
             "user": {},
-            # "incomplete": 0,
         }
 
         n_not_started = 0

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -47,9 +47,6 @@ from biokbase.narrative.tests.job_test_constants import (
     BATCH_ERROR_RETRIED,
     JOB_NOT_FOUND,
     BAD_JOB_ID,
-    TEST_CELL_ID_LIST,
-    JOBS_BY_CELL_ID,
-    TEST_CELL_IDs,
     JOBS_TERMINALITY,
     ALL_JOBS,
     BAD_JOBS,
@@ -57,12 +54,16 @@ from biokbase.narrative.tests.job_test_constants import (
     ACTIVE_JOBS,
     BATCH_CHILDREN,
     TEST_JOBS,
-    TEST_JOB_IDS,
     get_test_job,
     generate_error,
 )
 
-from biokbase.narrative.tests.generate_test_results import ALL_RESPONSE_DATA
+from biokbase.narrative.tests.generate_test_results import (
+    ALL_RESPONSE_DATA,
+    JOBS_BY_CELL_ID,
+    TEST_CELL_ID_LIST,
+    TEST_CELL_IDs,
+)
 
 from .narrative_mock.mockclients import (
     get_mock_client,
@@ -121,7 +122,7 @@ class JobManagerTest(unittest.TestCase):
             set(TERMINAL_JOBS),
             set(terminal_ids),
         )
-        self.assertEqual(set(TEST_JOB_IDS), set(self.jm._running_jobs.keys()))
+        self.assertEqual(set(ALL_JOBS), set(self.jm._running_jobs.keys()))
 
         for job_id in TERMINAL_IDS:
             self.assertFalse(self.jm._running_jobs[job_id]["refresh"])
@@ -257,7 +258,7 @@ class JobManagerTest(unittest.TestCase):
         self.assertEqual(self.jm._create_jobs(job_list), {})
 
     def test__get_job_good(self):
-        job_id = TEST_JOB_IDS[0]
+        job_id = ALL_JOBS[0]
         job = self.jm.get_job(job_id)
         self.assertEqual(job_id, job.job_id)
         self.assertIsInstance(job, Job)
@@ -277,15 +278,51 @@ class JobManagerTest(unittest.TestCase):
         jobs_html = self.jm.list_jobs()
         self.assertIsInstance(jobs_html, HTML)
         html = jobs_html.data
-        for job_id in TEST_JOB_IDS:
-            self.assertIn("<td>" + job_id + "</td>", html)
-        self.assertIn("<td>NarrativeTest/test_editor</td>", html)
-        self.assertIn("<td>2019-08-26 ", html)
-        self.assertIn(":54:48</td>", html)
-        self.assertIn("<td>fake_test_user</td>", html)
-        self.assertIn("<td>completed</td>", html)
-        self.assertIn("<td>Not started</td>", html)
-        self.assertIn("<td>Incomplete</td>", html)
+
+        counts = {
+            "status": {},
+            "app_id": {},
+            "batch_id": {},
+            "user": {},
+            # "incomplete": 0,
+        }
+
+        n_not_started = 0
+        n_incomplete = 0
+        for job in TEST_JOBS.values():
+            for param in ["status", "user"]:
+                if param in job:
+                    value = job[param]
+                    if value not in counts[param]:
+                        counts[param][value] = 0
+                    counts[param][value] += 1
+
+            app_id = job["job_input"]["app_id"]
+            if app_id not in counts["app_id"]:
+                counts["app_id"][app_id] = 0
+            counts["app_id"][app_id] += 1
+
+            if "finished" not in job:
+                n_incomplete += 1
+            if "running" not in job:
+                n_not_started += 1
+
+        for job_id in ALL_JOBS:
+            self.assertIn(f"<td>{job_id}</td>", html)
+
+        for param in counts:
+            for value in counts[param]:
+                self.assertIn("<td>" + str(value) + "</td>", html)
+                value_count = html.count("<td>" + str(value) + "</td>")
+
+                self.assertEqual(counts[param][value], value_count)
+
+        if n_incomplete:
+            incomplete_count = html.count("<td>Incomplete</td>")
+            self.assertEqual(incomplete_count, n_incomplete)
+        if n_not_started:
+            not_started_count = html.count("<td>Not started</td>")
+            self.assertEqual(not_started_count, n_not_started)
 
     def test_list_jobs_twice(self):
         # with no jobs
@@ -484,8 +521,8 @@ class JobManagerTest(unittest.TestCase):
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_all_job_states__ignore_refresh_flag(self):
         states = self.jm.lookup_all_job_states(ignore_refresh_flag=True)
-        self.assertEqual(set(TEST_JOB_IDS), set(states.keys()))
-        self.assertEqual({id: ALL_RESPONSE_DATA[STATUS][id] for id in TEST_JOB_IDS}, states)
+        self.assertEqual(set(ALL_JOBS), set(states.keys()))
+        self.assertEqual({id: ALL_RESPONSE_DATA[STATUS][id] for id in ALL_JOBS}, states)
 
     ## lookup_job_states_by_cell_id
     @mock.patch(CLIENTS, get_mock_client)
@@ -521,7 +558,7 @@ class JobManagerTest(unittest.TestCase):
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_job_states_by_cell_id__cell_id_list_all_results(self):
         cell_ids = TEST_CELL_ID_LIST
-        self.check_lookup_job_states_by_cell_id_results(cell_ids, TEST_JOB_IDS)
+        self.check_lookup_job_states_by_cell_id_results(cell_ids, ALL_JOBS)
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_job_states_by_cell_id__cell_id_list__batch_job__one_cell(self):


### PR DESCRIPTION
# Description of PR purpose/changes

- Move generation of data-dependent constants to `generate_test_results.py`
- substitute in up-to-date ee2 job data structures

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
