### PR TITLE
DATAUP-497 VI b: cruft removal

### DIFF
--- a/src/biokbase/narrative/clients.py
+++ b/src/biokbase/narrative/clients.py
@@ -4,7 +4,6 @@ from biokbase.userandjobstate.client import UserAndJobState
 from biokbase.catalog.Client import Catalog
 from biokbase.service.Client import Client as ServiceClient
 from biokbase.execution_engine2.execution_engine2Client import execution_engine2
-
 from biokbase.narrative.common.url_config import URLS
 
 
@@ -13,6 +12,7 @@ def get(client_name, token=None):
 
 
 def reset():
+    # this is never used
     pass
 
 
@@ -33,20 +33,7 @@ def __init_client(client_name, token=None):
         or client_name == "job_service"
     ):
         c = execution_engine2(URLS.execution_engine2, token=token)
-    elif client_name == "job_service_mock":
-        c = JobServiceMock()
     else:
         raise ValueError('Unknown client name "%s"' % client_name)
 
     return c
-
-
-class JobServiceMock:
-    def __init__(self):
-        self.client = get("service")
-
-    def check_job(self, job_id):
-        return self.client.sync_call("narrative_job_mock.check_job", [job_id])[0]
-
-    def check_jobs(self, params):
-        return self.client.sync_call("narrative_job_mock.check_jobs", [params])[0]

--- a/src/biokbase/narrative/jobs/util.py
+++ b/src/biokbase/narrative/jobs/util.py
@@ -50,37 +50,3 @@ def load_job_constants(relative_path_to_file=JOB_CONFIG_FILE_PATH_PARTS):
             )
 
     return (config["params"], config["message_types"])
-
-
-def sanitize_state(state):
-    """
-    There's too many places where there's "cancelled" or "canceled" or other weird variants
-    in both narrative, UJS, and NJS. This is the central spot that attempts to deal with them.
-    It does this by ONLY returning "canceled" as the state string for use by the front end.
-
-    This takes a state structure (as returned by NJS.check_jobs or NJS.check_job) and returns
-    it with some keys changed.
-    """
-    if "cancelled" in state:
-        state["canceled"] = state.get("cancelled", 0)
-        del state["cancelled"]
-    if state.get("job_state", "") == "cancelled":
-        state["job_state"] = "canceled"
-    ujs_status = state.get("status", [])
-    if (
-        isinstance(ujs_status, list)
-        and len(ujs_status) >= 2
-        and ujs_status[1] == "cancelled"
-    ):
-        state["status"][1] = "canceled"
-    return state
-
-
-def sanitize_all_states(states):
-    """
-    Like sanitize_state above, but meant to be applied to the result of NJS.check_jobs. This maintains
-    the plural structure provided by that function while changing the names around.
-    """
-    for job_id in states.get("job_states", {}):
-        states["job_states"][job_id] = sanitize_state(states["job_states"][job_id])
-    return states

--- a/src/biokbase/narrative/tests/test_job_util.py
+++ b/src/biokbase/narrative/tests/test_job_util.py
@@ -1,46 +1,5 @@
-from biokbase.narrative.jobs.util import (
-    load_job_constants,
-    sanitize_all_states,
-    sanitize_state,
-)
+from biokbase.narrative.jobs.util import load_job_constants
 import unittest
-from copy import deepcopy
-
-cancelled_state = {
-    "awe_job_state": "cancelled",
-    "cell_id": "9e338b5d-e3b0-4e94-8aa0-e97c402416ab",
-    "creation_time": 1557268961909,
-    "finished": 0,
-    "job_id": "1",
-    "job_state": "cancelled",
-    "run_id": "0d0203f2-58c5-4eb6-9ecb-8e44ba8a2308",
-    "status": [
-        "2019-05-07T22:42:41+0000",
-        "cancelled",
-        "canceled by user",
-        None,
-        None,
-        0,
-        0,
-    ],
-    "child_jobs": [],
-    "token_id": "5a8fcf6d-5e06-4a98-b56e-62bc2c095e69",
-    "ujs_url": "https://ci.kbase.us/services/userandjobstate/",
-}
-
-queued_state = {
-    "awe_job_state": "queued",
-    "cell_id": "9e338b5d-e3b0-4e94-8aa0-e97c402416ab",
-    "creation_time": 1557268961909,
-    "finished": 0,
-    "job_id": "2",
-    "job_state": "queued",
-    "run_id": "0d0203f2-58c5-4eb6-9ecb-8e44ba8a2308",
-    "status": ["2019-05-07T22:42:41+0000", "queued", "started", None, None, 0, 0],
-    "child_jobs": [],
-    "token_id": "5a8fcf6d-5e06-4a98-b56e-62bc2c095e69",
-    "ujs_url": "https://ci.kbase.us/services/userandjobstate/",
-}
 
 
 class JobUtilTestCase(unittest.TestCase):
@@ -95,35 +54,6 @@ class JobUtilTestCase(unittest.TestCase):
             self.assertIn(item, params)
         for item in ["STATUS", "RETRY", "INFO", "ERROR"]:
             self.assertIn(item, message_types)
-
-    def test_sanitize_state(self):
-        sani_state = sanitize_state(deepcopy(cancelled_state))
-        self.assertEqual(sani_state["job_state"], "canceled")
-        self.assertEqual(sani_state["status"][1], "canceled")
-
-        sani_state = sanitize_state(deepcopy(queued_state))
-        self.assertEqual(sani_state["job_state"], "queued")
-        self.assertEqual(sani_state["status"][1], "queued")
-
-    def test_sanitize_state_no_status(self):
-        state = {"job_state": "cancelled", "status": None}
-        sani_state = sanitize_state(state)
-        self.assertEqual(sani_state["job_state"], "canceled")
-        self.assertIsNone(sani_state["status"])
-
-    def test_sanitize_all_states(self):
-        all_states = {
-            "job_states": {"1": deepcopy(cancelled_state), "2": deepcopy(queued_state)}
-        }
-        sani_states = sanitize_all_states(all_states)
-        self.assertEqual(sani_states["job_states"]["1"]["job_state"], "canceled")
-        self.assertEqual(sani_states["job_states"]["1"]["status"][1], "canceled")
-        self.assertEqual(sani_states["job_states"]["2"]["job_state"], "queued")
-        self.assertEqual(sani_states["job_states"]["2"]["status"][1], "queued")
-
-    def test_sanitize_all_states_none(self):
-        all_states = {"job_states": {}}
-        self.assertEqual(all_states, sanitize_all_states(all_states))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description of PR purpose/changes

Remove unused code in job utils and clients python files

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
