### PR TITLE
DATAUP-497 PR VII: error handling

### DIFF
--- a/src/biokbase/narrative/clients.py
+++ b/src/biokbase/narrative/clients.py
@@ -19,20 +19,20 @@ def reset():
 def __init_client(client_name, token=None):
     if client_name == "workspace":
         c = Workspace(URLS.workspace, token=token)
-    elif client_name == "narrative_method_store":
-        c = NarrativeMethodStore(URLS.narrative_method_store, token=token)
-    elif client_name == "user_and_job_state":
-        c = UserAndJobState(URLS.user_and_job_state, token=token)
-    elif client_name == "catalog":
-        c = Catalog(URLS.catalog, token=token)
-    elif client_name == "service" or client_name == "service_wizard":
-        c = ServiceClient(URLS.service_wizard, use_url_lookup=True, token=token)
     elif (
         client_name == "execution_engine2"
         or client_name == "execution_engine"
         or client_name == "job_service"
     ):
         c = execution_engine2(URLS.execution_engine2, token=token)
+    elif client_name == "narrative_method_store":
+        c = NarrativeMethodStore(URLS.narrative_method_store, token=token)
+    elif client_name == "service" or client_name == "service_wizard":
+        c = ServiceClient(URLS.service_wizard, use_url_lookup=True, token=token)
+    elif client_name == "catalog":
+        c = Catalog(URLS.catalog, token=token)
+    elif client_name == "user_and_job_state":
+        c = UserAndJobState(URLS.user_and_job_state, token=token)
     else:
         raise ValueError('Unknown client name "%s"' % client_name)
 

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -215,6 +215,9 @@ class JobComm:
                     "name": getattr(e, "name", type(e).__name__),
                 }
                 self.send_comm_message(MESSAGE_TYPE["ERROR"], error)
+                # if job init failed, set the lookup loop var back to False and return
+                self._running_lookup_loop = False
+                return
         if self._lookup_timer is None:
             self._lookup_job_status_loop()
 

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -248,8 +248,11 @@ class JobManager(object):
                     }
                 )
             except Exception as e:
+                error_message = str(e)
                 kblogging.log_event(
-                    self._log, "_construct_job_output_state_set", {"exception": str(e)}
+                    self._log,
+                    "_construct_job_output_state_set",
+                    {"exception": error_message},
                 )
 
             # fill in the output states for the missing jobs
@@ -262,9 +265,8 @@ class JobManager(object):
                 else:
                     # fetch the current state without updating it
                     output_states[job_id] = job.output_state({})
-                    # set the status to 'ee2_error' and the 'updated' timestamp to now
-                    output_states[job_id]["jobState"]["status"] = "ee2_error"
-                    output_states[job_id]["jobState"]["updated"] = int(time.time())
+                    # add an error field with the error message from the failed look up
+                    output_states[job_id]["error"] = error_message
 
         return output_states
 

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -2,7 +2,6 @@ from IPython.display import HTML
 from jinja2 import Template
 from datetime import datetime, timezone, timedelta
 import copy
-import time
 from typing import List, Tuple
 import biokbase.narrative.clients as clients
 from .job import (
@@ -38,12 +37,6 @@ JOBS_MISSING_ERR = "No valid job IDs provided"
 
 CELLS_NOT_PROVIDED_ERR = "cell_id_list not provided"
 DOES_NOT_EXIST = "does_not_exist"
-
-
-def get_error_output_state(job_id, error=DOES_NOT_EXIST):
-    if error not in [DOES_NOT_EXIST, "ee2_error"]:
-        raise ValueError(f"Unknown error type: {error}")
-    return {"jobState": {"job_id": job_id, "status": error}}
 
 
 class JobManager(object):
@@ -256,8 +249,8 @@ class JobManager(object):
                 )
 
             # fill in the output states for the missing jobs
-            # if the job fetch failed, set the job status to "ee2_error"
-            # without altering the cached job data
+            # if the job fetch failed, add an error message to the output
+            # and return the cached job state
             for job_id in jobs_to_lookup:
                 job = self.get_job(job_id)
                 if job_id in fetched_states:

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -80,9 +80,10 @@ class MockClients:
     config = ConfigTests()
     _job_state_data = TEST_JOBS
 
-    def __init__(self, token=None):
+    def __init__(self, client_name=None, token=None):
         if token is not None:
             assert isinstance(token, str)
+        self.client_name = client_name
         self.test_job_id = self.config.get("app_tests", "test_job_id")
 
     @property
@@ -504,7 +505,7 @@ class MockClients:
 
 
 def get_mock_client(client_name, token=None):
-    return MockClients(token=token)
+    return MockClients(client_name=client_name, token=token)
 
 
 def get_failing_mock_client(client_name, token=None):
@@ -516,10 +517,10 @@ class FailingMockClient:
         pass
 
     def check_workspace_jobs(self, params):
-        raise ServerError("JSONRPCError", -32000, "Job lookup failed.")
+        raise generate_ee2_error("check_workspace_jobs")
 
     def check_job(self, params):
-        raise ServerError("JSONRPCError", -32000, "Check job failed")
+        raise generate_ee2_error("check_job")
 
     def cancel_job(self, params):
         raise generate_ee2_error(MESSAGE_TYPE["CANCEL"])

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -2,7 +2,7 @@ import unittest
 import mock
 import copy
 import itertools
-from biokbase.workspace.baseclient import ServerError
+from biokbase.execution_engine2.baseclient import ServerError
 from biokbase.narrative.app_util import map_inputs_from_job, map_outputs_from_state
 from biokbase.narrative.jobs.job import (
     Job,
@@ -347,7 +347,7 @@ class JobTest(unittest.TestCase):
         """
         job = create_job_from_ee2(JOB_CREATED)
         self.assertFalse(job.was_terminal())
-        with self.assertRaisesRegex(ServerError, "Check job failed"):
+        with self.assertRaisesRegex(ServerError, "check_job failed"):
             job.state()
 
     def test_state__returns_none(self):

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -423,6 +423,25 @@ class JobCommTestCase(unittest.TestCase):
                 self.assertFalse(self.jc._running_lookup_loop)
                 self.assertIsNone(self.jc._lookup_timer)
 
+    @mock.patch(CLIENTS, get_failing_mock_client)
+    def test_start_job_status_loop__initialise_jobs_error(self):
+        # check_workspace_jobs throws an EEServerError
+        self.jc.start_job_status_loop(init_jobs=True)
+        self.assertEqual(
+            self.jc._comm.last_message,
+            {
+                "msg_type": ERROR,
+                "content": {
+                    "error": "Unable to get initial jobs list",
+                    "message": "check_workspace_jobs failed",
+                    "code": -32000,
+                    "source": "ee2",
+                    "name": "JSONRPCError",
+                }
+            }
+        )
+        self.assertFalse(self.jc._running_lookup_loop)
+
     # ---------------------
     # Lookup all job states
     # ---------------------
@@ -549,26 +568,25 @@ class JobCommTestCase(unittest.TestCase):
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_lookup_job_states__job_id_list__ee2_error(self):
-        def mock_check_jobs(self, params):
-            raise Exception("Test exception")
+        exc = Exception("Test exception")
+        exc_message = str(exc)
+
+        def mock_check_jobs(params):
+            raise exc
 
         job_id_list = ALL_JOBS
         req_dict = make_comm_msg(STATUS, job_id_list, False)
 
-        TIME_NOW = 987654321
-        with mock.patch("time.time") as fake_time:
-            fake_time.return_value = TIME_NOW
-            with mock.patch.object(
-                MockClients, "check_jobs", side_effect=mock_check_jobs
-            ):
-                self.jc._handle_comm_message(req_dict)
+        with mock.patch.object(
+            MockClients, "check_jobs", side_effect=mock_check_jobs
+        ):
+            self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
 
         expected = {id: copy.deepcopy(ALL_RESPONSE_DATA[STATUS][id]) for id in ALL_JOBS}
         for job_id in ACTIVE_JOBS:
             # add in the ee2_error status and updated timestamp
-            expected[job_id]["jobState"]["status"] = "ee2_error"
-            expected[job_id]["jobState"]["updated"] = TIME_NOW
+            expected[job_id]["error"] = exc_message
 
         self.assertEqual(
             {

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -100,7 +100,9 @@ class JobManagerTest(unittest.TestCase):
     @mock.patch(CLIENTS, get_failing_mock_client)
     def test_initialize_jobs_ee2_fail(self):
         # init jobs should fail. specifically, ee2.check_workspace_jobs should error.
-        with self.assertRaisesRegex(NarrativeException, re.escape("Job lookup failed")):
+        with self.assertRaisesRegex(
+            NarrativeException, re.escape("check_workspace_jobs failed")
+        ):
             self.jm.initialize_jobs()
 
     @mock.patch(CLIENTS, get_mock_client)
@@ -223,16 +225,14 @@ class JobManagerTest(unittest.TestCase):
 
     @mock.patch(CLIENTS, get_mock_client)
     def test__construct_job_output_state_set__ee2_error(self):
-        def mock_check_jobs(self, params):
-            raise Exception("Test exception")
+        exc = Exception("Test exception")
+        exc_message = str(exc)
 
-        TIME_NOW = 987654321
-        with mock.patch("time.time") as fake_time:
-            fake_time.return_value = TIME_NOW
-            with mock.patch.object(
-                MockClients, "check_jobs", side_effect=mock_check_jobs
-            ):
-                job_states = self.jm._construct_job_output_state_set(ALL_JOBS)
+        def mock_check_jobs(params):
+            raise exc
+
+        with mock.patch.object(MockClients, "check_jobs", side_effect=mock_check_jobs):
+            job_states = self.jm._construct_job_output_state_set(ALL_JOBS)
 
         expected = {
             job_id: copy.deepcopy(ALL_RESPONSE_DATA[MESSAGE_TYPE["STATUS"]][job_id])
@@ -240,9 +240,8 @@ class JobManagerTest(unittest.TestCase):
         }
 
         for job_id in ACTIVE_JOBS:
-            # add in the ee2_error status and updated timestamp
-            expected[job_id]["jobState"]["status"] = "ee2_error"
-            expected[job_id]["jobState"]["updated"] = TIME_NOW
+            # expect there to be an error message added
+            expected[job_id]["error"] = exc_message
 
         self.assertEqual(
             expected,


### PR DESCRIPTION
# Description of PR purpose/changes

Alter ee2 error handling to remove the alteration of the job state object and put the error into a separate field
Alter behaviour on failure of job initialisation to return (rather than trying to run the lookup loop); add in a test
Uniform error behaviour in tests for ee2 errors

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
