### PR TITLE
DATAUP-638 XSV errors part 1 - staging service

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
@@ -143,18 +143,20 @@ define(['common/ui', 'common/html'], (UI, html) => {
         }
 
         _formatErrors() {
-            const div = html.tag('div'),
-                ul = html.tag('ul'),
-                li = html.tag('li');
+            const tag = html.tag,
+                div = tag('div'),
+                ul = tag('ul'),
+                li = tag('li'),
+                b = tag('b');
 
-            let title = 'OMG ERROR';
+            let title = 'Bulk import error';
             let body = '';
             // some branching based on how errors were parsed out.
 
             if (this.noFileError) {
                 title = 'No files given';
                 body =
-                    'No files were given, though the bulk import specification was chosen. Blame Gavin.';
+                    'No CSV/TSV/Excel files were provided, but "Import Specification" was selected.';
             } else if (this.serverErrors.length) {
                 title = 'Server error';
                 body = div([
@@ -162,11 +164,23 @@ define(['common/ui', 'common/html'], (UI, html) => {
                     ul(this.serverErrors.map((err) => li(err))),
                 ]);
             } else {
+                let footer = '';
+                const numFiles = Object.keys(this.fileErrors).length;
+
                 const fileErrorText = Object.entries(this.fileErrors).map(([fileName, errors]) => {
                     const s = errors.length > 1 ? 's' : '';
-                    const header = `Error${s} in ${fileName}`;
+                    const header = b(`Error${s} in ${fileName}`);
                     return div([header, ul(errors.map((err) => li(err)))]);
                 });
+
+                if (numFiles === 1) {
+                    footer = `Check bulk import file ${
+                        Object.keys(this.fileErrors)[0]
+                    } and retry. `;
+                } else if (numFiles > 1) {
+                    footer = 'Check bulk import files and retry. ';
+                }
+                footer += 'Click OK to return to Staging.';
 
                 let unknownErrors = '';
                 if (this.unexpectedErrors.length) {
@@ -179,7 +193,7 @@ define(['common/ui', 'common/html'], (UI, html) => {
                     ]);
                 }
 
-                body = div([fileErrorText, unknownErrors]);
+                body = div([fileErrorText, unknownErrors, footer]);
             }
 
             if (this.totalErrors > 1) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
@@ -97,7 +97,7 @@ define(['common/ui', 'common/html'], (UI, html) => {
          * }
          */
         _processErrors() {
-            // a little lambda-ish to handle file error formatting
+            // a little helper to handle file error formatting
             const addFileError = (error) => {
                 let fileKey = error.file;
                 if (error.tab) {
@@ -221,6 +221,8 @@ define(['common/ui', 'common/html'], (UI, html) => {
         }
 
         /**
+         * Shows an error dialog composed of the various errors used to initialize this object. It
+         * can optionally run an extra function once the dialog gets rendered.
          * @param {function} doThisFirst - a function to run as soon as the dialog opens, before it gets closed
          * @returns {Promise} a Promise that resolves to false when the user closes the dialog.
          */

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
@@ -1,0 +1,224 @@
+define(['common/ui', 'common/html'], (UI, html) => {
+    'use strict';
+
+    const BULK_SPEC_ERRORS = {
+        NOT_FOUND: 'cannot_find_file',
+        CANNOT_PARSE: 'cannot_parse_file',
+        INCORRECT_COLUMN_COUNT: 'incorrect_column_count',
+        MULTIPLE_SPECS: 'multiple_specifications_for_data_type',
+        NO_FILES: 'no_files_provided',
+        UNKNOWN: 'unexpected_error',
+        SERVER: 'server_error',
+    };
+
+    /**
+     *
+     */
+    class ImportSetupError extends Error {
+        /**
+         * error structure = key-value pairs. all values are strings, keys are one or more of:
+         * {
+         *   type, (only required one, rest are dependent on it)
+         *   file,
+         *   tab,
+         *   message,
+         *   file_1,
+         *   file_2,
+         *   tab_1,
+         *   tab_2,
+         *   code
+         * }
+         * @param {string} text
+         * @param {Object} errors
+         */
+        constructor(text, errors) {
+            super(text);
+            this.errors = errors;
+            this.name = 'ImportSetupError';
+            this.text = text;
+            this._processErrors();
+        }
+
+        toString() {
+            return `${this.name} - ${this.text}: ${JSON.stringify(this.errors)}`;
+        }
+
+        /**
+         * Should take the list of errors, sort, and group them by file type as possible.
+         * Goal = go from list of errors of various formats to something more
+         * printable with some formatting.
+         * i.e. from:
+         * [{
+         *   type: 'cannot_find_file',
+         *   file: 'some_file.csv',
+         * }]
+         * to:
+         * {
+         *   some_file.csv: ['not found']
+         * }
+         * or, more complicated:
+         * [{
+         *   type: 'incorrect_column_count',
+         *   file: 'file1.xls',
+         *   tab: 'tab_1',
+         *   message: 'wrong column count, missing <some column>'
+         * }, {
+         *   type: 'multiple_specifications_for_data_type',
+         *   file_1: 'file1.xls',
+         *   tab_1: 'tab_1',
+         *   file_2: 'file2.csv',
+         *   tab_2: null,
+         *   message: 'duplicate specification found'
+         * }, {
+         *   type: 'unexpected_error',
+         *   message: 'an unexpected error occurred'
+         * }]
+         * to:
+         * {
+         *   'file1.xls tab "tab_1"': [
+         *     'wrong column count, missing <some column>',
+         *     'duplicate specification found in file2.csv'
+         *   ],
+         *   'file2.csv': [
+         *     'duplicate specification found in file1.xls tab "tab_1"'
+         *   ],
+         * }
+         */
+        _processErrors() {
+            // a little lambda-ish to handle file error formatting
+            const addFileError = (error) => {
+                let fileKey = error.file;
+                if (error.tab) {
+                    fileKey += ` tab ${error.tab}`;
+                }
+                if (!this.fileErrors[fileKey]) {
+                    this.fileErrors[fileKey] = [];
+                }
+                this.fileErrors[fileKey].push(error.message);
+            };
+
+            this.fileErrors = {};
+            this.serverErrors = [];
+            this.unexpectedErrors = [];
+            this.noFileError = false;
+            this.totalErrors = 0;
+            this.errors.forEach((error) => {
+                switch (error.type) {
+                    case BULK_SPEC_ERRORS.NOT_FOUND:
+                    case BULK_SPEC_ERRORS.CANNOT_PARSE:
+                    case BULK_SPEC_ERRORS.INCORRECT_COLUMN_COUNT:
+                        addFileError(error);
+                        break;
+                    case BULK_SPEC_ERRORS.MULTIPLE_SPECS:
+                        addFileError({
+                            file: error.file_1,
+                            tab: error.tab_1,
+                            message: error.message,
+                        });
+                        addFileError({
+                            file: error.file_2,
+                            tab: error.tab_2,
+                            message: error.message,
+                        });
+                        break;
+                    case BULK_SPEC_ERRORS.NO_FILES:
+                        this.noFileError = true;
+                        break;
+                    case BULK_SPEC_ERRORS.UNKNOWN:
+                        if (error.file) {
+                            addFileError(error);
+                        } else {
+                            this.unexpectedErrors.push(error.message);
+                        }
+                        break;
+                    case BULK_SPEC_ERRORS.SERVER:
+                        this.serverErrors.push(error.message);
+                        break;
+                    default:
+                        console.error('unknown file import error', error);
+                        break;
+                }
+                this.totalErrors++;
+            });
+        }
+
+        _formatErrors() {
+            const div = html.tag('div'),
+                ul = html.tag('ul'),
+                li = html.tag('li');
+
+            let title = 'OMG ERROR';
+            let body = '';
+            // some branching based on how errors were parsed out.
+
+            if (this.noFileError) {
+                title = 'No files given';
+                body =
+                    'No files were given, though the bulk import specification was chosen. Blame Gavin.';
+            } else if (this.serverErrors.length) {
+                title = 'Server error';
+                body = div([
+                    'Server error encountered. Please retry import.',
+                    ul(this.serverErrors.map((err) => li(err))),
+                ]);
+            } else {
+                const fileErrorText = Object.entries(this.fileErrors).map(([fileName, errors]) => {
+                    const s = errors.length > 1 ? 's' : '';
+                    const header = `Error${s} in ${fileName}`;
+                    return div([header, ul(errors.map((err) => li(err)))]);
+                });
+
+                let unknownErrors = '';
+                if (this.unexpectedErrors.length) {
+                    const s = this.unexpectedErrors.length > 1 ? 's' : '';
+                    const prefix = fileErrorText.length ? 'Additional u' : 'U';
+                    const unknownString = `${prefix}nexpected error${s} found`;
+                    unknownErrors = div([
+                        unknownString,
+                        ul([this.unexpectedErrors.map((err) => li(err))]),
+                    ]);
+                }
+
+                body = div([fileErrorText, unknownErrors]);
+            }
+
+            if (this.totalErrors > 1) {
+                title = 'Multiple Errors in bulk import';
+            }
+
+            return [title, body];
+        }
+
+        showErrorDialog() {
+            const [title, body] = this._formatErrors();
+
+            UI.showInfoDialog({
+                title,
+                body,
+                okLabel: 'OK',
+                bsClass: 'danger',
+            });
+        }
+    }
+
+    class SpreadsheetFetchError extends ImportSetupError {
+        constructor(errors) {
+            super('Error while fetching CSV/TSV/Excel import data', errors);
+            this.name = 'SpreadsheetFetchError';
+        }
+    }
+
+    class SpreadsheetValidationError extends ImportSetupError {
+        constructor(errors) {
+            super('Error while validating CSV/TSV/Excel import data', errors);
+            this.name = 'SpreadsheetValidationError';
+        }
+    }
+
+    return {
+        SpreadsheetFetchError,
+        SpreadsheetValidationError,
+        ImportSetupError,
+        BULK_SPEC_ERRORS,
+    };
+});

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -81,7 +81,10 @@ define([
                     // this would happen if the above isn't JSON, so send the error code instead
                     parsedError = [{ type: 'server_error', message: error.responseText }];
                 }
-                throw new Error.SpreadsheetFetchError(parsedError);
+                throw new Error.ImportSetupError(
+                    'Error while fetching CSV/TSV/Excel import data',
+                    parsedError
+                );
             })
             .then((result) => {
                 return processSpreadsheetFileData(result);

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -317,13 +317,6 @@ define([
             .then(() => {
                 return initSingleFileUploads(singleFiles);
             });
-        // .catch(SpreadsheetFetchError, (error) => {
-        //     console.error(error);
-        //     alert(error.errors);
-        // })
-        // .catch(SpreadsheetValidationError, (error) => {
-        //     alert(error);
-        // });
     }
 
     return {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -13,9 +13,26 @@ define([
     const bulkIds = new Set(uploaders.bulk_import_types);
 
     /**
-     * Fetches
-     * @param {Array[string]} files - array of file names to treat as import specifications
-     * @returns Promise that resolves into all the bulk upload stuff
+     * This makes a call to the Staging Service to fetch information from bulk specification files.
+     * This then gets processed through `processSpreadsheetFileData` before being returned.
+     * @param {Array[string]} files - array of file path names to treat as import specifications
+     * @returns Promise that resolves into information that can be used to open a bulk import cell.
+     * This has the format:
+     * {
+     *   types: {
+     *     dataType1: [{ import parameters }, { import parameters }, ...etc...],
+     *     dataType2: [{ ...etc... }]
+     *   },
+     *   files: {
+     *     dataType1: {
+     *       file: the given file path,
+     *       tab: null or the name of the excel file tab, if the file was an excel file
+     *     }
+     *     dataType2: { ...etc... }
+     *   }
+     * }
+     * @throws Error.ImportSetupError if an error occurs in either data fetching from the Staging
+     *   Service, or in the initial parsing done by `processSpreadsheetFileData`
      */
     function getSpreadsheetFileInfo(files) {
         if (!files || files.length === 0) {
@@ -60,6 +77,7 @@ define([
                         callResult = JSON.parse(callResult);
                         Object.keys(callResult.types).forEach((dataType) => {
                             // if we already have a file of that datatype, then throw an error.
+                            // TODO: cast this as an ImportSetupError
                             if (allCalls.files[dataType]) {
                                 throw new Error(
                                     'You cannot use multiple files to upload the same type.'
@@ -208,8 +226,9 @@ define([
     }
 
     /**
-     * Initializes and
-     * @param {Array} fileInfo
+     * Creates a new non-bulk import app cell for each file in the fileInfo array.
+     * @param {Array} fileInfo each object in the array is expected to have 'type' and 'name' keys,
+     *   both of which are strings.
      * @returns A Promise that resolves when all importer app cells are created
      */
     function initSingleFileUploads(fileInfo) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -79,7 +79,9 @@ define([
                     parsedError = JSON.parse(error.responseText).errors;
                 } catch (error) {
                     // this would happen if the above isn't JSON, so send the error code instead
-                    parsedError = [{ type: 'server_error', message: error.responseText }];
+                    parsedError = [
+                        { type: Error.BULK_SPEC_ERRORS.SERVER, message: error.responseText },
+                    ];
                 }
                 throw new Error.ImportSetupError(
                     'Error while fetching CSV/TSV/Excel import data',

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -15,6 +15,7 @@ define([
     './uploadTour',
     'util/stagingFileCache',
     './importSetup',
+    './importErrors',
     'text!kbase/templates/data_staging/ftp_file_table.html',
     'text!kbase/templates/data_staging/ftp_file_header.html',
     'text!kbase/templates/data_staging/file_path.html',
@@ -38,6 +39,7 @@ define([
     UploadTour,
     StagingFileCache,
     Import,
+    Error,
     FtpFileTableHtml,
     FtpFileHeaderHtml,
     FilePathHtml,
@@ -1151,17 +1153,10 @@ define([
                 .then(() => {
                     Jupyter.narrative.hideOverlay();
                 })
-                .catch(Import.ImportSetupError, (error) => {
+                .catch(Error.ImportSetupError, (error) => {
                     console.error(error.toString());
                     // make popup.
-                    UI.showInfoDialog({
-                        // TODO: title depends on error content
-                        title: 'Bulk Import Error',
-                        // TODO: format errors
-                        body: 'Stuff.<ul><li>and</li><li>things!</li></ul>',
-                        okLabel: 'OK',
-                        bsClass: 'danger',
-                    });
+                    error.showErrorDialog();
                 });
         },
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -7,6 +7,7 @@ define([
     'narrativeConfig',
     'common/runtime',
     'common/html',
+    'common/ui',
     'base/js/namespace',
     'handlebars',
     'util/string',
@@ -29,6 +30,7 @@ define([
     Config,
     Runtime,
     html,
+    UI,
     Jupyter,
     Handlebars,
     StringUtil,
@@ -1145,9 +1147,22 @@ define([
                 });
             });
 
-            return Import.setupImportCells(fileInfo).then(() => {
-                Jupyter.narrative.hideOverlay();
-            });
+            return Import.setupImportCells(fileInfo)
+                .then(() => {
+                    Jupyter.narrative.hideOverlay();
+                })
+                .catch(Import.ImportSetupError, (error) => {
+                    console.error(error.toString());
+                    // make popup.
+                    UI.showInfoDialog({
+                        // TODO: title depends on error content
+                        title: 'Bulk Import Error',
+                        // TODO: format errors
+                        body: 'Stuff.<ul><li>and</li><li>things!</li></ul>',
+                        okLabel: 'OK',
+                        bsClass: 'danger',
+                    });
+                });
         },
 
         startTour: function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001299",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
+            "version": "1.0.30001300",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001299",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
+            "version": "1.0.30001300",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
             "dev": true
         },
         "center-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001300",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+            "version": "1.0.30001301",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001300",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+            "version": "1.0.30001301",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
             "dev": true
         },
         "center-align": {

--- a/test/unit/spec/narrative_core/upload/importErrors-spec.js
+++ b/test/unit/spec/narrative_core/upload/importErrors-spec.js
@@ -4,7 +4,7 @@ define(['kbase/js/widgets/narrative_core/upload/importErrors'], (Errors) => {
     const user = 'some_user';
     const filePath = (file) => `${user}/${file}`;
 
-    fdescribe('ImportSetupError module', () => {
+    describe('ImportSetupError module', () => {
         it('should have a set of bulk import spec errors', () => {
             expect(Errors.BULK_SPEC_ERRORS).toBeDefined();
         });

--- a/test/unit/spec/narrative_core/upload/importErrors-spec.js
+++ b/test/unit/spec/narrative_core/upload/importErrors-spec.js
@@ -190,7 +190,7 @@ define(['kbase/js/widgets/narrative_core/upload/importErrors'], (Errors) => {
                 {
                     error: { stuff: 'happened' },
                     label: 'with no usual keys',
-                    expected: 'An unknown error occurred!',
+                    expected: 'An unexpected error occurred.',
                 },
             ];
             unknownErrorCases.forEach((testCase) => {
@@ -372,7 +372,7 @@ define(['kbase/js/widgets/narrative_core/upload/importErrors'], (Errors) => {
                     const prefix = 'Unexpected errors found';
                     const errorList = [
                         errors[0].message,
-                        'An unexpected error occurred!',
+                        'An unexpected error occurred.',
                         `Unknown error of type "${errors[2].type}"`,
                         errors[2].message,
                     ];

--- a/test/unit/spec/narrative_core/upload/importErrors-spec.js
+++ b/test/unit/spec/narrative_core/upload/importErrors-spec.js
@@ -1,0 +1,407 @@
+define(['kbase/js/widgets/narrative_core/upload/importErrors'], (Errors) => {
+    'use strict';
+
+    const user = 'some_user';
+    const filePath = (file) => `${user}/${file}`;
+
+    fdescribe('ImportSetupError module', () => {
+        it('should have a set of bulk import spec errors', () => {
+            expect(Errors.BULK_SPEC_ERRORS).toBeDefined();
+        });
+
+        it('should provide a toString function', () => {
+            const errors = [
+                {
+                    type: Errors.BULK_SPEC_ERRORS.NO_FILES,
+                },
+            ];
+            const errText = 'an error happened';
+            const error = new Errors.ImportSetupError(errText, errors);
+            const result = error.toString();
+            expect(result).toContain(error.name);
+            expect(result).toContain(errText);
+            expect(result).toContain(JSON.stringify(errors));
+        });
+
+        describe('Import Setup Error formatting', () => {
+            it('should generate a structure of file errors from a list of generated error values', () => {
+                // the BULK_SPEC_ERRORS structure isn't used here in order to do a little black-boxing.
+                // instead, all error types (except for the purposefully unknowns) are taken straight
+                // from the staging service.
+
+                // an example of each type of error, as expected from the staging service for a
+                // non-excel file. more detailed tests below. This should just capture the basics
+                // and demonstrate filling out the fileErrors
+                const notFoundFile = filePath('missing_file.csv'),
+                    unparsedFile = filePath('unparseable_file.csv'),
+                    badColumnFile = filePath('bad_column_count.csv'),
+                    unexpectedFile = filePath('spanish_inquisition.csv'),
+                    multiple1File = filePath('assembly1.csv'),
+                    multiple2File = filePath('assembly2.csv'),
+                    errorText = filePath('multiple errors found!'),
+                    cannotParseText = 'cannot parse file',
+                    badColumnsText = 'wrong number of columns',
+                    multipleSpecsText = 'Data type appears in two importer specification sources',
+                    unexpectedText = 'something unexpected happened',
+                    stagingErrors = [
+                        {
+                            type: 'cannot_find_file',
+                            file: notFoundFile,
+                        },
+                        {
+                            type: 'cannot_parse_file',
+                            file: unparsedFile,
+                            tab: null,
+                            message: cannotParseText,
+                        },
+                        {
+                            type: 'incorrect_column_count',
+                            file: badColumnFile,
+                            tab: null,
+                            message: badColumnsText,
+                        },
+                        {
+                            type: 'multiple_specifications_for_data_type',
+                            file_1: multiple1File,
+                            tab_1: null,
+                            file_2: multiple2File,
+                            tab_2: null,
+                            message: multipleSpecsText,
+                        },
+                        {
+                            type: 'unexpected_error',
+                            file: unexpectedFile,
+                            message: unexpectedText,
+                        },
+                    ];
+                const expectedFileErrors = {
+                    [notFoundFile]: ['File not found'],
+                    [unparsedFile]: [cannotParseText],
+                    [badColumnFile]: [badColumnsText],
+                    [multiple1File]: [multipleSpecsText],
+                    [multiple2File]: [multipleSpecsText],
+                    [unexpectedFile]: [unexpectedText],
+                };
+
+                const error = new Errors.ImportSetupError(errorText, stagingErrors);
+                expect(error.text).toEqual(errorText);
+                expect(error.name).toEqual('ImportSetupError');
+                expect(error.errors).toEqual(stagingErrors);
+                expect(error.noFileError).toBeFalse();
+                expect(error.serverErrors).toEqual([]);
+                expect(error.unexpectedErrors).toEqual([]);
+                expect(error.fileErrors).toEqual(expectedFileErrors);
+            });
+
+            it('should handle excel file errors from multiple tabs', () => {
+                const fileName = 'some_file.xlsx',
+                    tab1 = 'first_tab',
+                    tab2 = 'second_tab',
+                    noParseMessage = 'cannot parse',
+                    badColumnMessage = 'wrong number of columns',
+                    errors = [
+                        {
+                            type: 'cannot_parse_file',
+                            file: fileName,
+                            tab: tab1,
+                            message: noParseMessage,
+                        },
+                        {
+                            type: 'incorrect_column_count',
+                            file: fileName,
+                            tab: tab2,
+                            message: badColumnMessage,
+                        },
+                    ];
+                const expectedFileErrors = {
+                    [`${fileName} tab "${tab1}"`]: [noParseMessage],
+                    [`${fileName} tab "${tab2}"`]: [badColumnMessage],
+                };
+
+                const error = new Errors.ImportSetupError('an error occurred', errors);
+                expect(error.errors).toEqual(errors);
+                expect(error.fileErrors).toEqual(expectedFileErrors);
+            });
+
+            it('should handle server errors', () => {
+                const serverErrorMsg = '500 internal service error',
+                    serverError = [
+                        {
+                            type: 'server_error',
+                            message: serverErrorMsg,
+                        },
+                    ];
+
+                const error = new Errors.ImportSetupError('server error!', serverError);
+                expect(error.serverErrors).toEqual([serverErrorMsg]);
+            });
+
+            it('should generate an error for no files provided', () => {
+                const noFiles = [
+                    {
+                        type: 'no_files_provided',
+                    },
+                ];
+                const text = 'no files!';
+
+                const error = new Errors.ImportSetupError(text, noFiles);
+                expect(error.text).toEqual(text);
+                expect(error.noFileError).toBeTrue();
+            });
+
+            it('should make an unexpected error without a file or message', () => {
+                const fileName = 'some_file.csv',
+                    msg1 = 'an error message',
+                    msg2 = 'another error message',
+                    errors = [
+                        {
+                            type: 'unexpected_error',
+                            file: fileName,
+                            message: msg1,
+                        },
+                        {
+                            type: 'unexpected_error',
+                            message: msg2,
+                        },
+                    ];
+
+                const error = new Errors.ImportSetupError('weirdo errors', errors);
+                expect(error.fileErrors).toEqual({ [fileName]: [msg1] });
+                expect(error.unexpectedErrors).toEqual([msg2]);
+            });
+
+            const unknownType = 'some_random_error';
+            const unknownErrorCases = [
+                {
+                    error: { type: unknownType },
+                    label: 'with only type',
+                    expected: `Unknown error of type "${unknownType}"`,
+                },
+                {
+                    error: { type: unknownType, message: 'some error' },
+                    label: 'with type and message',
+                    expected: 'some error',
+                },
+                {
+                    error: { message: 'some error' },
+                    label: 'with only message',
+                    expected: 'some error',
+                },
+                {
+                    error: { stuff: 'happened' },
+                    label: 'with no usual keys',
+                    expected: 'An unknown error occurred!',
+                },
+            ];
+            unknownErrorCases.forEach((testCase) => {
+                it(`should cast an unknown error type to an unrecognized error ${testCase.label}`, () => {
+                    spyOn(console, 'error');
+                    const error = new Errors.ImportSetupError('unknown', [testCase.error]);
+                    expect(error.unexpectedErrors).toEqual([testCase.expected]);
+                    expect(console.error).toHaveBeenCalledWith(
+                        'Unexpected import setup error!',
+                        testCase.error
+                    );
+                });
+            });
+        });
+
+        describe('import error dialog for expected error types', () => {
+            // This batch uses the BULK_SPEC_ERRORS structure. We're just testing dialog formatting here
+            // for the expected error types.
+
+            const SPEC_ERRORS = Errors.BULK_SPEC_ERRORS;
+
+            async function testErrorDialog(error, title, bodyTester) {
+                const ret = await error.showErrorDialog(() => {
+                    if (title) {
+                        expect(document.querySelector('.modal-title').textContent).toBe(title);
+                    }
+                    if (bodyTester) {
+                        const bodyContent = document.querySelector('.modal-body').textContent;
+                        bodyTester(bodyContent);
+                    }
+                    document.querySelector('[data-element="ok"]').click();
+                });
+                expect(ret).toBeFalse();
+            }
+
+            it('should show a custom message when no files are imported', async () => {
+                const noFilesError = {
+                    type: SPEC_ERRORS.NO_FILES,
+                };
+                const error = new Errors.ImportSetupError('no files', [noFilesError]);
+                await testErrorDialog(error, 'No files provided', (body) => {
+                    expect(body).toContain(
+                        'No CSV/TSV/Excel files were provided, but "Import Specification" was selected.'
+                    );
+                });
+            });
+
+            it('should show a server error, overriding other errors', async () => {
+                const errors = [
+                    {
+                        type: SPEC_ERRORS.SERVER,
+                        message: 'server go boom',
+                    },
+                    {
+                        type: SPEC_ERRORS.CANNOT_PARSE,
+                        file: 'some_file.csv',
+                        message: 'cannot parse',
+                    },
+                ];
+                const error = new Errors.ImportSetupError('server', errors);
+                await testErrorDialog(error, 'Server error', (body) => {
+                    expect(body).toMatch(
+                        /Server error encountered\. Please retry import\..*server go boom/
+                    );
+                });
+            });
+
+            it('should show errors for a single file, and suggest checking that file', async () => {
+                const fileName = 'a_file.csv';
+                const message = 'cannot be parsed';
+                const error = new Errors.ImportSetupError('error', [
+                    {
+                        type: SPEC_ERRORS.CANNOT_PARSE,
+                        file: fileName,
+                        message,
+                    },
+                ]);
+                await testErrorDialog(error, 'Bulk import error', (body) => {
+                    expect(body).toMatch(
+                        new RegExp(`${fileName}.*${message}.*Check bulk import file ${fileName}`)
+                    );
+                });
+            });
+
+            it('should show errors for multiple files and suggest checking all', async () => {
+                const files = ['file1.csv', 'file2.tsv', 'file3.xlsx'];
+                const messages = ['error1', 'error2', 'error3'];
+                const errors = files.map((fileName, idx) => {
+                    return {
+                        file: fileName,
+                        message: messages[idx],
+                        type: SPEC_ERRORS.CANNOT_PARSE,
+                    };
+                });
+                const error = new Errors.ImportSetupError('errored', errors);
+                await testErrorDialog(error, 'Multiple errors in bulk import', (body) => {
+                    expect(body).toContain('Check bulk import files and retry.');
+                    files.forEach((fileName, idx) => {
+                        expect(body).toMatch(new RegExp(`${fileName}.*${messages[idx]}`));
+                    });
+                });
+            });
+
+            it('should show both file sections for a multiple specs error', async () => {
+                const file1 = ['file1.csv'];
+                const file2 = ['file2.csv'];
+                const errMsg = 'duplicate data type found';
+                const error = new Errors.ImportSetupError('duplicate', [
+                    {
+                        type: SPEC_ERRORS.MULTIPLE_SPECS,
+                        file_1: file1,
+                        file_2: file2,
+                        tab_1: null,
+                        tab_2: null,
+                        message: errMsg,
+                    },
+                ]);
+                await testErrorDialog(error, 'Bulk import error', (body) => {
+                    expect(body).toMatch(new RegExp(`${file1}.*${errMsg}`));
+                    expect(body).toMatch(new RegExp(`${file2}.*${errMsg}`));
+                });
+            });
+
+            it('should show multiple tabs from an excel file as individual "files"', async () => {
+                const fileName = 'some_file.xlsx',
+                    tab1 = 'tab1',
+                    tab2 = 'tab2',
+                    err1 = 'first tab failed',
+                    err2 = 'second tab failed';
+                const error = new Errors.ImportSetupError('multiple tabs', [
+                    {
+                        type: SPEC_ERRORS.CANNOT_PARSE,
+                        file: fileName,
+                        tab: tab1,
+                        message: err1,
+                    },
+                    {
+                        type: SPEC_ERRORS.CANNOT_PARSE,
+                        file: fileName,
+                        tab: tab2,
+                        message: err2,
+                    },
+                ]);
+                await testErrorDialog(error, 'Multiple errors in bulk import', (body) => {
+                    expect(body).toMatch(new RegExp(`${fileName} tab "${tab1}".*${err1}`));
+                    expect(body).toMatch(new RegExp(`${fileName} tab "${tab2}".*${err2}`));
+                });
+            });
+
+            it('should show unexpected errors with their own header if no others appear', async () => {
+                const errors = [
+                    {
+                        type: SPEC_ERRORS.UNKNOWN,
+                        message: 'a random thing happened',
+                    },
+                    {
+                        type: SPEC_ERRORS.UNKNOWN,
+                    },
+                    {
+                        type: 'some_other_type',
+                    },
+                    {
+                        type: 'some_unknown_random_type',
+                        message: 'something weird broke',
+                    },
+                ];
+
+                // test with just one, should see singular text
+                const error1 = new Errors.ImportSetupError('unknown', [errors[0]]);
+                await testErrorDialog(error1, 'Bulk import error', (body) => {
+                    expect(body).toMatch(
+                        new RegExp(`Unexpected error found.*${errors[0].message}`)
+                    );
+                });
+
+                // test with all, should get plural text with list of errors, one of which generated
+                const error2 = new Errors.ImportSetupError('unknown2', errors);
+                await testErrorDialog(error2, 'Multiple errors in bulk import', (body) => {
+                    const prefix = 'Unexpected errors found';
+                    const errorList = [
+                        errors[0].message,
+                        'An unexpected error occurred!',
+                        `Unknown error of type "${errors[2].type}"`,
+                        errors[2].message,
+                    ];
+                    expect(body).toMatch(new RegExp(`${prefix}.*${errorList.join('.*')}`));
+                });
+            });
+
+            it('should show unexpected errors below file errors', async () => {
+                const fileName = 'some_file.csv';
+                const errors = [
+                    {
+                        type: SPEC_ERRORS.CANNOT_PARSE,
+                        file: fileName,
+                        message: 'cannot parse',
+                    },
+                    {
+                        type: SPEC_ERRORS.UNKNOWN,
+                        message: 'something wacky went down',
+                    },
+                ];
+                const error = new Errors.ImportSetupError('errors happened', errors);
+                await testErrorDialog(error, 'Multiple errors in bulk import', (body) => {
+                    expect(body).toMatch(
+                        new RegExp(
+                            `${fileName}.*${errors[0].message}.*Additional unexpected error found.*${errors[1].message}`
+                        )
+                    );
+                });
+            });
+        });
+    });
+});

--- a/test/unit/spec/narrative_core/upload/importSetup-spec.js
+++ b/test/unit/spec/narrative_core/upload/importSetup-spec.js
@@ -289,19 +289,22 @@ define([
                 });
             });
 
-            // TODO
             it('should error properly when unable to find bulk specification info', async () => {
                 // see https://github.com/kbase/staging_service/tree/develop#error-response-12
                 // for error details
                 const filename = 'xsv_input.csv';
-                stubBulkSpecificationRequest(404, 'not found', {
-                    errors: [
-                        {
-                            type: 'cannot_find_file',
-                            file: filename,
-                        },
-                    ],
-                });
+                stubBulkSpecificationRequest(
+                    404,
+                    'not found',
+                    JSON.stringify({
+                        errors: [
+                            {
+                                type: 'cannot_find_file',
+                                file: filename,
+                            },
+                        ],
+                    })
+                );
 
                 const importInputs = [
                     {
@@ -309,9 +312,10 @@ define([
                         type: 'import_specification',
                     },
                 ];
-                await expectAsync(ImportSetup.setupImportCells(importInputs)).toThrow();
+                await expectAsync(ImportSetup.setupImportCells(importInputs)).toBeRejected();
             });
 
+            // TODO
             xit('should error when given multiple bulk spec files with the same type', async () => {});
         });
 


### PR DESCRIPTION
# Description of PR purpose/changes

This is the first part of handling errors in XSV files. It mainly deals with errors that come straight from the Staging Service's bulk_specification endpoint. Data errors in the files themselves will come later.

This adds a new ImportSetupError class that knows how to parse out all of the registered error structures with the Staging Service and make a dialog out of them. There might be a few gaps in style, especially around handling multiple files/tabs describing the same data type - these'll get handled in a later PR if necessary.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-638
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Try to import some faulty XSV files as Import Specifications!
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
