### PR TITLE
DATAUP-497: Params, Unite!

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -727,7 +727,8 @@ define([
          * @param {object} message
          */
         handleJobError(message) {
-            const { jobId, error } = message;
+            const jobId = message.job_id,
+                { error } = message;
             if (!error) {
                 return;
             }

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -51,15 +51,8 @@ define([
             CELL,
             JOB,
         },
-        // backend param names
-        BE_PARAMS = JobConfig.params,
-        // frontend param names
-        PARAMS = {
-            JOB_ID: 'jobId',
-            JOB_ID_LIST: 'jobIdList',
-            BATCH_ID: 'batchId',
-            CELL_ID_LIST: 'cellIdList',
-        },
+        // param names
+        PARAMS = JobConfig.params,
         REQUESTS = {},
         RESPONSES = {};
 
@@ -72,16 +65,13 @@ define([
     });
 
     const JobCommMessages = {
-        validIncomingMessageTypes: function () {
-            return Object.values(REQUESTS);
-        },
-        validOutgoingMessageTypes: function () {
-            return Object.values(RESPONSES);
-        },
+        // message types
+        MESSAGE_TYPES: JobConfig.message_types,
         RESPONSES,
         REQUESTS,
+        // standardised params
         PARAMS,
-        BE_PARAMS,
+        // channel types
         CHANNELS,
     };
 
@@ -172,18 +162,13 @@ define([
                 request_type: msgType,
             };
 
-            const translations = {
-                [PARAMS.BATCH_ID]: BE_PARAMS.BATCH_ID,
-                [PARAMS.JOB_ID]: BE_PARAMS.JOB_ID,
-                [PARAMS.JOB_ID_LIST]: BE_PARAMS.JOB_ID_LIST,
-            };
+            return Object.assign({}, transformedMsg, msgData);
 
-            for (const [key, value] of Object.entries(msgData)) {
-                const msgKey = translations[key] || key;
-                transformedMsg[msgKey] = value;
-            }
-
-            return transformedMsg;
+            // return {
+            //     target_name: COMM_NAME,
+            //     request_type: msgType,
+            //     ...msgData
+            // };
         }
 
         /**
@@ -297,13 +282,13 @@ define([
                     }
                     // treat messages relating to single jobs as if they were for a job list
                     // eslint-disable-next-line no-case-declarations
-                    const jobIdList = msgData[BE_PARAMS.JOB_ID]
-                        ? [msgData[BE_PARAMS.JOB_ID]]
-                        : msgData[BE_PARAMS.JOB_ID_LIST];
+                    const jobIdList = msgData[PARAMS.JOB_ID]
+                        ? [msgData[PARAMS.JOB_ID]]
+                        : msgData[PARAMS.JOB_ID_LIST];
 
                     jobIdList.forEach((_jobId) => {
                         this.sendBusMessage(CHANNELS.JOB, _jobId, RESPONSES.ERROR, {
-                            jobId: _jobId,
+                            [PARAMS.JOB_ID]: _jobId,
                             error: msgData,
                             request: msgData.source,
                         });

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -157,18 +157,14 @@ define([
                 throw new Error(`Ignoring unknown message type "${msgType}"`);
             }
 
-            const transformedMsg = {
-                target_name: COMM_NAME,
-                request_type: msgType,
-            };
-
-            return Object.assign({}, transformedMsg, msgData);
-
-            // return {
-            //     target_name: COMM_NAME,
-            //     request_type: msgType,
-            //     ...msgData
-            // };
+            return Object.assign(
+                {},
+                {
+                    target_name: COMM_NAME,
+                    request_type: msgType,
+                },
+                msgData
+            );
         }
 
         /**

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -9,7 +9,7 @@ define([
 
     const jcm = JobComms.JobCommMessages;
 
-    const validOutgoingMessageTypes = jcm.validOutgoingMessageTypes();
+    const validOutgoingMessageTypes = Object.values(jcm.RESPONSES);
 
     const jobCommand = {
         cancel: {

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -383,6 +383,7 @@ define([
         sendBusMessage(
             ctx,
             {
+                [jcm.PARAMS.JOB_ID]: jobId,
                 jobState: ctx.input,
             },
             { [jcm.CHANNELS.JOB]: jobId },
@@ -413,7 +414,7 @@ define([
         sendBusMessage(
             ctx,
             {
-                job_id: retryParent.job_id,
+                [jcm.PARAMS.JOB_ID]: retryParent.job_id,
                 job: {
                     jobState: retryParent,
                 },
@@ -437,7 +438,7 @@ define([
         sendBusMessage(
             ctx,
             {
-                jobId,
+                [jcm.PARAMS.JOB_ID]: jobId,
                 error,
                 request: error.source,
             },

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -19,12 +19,7 @@ define([
         TEST_JOB_LIST = [TEST_JOB_ID, 'anotherJob', 'aThirdJob'],
         ERROR_STR = 'Some error string';
 
-    const JOB_ID = jcm.PARAMS.JOB_ID,
-        JOB_ID_LIST = jcm.PARAMS.JOB_ID_LIST,
-        BATCH_ID = jcm.PARAMS.BATCH_ID,
-        BACKEND_JOB_ID = jcm.BE_PARAMS.JOB_ID,
-        BACKEND_JOB_ID_LIST = jcm.BE_PARAMS.JOB_ID_LIST,
-        BACKEND_BATCH_ID = jcm.BE_PARAMS.BATCH_ID,
+    const { JOB_ID, JOB_ID_LIST, BATCH_ID } = jcm.PARAMS,
         JOB_CHANNEL = jcm.CHANNELS.JOB,
         CELL_CHANNEL = jcm.CHANNELS.CELL;
 
@@ -50,6 +45,7 @@ define([
 
     const convertToJobState = (acc, curr) => {
         acc[curr.job_id] = {
+            [JOB_ID]: curr.job_id,
             jobState: curr,
             outputWidgetInfo: {},
         };
@@ -59,6 +55,7 @@ define([
     const convertToJobStateBusMessage = (job) => {
         return [
             {
+                [JOB_ID]: job.job_id,
                 jobState: job,
                 outputWidgetInfo: {},
             },
@@ -167,9 +164,9 @@ define([
         });
 
         const messagesToSend = [
-            [jcm.REQUESTS.STATUS, { [JOB_CHANNEL]: 0 }],
-            [jcm.REQUESTS.STATUS, { [JOB_CHANNEL]: 1 }],
-            [jcm.REQUESTS.STATUS, { [JOB_CHANNEL]: 2 }],
+            [jcm.REQUESTS.STATUS, { [JOB_ID]: 0 }],
+            [jcm.REQUESTS.STATUS, { [JOB_ID]: 1 }],
+            [jcm.REQUESTS.STATUS, { [JOB_ID]: 2 }],
         ];
         const messagesInQueue = messagesToSend.map((arg) => {
             return {
@@ -182,7 +179,7 @@ define([
                 {
                     target_name: 'KBaseJobs',
                     request_type: jcm.REQUESTS.STATUS,
-                    job_id: num,
+                    [JOB_ID]: num,
                 },
             ];
         });
@@ -202,7 +199,7 @@ define([
                         'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
                     );
                     // resolve the promise on receiving the last message
-                    if (args[1][JOB_CHANNEL] === 2) {
+                    if (args[1][JOB_ID] === 2) {
                         resolve();
                     }
                 });
@@ -234,7 +231,7 @@ define([
                         }
                         return comm.sendCommMessage.and.originalFn.call(comm, ...args);
                     }
-                    const jobId = args[1][JOB_CHANNEL];
+                    const jobId = args[1][JOB_ID];
                     // original function should throw an error
                     await expectAsync(
                         comm.sendCommMessage.and.originalFn.call(comm, ...args)
@@ -283,7 +280,7 @@ define([
                         }
                         return comm.sendCommMessage.and.originalFn.call(comm, ...args);
                     }
-                    const jobId = args[1][JOB_CHANNEL];
+                    const jobId = args[1][JOB_ID];
                     if (jobId < 2) {
                         // original function should throw an error
                         await expectAsync(
@@ -342,7 +339,7 @@ define([
                 message: { [JOB_ID]: TEST_JOB_ID },
                 expected: {
                     request_type: jcm.REQUESTS.LOGS,
-                    [BACKEND_JOB_ID]: TEST_JOB_ID,
+                    [JOB_ID]: TEST_JOB_ID,
                 },
             },
             {
@@ -353,7 +350,7 @@ define([
                 },
                 expected: {
                     request_type: jcm.REQUESTS.LOGS,
-                    [BACKEND_JOB_ID]: TEST_JOB_ID,
+                    [JOB_ID]: TEST_JOB_ID,
                     latest: true,
                 },
             },
@@ -366,7 +363,7 @@ define([
                 },
                 expected: {
                     request_type: jcm.REQUESTS.LOGS,
-                    [BACKEND_JOB_ID]: TEST_JOB_ID,
+                    [JOB_ID]: TEST_JOB_ID,
                     first_line: 2000,
                     latest: true,
                 },
@@ -376,7 +373,7 @@ define([
                 message: { [JOB_ID]: TEST_JOB_ID },
                 expected: {
                     request_type: jcm.REQUESTS.CANCEL,
-                    [BACKEND_JOB_ID]: TEST_JOB_ID,
+                    [JOB_ID]: TEST_JOB_ID,
                 },
             },
             {
@@ -384,7 +381,7 @@ define([
                 message: { [JOB_ID_LIST]: TEST_JOB_LIST },
                 expected: {
                     request_type: jcm.REQUESTS.CANCEL,
-                    [BACKEND_JOB_ID_LIST]: TEST_JOB_LIST,
+                    [JOB_ID_LIST]: TEST_JOB_LIST,
                 },
             },
             {
@@ -392,7 +389,7 @@ define([
                 message: { [JOB_ID]: TEST_JOB_ID },
                 expected: {
                     request_type: jcm.REQUESTS.RETRY,
-                    [BACKEND_JOB_ID]: TEST_JOB_ID,
+                    [JOB_ID]: TEST_JOB_ID,
                 },
             },
             {
@@ -400,7 +397,7 @@ define([
                 message: { [JOB_ID_LIST]: TEST_JOB_LIST },
                 expected: {
                     request_type: jcm.REQUESTS.RETRY,
-                    [BACKEND_JOB_ID_LIST]: TEST_JOB_LIST,
+                    [JOB_ID_LIST]: TEST_JOB_LIST,
                 },
             },
         ];
@@ -414,7 +411,7 @@ define([
                     message: { [JOB_ID]: TEST_JOB_ID },
                     expected: {
                         request_type: jcm.REQUESTS[type],
-                        [BACKEND_JOB_ID]: TEST_JOB_ID,
+                        [JOB_ID]: TEST_JOB_ID,
                     },
                 },
                 {
@@ -422,7 +419,7 @@ define([
                     message: { [JOB_ID_LIST]: TEST_JOB_LIST },
                     expected: {
                         request_type: jcm.REQUESTS[type],
-                        [BACKEND_JOB_ID_LIST]: TEST_JOB_LIST,
+                        [JOB_ID_LIST]: TEST_JOB_LIST,
                     },
                 },
                 {
@@ -430,7 +427,7 @@ define([
                     message: { [BATCH_ID]: 'batch_job' },
                     expected: {
                         request_type: `${jcm.REQUESTS[type]}`,
-                        [BACKEND_BATCH_ID]: 'batch_job',
+                        [BATCH_ID]: 'batch_job',
                     },
                 }
             );
@@ -584,13 +581,13 @@ define([
                 type: jcm.RESPONSES.LOGS,
                 message: {
                     [TEST_JOB_ID]: {
-                        job_id: TEST_JOB_ID,
+                        [JOB_ID]: TEST_JOB_ID,
                         error: `Cannot find job log with id: {TEST_JOB_ID}`,
                     },
                 },
                 expected: [
                     {
-                        job_id: TEST_JOB_ID,
+                        [JOB_ID]: TEST_JOB_ID,
                         error: `Cannot find job log with id: {TEST_JOB_ID}`,
                     },
                     {
@@ -635,6 +632,7 @@ define([
                 message: (() => {
                     const output = {};
                     output[JobsData.allJobs[0].job_id] = {
+                        [JOB_ID]: JobsData.allJobs[0].job_id,
                         jobState: JobsData.allJobs[0],
                         outputWidgetInfo: {},
                     };
@@ -642,6 +640,7 @@ define([
                 })(),
                 expected: [
                     {
+                        [JOB_ID]: JobsData.allJobs[0].job_id,
                         jobState: JobsData.allJobs[0],
                         outputWidgetInfo: {},
                     },
@@ -656,7 +655,7 @@ define([
                 type: jcm.RESPONSES.STATUS,
                 message: {
                     [TEST_JOB_ID]: {
-                        job_id: TEST_JOB_ID,
+                        [JOB_ID]: TEST_JOB_ID,
                         jobState: {
                             job_id: TEST_JOB_ID,
                             status: 'running',
@@ -667,7 +666,7 @@ define([
                 },
                 expected: [
                     {
-                        job_id: TEST_JOB_ID,
+                        [JOB_ID]: TEST_JOB_ID,
                         jobState: {
                             job_id: TEST_JOB_ID,
                             status: 'running',
@@ -699,6 +698,7 @@ define([
                 expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage).concat([
                     [
                         {
+                            [JOB_ID]: '1234567890abcdef',
                             jobState: {
                                 job_id: '1234567890abcdef',
                                 status: 'does_not_exist',
@@ -727,7 +727,7 @@ define([
                 },
                 expected: [
                     {
-                        jobId: TEST_JOB_ID,
+                        [JOB_ID]: TEST_JOB_ID,
                         error: {
                             job_id: TEST_JOB_ID,
                             message: 'cancel error',
@@ -753,7 +753,7 @@ define([
                 },
                 expected: [
                     {
-                        jobId: TEST_JOB_ID,
+                        [JOB_ID]: TEST_JOB_ID,
                         error: {
                             source: 'some-unknown-error',
                             job_id: TEST_JOB_ID,
@@ -771,7 +771,7 @@ define([
             {
                 type: jcm.RESPONSES.ERROR,
                 message: {
-                    [BACKEND_JOB_ID_LIST]: [
+                    [JOB_ID_LIST]: [
                         'job_1_RetryWithErrors',
                         'job_2_RetryWithErrors',
                         'job_3_RetryWithErrors',
@@ -783,9 +783,9 @@ define([
                 expectedMultiple: [
                     [
                         {
-                            jobId: 'job_1_RetryWithErrors',
+                            [JOB_ID]: 'job_1_RetryWithErrors',
                             error: {
-                                [BACKEND_JOB_ID_LIST]: [
+                                [JOB_ID_LIST]: [
                                     'job_1_RetryWithErrors',
                                     'job_2_RetryWithErrors',
                                     'job_3_RetryWithErrors',
@@ -803,9 +803,9 @@ define([
                     ],
                     [
                         {
-                            jobId: 'job_2_RetryWithErrors',
+                            [JOB_ID]: 'job_2_RetryWithErrors',
                             error: {
-                                [BACKEND_JOB_ID_LIST]: [
+                                [JOB_ID_LIST]: [
                                     'job_1_RetryWithErrors',
                                     'job_2_RetryWithErrors',
                                     'job_3_RetryWithErrors',
@@ -823,9 +823,9 @@ define([
                     ],
                     [
                         {
-                            jobId: 'job_3_RetryWithErrors',
+                            [JOB_ID]: 'job_3_RetryWithErrors',
                             error: {
-                                [BACKEND_JOB_ID_LIST]: [
+                                [JOB_ID_LIST]: [
                                     'job_1_RetryWithErrors',
                                     'job_2_RetryWithErrors',
                                     'job_3_RetryWithErrors',


### PR DESCRIPTION
# Description of PR purpose/changes

Unify FE and BE job request/response params and update components and tests accordingly.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook