### PR TITLE
DATAUP-497: big dumb regex

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -23,8 +23,8 @@ define(['common/jobCommChannel'], (JobComms) => {
   // use the JobCommMessages object
   const jcm = JobComms.JobCommMessages;
 
-  console.log("job status message type: " + jcm.REQUESTS.STATUS)
-  console.log("job ID parameter: " + jcm.PARAMS.JOB_ID)
+  console.log("job status message type: " + jcm.MESSAGE_TYPE.STATUS)
+  console.log("job ID parameter: " + jcm.PARAM.JOB_ID)
 ```
 
 # Frontend messages
@@ -96,15 +96,15 @@ define(
       jcm = JobComms.JobCommMessages;
 
     // request the first 10 job log lines:
-    runtime.bus().emit(jcm.REQUESTS.LOGS, {
-      [jcm.PARAMS.JOB_ID]: 'some_job_id',
+    runtime.bus().emit(jcm.MESSAGE_TYPE.LOGS, {
+      [jcm.PARAM.JOB_ID]: 'some_job_id',
       first_line: 0,
       num_lines: 10
     });
 
     // request the status of all jobs in a batch:
-    runtime.bus().emit(jcm.REQUESTS.STATUS, {
-      [jcm.PARAMS.BATCH_ID]: 'some_batch_id',
+    runtime.bus().emit(jcm.MESSAGE_TYPE.STATUS, {
+      [jcm.PARAM.BATCH_ID]: 'some_batch_id',
     });
   }
 );
@@ -150,10 +150,10 @@ define(
 
     const listener = runtime.bus().listen({
       channel: {
-        [jcm.CHANNELS.JOB]: 'some_job_id'
+        [jcm.CHANNEL.JOB]: 'some_job_id'
       },
       key: {
-        type: jcm.RESPONSES.STATUS,
+        type: jcm.MESSAGE_TYPE.STATUS,
       },
       handle: (message) => {
         ...process the message...
@@ -176,7 +176,7 @@ const cellBus = runtime.bus().makeChannelBus({
         cell: 'some_cell_id'
       }
     });
-    const listenerId = cellBus.on(jcm.RESPONSES.RUN_STATUS, (message) => {
+    const listenerId = cellBus.on(jcm.MESSAGE_TYPE.RUN_STATUS, (message) => {
       // process the message...
     });
   }

--- a/kbase-extension/static/kbase/config/job_config.json
+++ b/kbase-extension/static/kbase/config/job_config.json
@@ -1,6 +1,7 @@
 {
     "params": {
         "BATCH_ID": "batch_id",
+        "CELL_ID": "cell_id",
         "CELL_ID_LIST": "cell_id_list",
         "JOB_ID": "job_id",
         "JOB_ID_LIST": "job_id_list"
@@ -37,7 +38,7 @@
         "LOGS",
         "NEW",
         "RETRY",
-        "RUN STATUS",
+        "RUN_STATUS",
         "STATUS",
         "STATUS_ALL"
     ]

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -266,8 +266,8 @@ define([
             Object.values(this.widgetsById).map((widget) => widget.stop());
             this.jobManager.removeEventHandler('modelUpdate', 'jobStatusTable_status');
             this.jobManager.removeEventHandler('modelUpdate', 'dropdown');
-            this.jobManager.removeEventHandler(jcm.RESPONSES.INFO, 'jobStatusTable_info');
-            this.jobManager.removeEventHandler(jcm.RESPONSES.ERROR, 'jobStatusTable_error');
+            this.jobManager.removeEventHandler(jcm.MESSAGE_TYPE.INFO, 'jobStatusTable_info');
+            this.jobManager.removeEventHandler(jcm.MESSAGE_TYPE.ERROR, 'jobStatusTable_error');
             this.container.innerHTML = '';
             if (this.dropdownWidget) {
                 return this.dropdownWidget.stop();
@@ -618,12 +618,12 @@ define([
                     );
                 },
             });
-            this.jobManager.addEventHandler(jcm.RESPONSES.ERROR, {
+            this.jobManager.addEventHandler(jcm.MESSAGE_TYPE.ERROR, {
                 jobStatusTable_error: (_, jobError) => {
                     this.handleJobError.bind(self)(jobError);
                 },
             });
-            this.jobManager.addEventHandler(jcm.RESPONSES.INFO, {
+            this.jobManager.addEventHandler(jcm.MESSAGE_TYPE.INFO, {
                 jobStatusTable_info: (_, jobInfo) => {
                     this.handleJobInfo.bind(self)(jobInfo);
                 },
@@ -652,18 +652,18 @@ define([
             });
 
             ['STATUS', 'ERROR'].forEach((event) => {
-                this.jobManager.addListener(jcm.RESPONSES[event], [batchId].concat(jobIdList));
+                this.jobManager.addListener(jcm.MESSAGE_TYPE[event], [batchId].concat(jobIdList));
             });
 
             if (paramsRequired.length) {
-                this.jobManager.addListener(jcm.RESPONSES.INFO, paramsRequired);
+                this.jobManager.addListener(jcm.MESSAGE_TYPE.INFO, paramsRequired);
                 const jobInfoRequestParams =
                     paramsRequired.length === jobIdList.length
-                        ? { [jcm.PARAMS.BATCH_ID]: batchId }
-                        : { [jcm.PARAMS.JOB_ID_LIST]: paramsRequired };
-                this.jobManager.bus.emit(jcm.REQUESTS.INFO, jobInfoRequestParams);
+                        ? { [jcm.PARAM.BATCH_ID]: batchId }
+                        : { [jcm.PARAM.JOB_ID_LIST]: paramsRequired };
+                this.jobManager.bus.emit(jcm.MESSAGE_TYPE.INFO, jobInfoRequestParams);
             }
-            this.jobManager.bus.emit(jcm.REQUESTS.STATUS, { [jcm.PARAMS.BATCH_ID]: batchId });
+            this.jobManager.bus.emit(jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.BATCH_ID]: batchId });
         }
 
         // HANDLERS

--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -47,12 +47,12 @@ define([
         // channel types
         CELL = 'cell',
         JOB = 'jobId',
-        CHANNELS = {
+        CHANNEL = {
             CELL,
             JOB,
         },
         // param names
-        PARAMS = JobConfig.params,
+        PARAM = JobConfig.params,
         REQUESTS = {},
         RESPONSES = {};
 
@@ -66,13 +66,13 @@ define([
 
     const JobCommMessages = {
         // message types
-        MESSAGE_TYPES: JobConfig.message_types,
+        MESSAGE_TYPE: JobConfig.message_types,
         RESPONSES,
         REQUESTS,
         // standardised params
-        PARAMS,
+        PARAM,
         // channel types
-        CHANNELS,
+        CHANNEL,
     };
 
     class JobCommChannel {
@@ -179,7 +179,7 @@ define([
          *                  values in the REQUESTS object (optional)
          *
          * @param {object}  msgData - additional parameters for the request,
-         *                  such as one of the values in the PARAMS object or
+         *                  such as one of the values in the PARAM object or
          *                  a request-specific param (optional)
          */
         sendCommMessage(msgType, msgData) {
@@ -254,7 +254,7 @@ define([
                 // CELL messages
                 case RESPONSES.RUN_STATUS:
                     this.sendBusMessage(
-                        CHANNELS.CELL,
+                        CHANNEL.CELL,
                         msgData.cell_id,
                         RESPONSES.RUN_STATUS,
                         msgData
@@ -278,13 +278,13 @@ define([
                     }
                     // treat messages relating to single jobs as if they were for a job list
                     // eslint-disable-next-line no-case-declarations
-                    const jobIdList = msgData[PARAMS.JOB_ID]
-                        ? [msgData[PARAMS.JOB_ID]]
-                        : msgData[PARAMS.JOB_ID_LIST];
+                    const jobIdList = msgData[PARAM.JOB_ID]
+                        ? [msgData[PARAM.JOB_ID]]
+                        : msgData[PARAM.JOB_ID_LIST];
 
                     jobIdList.forEach((_jobId) => {
-                        this.sendBusMessage(CHANNELS.JOB, _jobId, RESPONSES.ERROR, {
-                            [PARAMS.JOB_ID]: _jobId,
+                        this.sendBusMessage(CHANNEL.JOB, _jobId, RESPONSES.ERROR, {
+                            [PARAM.JOB_ID]: _jobId,
                             error: msgData,
                             request: msgData.source,
                         });
@@ -296,7 +296,7 @@ define([
                     Object.keys(msgData).forEach((_jobId) => {
                         const jobData = msgData[_jobId];
                         if (this.validationFn[msgType](jobData)) {
-                            this.sendBusMessage(CHANNELS.JOB, _jobId, RESPONSES.INFO, jobData);
+                            this.sendBusMessage(CHANNEL.JOB, _jobId, RESPONSES.INFO, jobData);
                         } else {
                             this.reportCommMessageError({ msgType, msgData: jobData });
                         }
@@ -307,7 +307,7 @@ define([
                     Object.keys(msgData).forEach((_jobId) => {
                         const jobData = msgData[_jobId];
                         if (this.validationFn[msgType](jobData)) {
-                            this.sendBusMessage(CHANNELS.JOB, _jobId, RESPONSES.LOGS, jobData);
+                            this.sendBusMessage(CHANNEL.JOB, _jobId, RESPONSES.LOGS, jobData);
                         } else {
                             this.reportCommMessageError({ msgType, msgData: jobData });
                         }
@@ -318,7 +318,7 @@ define([
                     Object.keys(msgData).forEach((_jobId) => {
                         const jobData = msgData[_jobId];
                         if (this.validationFn[msgType](jobData)) {
-                            this.sendBusMessage(CHANNELS.JOB, _jobId, RESPONSES.RETRY, jobData);
+                            this.sendBusMessage(CHANNEL.JOB, _jobId, RESPONSES.RETRY, jobData);
                         } else {
                             this.reportCommMessageError({ msgType, msgData: jobData });
                         }
@@ -337,7 +337,7 @@ define([
                     Object.keys(msgData).forEach((_jobId) => {
                         const jobData = msgData[_jobId];
                         if (this.validationFn[msgType](jobData)) {
-                            this.sendBusMessage(CHANNELS.JOB, _jobId, RESPONSES.STATUS, jobData);
+                            this.sendBusMessage(CHANNEL.JOB, _jobId, RESPONSES.STATUS, jobData);
                         } else {
                             this.reportCommMessageError({ msgType, msgData: jobData });
                         }

--- a/kbase-extension/static/kbase/js/util/jobLogViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobLogViewer.js
@@ -409,8 +409,8 @@ define([
 
                 this.renderJobState(this.lastJobState || { job_id: this.jobId });
 
-                this.bus.emit(jcm.REQUESTS.STATUS, {
-                    [jcm.PARAMS.JOB_ID]: this.jobId,
+                this.bus.emit(jcm.MESSAGE_TYPE.STATUS, {
+                    [jcm.PARAM.JOB_ID]: this.jobId,
                 });
                 this.state.listeningForJob = true;
             }).catch((err) => {
@@ -445,8 +445,8 @@ define([
          * request regular job status updates
          */
         startJobStatusUpdates() {
-            this.bus.emit(jcm.REQUESTS.START_UPDATE, {
-                [jcm.PARAMS.JOB_ID]: this.jobId,
+            this.bus.emit(jcm.MESSAGE_TYPE.START_UPDATE, {
+                [jcm.PARAM.JOB_ID]: this.jobId,
             });
             this.state.listeningForJob = true;
         }
@@ -458,7 +458,7 @@ define([
             this.state.listeningForJob = false;
 
             if (this.state.awaitingLog) {
-                this.stopEventListeners([jcm.RESPONSES.STATUS]);
+                this.stopEventListeners([jcm.MESSAGE_TYPE.STATUS]);
             } else {
                 this.stopEventListeners();
             }
@@ -474,8 +474,8 @@ define([
         requestJobLog(firstLine) {
             this.ui.showElement('spinner');
             this.state.awaitingLog = true;
-            this.bus.emit(jcm.REQUESTS.LOGS, {
-                [jcm.PARAMS.JOB_ID]: this.jobId,
+            this.bus.emit(jcm.MESSAGE_TYPE.LOGS, {
+                [jcm.PARAM.JOB_ID]: this.jobId,
                 first_line: firstLine,
             });
         }
@@ -488,8 +488,8 @@ define([
             this.state.scrollToEndOnNext = true;
             this.ui.showElement('spinner');
             this.state.awaitingLog = true;
-            this.bus.emit(jcm.REQUESTS.LOGS, {
-                [jcm.PARAMS.JOB_ID]: this.jobId,
+            this.bus.emit(jcm.MESSAGE_TYPE.LOGS, {
+                [jcm.PARAM.JOB_ID]: this.jobId,
                 latest: true,
             });
         }
@@ -1264,9 +1264,9 @@ define([
                     // ensure that the correct `this` context is bound
                     const handle = handlers[type].bind(this);
                     // listen for job-related bus messages
-                    this.listenersByType[jcm.RESPONSES[type]] = this.bus.listen({
-                        channel: { [jcm.CHANNELS.JOB]: this.jobId },
-                        key: { type: jcm.RESPONSES[type] },
+                    this.listenersByType[jcm.MESSAGE_TYPE[type]] = this.bus.listen({
+                        channel: { [jcm.CHANNEL.JOB]: this.jobId },
+                        key: { type: jcm.MESSAGE_TYPE[type] },
                         handle,
                     });
                 }, this);

--- a/kbase-extension/static/kbase/js/util/jobStateViewer.js
+++ b/kbase-extension/static/kbase/js/util/jobStateViewer.js
@@ -324,8 +324,8 @@ define([
             if (listeningForJob) {
                 return;
             }
-            runtime.bus().emit(jcm.REQUESTS.START_UPDATE, {
-                [jcm.PARAMS.JOB_ID]: jobId,
+            runtime.bus().emit(jcm.MESSAGE_TYPE.START_UPDATE, {
+                [jcm.PARAM.JOB_ID]: jobId,
             });
             listeningForJob = true;
         }
@@ -374,10 +374,10 @@ define([
                 // listen for job-related bus messages
                 runtime.bus().listen({
                     channel: {
-                        [jcm.CHANNELS.JOB]: jobId,
+                        [jcm.CHANNEL.JOB]: jobId,
                     },
                     key: {
-                        type: jcm.RESPONSES.STATUS,
+                        type: jcm.MESSAGE_TYPE.STATUS,
                     },
                     handle: handleJobStatusUpdate,
                 })
@@ -413,8 +413,8 @@ define([
                     listenForJobStatus();
 
                     // request a new job status update from the kernel on start
-                    runtime.bus().emit(jcm.REQUESTS.STATUS, {
-                        [jcm.PARAMS.JOB_ID]: jobId,
+                    runtime.bus().emit(jcm.MESSAGE_TYPE.STATUS, {
+                        [jcm.PARAM.JOB_ID]: jobId,
                     });
                     listeningForJob = true;
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/customWidgetWrapper.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/customWidgetWrapper.js
@@ -43,7 +43,7 @@ define(['bluebird', 'jquery', 'base/js/namespace', 'common/runtime', 'common/job
                             },
                             {
                                 channel: {
-                                    [jcm.CHANNELS.CELL]: cellId,
+                                    [jcm.CHANNEL.CELL]: cellId,
                                 },
                                 key: {
                                     type: 'parameter-changed',
@@ -69,7 +69,7 @@ define(['bluebird', 'jquery', 'base/js/namespace', 'common/runtime', 'common/job
                     {},
                     {
                         channel: {
-                            [jcm.CHANNELS.CELL]: cellId,
+                            [jcm.CHANNEL.CELL]: cellId,
                         },
                         key: {
                             type: 'sync-params',
@@ -79,7 +79,7 @@ define(['bluebird', 'jquery', 'base/js/namespace', 'common/runtime', 'common/job
                 // listen for cell-related bus messages
                 runtime.bus().listen({
                     channel: {
-                        [jcm.CHANNELS.CELL]: cellId,
+                        [jcm.CHANNEL.CELL]: cellId,
                     },
                     key: {
                         type: 'parameter-value',

--- a/kbase-extension/static/kbase/js/widgets/custom/advancedViewerOutputWrapper.js
+++ b/kbase-extension/static/kbase/js/widgets/custom/advancedViewerOutputWrapper.js
@@ -39,7 +39,7 @@ define([
             }
 
             function emit(key, message) {
-                bus.channel({ [jcm.CHANNELS.CELL]: config.cellId }).emit(key, message);
+                bus.channel({ [jcm.CHANNEL.CELL]: config.cellId }).emit(key, message);
             }
 
             return {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeJobStatus.js
@@ -144,10 +144,10 @@ define([
                     // listen for job-related bus messages
                     this.busConnection.listen({
                         channel: {
-                            [jcm.CHANNELS.JOB]: this.jobId,
+                            [jcm.CHANNEL.JOB]: this.jobId,
                         },
                         key: {
-                            type: jcm.RESPONSES.INFO,
+                            type: jcm.MESSAGE_TYPE.INFO,
                         },
                         handle: function (message) {
                             this.handleJobInfo(message);
@@ -157,22 +157,22 @@ define([
                     // listen for job-related bus messages
                     this.busConnection.listen({
                         channel: {
-                            [jcm.CHANNELS.JOB]: this.jobId,
+                            [jcm.CHANNEL.JOB]: this.jobId,
                         },
                         key: {
-                            type: jcm.RESPONSES.STATUS,
+                            type: jcm.MESSAGE_TYPE.STATUS,
                         },
                         handle: function (message) {
                             this.handleJobStatus(message);
                         }.bind(this),
                     });
 
-                    this.channel.emit(jcm.REQUESTS.INFO, {
-                        [jcm.PARAMS.JOB_ID]: this.jobId,
+                    this.channel.emit(jcm.MESSAGE_TYPE.INFO, {
+                        [jcm.PARAM.JOB_ID]: this.jobId,
                     });
 
-                    this.channel.emit(jcm.REQUESTS.STATUS, {
-                        [jcm.PARAMS.JOB_ID]: this.jobId,
+                    this.channel.emit(jcm.MESSAGE_TYPE.STATUS, {
+                        [jcm.PARAM.JOB_ID]: this.jobId,
                     });
                 })
                 .catch((err) => {
@@ -498,8 +498,8 @@ define([
                 case 'completed':
                     if (this.requestedUpdates) {
                         this.requestedUpdates = false;
-                        this.channel.emit(jcm.REQUESTS.STOP_UPDATE, {
-                            [jcm.PARAMS.JOB_ID]: this.jobId,
+                        this.channel.emit(jcm.MESSAGE_TYPE.STOP_UPDATE, {
+                            [jcm.PARAM.JOB_ID]: this.jobId,
                         });
                     }
                     // TODO: we need to remove all of the job listeners at this point, but
@@ -522,15 +522,15 @@ define([
         },
 
         requestJobInfo: function () {
-            this.channel.emit(jcm.REQUESTS.INFO, {
-                [jcm.PARAMS.JOB_ID]: this.jobId,
+            this.channel.emit(jcm.MESSAGE_TYPE.INFO, {
+                [jcm.PARAM.JOB_ID]: this.jobId,
             });
         },
 
         requestJobStatus: function () {
             window.setTimeout(() => {
-                this.channel.emit(jcm.REQUESTS.STATUS, {
-                    [jcm.PARAMS.JOB_ID]: this.jobId,
+                this.channel.emit(jcm.MESSAGE_TYPE.STATUS, {
+                    [jcm.PARAM.JOB_ID]: this.jobId,
                 });
             }, this.statusRequestInterval);
         },

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -553,7 +553,7 @@ define([
                 {},
                 {
                     channel: {
-                        [jcm.CHANNELS.CELL]: cellId,
+                        [jcm.CHANNEL.CELL]: cellId,
                     },
                     key: {
                         type: 'delete-cell',

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1199,8 +1199,8 @@ define(
              * narrative metadata.
              */
             function cancelJob(jobId) {
-                runtime.bus().emit(jcm.REQUESTS.CANCEL, {
-                    [jcm.PARAMS.JOB_ID]: jobId,
+                runtime.bus().emit(jcm.MESSAGE_TYPE.CANCEL, {
+                    [jcm.PARAM.JOB_ID]: jobId,
                 });
             }
 
@@ -1208,8 +1208,8 @@ define(
                 if (!jobId) {
                     return;
                 }
-                runtime.bus().emit(jcm.REQUESTS.STATUS, {
-                    [jcm.PARAMS.JOB_ID]: jobId,
+                runtime.bus().emit(jcm.MESSAGE_TYPE.STATUS, {
+                    [jcm.PARAM.JOB_ID]: jobId,
                 });
             }
 
@@ -1416,14 +1416,14 @@ define(
                             jobId,
                         },
                         key: {
-                            type: jcm.RESPONSES.STATUS,
+                            type: jcm.MESSAGE_TYPE.STATUS,
                         },
                         handle: doJobStatus,
                     })
                 );
 
-                runtime.bus().emit(jcm.REQUESTS.START_UPDATE, {
-                    [jcm.PARAMS.JOB_ID]: jobId,
+                runtime.bus().emit(jcm.MESSAGE_TYPE.START_UPDATE, {
+                    [jcm.PARAM.JOB_ID]: jobId,
                 });
             }
 
@@ -1466,8 +1466,8 @@ define(
 
                 const jobId = model.getItem('exec.jobState.job_id');
                 if (jobId) {
-                    runtime.bus().emit(jcm.REQUESTS.STOP_UPDATE, {
-                        [jcm.PARAMS.JOB_ID]: jobId,
+                    runtime.bus().emit(jcm.MESSAGE_TYPE.STOP_UPDATE, {
+                        [jcm.PARAM.JOB_ID]: jobId,
                     });
                 }
             }
@@ -1756,7 +1756,7 @@ define(
 
                         // TODO: only turn this on when we need it!
                         busEventManager.add(
-                            cellBus.on(jcm.RESPONSES.RUN_STATUS, (message) => {
+                            cellBus.on(jcm.MESSAGE_TYPE.RUN_STATUS, (message) => {
                                 updateFromLaunchEvent(message);
 
                                 model.setItem('exec.launchState', message);

--- a/nbextensions/appCell2/widgets/appOutputWidget.js
+++ b/nbextensions/appCell2/widgets/appOutputWidget.js
@@ -104,7 +104,7 @@ define([
                         },
                         {
                             channel: {
-                                [jcm.CHANNELS.CELL]: cellId,
+                                [jcm.CHANNEL.CELL]: cellId,
                             },
                             key: {
                                 type: 'output-cell-removed',

--- a/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
+++ b/nbextensions/appCell2/widgets/tabs/status/jobInputParams.js
@@ -59,10 +59,10 @@ define([
             // listen for job-related bus messages
             paramsListener = runtime.bus().listen({
                 channel: {
-                    [jcm.CHANNELS.JOB]: jobId,
+                    [jcm.CHANNEL.JOB]: jobId,
                 },
                 key: {
-                    type: jcm.RESPONSES.INFO,
+                    type: jcm.MESSAGE_TYPE.INFO,
                 },
                 handle: (message) => {
                     updateRowStatus(ui, message.job_params[0], container);
@@ -84,8 +84,8 @@ define([
                 isParentJob = arg.isParentJob;
 
                 startParamsListener();
-                runtime.bus().emit(jcm.REQUESTS.INFO, {
-                    [jcm.PARAMS.JOB_ID]: jobId,
+                runtime.bus().emit(jcm.MESSAGE_TYPE.INFO, {
+                    [jcm.PARAM.JOB_ID]: jobId,
                 });
                 params = arg.params;
                 updateRowStatus(ui, params, container);

--- a/nbextensions/appCell2/widgets/tabs/status/jobStateList.js
+++ b/nbextensions/appCell2/widgets/tabs/status/jobStateList.js
@@ -69,10 +69,10 @@ define([
             // listen for job-related bus messages
             parentListener = runtime.bus().listen({
                 channel: {
-                    [jcm.CHANNELS.JOB]: parentJobId,
+                    [jcm.CHANNEL.JOB]: parentJobId,
                 },
                 key: {
-                    type: jcm.RESPONSES.STATUS,
+                    type: jcm.MESSAGE_TYPE.STATUS,
                 },
                 handle: handleJobStatusUpdate,
             });

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -842,7 +842,7 @@ define([
          * Then changes the global cell state to "launching".
          */
         function doRunCellAction() {
-            runStatusListener = cellBus.on(jcm.RESPONSES.RUN_STATUS, handleRunStatus);
+            runStatusListener = cellBus.on(jcm.MESSAGE_TYPE.RUN_STATUS, handleRunStatus);
             busEventManager.add(runStatusListener);
             cell.execute();
             updateState('launching');

--- a/nbextensions/outputCell/widgets/outputCell.js
+++ b/nbextensions/outputCell/widgets/outputCell.js
@@ -49,7 +49,7 @@ define([
                         },
                         {
                             channel: {
-                                [jcm.CHANNELS.CELL]: parentCellId,
+                                [jcm.CHANNEL.CELL]: parentCellId,
                             },
                             key: {
                                 type: 'output-cell-removed',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001300",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+            "version": "1.0.30001301",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001300",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
+            "version": "1.0.30001301",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
             "dev": true
         },
         "center-align": {

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -19,9 +19,9 @@ define([
         TEST_JOB_LIST = [TEST_JOB_ID, 'anotherJob', 'aThirdJob'],
         ERROR_STR = 'Some error string';
 
-    const { JOB_ID, JOB_ID_LIST, BATCH_ID } = jcm.PARAMS,
-        JOB_CHANNEL = jcm.CHANNELS.JOB,
-        CELL_CHANNEL = jcm.CHANNELS.CELL;
+    const { JOB_ID, JOB_ID_LIST, BATCH_ID } = jcm.PARAM,
+        JOB_CHANNEL = jcm.CHANNEL.JOB,
+        CELL_CHANNEL = jcm.CHANNEL.CELL;
 
     function makeMockNotebook(commInfoReturn, registerTargetReturn, executeReply, cells = []) {
         return Mocks.buildMockNotebook({
@@ -61,7 +61,7 @@ define([
             },
             {
                 channel: { [JOB_CHANNEL]: job.job_id },
-                key: { type: jcm.RESPONSES.STATUS },
+                key: { type: jcm.MESSAGE_TYPE.STATUS },
             },
         ];
     };
@@ -164,9 +164,9 @@ define([
         });
 
         const messagesToSend = [
-            [jcm.REQUESTS.STATUS, { [JOB_ID]: 0 }],
-            [jcm.REQUESTS.STATUS, { [JOB_ID]: 1 }],
-            [jcm.REQUESTS.STATUS, { [JOB_ID]: 2 }],
+            [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 0 }],
+            [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 1 }],
+            [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 2 }],
         ];
         const messagesInQueue = messagesToSend.map((arg) => {
             return {
@@ -178,7 +178,7 @@ define([
             return [
                 {
                     target_name: 'KBaseJobs',
-                    request_type: jcm.REQUESTS.STATUS,
+                    request_type: jcm.MESSAGE_TYPE.STATUS,
                     [JOB_ID]: num,
                 },
             ];
@@ -335,68 +335,68 @@ define([
 
         const busMsgCases = [
             {
-                channel: jcm.REQUESTS.LOGS,
+                channel: jcm.MESSAGE_TYPE.LOGS,
                 message: { [JOB_ID]: TEST_JOB_ID },
                 expected: {
-                    request_type: jcm.REQUESTS.LOGS,
+                    request_type: jcm.MESSAGE_TYPE.LOGS,
                     [JOB_ID]: TEST_JOB_ID,
                 },
             },
             {
-                channel: jcm.REQUESTS.LOGS,
+                channel: jcm.MESSAGE_TYPE.LOGS,
                 message: {
                     [JOB_ID]: TEST_JOB_ID,
                     latest: true,
                 },
                 expected: {
-                    request_type: jcm.REQUESTS.LOGS,
+                    request_type: jcm.MESSAGE_TYPE.LOGS,
                     [JOB_ID]: TEST_JOB_ID,
                     latest: true,
                 },
             },
             {
-                channel: jcm.REQUESTS.LOGS,
+                channel: jcm.MESSAGE_TYPE.LOGS,
                 message: {
                     [JOB_ID]: TEST_JOB_ID,
                     first_line: 2000,
                     latest: true,
                 },
                 expected: {
-                    request_type: jcm.REQUESTS.LOGS,
+                    request_type: jcm.MESSAGE_TYPE.LOGS,
                     [JOB_ID]: TEST_JOB_ID,
                     first_line: 2000,
                     latest: true,
                 },
             },
             {
-                channel: jcm.REQUESTS.CANCEL,
+                channel: jcm.MESSAGE_TYPE.CANCEL,
                 message: { [JOB_ID]: TEST_JOB_ID },
                 expected: {
-                    request_type: jcm.REQUESTS.CANCEL,
+                    request_type: jcm.MESSAGE_TYPE.CANCEL,
                     [JOB_ID]: TEST_JOB_ID,
                 },
             },
             {
-                channel: jcm.REQUESTS.CANCEL,
+                channel: jcm.MESSAGE_TYPE.CANCEL,
                 message: { [JOB_ID_LIST]: TEST_JOB_LIST },
                 expected: {
-                    request_type: jcm.REQUESTS.CANCEL,
+                    request_type: jcm.MESSAGE_TYPE.CANCEL,
                     [JOB_ID_LIST]: TEST_JOB_LIST,
                 },
             },
             {
-                channel: jcm.REQUESTS.RETRY,
+                channel: jcm.MESSAGE_TYPE.RETRY,
                 message: { [JOB_ID]: TEST_JOB_ID },
                 expected: {
-                    request_type: jcm.REQUESTS.RETRY,
+                    request_type: jcm.MESSAGE_TYPE.RETRY,
                     [JOB_ID]: TEST_JOB_ID,
                 },
             },
             {
-                channel: jcm.REQUESTS.RETRY,
+                channel: jcm.MESSAGE_TYPE.RETRY,
                 message: { [JOB_ID_LIST]: TEST_JOB_LIST },
                 expected: {
-                    request_type: jcm.REQUESTS.RETRY,
+                    request_type: jcm.MESSAGE_TYPE.RETRY,
                     [JOB_ID_LIST]: TEST_JOB_LIST,
                 },
             },
@@ -407,26 +407,26 @@ define([
         batchRequests.forEach((type) => {
             busMsgCases.push(
                 {
-                    channel: jcm.REQUESTS[type],
+                    channel: jcm.MESSAGE_TYPE[type],
                     message: { [JOB_ID]: TEST_JOB_ID },
                     expected: {
-                        request_type: jcm.REQUESTS[type],
+                        request_type: jcm.MESSAGE_TYPE[type],
                         [JOB_ID]: TEST_JOB_ID,
                     },
                 },
                 {
-                    channel: jcm.REQUESTS[type],
+                    channel: jcm.MESSAGE_TYPE[type],
                     message: { [JOB_ID_LIST]: TEST_JOB_LIST },
                     expected: {
-                        request_type: jcm.REQUESTS[type],
+                        request_type: jcm.MESSAGE_TYPE[type],
                         [JOB_ID_LIST]: TEST_JOB_LIST,
                     },
                 },
                 {
-                    channel: jcm.REQUESTS[type],
+                    channel: jcm.MESSAGE_TYPE[type],
                     message: { [BATCH_ID]: 'batch_job' },
                     expected: {
-                        request_type: `${jcm.REQUESTS[type]}`,
+                        request_type: `${jcm.MESSAGE_TYPE[type]}`,
                         [BATCH_ID]: 'batch_job',
                     },
                 }
@@ -512,9 +512,9 @@ define([
                 const comm = new JobCommChannel();
                 spyOn(comm, 'reportCommMessageError');
                 return comm.initCommChannel().then(() => {
-                    comm.handleCommMessages(makeCommMsg(jcm.RESPONSES.JOB_STATUS, sample));
+                    comm.handleCommMessages(makeCommMsg(jcm.MESSAGE_TYPE.JOB_STATUS, sample));
                     expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
-                        [{ msgType: jcm.RESPONSES.JOB_STATUS, msgData: sample }],
+                        [{ msgType: jcm.MESSAGE_TYPE.JOB_STATUS, msgData: sample }],
                     ]);
                 });
             });
@@ -522,19 +522,19 @@ define([
 
         const busTests = [
             {
-                type: jcm.RESPONSES.RUN_STATUS,
+                type: jcm.MESSAGE_TYPE.RUN_STATUS,
                 message: { job_id: TEST_JOB_ID, cell_id: 'bar' },
                 expected: [
                     { job_id: TEST_JOB_ID, cell_id: 'bar' },
                     {
                         channel: { [CELL_CHANNEL]: 'bar' },
-                        key: { type: jcm.RESPONSES.RUN_STATUS },
+                        key: { type: jcm.MESSAGE_TYPE.RUN_STATUS },
                     },
                 ],
             },
             {
                 // info for a single job
-                type: jcm.RESPONSES.INFO,
+                type: jcm.MESSAGE_TYPE.INFO,
                 message: (() => {
                     const output = {};
                     output[JobsData.example.Info.valid[0].job_id] = JobsData.example.Info.valid[0];
@@ -544,27 +544,27 @@ define([
                     JobsData.example.Info.valid[0],
                     {
                         channel: { [JOB_CHANNEL]: JobsData.example.Info.valid[0].job_id },
-                        key: { type: jcm.RESPONSES.INFO },
+                        key: { type: jcm.MESSAGE_TYPE.INFO },
                     },
                 ],
             },
             {
                 // info multiple jobs
-                type: jcm.RESPONSES.INFO,
-                message: ResponseData[jcm.RESPONSES.INFO],
-                expectedMultiple: Object.values(ResponseData[jcm.RESPONSES.INFO]).map((info) => {
+                type: jcm.MESSAGE_TYPE.INFO,
+                message: ResponseData[jcm.MESSAGE_TYPE.INFO],
+                expectedMultiple: Object.values(ResponseData[jcm.MESSAGE_TYPE.INFO]).map((info) => {
                     return [
                         info,
                         {
                             channel: { [JOB_CHANNEL]: info.job_id },
-                            key: { type: jcm.RESPONSES.INFO },
+                            key: { type: jcm.MESSAGE_TYPE.INFO },
                         },
                     ];
                 }),
             },
             {
                 // log with data
-                type: jcm.RESPONSES.LOGS,
+                type: jcm.MESSAGE_TYPE.LOGS,
                 message: {
                     [TEST_JOB_ID]: JobsData.example.Logs.valid[0],
                 },
@@ -572,13 +572,13 @@ define([
                     JobsData.example.Logs.valid[0],
                     {
                         channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.RESPONSES.LOGS },
+                        key: { type: jcm.MESSAGE_TYPE.LOGS },
                     },
                 ],
             },
             {
                 // log with message saying that the log cannot be found
-                type: jcm.RESPONSES.LOGS,
+                type: jcm.MESSAGE_TYPE.LOGS,
                 message: {
                     [TEST_JOB_ID]: {
                         [JOB_ID]: TEST_JOB_ID,
@@ -592,12 +592,12 @@ define([
                     },
                     {
                         channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.RESPONSES.LOGS },
+                        key: { type: jcm.MESSAGE_TYPE.LOGS },
                     },
                 ],
             },
             {
-                type: jcm.RESPONSES.RETRY,
+                type: jcm.MESSAGE_TYPE.RETRY,
                 message: (() => {
                     const retryData = {};
                     JobsData.example.Retry.valid.forEach((retry) => {
@@ -612,7 +612,7 @@ define([
                             channel: {
                                 [JOB_CHANNEL]: JobsData.example.Retry.valid[0].job.jobState.job_id,
                             },
-                            key: { type: jcm.RESPONSES.RETRY },
+                            key: { type: jcm.MESSAGE_TYPE.RETRY },
                         },
                     ],
                     [
@@ -621,14 +621,14 @@ define([
                             channel: {
                                 [JOB_CHANNEL]: JobsData.example.Retry.valid[1].job.jobState.job_id,
                             },
-                            key: { type: jcm.RESPONSES.RETRY },
+                            key: { type: jcm.MESSAGE_TYPE.RETRY },
                         },
                     ],
                 ],
             },
             {
                 // single job status message
-                type: jcm.RESPONSES.STATUS,
+                type: jcm.MESSAGE_TYPE.STATUS,
                 message: (() => {
                     const output = {};
                     output[JobsData.allJobs[0].job_id] = {
@@ -646,13 +646,13 @@ define([
                     },
                     {
                         channel: { [JOB_CHANNEL]: JobsData.allJobs[0].job_id },
-                        key: { type: jcm.RESPONSES.STATUS },
+                        key: { type: jcm.MESSAGE_TYPE.STATUS },
                     },
                 ],
             },
             {
                 // single job status message, ee2 error
-                type: jcm.RESPONSES.STATUS,
+                type: jcm.MESSAGE_TYPE.STATUS,
                 message: {
                     [TEST_JOB_ID]: {
                         [JOB_ID]: TEST_JOB_ID,
@@ -676,19 +676,19 @@ define([
                     },
                     {
                         channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.RESPONSES.STATUS },
+                        key: { type: jcm.MESSAGE_TYPE.STATUS },
                     },
                 ],
             },
             {
                 // more than one job, indexed by job ID
-                type: jcm.RESPONSES.STATUS,
+                type: jcm.MESSAGE_TYPE.STATUS,
                 message: JobsData.allJobs.reduce(convertToJobState, {}),
                 expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage),
             },
             {
                 // OK job and an errored job
-                type: jcm.RESPONSES.STATUS,
+                type: jcm.MESSAGE_TYPE.STATUS,
                 message: JobsData.allJobs
                     .concat({
                         job_id: '1234567890abcdef',
@@ -707,18 +707,18 @@ define([
                         },
                         {
                             channel: { [JOB_CHANNEL]: '1234567890abcdef' },
-                            key: { type: jcm.RESPONSES.STATUS },
+                            key: { type: jcm.MESSAGE_TYPE.STATUS },
                         },
                     ],
                 ]),
             },
             {
-                type: jcm.RESPONSES.STATUS_ALL,
+                type: jcm.MESSAGE_TYPE.STATUS_ALL,
                 message: JobsData.allJobsWithBatchParent.reduce(convertToJobState, {}),
                 expectedMultiple: JobsData.allJobsWithBatchParent.map(convertToJobStateBusMessage),
             },
             {
-                type: jcm.RESPONSES.ERROR,
+                type: jcm.MESSAGE_TYPE.ERROR,
                 message: {
                     job_id: TEST_JOB_ID,
                     message: 'cancel error',
@@ -738,13 +738,13 @@ define([
                     },
                     {
                         channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.RESPONSES.ERROR },
+                        key: { type: jcm.MESSAGE_TYPE.ERROR },
                     },
                 ],
             },
             {
                 // unrecognised error type
-                type: jcm.RESPONSES.ERROR,
+                type: jcm.MESSAGE_TYPE.ERROR,
                 message: {
                     source: 'some-unknown-error',
                     job_id: TEST_JOB_ID,
@@ -764,12 +764,12 @@ define([
                     },
                     {
                         channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.RESPONSES.ERROR },
+                        key: { type: jcm.MESSAGE_TYPE.ERROR },
                     },
                 ],
             },
             {
-                type: jcm.RESPONSES.ERROR,
+                type: jcm.MESSAGE_TYPE.ERROR,
                 message: {
                     [JOB_ID_LIST]: [
                         'job_1_RetryWithErrors',
@@ -798,7 +798,7 @@ define([
                         },
                         {
                             channel: { [JOB_CHANNEL]: 'job_1_RetryWithErrors' },
-                            key: { type: jcm.RESPONSES.ERROR },
+                            key: { type: jcm.MESSAGE_TYPE.ERROR },
                         },
                     ],
                     [
@@ -818,7 +818,7 @@ define([
                         },
                         {
                             channel: { [JOB_CHANNEL]: 'job_2_RetryWithErrors' },
-                            key: { type: jcm.RESPONSES.ERROR },
+                            key: { type: jcm.MESSAGE_TYPE.ERROR },
                         },
                     ],
                     [
@@ -838,7 +838,7 @@ define([
                         },
                         {
                             channel: { [JOB_CHANNEL]: 'job_3_RetryWithErrors' },
-                            key: { type: jcm.RESPONSES.ERROR },
+                            key: { type: jcm.MESSAGE_TYPE.ERROR },
                         },
                     ],
                 ],
@@ -884,7 +884,7 @@ define([
 
         ['JobState', 'Info', 'Retry', 'Logs'].forEach((type) => {
             const ucType = type === 'JobState' ? 'STATUS' : type.toUpperCase();
-            const msgType = jcm.RESPONSES[ucType];
+            const msgType = jcm.MESSAGE_TYPE[ucType];
             const values = JobsData.example[type].invalid;
 
             values.forEach((value) => {

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -314,7 +314,7 @@ define([
                 });
 
                 it('can have numerous handlers', function () {
-                    const event = jcm.RESPONSES.INFO;
+                    const event = jcm.MESSAGE_TYPE.INFO;
                     expect(this.jobManagerInstance.handlers).toEqual({});
                     this.jobManagerInstance.addEventHandler(event, { scream, shout });
                     expectHandlersDefined(this.jobManagerInstance, event, true, [
@@ -324,7 +324,7 @@ define([
                 });
 
                 it('cannot add handlers that are not functions', function () {
-                    const event = jcm.RESPONSES.STATUS;
+                    const event = jcm.MESSAGE_TYPE.STATUS;
                     expect(this.jobManagerInstance.handlers).toEqual({});
                     expect(() => {
                         this.jobManagerInstance.addEventHandler(event, { shout: { key: 'value' } });
@@ -365,8 +365,8 @@ define([
                 });
 
                 it('adds an existing handler if null is supplied as the function', function () {
-                    const event = jcm.RESPONSES.LOGS,
-                        secondEvent = jcm.RESPONSES.STATUS;
+                    const event = jcm.MESSAGE_TYPE.LOGS,
+                        secondEvent = jcm.MESSAGE_TYPE.STATUS;
                     expect(this.jobManagerInstance.handlers).toEqual({});
                     spyOn(console, 'warn');
                     this.jobManagerInstance.addEventHandler(event, { scream, shout });
@@ -382,8 +382,8 @@ define([
 
                 it('accepts an array of defined handler names', function () {
                     const event = 'modelUpdate',
-                        secondEvent = jcm.RESPONSES.ERROR,
-                        thirdEvent = jcm.RESPONSES.LOGS;
+                        secondEvent = jcm.MESSAGE_TYPE.ERROR,
+                        thirdEvent = jcm.MESSAGE_TYPE.LOGS;
                     expect(this.jobManagerInstance.handlers).toEqual({});
                     this.jobManagerInstance.addEventHandler(event, {
                         scream,
@@ -400,8 +400,8 @@ define([
                 });
 
                 it('throws an error if no handlers are supplied', function () {
-                    const event = jcm.RESPONSES.LOGS,
-                        secondEvent = jcm.RESPONSES.STATUS,
+                    const event = jcm.MESSAGE_TYPE.LOGS,
+                        secondEvent = jcm.MESSAGE_TYPE.STATUS,
                         context = this;
                     expect(() => {
                         context.jobManagerInstance.addEventHandler(event, {});
@@ -415,8 +415,8 @@ define([
 
                 it('throws an error if a saved function does not exist', function () {
                     const event = 'modelUpdate',
-                        secondEvent = jcm.RESPONSES.ERROR,
-                        thirdEvent = jcm.RESPONSES.LOGS,
+                        secondEvent = jcm.MESSAGE_TYPE.ERROR,
+                        thirdEvent = jcm.MESSAGE_TYPE.LOGS,
                         context = this;
                     expect(this.jobManagerInstance.handlers).toEqual({});
                     spyOn(console, 'error');
@@ -446,8 +446,8 @@ define([
                 });
 
                 it('warns if the handler already exists', function () {
-                    const event = jcm.RESPONSES.LOGS,
-                        secondEvent = jcm.RESPONSES.STATUS;
+                    const event = jcm.MESSAGE_TYPE.LOGS,
+                        secondEvent = jcm.MESSAGE_TYPE.STATUS;
                     expect(this.jobManagerInstance.handlers).toEqual({});
                     spyOn(console, 'warn');
                     spyOn(console, 'error');
@@ -527,7 +527,7 @@ define([
 
             describe('removeEventHandler', () => {
                 it('can have handlers removed', function () {
-                    const event = jcm.RESPONSES.LOGS;
+                    const event = jcm.MESSAGE_TYPE.LOGS;
                     this.jobManagerInstance.handlers[event] = {
                         scream,
                     };
@@ -539,7 +539,7 @@ define([
                 });
 
                 it('does not die if the handler name does not exist', function () {
-                    const event = jcm.RESPONSES.LOGS;
+                    const event = jcm.MESSAGE_TYPE.LOGS;
                     expect(this.jobManagerInstance.handlers[event]).toBeUndefined();
                     this.jobManagerInstance.removeEventHandler(event, 'scream');
                     expectHandlersDefined(this.jobManagerInstance, event, false, ['scream']);
@@ -591,7 +591,7 @@ define([
 
                 it('warns if a handler throws an error', function () {
                     const extraArg = [1, 2, 3];
-                    const event = jcm.RESPONSES.LOGS;
+                    const event = jcm.MESSAGE_TYPE.LOGS;
                     this.jobManagerInstance.handlers[event] = {
                         handler_a: scream,
                         handler_b: () => {
@@ -619,7 +619,7 @@ define([
                 });
 
                 it('can have listeners added', function () {
-                    const type = jcm.RESPONSES.INFO,
+                    const type = jcm.MESSAGE_TYPE.INFO,
                         jobId = 'fakeJob';
                     expect(this.jobManagerInstance.listeners).toEqual({});
                     spyOn(this.bus, 'listen').and.returnValue(true);
@@ -630,7 +630,7 @@ define([
                     expect(allArgs.length).toEqual(1);
                     expect(allArgs[0].length).toEqual(1);
                     expect(allArgs[0][0].key).toEqual({ type: type });
-                    expect(allArgs[0][0].channel).toEqual({ [jcm.CHANNELS.JOB]: jobId });
+                    expect(allArgs[0][0].channel).toEqual({ [jcm.CHANNEL.JOB]: jobId });
                     expect(allArgs[0][0].handle).toEqual(jasmine.any(Function));
                 });
 
@@ -644,7 +644,7 @@ define([
 
                 it('will not add undefined or null listeners', function () {
                     expect(this.jobManagerInstance.listeners).toEqual({});
-                    this.jobManagerInstance.addListener(jcm.RESPONSES.STATUS, [
+                    this.jobManagerInstance.addListener(jcm.MESSAGE_TYPE.STATUS, [
                         null,
                         '',
                         undefined,
@@ -653,7 +653,7 @@ define([
                 });
 
                 it('will take a list of job IDs', function () {
-                    const type = jcm.RESPONSES.INFO,
+                    const type = jcm.MESSAGE_TYPE.INFO,
                         jobIdList = ['fee', 'fi', 'fo', 'fum'];
                     expect(this.jobManagerInstance.listeners).toEqual({});
                     spyOn(this.bus, 'listen').and.returnValue(true);
@@ -666,14 +666,14 @@ define([
                     allArgs.forEach((arg, ix) => {
                         expect(arg.length).toEqual(1);
                         expect(arg[0].key).toEqual({ type: type });
-                        expect(arg[0].channel).toEqual({ [jcm.CHANNELS.JOB]: jobIdList[ix] });
+                        expect(arg[0].channel).toEqual({ [jcm.CHANNEL.JOB]: jobIdList[ix] });
                         expect(arg[0].handle).toEqual(jasmine.any(Function));
                     });
                 });
 
                 it('will also add handlers', function () {
                     // add a mix of valid and invalid handlers
-                    const type = jcm.RESPONSES.INFO,
+                    const type = jcm.MESSAGE_TYPE.INFO,
                         jobIdList = ['this', 'that', 'the_other'];
                     expect(() => {
                         this.jobManagerInstance.addListener(type, jobIdList, {
@@ -698,23 +698,23 @@ define([
 
                 it('does not die if the job or listener does not exist', function () {
                     expect(() => {
-                        this.jobManagerInstance.removeListener('fakeJob', jcm.RESPONSES.INFO);
+                        this.jobManagerInstance.removeListener('fakeJob', jcm.MESSAGE_TYPE.INFO);
                     }).not.toThrow();
                 });
 
                 it('will remove a specified job ID / type listener combo', function () {
                     spyOn(this.bus, 'removeListener').and.returnValue(true);
                     const fakeJob = {
-                        [jcm.RESPONSES.INFO]: 'job-info-fake-job',
-                        [jcm.RESPONSES.STATUS]: 'job-status-fake-job',
-                        [jcm.RESPONSES.LOGS]: 'job-logs-fake-job',
+                        [jcm.MESSAGE_TYPE.INFO]: 'job-info-fake-job',
+                        [jcm.MESSAGE_TYPE.STATUS]: 'job-status-fake-job',
+                        [jcm.MESSAGE_TYPE.LOGS]: 'job-logs-fake-job',
                     };
                     this.jobManagerInstance.listeners.fakeJob = fakeJob;
 
-                    this.jobManagerInstance.removeListener('fakeJob', jcm.RESPONSES.INFO);
+                    this.jobManagerInstance.removeListener('fakeJob', jcm.MESSAGE_TYPE.INFO);
                     const expected = {
-                        [jcm.RESPONSES.STATUS]: 'job-status-fake-job',
-                        [jcm.RESPONSES.LOGS]: 'job-logs-fake-job',
+                        [jcm.MESSAGE_TYPE.STATUS]: 'job-status-fake-job',
+                        [jcm.MESSAGE_TYPE.LOGS]: 'job-logs-fake-job',
                     };
 
                     expect(this.jobManagerInstance.listeners.fakeJob).toEqual(expected);
@@ -731,9 +731,9 @@ define([
                 });
                 it('will remove all listeners from a certain job ID', function () {
                     const fakeJob = {
-                        [jcm.RESPONSES.INFO]: 'job-info-fake-job',
-                        [jcm.RESPONSES.STATUS]: 'job-status-fake-job',
-                        [jcm.RESPONSES.LOGS]: 'job-logs-fake-job',
+                        [jcm.MESSAGE_TYPE.INFO]: 'job-info-fake-job',
+                        [jcm.MESSAGE_TYPE.STATUS]: 'job-status-fake-job',
+                        [jcm.MESSAGE_TYPE.LOGS]: 'job-logs-fake-job',
                     };
                     this.jobManagerInstance.listeners.fakeJob = fakeJob;
 
@@ -765,9 +765,9 @@ define([
             const currentHandlers = jobManagerInstance.handlers;
             expect(Object.keys(currentHandlers)).toEqual(
                 jasmine.arrayWithExactContents([
-                    jcm.RESPONSES.INFO,
-                    jcm.RESPONSES.RETRY,
-                    jcm.RESPONSES.STATUS,
+                    jcm.MESSAGE_TYPE.INFO,
+                    jcm.MESSAGE_TYPE.RETRY,
+                    jcm.MESSAGE_TYPE.STATUS,
                 ])
             );
             Object.keys(currentHandlers).forEach((handlerName) => {
@@ -801,7 +801,7 @@ define([
             });
 
             describe('handleJobInfo', () => {
-                const event = jcm.RESPONSES.INFO,
+                const event = jcm.MESSAGE_TYPE.INFO,
                     jobId = 'testJobId';
                 it('handles successful job info requests', function () {
                     this.jobId = jobId;
@@ -822,7 +822,7 @@ define([
                     ).not.toBeDefined();
                     // rather than faffing around with sending messages over the bus,
                     // trigger the job handler directly
-                    this.jobManagerInstance.runHandler(jcm.RESPONSES.INFO, jobInfo, jobId);
+                    this.jobManagerInstance.runHandler(jcm.MESSAGE_TYPE.INFO, jobInfo, jobId);
 
                     expect(
                         this.jobManagerInstance.model.getItem(`exec.jobs.info.${jobId}`)
@@ -838,8 +838,8 @@ define([
                     ).not.toBeDefined();
                     const error = 'Some made-up error';
                     this.jobManagerInstance.runHandler(
-                        jcm.RESPONSES.INFO,
-                        { error, [jcm.PARAMS.JOB_ID]: jobId },
+                        jcm.MESSAGE_TYPE.INFO,
+                        { error, [jcm.PARAM.JOB_ID]: jobId },
                         jobId
                     );
                     expect(
@@ -850,7 +850,7 @@ define([
             });
 
             describe('handleJobRetry', () => {
-                const event = jcm.RESPONSES.RETRY,
+                const event = jcm.MESSAGE_TYPE.RETRY,
                     jobState = JobsData.jobsByStatus.terminated[0],
                     jobId = jobState.job_id;
                 it('handles successful job retries', function () {
@@ -879,7 +879,7 @@ define([
                         this.jobManagerInstance.model.getItem(`exec.jobs.params.${newJobId}`)
                     ).not.toBeDefined();
                     expect(
-                        this.jobManagerInstance.listeners[jobId][jcm.RESPONSES.RETRY]
+                        this.jobManagerInstance.listeners[jobId][jcm.MESSAGE_TYPE.RETRY]
                     ).toBeDefined();
                     expect(this.jobManagerInstance.listeners[newJobId]).not.toBeDefined();
 
@@ -889,7 +889,7 @@ define([
                     this.jobManagerInstance.runHandler(
                         event,
                         {
-                            [jcm.PARAMS.JOB_ID]: this.jobId,
+                            [jcm.PARAM.JOB_ID]: this.jobId,
                             job: { jobState: updatedJobState },
                             retry: { jobState: retryJobState },
                         },
@@ -897,17 +897,17 @@ define([
                     );
 
                     expect(
-                        this.jobManagerInstance.listeners[jobId][jcm.RESPONSES.RETRY]
+                        this.jobManagerInstance.listeners[jobId][jcm.MESSAGE_TYPE.RETRY]
                     ).toBeDefined();
                     expect(
-                        this.jobManagerInstance.listeners[newJobId][jcm.RESPONSES.STATUS]
+                        this.jobManagerInstance.listeners[newJobId][jcm.MESSAGE_TYPE.STATUS]
                     ).toBeDefined();
                     const storedJobs = this.jobManagerInstance.model.getItem('exec.jobs.byId');
                     expect(storedJobs[jobId]).toEqual(updatedJobState);
                     expect(storedJobs[newJobId]).toEqual(retryJobState);
                     expect(this.bus.emit).toHaveBeenCalled();
                     expect(this.jobManagerInstance.bus.emit.calls.allArgs()).toEqual([
-                        [jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.JOB_ID]: newJobId }],
+                        [jcm.MESSAGE_TYPE.START_UPDATE, { [jcm.PARAM.JOB_ID]: newJobId }],
                     ]);
                 });
 
@@ -919,7 +919,7 @@ define([
                         JobsData.allJobsWithBatchParent
                     );
                     expect(
-                        this.jobManagerInstance.listeners[jobId][jcm.RESPONSES.RETRY]
+                        this.jobManagerInstance.listeners[jobId][jcm.MESSAGE_TYPE.RETRY]
                     ).toBeDefined();
 
                     spyOn(this.bus, 'emit');
@@ -928,7 +928,7 @@ define([
                     this.jobManagerInstance.runHandler(
                         event,
                         {
-                            [jcm.PARAMS.JOB_ID]: this.jobId,
+                            [jcm.PARAM.JOB_ID]: this.jobId,
                             job: { jobState },
                             error: 'Could not execute action',
                         },
@@ -940,7 +940,7 @@ define([
             });
 
             describe('handleJobStatus', () => {
-                const event = jcm.RESPONSES.STATUS;
+                const event = jcm.MESSAGE_TYPE.STATUS;
 
                 it('can update the model if a job has been updated', function () {
                     // job to test
@@ -966,7 +966,7 @@ define([
                     spyOn(console, 'error');
                     spyOn(this.jobManagerInstance, 'updateModel').and.callThrough();
                     // the first message will not trigger `updateModel` as it is identical to the existing jobState
-                    this.jobManagerInstance.runHandler(jcm.RESPONSES.STATUS, messageOne, jobId);
+                    this.jobManagerInstance.runHandler(jcm.MESSAGE_TYPE.STATUS, messageOne, jobId);
                     expect(this.jobManagerInstance.model.getItem(`exec.jobState`)).toEqual(
                         jobState
                     );
@@ -974,7 +974,7 @@ define([
                     expect(this.jobManagerInstance.updateModel).toHaveBeenCalledTimes(0);
 
                     // the second message will trigger `updateModel`
-                    this.jobManagerInstance.runHandler(jcm.RESPONSES.STATUS, messageTwo, jobId);
+                    this.jobManagerInstance.runHandler(jcm.MESSAGE_TYPE.STATUS, messageTwo, jobId);
                     expect(this.jobManagerInstance.model.getItem(`exec.jobState`)).toEqual(
                         updateOne
                     );
@@ -985,7 +985,11 @@ define([
                     expect(updateModelCallArgs).toEqual([[[updateOne]]]);
 
                     // third message will also trigger an update
-                    this.jobManagerInstance.runHandler(jcm.RESPONSES.STATUS, messageThree, jobId);
+                    this.jobManagerInstance.runHandler(
+                        jcm.MESSAGE_TYPE.STATUS,
+                        messageThree,
+                        jobId
+                    );
                     expect(this.jobManagerInstance.model.getItem(`exec.jobState`)).toEqual(
                         updateTwo
                     );
@@ -1017,8 +1021,8 @@ define([
 
                         // trigger the update
                         this.jobManagerInstance.runHandler(
-                            jcm.RESPONSES.STATUS,
-                            { jobState: updatedJobState, [jcm.PARAMS.JOB_ID]: jobId },
+                            jcm.MESSAGE_TYPE.STATUS,
+                            { jobState: updatedJobState, [jcm.PARAM.JOB_ID]: jobId },
                             jobId
                         );
                         expect(
@@ -1031,18 +1035,18 @@ define([
                         // the listener should still be in place
                         if (!jobState.meta.terminal || jobState.meta.canRetry) {
                             expect(
-                                this.jobManagerInstance.listeners[jobId][jcm.RESPONSES.STATUS]
+                                this.jobManagerInstance.listeners[jobId][jcm.MESSAGE_TYPE.STATUS]
                             ).toBeDefined();
                             expect(this.bus.emit).not.toHaveBeenCalled();
                         } else {
                             expect(
-                                this.jobManagerInstance.listeners[jobId][jcm.RESPONSES.STATUS]
+                                this.jobManagerInstance.listeners[jobId][jcm.MESSAGE_TYPE.STATUS]
                             ).not.toBeDefined();
-                            // jcm.REQUESTS.STOP_UPDATE should have been called
+                            // jcm.MESSAGE_TYPE.STOP_UPDATE should have been called
                             expect(this.bus.emit).toHaveBeenCalled();
                             const callArgs = this.bus.emit.calls.allArgs();
                             expect(callArgs).toEqual([
-                                [jcm.REQUESTS.STOP_UPDATE, { [jcm.PARAMS.JOB_ID]: jobId }],
+                                [jcm.MESSAGE_TYPE.STOP_UPDATE, { [jcm.PARAM.JOB_ID]: jobId }],
                             ]);
                         }
                     });
@@ -1060,13 +1064,13 @@ define([
                     batchParentUpdate.updated += 10;
                     setUpHandlerTest(this, event);
                     Jobs.populateModelFromJobArray(this.jobManagerInstance.model, [batchParent]);
-                    this.jobManagerInstance.addListener(jcm.RESPONSES.STATUS, [jobId]);
+                    this.jobManagerInstance.addListener(jcm.MESSAGE_TYPE.STATUS, [jobId]);
 
                     expect(this.jobManagerInstance.model.getItem('exec.jobState')).toEqual(
                         batchParent
                     );
                     expect(
-                        this.jobManagerInstance.listeners[jobId][jcm.RESPONSES.STATUS]
+                        this.jobManagerInstance.listeners[jobId][jcm.MESSAGE_TYPE.STATUS]
                     ).toBeDefined();
 
                     spyOn(console, 'error');
@@ -1075,15 +1079,15 @@ define([
 
                     // trigger the update
                     this.jobManagerInstance.runHandler(
-                        jcm.RESPONSES.STATUS,
-                        { jobState: batchParentUpdate, [jcm.PARAMS.JOB_ID]: jobId },
+                        jcm.MESSAGE_TYPE.STATUS,
+                        { jobState: batchParentUpdate, [jcm.PARAM.JOB_ID]: jobId },
                         jobId
                     );
                     expect(this.jobManagerInstance.model.getItem(`exec.jobState`)).toEqual(
                         batchParentUpdate
                     );
                     expect(
-                        this.jobManagerInstance.listeners[jobId][jcm.RESPONSES.STATUS]
+                        this.jobManagerInstance.listeners[jobId][jcm.MESSAGE_TYPE.STATUS]
                     ).toBeDefined();
                     expect(this.jobManagerInstance.updateModel).toHaveBeenCalledTimes(1);
                     expect(console.error).toHaveBeenCalledTimes(1);
@@ -1091,19 +1095,19 @@ define([
                     // all child jobs should have job status and job info listeners
                     batchParentUpdate.child_jobs.forEach((_jobId) => {
                         expect(
-                            this.jobManagerInstance.listeners[_jobId][jcm.RESPONSES.STATUS]
+                            this.jobManagerInstance.listeners[_jobId][jcm.MESSAGE_TYPE.STATUS]
                         ).toBeDefined();
                         expect(
-                            this.jobManagerInstance.listeners[_jobId][jcm.RESPONSES.INFO]
+                            this.jobManagerInstance.listeners[_jobId][jcm.MESSAGE_TYPE.INFO]
                         ).toBeDefined();
                     });
                     const callArgs = this.bus.emit.calls.allArgs();
                     expect(this.bus.emit).toHaveBeenCalledTimes(1);
                     expect(callArgs).toEqual([
                         [
-                            jcm.REQUESTS.START_UPDATE,
+                            jcm.MESSAGE_TYPE.START_UPDATE,
                             {
-                                [jcm.PARAMS.JOB_ID_LIST]: jasmine.arrayWithExactContents(
+                                [jcm.PARAM.JOB_ID_LIST]: jasmine.arrayWithExactContents(
                                     batchParentUpdate.child_jobs
                                 ),
                             },
@@ -1127,13 +1131,13 @@ define([
                     valid: Jobs.validStatusesForAction.cancel,
                     invalid: [],
                     request: 'cancel',
-                    jobRequest: jcm.REQUESTS.CANCEL,
+                    jobRequest: jcm.MESSAGE_TYPE.CANCEL,
                 },
                 retry: {
                     valid: Jobs.validStatusesForAction.retry,
                     invalid: [],
                     request: 'retry',
-                    jobRequest: jcm.REQUESTS.RETRY,
+                    jobRequest: jcm.MESSAGE_TYPE.RETRY,
                 },
             };
 
@@ -1170,7 +1174,7 @@ define([
                             const actionRequest = actionStatusMatrix[action].jobRequest;
                             expect(callArgs[0]).toEqual([
                                 actionRequest,
-                                { [jcm.PARAMS.JOB_ID_LIST]: [`${jobId}-v2`] },
+                                { [jcm.PARAM.JOB_ID_LIST]: [`${jobId}-v2`] },
                             ]);
                         });
                         it(`can ${action} a retried job in status ${status}`, function () {
@@ -1187,7 +1191,7 @@ define([
                             const actionJobId = action === 'retry' ? jobId : `${jobId}-retry`;
                             expect(callArgs[0]).toEqual([
                                 actionRequest,
-                                { [jcm.PARAMS.JOB_ID_LIST]: [actionJobId] },
+                                { [jcm.PARAM.JOB_ID_LIST]: [actionJobId] },
                             ]);
                         });
                     });
@@ -1255,7 +1259,7 @@ define([
                             );
                             expect(callArgs.length).toEqual(1);
                             expect(callArgs[0][0]).toEqual(requestType);
-                            expect(callArgs[0][1][jcm.PARAMS.JOB_ID_LIST]).toEqual(
+                            expect(callArgs[0][1][jcm.PARAM.JOB_ID_LIST]).toEqual(
                                 jasmine.arrayWithExactContents(expectedJobIds)
                             );
                         });
@@ -1296,7 +1300,7 @@ define([
                                 .flat();
                             expect(callArgs.length).toEqual(1);
                             expect(callArgs[0][0]).toEqual(requestType);
-                            expect(callArgs[0][1][jcm.PARAMS.JOB_ID_LIST]).toEqual(
+                            expect(callArgs[0][1][jcm.PARAM.JOB_ID_LIST]).toEqual(
                                 jasmine.arrayWithExactContents(expectedJobIds)
                             );
                         });
@@ -1374,12 +1378,12 @@ define([
                             .map((jobState) => jobState.job_id)
                             .forEach((jobId) => {
                                 expect(
-                                    callArgs[0][1][jcm.PARAMS.JOB_ID_LIST].includes(jobId)
+                                    callArgs[0][1][jcm.PARAM.JOB_ID_LIST].includes(jobId)
                                 ).toBeTrue();
                                 acc++;
                             });
                     });
-                    expect(callArgs[0][1][jcm.PARAMS.JOB_ID_LIST].length).toEqual(acc);
+                    expect(callArgs[0][1][jcm.PARAM.JOB_ID_LIST].length).toEqual(acc);
                 });
 
                 it('does nothing if the user responds no to the modal', async function () {
@@ -1392,8 +1396,8 @@ define([
             });
 
             const resetJobsCallArgs = [
-                jcm.REQUESTS.STOP_UPDATE,
-                { [jcm.PARAMS.BATCH_ID]: JobsData.batchParentJob.job_id },
+                jcm.MESSAGE_TYPE.STOP_UPDATE,
+                { [jcm.PARAM.BATCH_ID]: JobsData.batchParentJob.job_id },
             ];
 
             describe('cancelBatchJob', () => {
@@ -1415,7 +1419,7 @@ define([
                         jasmine.arrayWithExactContents([
                             [
                                 actionRequest,
-                                { [jcm.PARAMS.JOB_ID_LIST]: [JobsData.batchParentJob.job_id] },
+                                { [jcm.PARAM.JOB_ID_LIST]: [JobsData.batchParentJob.job_id] },
                             ],
                         ])
                     );
@@ -1426,7 +1430,7 @@ define([
                     // there should be a status listener for the batch parent
                     expect(
                         this.jobManagerInstance.listeners[JobsData.batchParentJob.job_id]
-                    ).toEqual({ [jcm.RESPONSES.STATUS]: this.bus.listen() });
+                    ).toEqual({ [jcm.MESSAGE_TYPE.STATUS]: this.bus.listen() });
                 });
             });
 
@@ -1473,7 +1477,7 @@ define([
          *          batchId         batch job ID
          *          allJobIds       IDs of batch job and all children
          *          listenerArray   listeners expected to be active; array of strings, e.g.
-         *                          [jcm.RESPONSES.STATUS, jcm.RESPONSES.INFO]
+         *                          [jcm.MESSAGE_TYPE.STATUS, jcm.MESSAGE_TYPE.INFO]
          */
         function check_initJobs(ctx, args) {
             const { batchId, allJobIds, listenerArray } = args;
@@ -1488,9 +1492,11 @@ define([
                 );
             });
 
-            const busCallArgs = [[jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }]];
-            if (listenerArray.includes(jcm.RESPONSES.INFO)) {
-                busCallArgs.push([jcm.REQUESTS.INFO, { [jcm.PARAMS.BATCH_ID]: batchId }]);
+            const busCallArgs = [
+                [jcm.MESSAGE_TYPE.START_UPDATE, { [jcm.PARAM.BATCH_ID]: batchId }],
+            ];
+            if (listenerArray.includes(jcm.MESSAGE_TYPE.INFO)) {
+                busCallArgs.push([jcm.MESSAGE_TYPE.INFO, { [jcm.PARAM.BATCH_ID]: batchId }]);
             }
 
             expect(ctx.jobManagerInstance.bus.emit.calls.allArgs()).toEqual(
@@ -1549,7 +1555,11 @@ define([
                 check_initJobs(this, {
                     batchId,
                     allJobIds: childIds.concat([batchId]),
-                    listenerArray: [jcm.RESPONSES.STATUS, jcm.RESPONSES.INFO, jcm.RESPONSES.ERROR],
+                    listenerArray: [
+                        jcm.MESSAGE_TYPE.STATUS,
+                        jcm.MESSAGE_TYPE.INFO,
+                        jcm.MESSAGE_TYPE.ERROR,
+                    ],
                 });
             });
 
@@ -1582,7 +1592,11 @@ define([
                 check_initJobs(this, {
                     batchId,
                     allJobIds: childIds.concat([batchId]),
-                    listenerArray: [jcm.RESPONSES.STATUS, jcm.RESPONSES.INFO, jcm.RESPONSES.ERROR],
+                    listenerArray: [
+                        jcm.MESSAGE_TYPE.STATUS,
+                        jcm.MESSAGE_TYPE.INFO,
+                        jcm.MESSAGE_TYPE.ERROR,
+                    ],
                 });
             });
         });
@@ -1621,7 +1635,7 @@ define([
                 check_initJobs(this, {
                     batchId: JobsData.batchParentJob.job_id,
                     allJobIds: JobsData.allJobsWithBatchParent.map((job) => job.job_id),
-                    listenerArray: [jcm.RESPONSES.STATUS, jcm.RESPONSES.ERROR],
+                    listenerArray: [jcm.MESSAGE_TYPE.STATUS, jcm.MESSAGE_TYPE.ERROR],
                 });
             });
 
@@ -1638,7 +1652,7 @@ define([
                 check_initJobs(this, {
                     batchId: JobsData.batchParentJob.job_id,
                     allJobIds: JobsData.allJobsWithBatchParent.map((job) => job.job_id),
-                    listenerArray: [jcm.RESPONSES.STATUS, jcm.RESPONSES.ERROR],
+                    listenerArray: [jcm.MESSAGE_TYPE.STATUS, jcm.MESSAGE_TYPE.ERROR],
                 });
             });
         });

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -102,10 +102,10 @@ define([
             });
         });
         const mapping = {
-            [jcm.RESPONSES.STATUS]: 'isValidBackendJobStateObject',
-            [jcm.RESPONSES.INFO]: 'isValidJobInfoObject',
-            [jcm.RESPONSES.LOGS]: 'isValidJobLogsObject',
-            [jcm.RESPONSES.RETRY]: 'isValidJobRetryObject',
+            [jcm.MESSAGE_TYPE.STATUS]: 'isValidBackendJobStateObject',
+            [jcm.MESSAGE_TYPE.INFO]: 'isValidJobInfoObject',
+            [jcm.MESSAGE_TYPE.LOGS]: 'isValidJobLogsObject',
+            [jcm.MESSAGE_TYPE.RETRY]: 'isValidJobRetryObject',
         };
 
         Object.keys(ResponseData).forEach((respType) => {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -282,7 +282,7 @@ define([
                         {},
                         {
                             channel: {
-                                [jcm.CHANNELS.CELL]: cell.metadata.kbase.attributes.id,
+                                [jcm.CHANNEL.CELL]: cell.metadata.kbase.attributes.id,
                             },
                             key: {
                                 type: 'delete-cell',
@@ -384,10 +384,10 @@ define([
                             );
                             runtime.bus().send(message, {
                                 channel: {
-                                    [jcm.CHANNELS.CELL]: cell.metadata.kbase.attributes.id,
+                                    [jcm.CHANNEL.CELL]: cell.metadata.kbase.attributes.id,
                                 },
                                 key: {
-                                    type: jcm.RESPONSES.RUN_STATUS,
+                                    type: jcm.MESSAGE_TYPE.RUN_STATUS,
                                 },
                             });
                         }
@@ -574,9 +574,18 @@ define([
                                 const allEmissions =
                                     bulkImportCellInstance.jobManager.bus.emit.calls.allArgs();
                                 expect([
-                                    [jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
-                                    [jcm.REQUESTS.CANCEL, { [jcm.PARAMS.JOB_ID_LIST]: [batchId] }],
-                                    [jcm.REQUESTS.STOP_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
+                                    [
+                                        jcm.MESSAGE_TYPE.START_UPDATE,
+                                        { [jcm.PARAM.BATCH_ID]: batchId },
+                                    ],
+                                    [
+                                        jcm.MESSAGE_TYPE.CANCEL,
+                                        { [jcm.PARAM.JOB_ID_LIST]: [batchId] },
+                                    ],
+                                    [
+                                        jcm.MESSAGE_TYPE.STOP_UPDATE,
+                                        { [jcm.PARAM.BATCH_ID]: batchId },
+                                    ],
                                     [
                                         'reset-cell',
                                         { cellId: `${testCase.cellId}-test-cell`, ts: 1234567890 },
@@ -666,10 +675,10 @@ define([
                             },
                             {
                                 channel: {
-                                    [jcm.CHANNELS.CELL]: cell.metadata.kbase.attributes.id,
+                                    [jcm.CHANNEL.CELL]: cell.metadata.kbase.attributes.id,
                                 },
                                 key: {
-                                    type: jcm.RESPONSES.RUN_STATUS,
+                                    type: jcm.MESSAGE_TYPE.RUN_STATUS,
                                 },
                             }
                         );
@@ -679,10 +688,10 @@ define([
                 expect(bulkImportCellInstance.jobManager.initBatchJob).toHaveBeenCalledTimes(1);
                 // bus calls to init jobs, request info, cancel jobs, and stop updates
                 const callArgs = [
-                    [jcm.REQUESTS.START_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
-                    [jcm.REQUESTS.INFO, { [jcm.PARAMS.BATCH_ID]: batchId }],
-                    [jcm.REQUESTS.CANCEL, { [jcm.PARAMS.JOB_ID_LIST]: [batchId] }],
-                    [jcm.REQUESTS.STOP_UPDATE, { [jcm.PARAMS.BATCH_ID]: batchId }],
+                    [jcm.MESSAGE_TYPE.START_UPDATE, { [jcm.PARAM.BATCH_ID]: batchId }],
+                    [jcm.MESSAGE_TYPE.INFO, { [jcm.PARAM.BATCH_ID]: batchId }],
+                    [jcm.MESSAGE_TYPE.CANCEL, { [jcm.PARAM.JOB_ID_LIST]: [batchId] }],
+                    [jcm.MESSAGE_TYPE.STOP_UPDATE, { [jcm.PARAM.BATCH_ID]: batchId }],
                 ];
                 expect(Jupyter.notebook.save_checkpoint.calls.allArgs()).toEqual([[]]);
                 expect(bulkImportCellInstance.jobManager.bus.emit.calls.allArgs()).toEqual(

--- a/test/unit/spec/util/jobLogViewerSpec.js
+++ b/test/unit/spec/util/jobLogViewerSpec.js
@@ -48,13 +48,13 @@ define([
      */
     function formatMessage(jobId, type, messageData = {}) {
         return [
-            Object.assign({}, { [jcm.PARAMS.JOB_ID]: jobId }, messageData),
+            Object.assign({}, { [jcm.PARAM.JOB_ID]: jobId }, messageData),
             {
                 channel: {
                     jobId,
                 },
                 key: {
-                    type: jcm.RESPONSES[type.toUpperCase()],
+                    type: jcm.MESSAGE_TYPE[type.toUpperCase()],
                 },
             },
         ];
@@ -245,8 +245,8 @@ define([
             await this.jobLogViewerInstance.start(arg);
 
             return new Promise((resolve) => {
-                this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                     resolve();
                 });
             });
@@ -374,9 +374,9 @@ define([
                     it(`should create a string for status ${jobState.status}, history mode ${
                         mode ? 'on' : 'off'
                     }`, async function () {
-                        this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
+                        this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
                             testJobStatus(this, mode);
-                            expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
+                            expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobState.job_id });
                         });
 
                         await this.jobLogViewerInstance.start({
@@ -398,9 +398,9 @@ define([
             it('should create a string for an unknown job', async function () {
                 const jobState = JobsData.unknownJob;
 
-                this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
                     testJobStatus(this);
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobState.job_id });
                 });
 
                 await this.jobLogViewerInstance.start({
@@ -452,8 +452,8 @@ define([
                         return response;
                     });
 
-                    this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                         testJobStatus(this);
                         this.runtimeBus.send(
                             ...formatMessage(jobId, 'status', { jobState: state })
@@ -491,13 +491,13 @@ define([
                 beforeEach(async function () {
                     jlv = this.jobLogViewerInstance;
                     container = this.node;
-                    this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                         this.runtimeBus.send(...formatStatusMessage(jobState));
                     });
 
-                    this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, latest: true });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId, latest: true });
                         this.runtimeBus.send(...formatLogMessage(jobId, lotsOfLogLines));
                     });
 
@@ -588,8 +588,8 @@ define([
                 const jobState = jobsByStatus['does_not_exist'][0];
                 const jobId = jobState.job_id;
 
-                this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobState.job_id });
                     // send the job message
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
@@ -612,8 +612,8 @@ define([
                     const jobState = jobsByStatus[queueState][0];
                     const jobId = jobState.job_id;
 
-                    this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobState.job_id });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobState.job_id });
                         // send the job message
                         const jobMessage = formatStatusMessage(jobState);
                         this.runtimeBus.send(...jobMessage);
@@ -643,13 +643,13 @@ define([
                 const logs = [[], logLines.slice(0, 2), logLines.slice(0, 2), logLines]; //
                 let acc = 0;
 
-                this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
-                this.runtimeBus.on(jcm.REQUESTS.START_UPDATE, (msg) => {
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.START_UPDATE, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
@@ -659,8 +659,8 @@ define([
                 });
 
                 return new Promise((resolve) => {
-                    this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, latest: true });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId, latest: true });
                         const logUpdate = logs[acc];
                         acc += 1;
                         // set up the mutation observer to watch for UI spinner changes
@@ -691,19 +691,19 @@ define([
                 const jobState = jobsByStatus['running'][0];
                 const jobId = jobState.job_id;
 
-                this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
-                this.runtimeBus.on(jcm.REQUESTS.START_UPDATE, (msg) => {
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.START_UPDATE, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                     this.runtimeBus.send(...formatStatusMessage(jobState));
                 });
 
                 // this is called when the state is 'running'
-                this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                    expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, latest: true });
+                this.runtimeBus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId, latest: true });
                     this.runtimeBus.send(
                         ...formatMessage(jobId, 'logs', {
                             error: 'summat went wrong',
@@ -739,13 +739,13 @@ define([
                     const jobState = jobsByStatus[endState][0];
                     const jobId = jobState.job_id;
 
-                    this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                         this.runtimeBus.send(...formatStatusMessage(jobState));
                     });
 
-                    this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, first_line: 0 });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId, first_line: 0 });
                         this.runtimeBus.send(...formatLogMessage(jobId, logLines));
                     });
 
@@ -767,13 +767,13 @@ define([
                     const jobState = jobsByStatus[endState][0];
                     const jobId = jobState.job_id;
 
-                    this.runtimeBus.on(jcm.REQUESTS.STATUS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
                         this.runtimeBus.send(...formatStatusMessage(jobState));
                     });
 
-                    this.runtimeBus.on(jcm.REQUESTS.LOGS, (msg) => {
-                        expect(msg).toEqual({ [jcm.PARAMS.JOB_ID]: jobId, first_line: 0 });
+                    this.runtimeBus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId, first_line: 0 });
                         this.runtimeBus.send(
                             ...formatMessage(jobId, 'logs', {
                                 error: 'DANGER!',


### PR DESCRIPTION
# Description of PR purpose/changes

Standardised all the frontend job vocab to use the singular form (e.g. `PARAM` instead of `PARAMS`) and to generally use `jcm.MESSAGE_TYPE` instead of `jcm.REQUESTS` or `jcm.RESPONSES`. Should really have done this in the first place but never mind...

Two other minor changes: (1) add missing underscore in job_config file, and (2) use `jcm.RESPONSES` in the job manager file where we do actually want to restrict the code to looking at valid response types.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
