### PR TITLE
Remove "import specification" from the staging area options

### DIFF
--- a/kbase-extension/static/kbase/config/staging_upload.json
+++ b/kbase-extension/static/kbase/config/staging_upload.json
@@ -49,10 +49,6 @@
             "name": "Sample Set"
         },
         {
-            "id": "import_specification",
-            "name": "Import Specification"
-        },
-        {
             "id": "decompress",
             "name": "Decompress/Unpack"
         }
@@ -68,9 +64,6 @@
     "app_info": {
         "web_upload": {
             "app_id": "kb_uploadmethods/upload_web_file"
-        },
-        "import_specification": {
-
         },
         "test_fastq_reads": {
             "app_id": "NarrativeTest/example_reads_upload",


### PR DESCRIPTION
# Description of PR purpose/changes

As the title says - remove the option to load an XSV file as an import specification. This lets us keep working in the codebase  on `develop` but prevents unfinished features from leaking out to the upcoming 5.0.1 release (and others after that).
