### PR TITLE
DATAUP-497: create a job ID to batch ID mapping

### DIFF
--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -64,7 +64,7 @@ define([
         ];
     };
 
-    describe('The jobCommChannel widget', () => {
+    describe('The JobCommChannel', () => {
         let testBus;
         beforeEach(() => {
             testBus = Runtime.make().bus();
@@ -86,887 +86,962 @@ define([
             expect(comm.initCommChannel).toBeDefined();
         });
 
-        it('Should initialize correctly in the base case', () => {
-            const comm = new JobCommChannel();
-            return comm.initCommChannel().then(() => {
-                expect(comm.comm).not.toBeNull();
-            });
-        });
-
-        it('Should re-initialize with an existing channel', () => {
-            const comm = new JobCommChannel();
-            Jupyter.notebook = makeMockNotebook({
-                content: {
-                    comms: {
-                        12345: {
-                            target_name: 'KBaseJobs',
-                        },
-                    },
-                },
-            });
-            return comm.initCommChannel().then(() => {
-                expect(comm.comm).not.toBeNull();
-            });
-        });
-
-        it('should generate the correct python code for the cells', () => {
-            Jupyter.notebook = makeMockNotebook(null, null, null, [
-                { metadata: { kbase: { attributes: { id: '12345' } } } },
-                { metadata: { kbase: { attributes: { id: 'abcde' } } } },
-                { id: 'whatever' },
-                { metadata: { kbase: { attributes: { id: 'who cares?' } } } },
-            ]);
-            const comm = new JobCommChannel();
-            const jobCommInitString = comm.getJobInitCode();
-            expect(jobCommInitString.split('\n')).toEqual([
-                'from biokbase.narrative.jobs.jobcomm import JobComm',
-                'cell_list = ["12345","abcde","who cares?"]',
-                // DATAUP-575: temporary disabling of cell_list
-                // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
-                'JobComm().start_job_status_loop(init_jobs=True)',
-            ]);
-        });
-
-        it('should generate the correct python code for an empty narrative', () => {
-            Jupyter.notebook = makeMockNotebook();
-            const comm = new JobCommChannel();
-            const jobCommInitString = comm.getJobInitCode();
-            expect(jobCommInitString.split('\n')).toEqual([
-                'from biokbase.narrative.jobs.jobcomm import JobComm',
-                'cell_list = []',
-                // DATAUP-575: temporary disabling of cell_list
-                // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
-                'JobComm().start_job_status_loop(init_jobs=True)',
-            ]);
-        });
-
-        it('Should fail to initialize with a failed reply from the backend JobManager startup', async () => {
-            Jupyter.notebook = makeMockNotebook(null, null, {
-                name: 'Failed to start',
-                evalue: ERROR_STR,
-                error: 'Yes. Very yes.',
-            });
-            const comm = new JobCommChannel();
-            expect(comm.comm).toBeUndefined();
-            await expectAsync(comm.initCommChannel()).toBeRejectedWith(
-                new Error(`Failed to start: ${ERROR_STR}`)
-            );
-        });
-
-        it('Should error properly when trying to send a comm with an uninited channel', async () => {
-            const comm = new JobCommChannel();
-            expect(comm.comm).toBeUndefined();
-            await expectAsync(comm.sendCommMessage('some_msg', {})).toBeRejectedWithError(
-                'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
-            );
-        });
-
-        const messagesToSend = [
-            [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 0 }],
-            [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 1 }],
-            [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 2 }],
-        ];
-        const messagesInQueue = messagesToSend.map((arg) => {
-            return {
-                msgType: arg[0],
-                msgData: arg[1],
-            };
-        });
-        const messagesSent = [0, 1, 2].map((num) => {
-            return [
-                {
-                    target_name: 'KBaseJobs',
-                    request_type: jcm.MESSAGE_TYPE.STATUS,
-                    [JOB_ID]: num,
-                },
-            ];
-        });
-
-        it('should not lose messages if the comm channel is not inited', () => {
-            const comm = new JobCommChannel();
-            expect(comm.comm).toBeUndefined();
-
-            // send three messages over the channel
-            // expect all three to be stored in comm.messageQueue
-            return new Promise((resolve) => {
-                spyOn(comm, 'sendCommMessage').and.callFake(async (...args) => {
-                    // expect sendCommMessage to throw an error
-                    await expectAsync(
-                        comm.sendCommMessage.and.originalFn.call(comm, ...args)
-                    ).toBeRejectedWithError(
-                        'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
-                    );
-                    // resolve the promise on receiving the last message
-                    if (args[1][JOB_ID] === 2) {
-                        resolve();
-                    }
-                });
-                messagesToSend.forEach((msg) => {
-                    testBus.emit(...msg);
-                });
-            }).then(() => {
-                expect(comm.sendCommMessage).toHaveBeenCalledTimes(messagesToSend.length);
-                expect(comm.sendCommMessage.calls.allArgs()).toEqual(messagesToSend);
-                expect(comm.messageQueue).toEqual(messagesInQueue);
-            });
-        });
-
-        it('should send any stored messages on initing the comm channel', () => {
-            const comm = new JobCommChannel();
-            expect(comm.comm).toBeUndefined();
-            // send three messages over the bus
-            // init the comm channel after the last message
-            // all messages should generate an error and be stored
-            // when the channel is initialised, the stored messages will be sent
-            return new Promise((resolve) => {
-                spyOn(comm, 'sendCommMessage').and.callFake(async (...args) => {
-                    // after initialising the comm channel,
-                    // sendCommMessage is called with no args
-                    // install a spy on comm.comm.send to monitor the output
-                    if (!args.length) {
-                        if (comm.comm) {
-                            spyOn(comm.comm, 'send');
-                        }
-                        return comm.sendCommMessage.and.originalFn.call(comm, ...args);
-                    }
-                    const jobId = args[1][JOB_ID];
-                    // original function should throw an error
-                    await expectAsync(
-                        comm.sendCommMessage.and.originalFn.call(comm, ...args)
-                    ).toBeRejectedWithError(
-                        'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
-                    );
-                    // resolve the promise on receiving the last message
-                    if (jobId === 2) {
-                        resolve();
-                    }
-                });
-                // emit the messages
-                messagesToSend.forEach((msg) => {
-                    testBus.emit(...msg);
-                });
-            }).then(() => {
-                // all messages will be stored
-                expect(comm.messageQueue).toEqual(messagesInQueue);
-                // init the comm channel, which will send everything in the message queue
+        describe('start up', () => {
+            it('Should initialize correctly in the base case', () => {
+                const comm = new JobCommChannel();
                 return comm.initCommChannel().then(() => {
                     expect(comm.comm).not.toBeNull();
-                    expect(comm.sendCommMessage).toHaveBeenCalledTimes(messagesToSend.length + 1);
-                    // the last call comes from comm.initCommChannel, and has no args
-                    expect(comm.sendCommMessage.calls.allArgs()).toEqual(
-                        messagesToSend.concat([[]])
-                    );
-
-                    expect(comm.comm.send).toHaveBeenCalled();
-                    expect(comm.comm.send.calls.allArgs()).toEqual(messagesSent);
                 });
             });
-        });
 
-        it('should send new and stored messages after initing the channel', () => {
-            const comm = new JobCommChannel();
-            expect(comm.comm).toBeUndefined();
-            // send three messages over the bus
-            // init the comm channel after the second message
-            // the first two messages should generate an error and be stored
-            // the third message should be processed successfully
-            return new Promise((resolve) => {
-                spyOn(comm, 'sendCommMessage').and.callFake(async (...args) => {
-                    if (!args.length) {
-                        if (comm.comm) {
-                            spyOn(comm.comm, 'send');
+            it('Should re-initialize with an existing channel', () => {
+                const comm = new JobCommChannel();
+                Jupyter.notebook = makeMockNotebook({
+                    content: {
+                        comms: {
+                            12345: {
+                                target_name: 'KBaseJobs',
+                            },
+                        },
+                    },
+                });
+                return comm.initCommChannel().then(() => {
+                    expect(comm.comm).not.toBeNull();
+                });
+            });
+
+            it('should generate the correct python code for the cells', () => {
+                Jupyter.notebook = makeMockNotebook(null, null, null, [
+                    { metadata: { kbase: { attributes: { id: '12345' } } } },
+                    { metadata: { kbase: { attributes: { id: 'abcde' } } } },
+                    { id: 'whatever' },
+                    { metadata: { kbase: { attributes: { id: 'who cares?' } } } },
+                ]);
+                const comm = new JobCommChannel();
+                const jobCommInitString = comm.getJobInitCode();
+                expect(jobCommInitString.split('\n')).toEqual([
+                    'from biokbase.narrative.jobs.jobcomm import JobComm',
+                    'cell_list = ["12345","abcde","who cares?"]',
+                    // DATAUP-575: temporary disabling of cell_list
+                    // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
+                    'JobComm().start_job_status_loop(init_jobs=True)',
+                ]);
+            });
+
+            it('should generate the correct python code for an empty narrative', () => {
+                Jupyter.notebook = makeMockNotebook();
+                const comm = new JobCommChannel();
+                const jobCommInitString = comm.getJobInitCode();
+                expect(jobCommInitString.split('\n')).toEqual([
+                    'from biokbase.narrative.jobs.jobcomm import JobComm',
+                    'cell_list = []',
+                    // DATAUP-575: temporary disabling of cell_list
+                    // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
+                    'JobComm().start_job_status_loop(init_jobs=True)',
+                ]);
+            });
+
+            it('Should fail to initialize with a failed reply from the backend JobManager startup', async () => {
+                Jupyter.notebook = makeMockNotebook(null, null, {
+                    name: 'Failed to start',
+                    evalue: ERROR_STR,
+                    error: 'Yes. Very yes.',
+                });
+                const comm = new JobCommChannel();
+                expect(comm.comm).toBeUndefined();
+                await expectAsync(comm.initCommChannel()).toBeRejectedWith(
+                    new Error(`Failed to start: ${ERROR_STR}`)
+                );
+            });
+
+            it('Should error properly when trying to send a comm with an uninited channel', async () => {
+                const comm = new JobCommChannel();
+                expect(comm.comm).toBeUndefined();
+                await expectAsync(comm.sendCommMessage('some_msg', {})).toBeRejectedWithError(
+                    'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
+                );
+            });
+
+            const messagesToSend = [
+                [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 0 }],
+                [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 1 }],
+                [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 2 }],
+            ];
+            const messagesInQueue = messagesToSend.map((arg) => {
+                return {
+                    msgType: arg[0],
+                    msgData: arg[1],
+                };
+            });
+            const messagesSent = [0, 1, 2].map((num) => {
+                return [
+                    {
+                        target_name: 'KBaseJobs',
+                        request_type: jcm.MESSAGE_TYPE.STATUS,
+                        [JOB_ID]: num,
+                    },
+                ];
+            });
+
+            it('should not lose messages if the comm channel is not inited', () => {
+                const comm = new JobCommChannel();
+                expect(comm.comm).toBeUndefined();
+
+                // send three messages over the channel
+                // expect all three to be stored in comm.messageQueue
+                return new Promise((resolve) => {
+                    spyOn(comm, 'sendCommMessage').and.callFake(async (...args) => {
+                        // expect sendCommMessage to throw an error
+                        await expectAsync(
+                            comm.sendCommMessage.and.originalFn.call(comm, ...args)
+                        ).toBeRejectedWithError(
+                            'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
+                        );
+                        // resolve the promise on receiving the last message
+                        if (args[1][JOB_ID] === 2) {
+                            resolve();
                         }
-                        return comm.sendCommMessage.and.originalFn.call(comm, ...args);
-                    }
-                    const jobId = args[1][JOB_ID];
-                    if (jobId < 2) {
+                    });
+                    messagesToSend.forEach((msg) => {
+                        testBus.emit(...msg);
+                    });
+                }).then(() => {
+                    expect(comm.sendCommMessage).toHaveBeenCalledTimes(messagesToSend.length);
+                    expect(comm.sendCommMessage.calls.allArgs()).toEqual(messagesToSend);
+                    expect(comm.messageQueue).toEqual(messagesInQueue);
+                });
+            });
+
+            it('should send any stored messages on initing the comm channel', () => {
+                const comm = new JobCommChannel();
+                expect(comm.comm).toBeUndefined();
+                // send three messages over the bus
+                // init the comm channel after the last message
+                // all messages should generate an error and be stored
+                // when the channel is initialised, the stored messages will be sent
+                return new Promise((resolve) => {
+                    spyOn(comm, 'sendCommMessage').and.callFake(async (...args) => {
+                        // after initialising the comm channel,
+                        // sendCommMessage is called with no args
+                        // install a spy on comm.comm.send to monitor the output
+                        if (!args.length) {
+                            if (comm.comm) {
+                                spyOn(comm.comm, 'send');
+                            }
+                            return comm.sendCommMessage.and.originalFn.call(comm, ...args);
+                        }
+                        const jobId = args[1][JOB_ID];
                         // original function should throw an error
                         await expectAsync(
                             comm.sendCommMessage.and.originalFn.call(comm, ...args)
                         ).toBeRejectedWithError(
                             'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
                         );
-                    } else {
-                        // call the original function
-                        await comm.sendCommMessage.and.originalFn.call(comm, ...args);
-                    }
-                    // resolve the promise on receiving the second message
-                    // this allows the test to progress to the next "then"
-                    if (jobId === 1) {
-                        resolve();
-                    }
-                });
-                // emit the first two messages
-                [0, 1].forEach((ix) => {
-                    testBus.emit(...messagesToSend[ix]);
-                });
-            }).then(() => {
-                // first two messages will be stored
-                expect(comm.messageQueue).toEqual(messagesInQueue.slice(0, 2));
-                // init the comm channel and send the last message
-                return comm.initCommChannel().then(() => {
-                    expect(comm.comm).not.toBeNull();
-                    return new Promise((resolve) => {
-                        // resolve the promise when we see comm.comm.send(...)
-                        spyOn(comm.comm, 'send').and.callFake(() => {
+                        // resolve the promise on receiving the last message
+                        if (jobId === 2) {
                             resolve();
-                        });
-                        // emit the last message
-                        testBus.emit(...messagesToSend[2]);
-                    }).then(() => {
+                        }
+                    });
+                    // emit the messages
+                    messagesToSend.forEach((msg) => {
+                        testBus.emit(...msg);
+                    });
+                }).then(() => {
+                    // all messages will be stored
+                    expect(comm.messageQueue).toEqual(messagesInQueue);
+                    // init the comm channel, which will send everything in the message queue
+                    return comm.initCommChannel().then(() => {
+                        expect(comm.comm).not.toBeNull();
                         expect(comm.sendCommMessage).toHaveBeenCalledTimes(
                             messagesToSend.length + 1
                         );
-                        expect(comm.sendCommMessage.calls.allArgs()).toEqual([
-                            messagesToSend[0],
-                            messagesToSend[1],
-                            [],
-                            messagesToSend[2],
-                        ]);
+                        // the last call comes from comm.initCommChannel, and has no args
+                        expect(comm.sendCommMessage.calls.allArgs()).toEqual(
+                            messagesToSend.concat([[]])
+                        );
 
                         expect(comm.comm.send).toHaveBeenCalled();
                         expect(comm.comm.send.calls.allArgs()).toEqual(messagesSent);
                     });
                 });
             });
-        });
 
-        const busMsgCases = [
-            {
-                channel: jcm.MESSAGE_TYPE.LOGS,
-                message: { [JOB_ID]: TEST_JOB_ID },
-                expected: {
-                    request_type: jcm.MESSAGE_TYPE.LOGS,
-                    [JOB_ID]: TEST_JOB_ID,
-                },
-            },
-            {
-                channel: jcm.MESSAGE_TYPE.LOGS,
-                message: {
-                    [JOB_ID]: TEST_JOB_ID,
-                    latest: true,
-                },
-                expected: {
-                    request_type: jcm.MESSAGE_TYPE.LOGS,
-                    [JOB_ID]: TEST_JOB_ID,
-                    latest: true,
-                },
-            },
-            {
-                channel: jcm.MESSAGE_TYPE.LOGS,
-                message: {
-                    [JOB_ID]: TEST_JOB_ID,
-                    first_line: 2000,
-                    latest: true,
-                },
-                expected: {
-                    request_type: jcm.MESSAGE_TYPE.LOGS,
-                    [JOB_ID]: TEST_JOB_ID,
-                    first_line: 2000,
-                    latest: true,
-                },
-            },
-            {
-                channel: jcm.MESSAGE_TYPE.CANCEL,
-                message: { [JOB_ID]: TEST_JOB_ID },
-                expected: {
-                    request_type: jcm.MESSAGE_TYPE.CANCEL,
-                    [JOB_ID]: TEST_JOB_ID,
-                },
-            },
-            {
-                channel: jcm.MESSAGE_TYPE.CANCEL,
-                message: { [JOB_ID_LIST]: TEST_JOB_LIST },
-                expected: {
-                    request_type: jcm.MESSAGE_TYPE.CANCEL,
-                    [JOB_ID_LIST]: TEST_JOB_LIST,
-                },
-            },
-            {
-                channel: jcm.MESSAGE_TYPE.RETRY,
-                message: { [JOB_ID]: TEST_JOB_ID },
-                expected: {
-                    request_type: jcm.MESSAGE_TYPE.RETRY,
-                    [JOB_ID]: TEST_JOB_ID,
-                },
-            },
-            {
-                channel: jcm.MESSAGE_TYPE.RETRY,
-                message: { [JOB_ID_LIST]: TEST_JOB_LIST },
-                expected: {
-                    request_type: jcm.MESSAGE_TYPE.RETRY,
-                    [JOB_ID_LIST]: TEST_JOB_LIST,
-                },
-            },
-        ];
-
-        const batchRequests = ['INFO', 'STATUS', 'START_UPDATE', 'STOP_UPDATE'];
-        // all these can have a single job ID, a job ID list, or a batch ID as input
-        batchRequests.forEach((type) => {
-            busMsgCases.push(
-                {
-                    channel: jcm.MESSAGE_TYPE[type],
-                    message: { [JOB_ID]: TEST_JOB_ID },
-                    expected: {
-                        request_type: jcm.MESSAGE_TYPE[type],
-                        [JOB_ID]: TEST_JOB_ID,
-                    },
-                },
-                {
-                    channel: jcm.MESSAGE_TYPE[type],
-                    message: { [JOB_ID_LIST]: TEST_JOB_LIST },
-                    expected: {
-                        request_type: jcm.MESSAGE_TYPE[type],
-                        [JOB_ID_LIST]: TEST_JOB_LIST,
-                    },
-                },
-                {
-                    channel: jcm.MESSAGE_TYPE[type],
-                    message: { [BATCH_ID]: 'batch_job' },
-                    expected: {
-                        request_type: `${jcm.MESSAGE_TYPE[type]}`,
-                        [BATCH_ID]: 'batch_job',
-                    },
-                }
-            );
-        });
-
-        busMsgCases.forEach((testCase) => {
-            it(`should handle a ${testCase.channel} bus message`, () => {
+            it('should send new and stored messages after initing the channel', () => {
                 const comm = new JobCommChannel();
-                return comm
-                    .initCommChannel()
-                    .then(() => {
-                        expect(comm.comm).not.toBeNull();
-                        spyOn(comm, 'sendCommMessage').and.callFake((...args) => {
+                expect(comm.comm).toBeUndefined();
+                // send three messages over the bus
+                // init the comm channel after the second message
+                // the first two messages should generate an error and be stored
+                // the third message should be processed successfully
+                return new Promise((resolve) => {
+                    spyOn(comm, 'sendCommMessage').and.callFake(async (...args) => {
+                        if (!args.length) {
+                            if (comm.comm) {
+                                spyOn(comm.comm, 'send');
+                            }
                             return comm.sendCommMessage.and.originalFn.call(comm, ...args);
-                        });
+                        }
+                        const jobId = args[1][JOB_ID];
+                        if (jobId < 2) {
+                            // original function should throw an error
+                            await expectAsync(
+                                comm.sendCommMessage.and.originalFn.call(comm, ...args)
+                            ).toBeRejectedWithError(
+                                'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
+                            );
+                        } else {
+                            // call the original function
+                            await comm.sendCommMessage.and.originalFn.call(comm, ...args);
+                        }
+                        // resolve the promise on receiving the second message
+                        // this allows the test to progress to the next "then"
+                        if (jobId === 1) {
+                            resolve();
+                        }
+                    });
+                    // emit the first two messages
+                    [0, 1].forEach((ix) => {
+                        testBus.emit(...messagesToSend[ix]);
+                    });
+                }).then(() => {
+                    // first two messages will be stored
+                    expect(comm.messageQueue).toEqual(messagesInQueue.slice(0, 2));
+                    // init the comm channel and send the last message
+                    return comm.initCommChannel().then(() => {
+                        expect(comm.comm).not.toBeNull();
                         return new Promise((resolve) => {
                             // resolve the promise when we see comm.comm.send(...)
                             spyOn(comm.comm, 'send').and.callFake(() => {
                                 resolve();
                             });
-                            testBus.emit(testCase.channel, testCase.message);
+                            // emit the last message
+                            testBus.emit(...messagesToSend[2]);
+                        }).then(() => {
+                            expect(comm.sendCommMessage).toHaveBeenCalledTimes(
+                                messagesToSend.length + 1
+                            );
+                            expect(comm.sendCommMessage.calls.allArgs()).toEqual([
+                                messagesToSend[0],
+                                messagesToSend[1],
+                                [],
+                                messagesToSend[2],
+                            ]);
+
+                            expect(comm.comm.send).toHaveBeenCalled();
+                            expect(comm.comm.send.calls.allArgs()).toEqual(messagesSent);
                         });
-                    })
-                    .then(() => {
-                        expect(comm.comm.send).toHaveBeenCalled();
-                        expect(comm.comm.send.calls.allArgs()).toEqual([
-                            [Object.assign(testCase.expected, { target_name: 'KBaseJobs' })],
-                        ]);
-                        expect(comm.sendCommMessage).toHaveBeenCalled();
-                        expect(comm.sendCommMessage.calls.allArgs()).toEqual([
-                            [testCase.channel, testCase.message],
+                    });
+                });
+            });
+        });
+        describe('bus messages', () => {
+            const busMsgCases = [
+                {
+                    channel: jcm.MESSAGE_TYPE.LOGS,
+                    message: { [JOB_ID]: TEST_JOB_ID },
+                    expected: {
+                        request_type: jcm.MESSAGE_TYPE.LOGS,
+                        [JOB_ID]: TEST_JOB_ID,
+                    },
+                },
+                {
+                    channel: jcm.MESSAGE_TYPE.LOGS,
+                    message: {
+                        [JOB_ID]: TEST_JOB_ID,
+                        latest: true,
+                    },
+                    expected: {
+                        request_type: jcm.MESSAGE_TYPE.LOGS,
+                        [JOB_ID]: TEST_JOB_ID,
+                        latest: true,
+                    },
+                },
+                {
+                    channel: jcm.MESSAGE_TYPE.LOGS,
+                    message: {
+                        [JOB_ID]: TEST_JOB_ID,
+                        first_line: 2000,
+                        latest: true,
+                    },
+                    expected: {
+                        request_type: jcm.MESSAGE_TYPE.LOGS,
+                        [JOB_ID]: TEST_JOB_ID,
+                        first_line: 2000,
+                        latest: true,
+                    },
+                },
+                {
+                    channel: jcm.MESSAGE_TYPE.CANCEL,
+                    message: { [JOB_ID]: TEST_JOB_ID },
+                    expected: {
+                        request_type: jcm.MESSAGE_TYPE.CANCEL,
+                        [JOB_ID]: TEST_JOB_ID,
+                    },
+                },
+                {
+                    channel: jcm.MESSAGE_TYPE.CANCEL,
+                    message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                    expected: {
+                        request_type: jcm.MESSAGE_TYPE.CANCEL,
+                        [JOB_ID_LIST]: TEST_JOB_LIST,
+                    },
+                },
+                {
+                    channel: jcm.MESSAGE_TYPE.RETRY,
+                    message: { [JOB_ID]: TEST_JOB_ID },
+                    expected: {
+                        request_type: jcm.MESSAGE_TYPE.RETRY,
+                        [JOB_ID]: TEST_JOB_ID,
+                    },
+                },
+                {
+                    channel: jcm.MESSAGE_TYPE.RETRY,
+                    message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                    expected: {
+                        request_type: jcm.MESSAGE_TYPE.RETRY,
+                        [JOB_ID_LIST]: TEST_JOB_LIST,
+                    },
+                },
+            ];
+
+            const batchRequests = ['INFO', 'STATUS', 'START_UPDATE', 'STOP_UPDATE'];
+            // all these can have a single job ID, a job ID list, or a batch ID as input
+            batchRequests.forEach((type) => {
+                busMsgCases.push(
+                    {
+                        channel: jcm.MESSAGE_TYPE[type],
+                        message: { [JOB_ID]: TEST_JOB_ID },
+                        expected: {
+                            request_type: jcm.MESSAGE_TYPE[type],
+                            [JOB_ID]: TEST_JOB_ID,
+                        },
+                    },
+                    {
+                        channel: jcm.MESSAGE_TYPE[type],
+                        message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                        expected: {
+                            request_type: jcm.MESSAGE_TYPE[type],
+                            [JOB_ID_LIST]: TEST_JOB_LIST,
+                        },
+                    },
+                    {
+                        channel: jcm.MESSAGE_TYPE[type],
+                        message: { [BATCH_ID]: 'batch_job' },
+                        expected: {
+                            request_type: `${jcm.MESSAGE_TYPE[type]}`,
+                            [BATCH_ID]: 'batch_job',
+                        },
+                    }
+                );
+            });
+
+            busMsgCases.forEach((testCase) => {
+                it(`should handle a ${testCase.channel} bus message`, () => {
+                    const comm = new JobCommChannel();
+                    return comm
+                        .initCommChannel()
+                        .then(() => {
+                            expect(comm.comm).not.toBeNull();
+                            spyOn(comm, 'sendCommMessage').and.callFake((...args) => {
+                                return comm.sendCommMessage.and.originalFn.call(comm, ...args);
+                            });
+                            return new Promise((resolve) => {
+                                // resolve the promise when we see comm.comm.send(...)
+                                spyOn(comm.comm, 'send').and.callFake(() => {
+                                    resolve();
+                                });
+                                testBus.emit(testCase.channel, testCase.message);
+                            });
+                        })
+                        .then(() => {
+                            expect(comm.comm.send).toHaveBeenCalled();
+                            expect(comm.comm.send.calls.allArgs()).toEqual([
+                                [Object.assign(testCase.expected, { target_name: 'KBaseJobs' })],
+                            ]);
+                            expect(comm.sendCommMessage).toHaveBeenCalled();
+                            expect(comm.sendCommMessage.calls.allArgs()).toEqual([
+                                [testCase.channel, testCase.message],
+                            ]);
+                        });
+                });
+            });
+
+            it('should handle unrecognised message types', async () => {
+                const comm = new JobCommChannel();
+                await comm.initCommChannel();
+
+                await expectAsync(
+                    comm.sendCommMessage('unknown', { [JOB_CHANNEL]: TEST_JOB_ID })
+                ).toBeRejectedWithError(
+                    'ERROR sending comm message: Ignoring unknown message type "unknown"'
+                );
+            });
+        });
+        describe('messages from the kernel', () => {
+            /*
+             * Mocking out comm messages coming back over the channel is gruesome. Just
+             * calling the handleCommMessage function directly.
+             */
+            it(`Should respond to ${jcm.MESSAGE_TYPE.NEW} by saving the Narrative`, () => {
+                const comm = new JobCommChannel();
+                spyOn(Jupyter.notebook, 'save_checkpoint');
+                return comm.initCommChannel().then(() => {
+                    comm.handleCommMessages(makeCommMsg(jcm.MESSAGE_TYPE.NEW, {}));
+                    expect(Jupyter.notebook.save_checkpoint).toHaveBeenCalled();
+                });
+            });
+
+            ['job-status', 'start', 'error', 'NEW', jcm.MESSAGE_TYPE.CANCEL].forEach((type) => {
+                it(`should reject invalid message type ${type}`, () => {
+                    const comm = new JobCommChannel();
+                    spyOn(comm, 'reportCommMessageError');
+                    return comm.initCommChannel().then(() => {
+                        comm.handleCommMessages(makeCommMsg(type, null));
+                        expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
+                            [{ msgType: type, msgData: null }],
                         ]);
                     });
-            });
-        });
-
-        it('should handle unrecognised message types', async () => {
-            const comm = new JobCommChannel();
-            await comm.initCommChannel();
-
-            await expectAsync(
-                comm.sendCommMessage('unknown', { [JOB_CHANNEL]: TEST_JOB_ID })
-            ).toBeRejectedWithError(
-                'ERROR sending comm message: Ignoring unknown message type "unknown"'
-            );
-        });
-
-        /*
-         * Mocking out comm messages coming back over the channel is gruesome. Just
-         * calling the handleCommMessage function directly.
-         */
-        it(`Should respond to ${jcm.MESSAGE_TYPE.NEW} by saving the Narrative`, () => {
-            const comm = new JobCommChannel();
-            spyOn(Jupyter.notebook, 'save_checkpoint');
-            return comm.initCommChannel().then(() => {
-                comm.handleCommMessages(makeCommMsg(jcm.MESSAGE_TYPE.NEW, {}));
-                expect(Jupyter.notebook.save_checkpoint).toHaveBeenCalled();
-            });
-        });
-
-        ['job-status', 'start', 'error', 'NEW', jcm.MESSAGE_TYPE.CANCEL].forEach((type) => {
-            it(`should reject invalid message type ${type}`, () => {
-                const comm = new JobCommChannel();
-                spyOn(comm, 'reportCommMessageError');
-                return comm.initCommChannel().then(() => {
-                    comm.handleCommMessages(makeCommMsg(type, null));
-                    expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
-                        [{ msgType: type, msgData: null }],
-                    ]);
                 });
             });
-        });
 
-        const tests = [
-            ['null', null],
-            ['undefined', undefined],
-            ['number', 123456],
-            ['string', 'string'],
-            ['string', ''],
-            ['array', [1, 2, 3]],
-        ];
-        tests.forEach((test) => {
-            const [type, sample] = test;
-            it(`should reject responses with ${type} content`, () => {
-                const comm = new JobCommChannel();
-                spyOn(comm, 'reportCommMessageError');
-                return comm.initCommChannel().then(() => {
-                    comm.handleCommMessages(makeCommMsg(jcm.MESSAGE_TYPE.STATUS, sample));
-                    expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
-                        [{ msgType: jcm.MESSAGE_TYPE.STATUS, msgData: sample }],
-                    ]);
+            const tests = [
+                ['null', null],
+                ['undefined', undefined],
+                ['number', 123456],
+                ['string', 'string'],
+                ['string', ''],
+                ['array', [1, 2, 3]],
+            ];
+            tests.forEach((test) => {
+                const [type, sample] = test;
+                it(`should reject responses with ${type} content`, () => {
+                    const comm = new JobCommChannel();
+                    spyOn(comm, 'reportCommMessageError');
+                    return comm.initCommChannel().then(() => {
+                        comm.handleCommMessages(makeCommMsg(jcm.MESSAGE_TYPE.STATUS, sample));
+                        expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
+                            [{ msgType: jcm.MESSAGE_TYPE.STATUS, msgData: sample }],
+                        ]);
+                    });
                 });
             });
-        });
 
-        const busTests = [
-            {
-                type: jcm.MESSAGE_TYPE.RUN_STATUS,
-                message: {
-                    event: 'launched_job',
-                    event_at: 12345,
-                    job_id: TEST_JOB_ID,
-                    cell_id: 'bar',
-                    run_id: 54321,
-                },
-                expected: [
-                    {
+            const busTests = [
+                {
+                    type: jcm.MESSAGE_TYPE.RUN_STATUS,
+                    message: {
                         event: 'launched_job',
                         event_at: 12345,
                         job_id: TEST_JOB_ID,
                         cell_id: 'bar',
                         run_id: 54321,
                     },
-                    {
-                        channel: { [CELL_CHANNEL]: 'bar' },
-                        key: { type: jcm.MESSAGE_TYPE.RUN_STATUS },
-                    },
-                ],
-            },
-            {
-                // info for a single job
-                type: jcm.MESSAGE_TYPE.INFO,
-                message: (() => {
-                    const output = {};
-                    output[JobsData.example.Info.valid[0].job_id] = JobsData.example.Info.valid[0];
-                    return output;
-                })(),
-                expected: [
-                    JobsData.example.Info.valid[0],
-                    {
-                        channel: { [JOB_CHANNEL]: JobsData.example.Info.valid[0].job_id },
-                        key: { type: jcm.MESSAGE_TYPE.INFO },
-                    },
-                ],
-            },
-            {
-                // info multiple jobs
-                type: jcm.MESSAGE_TYPE.INFO,
-                message: ResponseData[jcm.MESSAGE_TYPE.INFO],
-                expectedMultiple: Object.values(ResponseData[jcm.MESSAGE_TYPE.INFO]).map((info) => {
-                    return [
-                        info,
+                    expected: [
                         {
-                            channel: { [JOB_CHANNEL]: info.job_id },
+                            event: 'launched_job',
+                            event_at: 12345,
+                            job_id: TEST_JOB_ID,
+                            cell_id: 'bar',
+                            run_id: 54321,
+                        },
+                        {
+                            channel: { [CELL_CHANNEL]: 'bar' },
+                            key: { type: jcm.MESSAGE_TYPE.RUN_STATUS },
+                        },
+                    ],
+                },
+                {
+                    // info for a single job
+                    type: jcm.MESSAGE_TYPE.INFO,
+                    message: (() => {
+                        const output = {};
+                        output[JobsData.example.Info.valid[0].job_id] =
+                            JobsData.example.Info.valid[0];
+                        return output;
+                    })(),
+                    expected: [
+                        JobsData.example.Info.valid[0],
+                        {
+                            channel: { [JOB_CHANNEL]: JobsData.example.Info.valid[0].job_id },
                             key: { type: jcm.MESSAGE_TYPE.INFO },
                         },
-                    ];
-                }),
-            },
-            {
-                // log with data
-                type: jcm.MESSAGE_TYPE.LOGS,
-                message: {
-                    [TEST_JOB_ID]: JobsData.example.Logs.valid[0],
+                    ],
                 },
-                expected: [
-                    JobsData.example.Logs.valid[0],
-                    {
-                        channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.MESSAGE_TYPE.LOGS },
-                    },
-                ],
-            },
-            {
-                // log with message saying that the log cannot be found
-                type: jcm.MESSAGE_TYPE.LOGS,
-                message: {
-                    [TEST_JOB_ID]: {
-                        [JOB_ID]: TEST_JOB_ID,
-                        error: `Cannot find job log with id: {TEST_JOB_ID}`,
-                    },
+                {
+                    // info multiple jobs
+                    type: jcm.MESSAGE_TYPE.INFO,
+                    message: ResponseData[jcm.MESSAGE_TYPE.INFO],
+                    expectedMultiple: Object.values(ResponseData[jcm.MESSAGE_TYPE.INFO]).map(
+                        (info) => {
+                            return [
+                                info,
+                                {
+                                    channel: { [JOB_CHANNEL]: info.job_id },
+                                    key: { type: jcm.MESSAGE_TYPE.INFO },
+                                },
+                            ];
+                        }
+                    ),
                 },
-                expected: [
-                    {
-                        [JOB_ID]: TEST_JOB_ID,
-                        error: `Cannot find job log with id: {TEST_JOB_ID}`,
+                {
+                    // log with data
+                    type: jcm.MESSAGE_TYPE.LOGS,
+                    message: {
+                        [TEST_JOB_ID]: JobsData.example.Logs.valid[0],
                     },
-                    {
-                        channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.MESSAGE_TYPE.LOGS },
-                    },
-                ],
-            },
-            {
-                type: jcm.MESSAGE_TYPE.RETRY,
-                message: (() => {
-                    const retryData = {};
-                    JobsData.example.Retry.valid.forEach((retry) => {
-                        retryData[retry.job.jobState.job_id] = retry;
-                    });
-                    return retryData;
-                })(),
-                expectedMultiple: [
-                    [
-                        JobsData.example.Retry.valid[0],
+                    expected: [
+                        JobsData.example.Logs.valid[0],
                         {
-                            channel: {
-                                [JOB_CHANNEL]: JobsData.example.Retry.valid[0].job.jobState.job_id,
-                            },
-                            key: { type: jcm.MESSAGE_TYPE.RETRY },
+                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
+                            key: { type: jcm.MESSAGE_TYPE.LOGS },
                         },
                     ],
-                    [
-                        JobsData.example.Retry.valid[1],
+                },
+                {
+                    // log with message saying that the log cannot be found
+                    type: jcm.MESSAGE_TYPE.LOGS,
+                    message: {
+                        [TEST_JOB_ID]: {
+                            [JOB_ID]: TEST_JOB_ID,
+                            error: `Cannot find job log with id: {TEST_JOB_ID}`,
+                        },
+                    },
+                    expected: [
                         {
-                            channel: {
-                                [JOB_CHANNEL]: JobsData.example.Retry.valid[1].job.jobState.job_id,
-                            },
-                            key: { type: jcm.MESSAGE_TYPE.RETRY },
+                            [JOB_ID]: TEST_JOB_ID,
+                            error: `Cannot find job log with id: {TEST_JOB_ID}`,
+                        },
+                        {
+                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
+                            key: { type: jcm.MESSAGE_TYPE.LOGS },
                         },
                     ],
-                ],
-            },
-            {
-                // single job status message
-                type: jcm.MESSAGE_TYPE.STATUS,
-                message: (() => {
-                    const output = {};
-                    output[JobsData.allJobs[0].job_id] = {
-                        [JOB_ID]: JobsData.allJobs[0].job_id,
-                        jobState: JobsData.allJobs[0],
-                        outputWidgetInfo: {},
-                    };
-                    return output;
-                })(),
-                expected: [
-                    {
-                        [JOB_ID]: JobsData.allJobs[0].job_id,
-                        jobState: JobsData.allJobs[0],
-                        outputWidgetInfo: {},
-                    },
-                    {
-                        channel: { [JOB_CHANNEL]: JobsData.allJobs[0].job_id },
-                        key: { type: jcm.MESSAGE_TYPE.STATUS },
-                    },
-                ],
-            },
-            {
-                // single job status message, ee2 error
-                type: jcm.MESSAGE_TYPE.STATUS,
-                message: {
-                    [TEST_JOB_ID]: {
-                        [JOB_ID]: TEST_JOB_ID,
-                        jobState: {
-                            job_id: TEST_JOB_ID,
-                            status: 'running',
-                        },
-                        outputWidgetInfo: {},
-                        error: ERROR_STR,
-                    },
                 },
-                expected: [
-                    {
-                        [JOB_ID]: TEST_JOB_ID,
-                        jobState: {
-                            job_id: TEST_JOB_ID,
-                            status: 'running',
-                        },
-                        outputWidgetInfo: {},
-                        error: ERROR_STR,
-                    },
-                    {
-                        channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.MESSAGE_TYPE.STATUS },
-                    },
-                ],
-            },
-            {
-                // more than one job, indexed by job ID
-                type: jcm.MESSAGE_TYPE.STATUS,
-                message: JobsData.allJobs.reduce(convertToJobState, {}),
-                expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage),
-            },
-            {
-                // OK job and an errored job
-                type: jcm.MESSAGE_TYPE.STATUS,
-                message: JobsData.allJobs
-                    .concat({
-                        job_id: '1234567890abcdef',
-                        status: 'does_not_exist',
-                    })
-                    .reduce(convertToJobState, {}),
-                expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage).concat([
-                    [
-                        {
-                            [JOB_ID]: '1234567890abcdef',
-                            jobState: {
-                                job_id: '1234567890abcdef',
-                                status: 'does_not_exist',
+                {
+                    type: jcm.MESSAGE_TYPE.RETRY,
+                    message: (() => {
+                        const retryData = {};
+                        JobsData.example.Retry.valid.forEach((retry) => {
+                            retryData[retry.job.jobState.job_id] = retry;
+                        });
+                        return retryData;
+                    })(),
+                    expectedMultiple: [
+                        [
+                            JobsData.example.Retry.valid[0],
+                            {
+                                channel: {
+                                    [JOB_CHANNEL]:
+                                        JobsData.example.Retry.valid[0].job.jobState.job_id,
+                                },
+                                key: { type: jcm.MESSAGE_TYPE.RETRY },
                             },
+                        ],
+                        [
+                            JobsData.example.Retry.valid[1],
+                            {
+                                channel: {
+                                    [JOB_CHANNEL]:
+                                        JobsData.example.Retry.valid[1].job.jobState.job_id,
+                                },
+                                key: { type: jcm.MESSAGE_TYPE.RETRY },
+                            },
+                        ],
+                    ],
+                },
+                {
+                    // single job status message
+                    type: jcm.MESSAGE_TYPE.STATUS,
+                    message: (() => {
+                        const output = {};
+                        output[JobsData.allJobs[0].job_id] = {
+                            [JOB_ID]: JobsData.allJobs[0].job_id,
+                            jobState: JobsData.allJobs[0],
+                            outputWidgetInfo: {},
+                        };
+                        return output;
+                    })(),
+                    expected: [
+                        {
+                            [JOB_ID]: JobsData.allJobs[0].job_id,
+                            jobState: JobsData.allJobs[0],
                             outputWidgetInfo: {},
                         },
                         {
-                            channel: { [JOB_CHANNEL]: '1234567890abcdef' },
+                            channel: { [JOB_CHANNEL]: JobsData.allJobs[0].job_id },
                             key: { type: jcm.MESSAGE_TYPE.STATUS },
                         },
                     ],
-                ]),
-            },
-            {
-                type: jcm.MESSAGE_TYPE.STATUS_ALL,
-                message: JobsData.allJobsWithBatchParent.reduce(convertToJobState, {}),
-                expectedMultiple: JobsData.allJobsWithBatchParent.map(convertToJobStateBusMessage),
-            },
-            {
-                type: jcm.MESSAGE_TYPE.ERROR,
-                message: {
-                    job_id: TEST_JOB_ID,
-                    message: 'cancel error',
-                    source: 'cancel_job',
-                    code: 'RED',
                 },
-                expected: [
-                    {
-                        [JOB_ID]: TEST_JOB_ID,
-                        error: {
-                            job_id: TEST_JOB_ID,
-                            message: 'cancel error',
-                            source: 'cancel_job',
-                            code: 'RED',
+                {
+                    // single job status message, ee2 error
+                    type: jcm.MESSAGE_TYPE.STATUS,
+                    message: {
+                        [TEST_JOB_ID]: {
+                            [JOB_ID]: TEST_JOB_ID,
+                            jobState: {
+                                job_id: TEST_JOB_ID,
+                                status: 'running',
+                            },
+                            outputWidgetInfo: {},
+                            error: ERROR_STR,
                         },
-                        request: 'cancel_job',
                     },
-                    {
-                        channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.MESSAGE_TYPE.ERROR },
-                    },
-                ],
-            },
-            {
-                // unrecognised error type
-                type: jcm.MESSAGE_TYPE.ERROR,
-                message: {
-                    source: 'some-unknown-error',
-                    job_id: TEST_JOB_ID,
-                    message: 'some random error',
-                    code: 404,
-                },
-                expected: [
-                    {
-                        [JOB_ID]: TEST_JOB_ID,
-                        error: {
-                            source: 'some-unknown-error',
-                            job_id: TEST_JOB_ID,
-                            message: 'some random error',
-                            code: 404,
-                        },
-                        request: 'some-unknown-error',
-                    },
-                    {
-                        channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                        key: { type: jcm.MESSAGE_TYPE.ERROR },
-                    },
-                ],
-            },
-            {
-                type: jcm.MESSAGE_TYPE.ERROR,
-                message: {
-                    [JOB_ID_LIST]: [
-                        'job_1_RetryWithErrors',
-                        'job_2_RetryWithErrors',
-                        'job_3_RetryWithErrors',
-                    ],
-                    message: 'multiple job error message',
-                    source: 'retry_job',
-                    code: 'RED',
-                },
-                expectedMultiple: [
-                    [
+                    expected: [
                         {
-                            [JOB_ID]: 'job_1_RetryWithErrors',
+                            [JOB_ID]: TEST_JOB_ID,
+                            jobState: {
+                                job_id: TEST_JOB_ID,
+                                status: 'running',
+                            },
+                            outputWidgetInfo: {},
+                            error: ERROR_STR,
+                        },
+                        {
+                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
+                            key: { type: jcm.MESSAGE_TYPE.STATUS },
+                        },
+                    ],
+                },
+                {
+                    // more than one job, indexed by job ID
+                    type: jcm.MESSAGE_TYPE.STATUS,
+                    message: JobsData.allJobs.reduce(convertToJobState, {}),
+                    expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage),
+                },
+                {
+                    // OK job and an errored job
+                    type: jcm.MESSAGE_TYPE.STATUS,
+                    message: JobsData.allJobs
+                        .concat({
+                            job_id: '1234567890abcdef',
+                            status: 'does_not_exist',
+                        })
+                        .reduce(convertToJobState, {}),
+                    expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage).concat([
+                        [
+                            {
+                                [JOB_ID]: '1234567890abcdef',
+                                jobState: {
+                                    job_id: '1234567890abcdef',
+                                    status: 'does_not_exist',
+                                },
+                                outputWidgetInfo: {},
+                            },
+                            {
+                                channel: { [JOB_CHANNEL]: '1234567890abcdef' },
+                                key: { type: jcm.MESSAGE_TYPE.STATUS },
+                            },
+                        ],
+                    ]),
+                },
+                {
+                    type: jcm.MESSAGE_TYPE.STATUS_ALL,
+                    message: JobsData.allJobsWithBatchParent.reduce(convertToJobState, {}),
+                    expectedMultiple: JobsData.allJobsWithBatchParent.map(
+                        convertToJobStateBusMessage
+                    ),
+                },
+                {
+                    type: jcm.MESSAGE_TYPE.ERROR,
+                    message: {
+                        job_id: TEST_JOB_ID,
+                        message: 'cancel error',
+                        source: 'cancel_job',
+                        code: 'RED',
+                    },
+                    expected: [
+                        {
+                            [JOB_ID]: TEST_JOB_ID,
                             error: {
-                                [JOB_ID_LIST]: [
-                                    'job_1_RetryWithErrors',
-                                    'job_2_RetryWithErrors',
-                                    'job_3_RetryWithErrors',
-                                ],
-                                message: 'multiple job error message',
-                                source: 'retry_job',
+                                job_id: TEST_JOB_ID,
+                                message: 'cancel error',
+                                source: 'cancel_job',
                                 code: 'RED',
                             },
-                            request: 'retry_job',
+                            request: 'cancel_job',
                         },
                         {
-                            channel: { [JOB_CHANNEL]: 'job_1_RetryWithErrors' },
+                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
                             key: { type: jcm.MESSAGE_TYPE.ERROR },
                         },
                     ],
-                    [
+                },
+                {
+                    // unrecognised error type
+                    type: jcm.MESSAGE_TYPE.ERROR,
+                    message: {
+                        source: 'some-unknown-error',
+                        job_id: TEST_JOB_ID,
+                        message: 'some random error',
+                        code: 404,
+                    },
+                    expected: [
                         {
-                            [JOB_ID]: 'job_2_RetryWithErrors',
+                            [JOB_ID]: TEST_JOB_ID,
                             error: {
-                                [JOB_ID_LIST]: [
-                                    'job_1_RetryWithErrors',
-                                    'job_2_RetryWithErrors',
-                                    'job_3_RetryWithErrors',
-                                ],
-                                message: 'multiple job error message',
-                                source: 'retry_job',
-                                code: 'RED',
+                                source: 'some-unknown-error',
+                                job_id: TEST_JOB_ID,
+                                message: 'some random error',
+                                code: 404,
                             },
-                            request: 'retry_job',
+                            request: 'some-unknown-error',
                         },
                         {
-                            channel: { [JOB_CHANNEL]: 'job_2_RetryWithErrors' },
+                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
                             key: { type: jcm.MESSAGE_TYPE.ERROR },
                         },
                     ],
-                    [
-                        {
-                            [JOB_ID]: 'job_3_RetryWithErrors',
-                            error: {
-                                [JOB_ID_LIST]: [
-                                    'job_1_RetryWithErrors',
-                                    'job_2_RetryWithErrors',
-                                    'job_3_RetryWithErrors',
-                                ],
-                                message: 'multiple job error message',
-                                source: 'retry_job',
-                                code: 'RED',
+                },
+                {
+                    type: jcm.MESSAGE_TYPE.ERROR,
+                    message: {
+                        [JOB_ID_LIST]: [
+                            'job_1_RetryWithErrors',
+                            'job_2_RetryWithErrors',
+                            'job_3_RetryWithErrors',
+                        ],
+                        message: 'multiple job error message',
+                        source: 'retry_job',
+                        code: 'RED',
+                    },
+                    expectedMultiple: [
+                        [
+                            {
+                                [JOB_ID]: 'job_1_RetryWithErrors',
+                                error: {
+                                    [JOB_ID_LIST]: [
+                                        'job_1_RetryWithErrors',
+                                        'job_2_RetryWithErrors',
+                                        'job_3_RetryWithErrors',
+                                    ],
+                                    message: 'multiple job error message',
+                                    source: 'retry_job',
+                                    code: 'RED',
+                                },
+                                request: 'retry_job',
                             },
-                            request: 'retry_job',
-                        },
-                        {
-                            channel: { [JOB_CHANNEL]: 'job_3_RetryWithErrors' },
-                            key: { type: jcm.MESSAGE_TYPE.ERROR },
-                        },
+                            {
+                                channel: { [JOB_CHANNEL]: 'job_1_RetryWithErrors' },
+                                key: { type: jcm.MESSAGE_TYPE.ERROR },
+                            },
+                        ],
+                        [
+                            {
+                                [JOB_ID]: 'job_2_RetryWithErrors',
+                                error: {
+                                    [JOB_ID_LIST]: [
+                                        'job_1_RetryWithErrors',
+                                        'job_2_RetryWithErrors',
+                                        'job_3_RetryWithErrors',
+                                    ],
+                                    message: 'multiple job error message',
+                                    source: 'retry_job',
+                                    code: 'RED',
+                                },
+                                request: 'retry_job',
+                            },
+                            {
+                                channel: { [JOB_CHANNEL]: 'job_2_RetryWithErrors' },
+                                key: { type: jcm.MESSAGE_TYPE.ERROR },
+                            },
+                        ],
+                        [
+                            {
+                                [JOB_ID]: 'job_3_RetryWithErrors',
+                                error: {
+                                    [JOB_ID_LIST]: [
+                                        'job_1_RetryWithErrors',
+                                        'job_2_RetryWithErrors',
+                                        'job_3_RetryWithErrors',
+                                    ],
+                                    message: 'multiple job error message',
+                                    source: 'retry_job',
+                                    code: 'RED',
+                                },
+                                request: 'retry_job',
+                            },
+                            {
+                                channel: { [JOB_CHANNEL]: 'job_3_RetryWithErrors' },
+                                key: { type: jcm.MESSAGE_TYPE.ERROR },
+                            },
+                        ],
                     ],
-                ],
-            },
-        ];
+                },
+            ];
 
-        Object.keys(ResponseData).forEach((respType) => {
-            busTests.push({
-                type: respType,
-                message: ResponseData[respType],
-                expectedMultiple: Object.values(ResponseData[respType]).map((response) => {
-                    if (response.jobState) {
-                        response.job_id = response.jobState.job_id;
-                    }
-                    return [
-                        response,
-                        {
-                            channel: { [JOB_CHANNEL]: response.job_id },
-                            key: { type: respType },
-                        },
-                    ];
-                }),
-            });
-        });
-
-        busTests.forEach((test) => {
-            it(`should send a ${test.type} message to the bus`, () => {
-                const msg = makeCommMsg(test.type, test.message),
-                    comm = new JobCommChannel();
-                spyOn(testBus, 'send');
-                return comm.initCommChannel().then(() => {
-                    comm.handleCommMessages(msg);
-                    if (test.expectedMultiple) {
-                        expect(testBus.send.calls.allArgs()).toEqual(
-                            jasmine.arrayWithExactContents(test.expectedMultiple)
-                        );
-                    } else if (test.expected) {
-                        expect(testBus.send.calls.allArgs()).toEqual([test.expected]);
-                    }
+            Object.keys(ResponseData).forEach((respType) => {
+                busTests.push({
+                    type: respType,
+                    message: ResponseData[respType],
+                    expectedMultiple: Object.values(ResponseData[respType]).map((response) => {
+                        if (response.jobState) {
+                            response.job_id = response.jobState.job_id;
+                        }
+                        return [
+                            response,
+                            {
+                                channel: { [JOB_CHANNEL]: response.job_id },
+                                key: { type: respType },
+                            },
+                        ];
+                    }),
                 });
             });
-        });
 
-        ['STATUS', 'INFO', 'RETRY', 'LOGS'].forEach((type) => {
-            const msgType = jcm.MESSAGE_TYPE[type];
-            const validAndInvalidData = {},
-                expected = {};
-            let i = 0;
-            ['valid', 'invalid'].forEach((validity) => {
-                expected[validity] = {};
-                JobsData.example[type][validity].forEach((elem) => {
-                    validAndInvalidData[`job_${i}`] = elem;
-                    expected[validity][`job_${i}`] = elem;
-                    i++;
+            busTests.forEach((test) => {
+                it(`should send a ${test.type} message to the bus`, () => {
+                    const msg = makeCommMsg(test.type, test.message),
+                        comm = new JobCommChannel();
+                    spyOn(testBus, 'send');
+                    return comm.initCommChannel().then(() => {
+                        comm.handleCommMessages(msg);
+                        if (test.expectedMultiple) {
+                            expect(testBus.send.calls.allArgs()).toEqual(
+                                jasmine.arrayWithExactContents(test.expectedMultiple)
+                            );
+                        } else if (test.expected) {
+                            expect(testBus.send.calls.allArgs()).toEqual([test.expected]);
+                        }
+                    });
                 });
             });
 
-            // message containing data for one job
-            JobsData.example[type].invalid.forEach((value) => {
-                it(`should not send a ${msgType} message, one job, invalid`, () => {
-                    const comm = new JobCommChannel(),
-                        msgData = { [TEST_JOB_ID]: value },
-                        msg = makeCommMsg(msgType, msgData);
+            ['STATUS', 'INFO', 'RETRY', 'LOGS'].forEach((type) => {
+                const msgType = jcm.MESSAGE_TYPE[type];
+                const validAndInvalidData = {},
+                    expected = {};
+                let i = 0;
+                ['valid', 'invalid'].forEach((validity) => {
+                    expected[validity] = {};
+                    JobsData.example[type][validity].forEach((elem) => {
+                        validAndInvalidData[`job_${i}`] = elem;
+                        expected[validity][`job_${i}`] = elem;
+                        i++;
+                    });
+                });
 
+                // message containing data for one job
+                JobsData.example[type].invalid.forEach((value) => {
+                    it(`should not send a ${msgType} message, one job, invalid`, () => {
+                        const comm = new JobCommChannel(),
+                            msgData = { [TEST_JOB_ID]: value },
+                            msg = makeCommMsg(msgType, msgData);
+
+                        return comm.initCommChannel().then(() => {
+                            spyOn(comm, 'reportCommMessageError');
+                            spyOn(console, 'error');
+                            comm.handleCommMessages(msg);
+                            expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
+                                [{ msgType, msgData }],
+                            ]);
+                        });
+                    });
+                });
+
+                // message where all data is invalid
+                it(`should not send a ${msgType} message, many jobs, invalid`, () => {
+                    const msg = makeCommMsg(msgType, expected.invalid),
+                        comm = new JobCommChannel();
                     return comm.initCommChannel().then(() => {
                         spyOn(comm, 'reportCommMessageError');
                         spyOn(console, 'error');
                         comm.handleCommMessages(msg);
                         expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
-                            [{ msgType, msgData }],
+                            [{ msgType, msgData: expected.invalid }],
                         ]);
                     });
                 });
+
+                // message with a mix of valid and invalid data
+                it(`should separate out valid and invalid ${type} data`, () => {
+                    const msg = makeCommMsg(msgType, validAndInvalidData),
+                        comm = new JobCommChannel();
+                    return comm.initCommChannel().then(() => {
+                        spyOn(comm, 'reportCommMessageError');
+                        spyOn(console, 'error');
+                        spyOn(testBus, 'send');
+                        comm.handleCommMessages(msg);
+                        expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
+                            [{ msgType, msgData: expected.invalid }],
+                        ]);
+
+                        const expectedMessages = Object.keys(expected.valid).map((key) => {
+                            return [
+                                expected.valid[key],
+                                {
+                                    channel: { [JOB_CHANNEL]: key },
+                                    key: { type: msgType },
+                                },
+                            ];
+                        });
+
+                        expect(testBus.send.calls.allArgs()).toEqual(
+                            jasmine.arrayWithExactContents(expectedMessages)
+                        );
+                    });
+                });
+            });
+        });
+
+        describe('job mapping', () => {
+            const statusData = ResponseData[jcm.MESSAGE_TYPE.STATUS];
+            // generate the expected mapping
+            const responseDataMapping = {};
+            Object.values(statusData).forEach((job) => {
+                const jobId = job[jcm.PARAM.JOB_ID];
+                if (job.jobState && job.jobState.batch_id) {
+                    responseDataMapping[jobId] = { [jcm.PARAM.BATCH_ID]: job.jobState.batch_id };
+                } else {
+                    responseDataMapping[jobId] = { [jcm.PARAM.JOB_ID]: jobId };
+                }
             });
 
-            // message where all data is invalid
-            it(`should not send a ${msgType} message, many jobs, invalid`, () => {
-                const msg = makeCommMsg(msgType, expected.invalid),
-                    comm = new JobCommChannel();
+            it('should create a job mapping from job updates', () => {
+                const comm = new JobCommChannel(),
+                    msg = makeCommMsg(jcm.MESSAGE_TYPE.STATUS, statusData);
+
                 return comm.initCommChannel().then(() => {
-                    spyOn(comm, 'reportCommMessageError');
-                    spyOn(console, 'error');
                     comm.handleCommMessages(msg);
-                    expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
-                        [{ msgType, msgData: expected.invalid }],
-                    ]);
+                    expect(comm._jobMapping).toEqual(responseDataMapping);
                 });
             });
 
-            // message with a mix of valid and invalid data
-            it(`should separate out valid and invalid ${type} data`, () => {
-                const msg = makeCommMsg(msgType, validAndInvalidData),
-                    comm = new JobCommChannel();
+            it('should create a job mapping from job info data', () => {
+                const infoData = ResponseData[jcm.MESSAGE_TYPE.INFO];
+                const comm = new JobCommChannel(),
+                    msg = makeCommMsg(jcm.MESSAGE_TYPE.INFO, infoData);
+
                 return comm.initCommChannel().then(() => {
-                    spyOn(comm, 'reportCommMessageError');
-                    spyOn(console, 'error');
-                    spyOn(testBus, 'send');
                     comm.handleCommMessages(msg);
-                    expect(comm.reportCommMessageError.calls.allArgs()).toEqual([
-                        [{ msgType, msgData: expected.invalid }],
-                    ]);
+                    expect(comm._jobMapping).toEqual(responseDataMapping);
+                });
+            });
 
-                    const expectedMessages = Object.keys(expected.valid).map((key) => {
-                        return [
-                            expected.valid[key],
-                            {
-                                channel: { [JOB_CHANNEL]: key },
-                                key: { type: msgType },
-                            },
-                        ];
+            // since the retry data includes the job status,
+            // we can reconstitute the job mapping from it
+            it('should create a job mapping from job retry data', () => {
+                const retryData = ResponseData[jcm.MESSAGE_TYPE.RETRY];
+                const comm = new JobCommChannel(),
+                    msg = makeCommMsg(jcm.MESSAGE_TYPE.RETRY, retryData);
+
+                return comm.initCommChannel().then(() => {
+                    comm.handleCommMessages(msg);
+                    expect(comm._jobMapping).toEqual(responseDataMapping);
+                });
+            });
+
+            it('should create and maintain a job mapping', () => {
+                const batchUpdates = JobsData.batchJob.jobUpdateSeries;
+                const comm = new JobCommChannel();
+                return comm.initCommChannel().then(() => {
+                    spyOn(testBus, 'send');
+                    batchUpdates.forEach((update) => {
+                        comm.handleCommMessages(makeCommMsg(update.type, update.msg));
+                        expect(Object.keys(comm._jobMapping)).toEqual(
+                            jasmine.arrayWithExactContents(update.allJobIds)
+                        );
                     });
-
-                    expect(testBus.send.calls.allArgs()).toEqual(
-                        jasmine.arrayWithExactContents(expectedMessages)
-                    );
                 });
             });
         });


### PR DESCRIPTION
# Description of PR purpose/changes

Use incoming kernel messages to generate a mapping of job IDs to batch IDs in the JobCommChannel module

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
