### PR TITLE
DATAUP-497: Prepping for batches

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -651,11 +651,15 @@ define([
             });
 
             ['STATUS', 'ERROR'].forEach((event) => {
-                this.jobManager.addListener(jcm.MESSAGE_TYPE[event], [batchId].concat(jobIdList));
+                this.jobManager.addListener(
+                    jcm.MESSAGE_TYPE[event],
+                    jcm.CHANNEL.JOB,
+                    [batchId].concat(jobIdList)
+                );
             });
 
             if (paramsRequired.length) {
-                this.jobManager.addListener(jcm.MESSAGE_TYPE.INFO, paramsRequired);
+                this.jobManager.addListener(jcm.MESSAGE_TYPE.INFO, jcm.CHANNEL.JOB, paramsRequired);
                 const jobInfoRequestParams =
                     paramsRequired.length === jobIdList.length
                         ? { [jcm.PARAM.BATCH_ID]: batchId }

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -821,7 +821,7 @@ define([
                             model: makeModel(paramTestsJobArray),
                             bus: Runtime.make().bus(),
                         });
-                        this.jobManager.addListener(jcm.MESSAGE_TYPE.INFO, [
+                        this.jobManager.addListener(jcm.MESSAGE_TYPE.INFO, jcm.CHANNEL.JOB, [
                             'job_update_test',
                             'generic_retry_parent',
                         ]);
@@ -1134,7 +1134,11 @@ define([
                     });
                     JobsData.allJobs.forEach((state) => {
                         it('should not update with incorrect job ID', function () {
-                            this.jobManager.addListener(jcm.MESSAGE_TYPE.STATUS, state.job_id);
+                            this.jobManager.addListener(
+                                jcm.MESSAGE_TYPE.STATUS,
+                                jcm.CHANNEL.JOB,
+                                state.job_id
+                            );
                             _checkRowStructure(this.row, this.job);
                             this.input = state;
                             spyOn(this.jobManager, 'updateModel').and.callThrough();
@@ -1228,7 +1232,11 @@ define([
                             jobManager: this.jobManager,
                         });
 
-                        this.jobManager.addListener(jcm.MESSAGE_TYPE.RETRY, originalJobsIds);
+                        this.jobManager.addListener(
+                            jcm.MESSAGE_TYPE.RETRY,
+                            jcm.CHANNEL.JOB,
+                            originalJobsIds
+                        );
                     });
 
                     it('sets up a table correctly', function () {
@@ -1566,7 +1574,7 @@ define([
                     beforeEach(async function () {
                         await createJobStatusTableWithContext(this, paramTestsJobArray);
                         this.job = TestUtil.JSONcopy(paramTestsJobArray[0]);
-                        this.jobManager.addListener(jcm.MESSAGE_TYPE.INFO, [
+                        this.jobManager.addListener(jcm.MESSAGE_TYPE.INFO, jcm.CHANNEL.JOB, [
                             'job_update_test',
                             'generic_retry_parent',
                         ]);
@@ -1591,7 +1599,10 @@ define([
                                 const expectedCallArgs = [
                                     jcm.MESSAGE_TYPE.INFO,
                                     { job_id: 'job_update_test', ...test.input },
-                                    'job_update_test',
+                                    {
+                                        channelType: jcm.CHANNEL.JOB,
+                                        channelId: 'job_update_test',
+                                    },
                                 ];
                                 postUpdateChecks(this, expectedCallArgs);
                             }
@@ -1621,7 +1632,10 @@ define([
                                         job_id: this.job.retry_parent,
                                         ...test.input,
                                     },
-                                    this.job.retry_parent,
+                                    {
+                                        channelType: jcm.CHANNEL.JOB,
+                                        channelId: this.job.retry_parent,
+                                    },
                                 ];
                                 postUpdateChecks(this, expectedCallArgs);
                             }


### PR DESCRIPTION
# Description of PR purpose/changes

A couple of minor changes to the job manager module:
- specify the type of listener to be added to a channel instead of defaulting to 'JOB'
- add in channel info as argument to job manager event handlers and update tests accordingly
- change a couple of variable names for clarity

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
