### PR TITLE
DATAUP-696 spec importer mismatch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Unreleased
+- DATAUP-696 - Prevent import specifications from being imported with either unknown data types, or data types not currently registered as using the bulk import cell.
+
 ### Version 5.0.1
 - SAM-73 - Updated DynamicDropdownInput to have access to full list of other app parameters when user selects dropdown. If an app developer specified to use a certain value from a different field, the field as it currently exists will be used as a parameter.
 - Updated AppParamsWidget to return all current values from `get-parameters` if no specific value was specified, allowing to see all current parameter values without having to know their names.

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
@@ -9,6 +9,8 @@ define(['common/ui', 'common/html'], (UI, html) => {
         NO_FILES: 'no_files_provided',
         UNKNOWN: 'unexpected_error',
         SERVER: 'server_error',
+        UNKNOWN_TYPE: 'unknown_data_type',
+        NOT_BULK_TYPE: 'non_bulk_import_data_type',
     };
 
     const DEFAULT_MESSAGES = {
@@ -137,6 +139,26 @@ define(['common/ui', 'common/html'], (UI, html) => {
                             message: error.message,
                         });
                         break;
+                    case BULK_SPEC_ERRORS.NOT_BULK_TYPE:
+                        addFileError(
+                            Object.assign(
+                                {
+                                    message: `Importer type "${error.dataType}" is not usable for bulk import`,
+                                },
+                                error
+                            )
+                        );
+                        break;
+                    case BULK_SPEC_ERRORS.UNKNOWN_TYPE:
+                        addFileError(
+                            Object.assign(
+                                {
+                                    message: `Unknown importer type "${error.dataType}"`,
+                                },
+                                error
+                            )
+                        );
+                        break;
                     case BULK_SPEC_ERRORS.NO_FILES:
                         this.noFileError = true;
                         break;
@@ -202,9 +224,9 @@ define(['common/ui', 'common/html'], (UI, html) => {
                 });
 
                 if (numFiles === 1) {
-                    footer = `Check bulk import file ${
+                    footer = `Check bulk import file ${b(
                         Object.keys(this.fileErrors)[0]
-                    } and retry. `;
+                    )} and retry. `;
                 } else if (numFiles > 1) {
                     footer = 'Check bulk import files and retry. ';
                 }

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
@@ -18,6 +18,11 @@ define(['common/ui', 'common/html'], (UI, html) => {
         FILE_NOT_FOUND: 'File not found',
     };
 
+    const TEMPLATE_MESSAGES = {
+        UNKNOWN_TYPE: (dataType) => `Unknown importer type "${dataType}"`,
+        NOT_BULK_TYPE: (dataType) => `Importer type "${dataType}" is not usable for bulk import`,
+    };
+
     /**
      * Expect to be given an Array of errors, each of which is a key-value pair.
      * Each object in this structure can have the following fields,
@@ -143,7 +148,7 @@ define(['common/ui', 'common/html'], (UI, html) => {
                         addFileError(
                             Object.assign(
                                 {
-                                    message: `Importer type "${error.dataType}" is not usable for bulk import`,
+                                    message: TEMPLATE_MESSAGES.NOT_BULK_TYPE(error.dataType),
                                 },
                                 error
                             )
@@ -153,7 +158,7 @@ define(['common/ui', 'common/html'], (UI, html) => {
                         addFileError(
                             Object.assign(
                                 {
-                                    message: `Unknown importer type "${error.dataType}"`,
+                                    message: TEMPLATE_MESSAGES.UNKNOWN_TYPE(error.dataType),
                                 },
                                 error
                             )

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -7,7 +7,7 @@ define([
     'common/runtime',
     'StagingServiceClient',
     './importErrors',
-], (Promise, Jupyter, Config, APIUtil, StringUtil, Runtime, StagingServiceClient, Error) => {
+], (Promise, Jupyter, Config, APIUtil, StringUtil, Runtime, StagingServiceClient, Errors) => {
     'use strict';
     const uploaders = Config.get('uploaders');
     const bulkIds = new Set(uploaders.bulk_import_types);
@@ -31,7 +31,7 @@ define([
      *     dataType2: { ...etc... }
      *   }
      * }
-     * @throws Error.ImportSetupError if an error occurs in either data fetching from the Staging
+     * @throws Errors.ImportSetupError if an error occurs in either data fetching from the Staging
      *   Service, or in the initial parsing done by `processSpreadsheetFileData`
      */
     function getSpreadsheetFileInfo(files) {
@@ -98,10 +98,10 @@ define([
                 } catch (error) {
                     // this would happen if the above isn't JSON, so send the error code instead
                     parsedError = [
-                        { type: Error.BULK_SPEC_ERRORS.SERVER, message: error.responseText },
+                        { type: Errors.BULK_SPEC_ERRORS.SERVER, message: error.responseText },
                     ];
                 }
-                throw new Error.ImportSetupError(
+                throw new Errors.ImportSetupError(
                     'Error while fetching CSV/TSV/Excel import data',
                     parsedError
                 );
@@ -138,11 +138,35 @@ define([
      * @param {Object} data
      */
     async function processSpreadsheetFileData(data) {
-        // get the appIds
-        const appIdToType = Object.keys(data.types).reduce((appIdToType, dataType) => {
-            appIdToType[uploaders.app_info[dataType].app_id] = dataType;
-            return appIdToType;
-        }, {});
+        // map from given datatype to app id.
+        // if any data types are missing, record that
+        // if any data types are not bulk import ready, record that, too.
+        const appIdToType = {};
+        const dataTypeErrors = [];
+        Object.keys(data.types).forEach((dataType) => {
+            if (!(dataType in uploaders.app_info)) {
+                dataTypeErrors.push({
+                    type: Errors.BULK_SPEC_ERRORS.UNKNOWN_TYPE,
+                    dataType,
+                    file: data.files[dataType].file,
+                    tab: data.files[dataType].tab,
+                });
+            } else if (!uploaders.bulk_import_types.includes(dataType)) {
+                dataTypeErrors.push({
+                    type: Errors.BULK_SPEC_ERRORS.NOT_BULK_TYPE,
+                    dataType,
+                    file: data.files[dataType].file,
+                    tab: data.files[dataType].tab,
+                });
+            } else {
+                appIdToType[uploaders.app_info[dataType].app_id] = dataType;
+            }
+        });
+
+        // throw errors now if there are incorrect data types
+        if (dataTypeErrors.length) {
+            throw new Errors.ImportSetupError('Data type error', dataTypeErrors);
+        }
 
         // get the app specs
         const appSpecs = await APIUtil.getAppSpecs(Object.keys(appIdToType));

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "kbase-narrative-core",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "dependencies": {
                 "bluebird": "3.7.2",
                 "bootstrap": "3.3.7",
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001301",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+            "version": "1.0.30001302",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
+            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001301",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-            "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+            "version": "1.0.30001302",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
+            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
             "dev": true
         },
         "center-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001302",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
-            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
+            "version": "1.0.30001303",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
+            "integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001302",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz",
-            "integrity": "sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==",
+            "version": "1.0.30001303",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
+            "integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
             "dev": true
         },
         "center-align": {

--- a/test/unit/spec/narrative_core/upload/importErrors-spec.js
+++ b/test/unit/spec/narrative_core/upload/importErrors-spec.js
@@ -123,6 +123,38 @@ define(['kbase/js/widgets/narrative_core/upload/importErrors'], (Errors) => {
                 expect(error.fileErrors).toEqual(expectedFileErrors);
             });
 
+            it('should handle errors for bad data types', () => {
+                const badDataType = 'notARealType';
+                const fileName = 'badDataType.csv';
+                const error = new Errors.ImportSetupError('Data type error', [
+                    {
+                        type: 'unknown_data_type',
+                        dataType: badDataType,
+                        file: fileName,
+                        tab: null,
+                    },
+                ]);
+                expect(error.fileErrors).toEqual({
+                    [fileName]: [`Unknown importer type "${badDataType}"`],
+                });
+            });
+
+            it('should handle errors for non-bulk data types', () => {
+                const badDataType = 'notABulkType';
+                const fileName = 'badDataType.csv';
+                const error = new Errors.ImportSetupError('Data type error', [
+                    {
+                        type: 'non_bulk_import_data_type',
+                        dataType: badDataType,
+                        file: fileName,
+                        tab: null,
+                    },
+                ]);
+                expect(error.fileErrors).toEqual({
+                    [fileName]: [`Importer type "${badDataType}" is not usable for bulk import`],
+                });
+            });
+
             it('should handle server errors', () => {
                 const serverErrorMsg = '500 internal service error',
                     serverError = [

--- a/test/unit/spec/narrative_core/upload/importSetup-spec.js
+++ b/test/unit/spec/narrative_core/upload/importSetup-spec.js
@@ -14,7 +14,7 @@ define([
     const stagingServiceUrl = Config.url('staging_api_url');
     const RELEASE_TAG = 'release';
 
-    fdescribe('ImportSetup module tests', () => {
+    describe('ImportSetup module tests', () => {
         beforeAll(() => {
             Jupyter.narrative = {
                 sidePanel: {


### PR DESCRIPTION
# Description of PR purpose/changes

The spreadsheet importer should throw errors when the data types are either invalid or not registered as bulk import data types. This adds the new data types and some tests around them.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-696
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Upload a xSV file where the data type in the top header row is something nonsensical.
* Upload a xSV file where the data type in the top header row is something not in the bulk import remit, like "media" or "matrix"
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
