### PR TITLE
DATAUP-638 properly escape file names and server errors

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importErrors.js
@@ -1,4 +1,4 @@
-define(['common/ui', 'common/html'], (UI, html) => {
+define(['common/ui', 'common/html', 'util/string'], (UI, html, StringUtil) => {
     'use strict';
 
     const BULK_SPEC_ERRORS = {
@@ -215,7 +215,7 @@ define(['common/ui', 'common/html'], (UI, html) => {
                     title: 'Server error',
                     body: div([
                         'Server error encountered. Please retry import.',
-                        ul(this.serverErrors.map((err) => li(err))),
+                        ul(this.serverErrors.map((err) => li(StringUtil.escape(err)))),
                     ]),
                 };
             } else {
@@ -224,13 +224,13 @@ define(['common/ui', 'common/html'], (UI, html) => {
 
                 const fileErrorText = Object.entries(this.fileErrors).map(([fileName, errors]) => {
                     const s = errors.length > 1 ? 's' : '';
-                    const header = `Error${s} in ${b(fileName)}`;
-                    return div([header, ul(errors.map((err) => li(err)))]);
+                    const header = `Error${s} in ${b(StringUtil.escape(fileName))}`;
+                    return div([header, ul(errors.map((err) => li(StringUtil.escape(err))))]);
                 });
 
                 if (numFiles === 1) {
                     footer = `Check bulk import file ${b(
-                        Object.keys(this.fileErrors)[0]
+                        StringUtil.escape(Object.keys(this.fileErrors)[0])
                     )} and retry. `;
                 } else if (numFiles > 1) {
                     footer = 'Check bulk import files and retry. ';
@@ -244,7 +244,7 @@ define(['common/ui', 'common/html'], (UI, html) => {
                     const unknownString = `${prefix}nexpected error${s} found`;
                     unknownErrors = div([
                         unknownString,
-                        ul([this.unexpectedErrors.map((err) => li(err))]),
+                        ul([this.unexpectedErrors.map((err) => li(StringUtil.escape(err)))]),
                     ]);
                 }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/stagingAreaViewer.js
@@ -483,6 +483,8 @@ define([
                                     );
                                 }
 
+                                data = StringUtil.escape(data);
+
                                 if (full.isFolder) {
                                     data = span(
                                         {

--- a/test/unit/spec/narrative_core/upload/importErrors-spec.js
+++ b/test/unit/spec/narrative_core/upload/importErrors-spec.js
@@ -434,6 +434,22 @@ define(['kbase/js/widgets/narrative_core/upload/importErrors'], (Errors) => {
                     );
                 });
             });
+
+            it('should properly escape html in server-generated strings', async () => {
+                const fileName = '<some>`weird`_file.csv';
+                const errors = [
+                    {
+                        type: SPEC_ERRORS.CANNOT_PARSE,
+                        file: fileName,
+                        message: 'cannot parse: <this stuff>',
+                    },
+                ];
+                const error = new Errors.ImportSetupError('weird language happened', errors);
+                await testErrorDialog(error, 'Bulk import error', (body) => {
+                    expect(body).toContain(fileName);
+                    expect(body).toContain(errors[0].message);
+                });
+            });
         });
     });
 });

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -46,8 +46,8 @@ define([
                         isFolder: false,
                     },
                     {
-                        name: 'unknown_file.txt',
-                        path: fakeUser + '/unknown_file.txt',
+                        name: '<some>unknown_file.txt',
+                        path: fakeUser + '/<some>unknown_file.txt',
                         mtime: 1532738637555,
                         size: 100,
                         source: 'KBase upload',
@@ -491,7 +491,7 @@ define([
                 },
                 {
                     subdir: null,
-                    filename: 'unknown_file.txt',
+                    filename: '<some>unknown_file.txt',
                     isBulk: false,
                 },
                 {
@@ -542,7 +542,7 @@ define([
                     } else {
                         const fileInputs = {
                             staging_file_subdir_path: filePath,
-                            matrix_name: testCase.filename + '_matrix',
+                            matrix_name: testCase.filename.replaceAll(/[<>]/g, '_') + '_matrix',
                         };
                         expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledWith(
                             nonBulkAppId,
@@ -611,7 +611,7 @@ define([
 
                 // filename -> 3rd row
                 // otherFileName -> 4th row
-                const otherFileName = 'unknown_file.txt';
+                const otherFileName = '<some>unknown_file.txt';
                 const [$thirdSelect, $fourthSelect] = [filename, otherFileName].map((name) =>
                     $container.find(`[data-download="${name}"]`).siblings('select')
                 );


### PR DESCRIPTION
# Description of PR purpose/changes

Server errors being displayed in the dialog for bulk specification files weren't being properly escaped. Neither were filenames. Neither, it turns out, were filenames in the staging area, so files named something like `<I'm a file>.txt` were just showing `.txt`.

This addresses all of that by escaping text on its way to display.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-638
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
