### PR TITLE
DATAUP-497: Slight alteration to the structure of the test jobs data

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobCommMessages.js
+++ b/kbase-extension/static/kbase/js/common/jobCommMessages.js
@@ -3,13 +3,14 @@ define(['json!kbase/config/job_config.json'], (JobConfig) => {
 
     const REQUESTS = {},
         RESPONSES = {},
+        // param names
+        PARAM = JobConfig.params,
         // channel types
         CHANNEL = {
             CELL: 'cell',
             JOB: 'jobId',
-        },
-        // param names
-        PARAM = JobConfig.params;
+            BATCH: JobConfig.params.BATCH_ID,
+        };
 
     JobConfig.requests.forEach((req) => {
         REQUESTS[req] = JobConfig.message_types[req];

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -1333,6 +1333,7 @@ define([
                         );
                         jobDiedWithErrorUpdate.updated += 15;
                         const rowIds = [
+                            'job-created',
                             'job-cancelled-whilst-in-the-queue',
                             'job-died-whilst-queueing',
                             'job-in-the-queue',

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -456,10 +456,10 @@ define([
             {
                 desc: 'jobs with retries',
                 jobs: { byId: JobsData.batchJob.jobsById },
-                expected: `${batch} in progress: 2 queued, 1 running, 1 success (3 jobs retried)`,
+                expected: `${batch} in progress: 3 queued, 1 running, 1 success (3 jobs retried)`,
                 fsmState: 'inProgressResultsAvailable',
                 statusBarSummary: summary.running,
-                statuses: { queued: 2, running: 1, completed: 1, retried: 3 },
+                statuses: { queued: 3, running: 1, completed: 1, retried: 3 },
             },
             {
                 desc: 'jobs with retries, original jobs only',
@@ -469,10 +469,10 @@ define([
                         retryBatchId: JobsData.batchJob.jobsById[retryBatchId],
                     },
                 },
-                expected: `${batch} in progress: 1 queued, 1 failed, 2 cancelled`,
+                expected: `${batch} in progress: 2 queued, 1 failed, 2 cancelled`,
                 fsmState: 'inProgress',
                 statusBarSummary: summary.queued,
-                statuses: { queued: 1, error: 1, terminated: 2 },
+                statuses: { queued: 2, error: 1, terminated: 2 },
             },
             {
                 desc: 'all jobs queued',


### PR DESCRIPTION
# Description of PR purpose/changes

Minor change to the structure of the test data

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
