### PR TITLE
DATAUP-497: Add retry_id to retry response from backend

### DIFF
--- a/docs/design/job_architecture.md
+++ b/docs/design/job_architecture.md
@@ -429,6 +429,7 @@ Dictionary with key(s) original job ID and value dictionaries with the following
   "job_id_1": {
     "job_id": "job_id_1",
     "job": {"jobState": {"job_id": "job_id_1", "status": status, ...} ...},
+    "retry_id": "retry_id_1",
     "retry": {"jobState": {"job_id": "retry_id_1", "status": status, ...} ...}
   },
   "job_id_2": {
@@ -445,8 +446,9 @@ Dictionary with key(s) original job ID and value dictionaries with the following
 ```
 Where the dict values corresponding to "job" or "retry" are the same data structures as for `job_status`
 Outer keys:
-  * `job_id` - string, ID of the retried job
-  * `job` - string, the job state object of the retried job
+  * `job_id` - string, ID of the job that was retried (the retry parent)
+  * `job` - string, the job state object of that job
+  * `retry_id` - string, ID of the new job
   * `retry` - string, the job state object of the new job that was launched
 
 In case of error, the response has the keys:

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -475,8 +475,10 @@ class JobManager(object):
         Returns
         [
             {
+                "job_id": job_id,
                 "job": {"state": {"job_id": job_id, "status": status, ...} ...},
-                "retry": {"state": {"job_id": job_id, "status": status, ...} ...}
+                "retry_id": retry_id,
+                "retry": {"state": {"job_id": retry_id, "status": status, ...} ...}
             },
             {
                 "job": {"state": {"job_id": job_id, "status": status, ...} ...},
@@ -516,6 +518,7 @@ class JobManager(object):
             results_by_job_id[job_id] = {"job_id": job_id, "job": job_states[job_id]}
             if "retry_id" in result:
                 retry_id = result["retry_id"]
+                results_by_job_id[job_id]["retry_id"] = retry_id
                 results_by_job_id[job_id]["retry"] = job_states[retry_id]
             if "error" in result:
                 results_by_job_id[job_id]["error"] = result["error"]

--- a/src/biokbase/narrative/tests/data/response_data.json
+++ b/src/biokbase/narrative/tests/data/response_data.json
@@ -933,7 +933,8 @@
                     "wsid": 10538
                 },
                 "outputWidgetInfo": null
-            }
+            },
+            "retry_id": "BATCH_RETRY_ERROR"
         },
         "BATCH_PARENT": {
             "error": "Cannot retry batch job parents. Must retry individual jobs",
@@ -1200,7 +1201,8 @@
                     },
                     "tag": "release"
                 }
-            }
+            },
+            "retry_id": "BATCH_RETRY_COMPLETED"
         },
         "JOB_COMPLETED": {
             "error": "Error retrying job JOB_COMPLETED with status completed: can only retry jobs with status 'error' or 'terminated'",

--- a/src/biokbase/narrative/tests/generate_test_results.py
+++ b/src/biokbase/narrative/tests/generate_test_results.py
@@ -161,6 +161,7 @@ def generate_job_retries(all_jobs, retried_jobs):
             job_retries[job_id] = {
                 "job_id": job_id,
                 "job": _generate_job_output(job_id),
+                "retry_id": retried_jobs[job_id],
                 "retry": _generate_job_output(retried_jobs[job_id]),
             }
         elif "batch_job" in all_jobs[job_id] and all_jobs[job_id]["batch_job"]:

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -438,12 +438,12 @@ class JobManagerTest(unittest.TestCase):
     ):
         self.assertEqual(expected, retry_results)
         orig_ids = [
-            result["job"]["jobState"]["job_id"]
+            result["job_id"]
             for result in retry_results.values()
             if "error" not in result
         ]
         retry_ids = [
-            result["retry"]["jobState"]["job_id"]
+            result["retry_id"]
             for result in retry_results.values()
             if "error" not in result
         ]


### PR DESCRIPTION
# Description of PR purpose/changes

Quick edit to include the retry_id field in the backend response to a retry request

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
