### PR TITLE
DATAUP-497: add job id to job status

### DIFF
--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -426,6 +426,7 @@ class Job(object):
                 state.update({"updated": int(time.time())})
 
         return {
+            "job_id": self.job_id,
             "jobState": state,
             "outputWidgetInfo": widget_info,
         }

--- a/src/biokbase/narrative/tests/data/response_data.json
+++ b/src/biokbase/narrative/tests/data/response_data.json
@@ -416,6 +416,7 @@
                 },
                 "wsid": 10538
             },
+            "job_id": "BATCH_COMPLETED",
             "outputWidgetInfo": {
                 "name": "no-display",
                 "params": {
@@ -459,6 +460,7 @@
                 "user": "alien_test_user",
                 "wsid": 10538
             },
+            "job_id": "BATCH_ERROR_RETRIED",
             "outputWidgetInfo": null
         },
         "BATCH_PARENT": {
@@ -487,6 +489,7 @@
                 "user": "alien_test_user",
                 "wsid": 10538
             },
+            "job_id": "BATCH_PARENT",
             "outputWidgetInfo": null
         },
         "BATCH_RETRY_COMPLETED": {
@@ -532,6 +535,7 @@
                 },
                 "wsid": 10538
             },
+            "job_id": "BATCH_RETRY_COMPLETED",
             "outputWidgetInfo": {
                 "name": "no-display",
                 "params": {
@@ -574,6 +578,7 @@
                 "user": "alien_test_user",
                 "wsid": 10538
             },
+            "job_id": "BATCH_RETRY_ERROR",
             "outputWidgetInfo": null
         },
         "BATCH_RETRY_RUNNING": {
@@ -597,6 +602,7 @@
                 "user": "alien_test_user",
                 "wsid": 10538
             },
+            "job_id": "BATCH_RETRY_RUNNING",
             "outputWidgetInfo": null
         },
         "BATCH_TERMINATED": {
@@ -621,6 +627,7 @@
                 "user": "alien_test_user",
                 "wsid": 10538
             },
+            "job_id": "BATCH_TERMINATED",
             "outputWidgetInfo": null
         },
         "BATCH_TERMINATED_RETRIED": {
@@ -648,6 +655,7 @@
                 "user": "alien_test_user",
                 "wsid": 10538
             },
+            "job_id": "BATCH_TERMINATED_RETRIED",
             "outputWidgetInfo": null
         },
         "JOB_COMPLETED": {
@@ -689,6 +697,7 @@
                 },
                 "wsid": 54321
             },
+            "job_id": "JOB_COMPLETED",
             "outputWidgetInfo": {
                 "name": "no-display",
                 "params": {
@@ -717,6 +726,7 @@
                 "user": "fake_test_user",
                 "wsid": 55555
             },
+            "job_id": "JOB_CREATED",
             "outputWidgetInfo": null
         },
         "JOB_ERROR": {
@@ -748,6 +758,7 @@
                 "user": "ialarmedalien",
                 "wsid": 65854
             },
+            "job_id": "JOB_ERROR",
             "outputWidgetInfo": null
         },
         "JOB_RUNNING": {
@@ -770,6 +781,7 @@
                 "user": "test_user",
                 "wsid": 54321
             },
+            "job_id": "JOB_RUNNING",
             "outputWidgetInfo": null
         },
         "JOB_TERMINATED": {
@@ -793,6 +805,7 @@
                 "user": "test_user",
                 "wsid": 54321
             },
+            "job_id": "JOB_TERMINATED",
             "outputWidgetInfo": null
         },
         "a_bad_job_id": {
@@ -853,6 +866,7 @@
                     },
                     "wsid": 10538
                 },
+                "job_id": "BATCH_COMPLETED",
                 "outputWidgetInfo": {
                     "name": "no-display",
                     "params": {
@@ -899,6 +913,7 @@
                     "user": "alien_test_user",
                     "wsid": 10538
                 },
+                "job_id": "BATCH_ERROR_RETRIED",
                 "outputWidgetInfo": null
             },
             "job_id": "BATCH_ERROR_RETRIED",
@@ -932,6 +947,7 @@
                     "user": "alien_test_user",
                     "wsid": 10538
                 },
+                "job_id": "BATCH_RETRY_ERROR",
                 "outputWidgetInfo": null
             },
             "retry_id": "BATCH_RETRY_ERROR"
@@ -964,6 +980,7 @@
                     "user": "alien_test_user",
                     "wsid": 10538
                 },
+                "job_id": "BATCH_PARENT",
                 "outputWidgetInfo": null
             },
             "job_id": "BATCH_PARENT"
@@ -1013,6 +1030,7 @@
                     },
                     "wsid": 10538
                 },
+                "job_id": "BATCH_RETRY_COMPLETED",
                 "outputWidgetInfo": {
                     "name": "no-display",
                     "params": {
@@ -1059,6 +1077,7 @@
                     "user": "alien_test_user",
                     "wsid": 10538
                 },
+                "job_id": "BATCH_RETRY_ERROR",
                 "outputWidgetInfo": null
             },
             "job_id": "BATCH_RETRY_ERROR"
@@ -1086,6 +1105,7 @@
                     "user": "alien_test_user",
                     "wsid": 10538
                 },
+                "job_id": "BATCH_RETRY_RUNNING",
                 "outputWidgetInfo": null
             },
             "job_id": "BATCH_RETRY_RUNNING"
@@ -1114,6 +1134,7 @@
                     "user": "alien_test_user",
                     "wsid": 10538
                 },
+                "job_id": "BATCH_TERMINATED",
                 "outputWidgetInfo": null
             },
             "job_id": "BATCH_TERMINATED"
@@ -1144,6 +1165,7 @@
                     "user": "alien_test_user",
                     "wsid": 10538
                 },
+                "job_id": "BATCH_TERMINATED_RETRIED",
                 "outputWidgetInfo": null
             },
             "job_id": "BATCH_TERMINATED_RETRIED",
@@ -1190,6 +1212,7 @@
                     },
                     "wsid": 10538
                 },
+                "job_id": "BATCH_RETRY_COMPLETED",
                 "outputWidgetInfo": {
                     "name": "no-display",
                     "params": {
@@ -1245,6 +1268,7 @@
                     },
                     "wsid": 54321
                 },
+                "job_id": "JOB_COMPLETED",
                 "outputWidgetInfo": {
                     "name": "no-display",
                     "params": {
@@ -1277,6 +1301,7 @@
                     "user": "fake_test_user",
                     "wsid": 55555
                 },
+                "job_id": "JOB_CREATED",
                 "outputWidgetInfo": null
             },
             "job_id": "JOB_CREATED"
@@ -1312,6 +1337,7 @@
                     "user": "ialarmedalien",
                     "wsid": 65854
                 },
+                "job_id": "JOB_ERROR",
                 "outputWidgetInfo": null
             },
             "job_id": "JOB_ERROR"
@@ -1338,6 +1364,7 @@
                     "user": "test_user",
                     "wsid": 54321
                 },
+                "job_id": "JOB_RUNNING",
                 "outputWidgetInfo": null
             },
             "job_id": "JOB_RUNNING"
@@ -1365,6 +1392,7 @@
                     "user": "test_user",
                     "wsid": 54321
                 },
+                "job_id": "JOB_TERMINATED",
                 "outputWidgetInfo": null
             },
             "job_id": "JOB_TERMINATED"

--- a/src/biokbase/narrative/tests/generate_test_results.py
+++ b/src/biokbase/narrative/tests/generate_test_results.py
@@ -90,12 +90,12 @@ def _generate_job_output(job_id):
             del state[f]
 
     if state["status"] != COMPLETED_STATUS:
-        return {"jobState": state, "outputWidgetInfo": widget_info}
+        return {"job_id": job_id, "jobState": state, "outputWidgetInfo": widget_info}
 
     if not widget_info:
         widget_info = {}
 
-    return {"jobState": state, "outputWidgetInfo": widget_info}
+    return {"job_id": job_id, "jobState": state, "outputWidgetInfo": widget_info}
 
 
 def generate_bad_jobs():

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -281,23 +281,25 @@ class MockClients:
         job_id = params.get("job_id")
         if not job_id:
             return {}
-        info = self.job_state_data.get(job_id, {"job_id": job_id, "status": "unmocked"})
+        job_state = self.job_state_data.get(
+            job_id, {"job_id": job_id, "status": "unmocked"}
+        )
         if "exclude_fields" in params:
             for f in params["exclude_fields"]:
-                if f in info:
-                    del info[f]
-        return info
+                if f in job_state:
+                    del job_state[f]
+        return job_state
 
     def check_jobs(self, params):
         job_ids = params.get("job_ids")
-        infos = dict()
+        job_states = dict()
         for job in job_ids:
-            infos[job] = self.check_job(
+            job_states[job] = self.check_job(
                 {"job_id": job, "exclude_fields": params.get("exclude_fields", [])}
             )
         if params.get("return_list"):
-            infos = list(infos.values())
-        return infos
+            job_states = list(job_states.values())
+        return job_states
 
     def get_job_logs(self, params):
         """


### PR DESCRIPTION
# Description of PR purpose/changes

Quickie - add the job ID to the output of the backend job status request

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
