### PR TITLE
DATAUP-497: job data structure updates and  job test data edits

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -254,7 +254,7 @@ define([
      * @returns {boolean} true|false
      */
     function isValidBackendJobStateObject(backendJobState) {
-        const required = ['jobState'];
+        const required = ['job_id', 'jobState'];
         if (
             backendJobState &&
             Utils.objectToString(backendJobState) === 'Object' &&
@@ -334,7 +334,7 @@ define([
      *
      * This function should be updated to stay in sync with ee2's output.
      *
-     * @param {object} jobLogs
+     * @param {object} jobRetry
      * @returns {boolean} true|false
      */
     function isValidJobRetryObject(jobRetry) {

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -1,4 +1,9 @@
-define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, TestUtil) => {
+define([
+    'common/format',
+    'common/jobCommMessages',
+    'testUtil',
+    'json!/src/biokbase/narrative/tests/data/response_data.json',
+], (format, jcm, TestUtil, ResponseData) => {
     'use strict';
     const t = {
         created: 1610065000000,
@@ -9,7 +14,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
 
     const TEST_JOB_ID = 'someJob',
         SOME_VALUE = 'some unimportant value',
-        BATCH_ID = 'batch-parent';
+        BATCH_ID = 'BATCH_PARENT';
 
     const jobStrings = {
         unknown: 'Awaiting job data...',
@@ -30,6 +35,20 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
         },
     };
 
+    const JOB = {
+        CREATED: 'JOB_CREATED',
+        ESTIMATING: 'JOB_ESTIMATING',
+        QUEUED: 'JOB_QUEUED',
+        TERMINATED_WHILST_QUEUED: 'JOB_TERMINATED_WHILST_QUEUED',
+        DIED_WHILST_QUEUED: 'JOB_DIED_WHILST_QUEUED',
+        RUNNING: 'JOB_RUNNING',
+        TERMINATED_WHILST_RUNNING: 'JOB_TERMINATED_WHILST_RUNNING',
+        DIED_WHILST_RUNNING: 'JOB_DIED_WHILST_RUNNING',
+        COMPLETED: 'JOB_COMPLETED',
+        UNKNOWN: 'JOB_UNKNOWN',
+        BATCH_PARENT: BATCH_ID,
+    };
+
     /*
         The following are valid job state objects as would be received from ee2.
 
@@ -39,7 +58,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
 
     const validJobs = [
         {
-            job_id: 'job-created',
+            job_id: JOB.CREATED,
             status: 'created',
             created: t.created,
             updated: t.created,
@@ -61,7 +80,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             },
         },
         {
-            job_id: 'job-estimating',
+            job_id: JOB.ESTIMATING,
             status: 'estimating',
             created: t.created,
             updated: t.created,
@@ -83,7 +102,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             },
         },
         {
-            job_id: 'job-in-the-queue',
+            job_id: JOB.QUEUED,
             status: 'queued',
             created: t.created,
             queued: t.queued,
@@ -106,7 +125,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             },
         },
         {
-            job_id: 'job-cancelled-whilst-in-the-queue',
+            job_id: JOB.TERMINATED_WHILST_QUEUED,
             status: 'terminated',
             created: t.created,
             finished: t.finished,
@@ -130,60 +149,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             },
         },
         {
-            job_id: 'job-running',
-            status: 'running',
-            created: t.created,
-            queued: t.queued,
-            running: t.running,
-            updated: t.running,
-            meta: {
-                canCancel: true,
-                canRetry: true,
-                createJobStatusLines: {
-                    line: jobStrings.running,
-                    history: [jobStrings.queueHistory, jobStrings.running],
-                },
-                jobAction: jobStrings.action.cancel,
-                jobLabel: 'running',
-                niceState: {
-                    class: 'kb-job-status__summary',
-                    label: 'running',
-                },
-                terminal: false,
-                appCellFsm: { mode: 'processing', stage: 'running' },
-            },
-        },
-        {
-            job_id: 'job-cancelled-during-run',
-            status: 'terminated',
-            created: t.created,
-            finished: t.finished,
-            queued: t.queued,
-            running: t.running,
-            updated: t.finished,
-            meta: {
-                canCancel: false,
-                canRetry: true,
-                createJobStatusLines: {
-                    line: jobStrings.termination,
-                    history: [
-                        jobStrings.queueHistory,
-                        jobStrings.runHistory,
-                        jobStrings.termination,
-                    ],
-                },
-                jobAction: jobStrings.action.retry,
-                jobLabel: 'cancelled',
-                niceState: {
-                    class: 'kb-job-status__summary--terminated',
-                    label: 'cancellation',
-                },
-                terminal: true,
-                appCellFsm: { mode: 'canceled' },
-            },
-        },
-        {
-            job_id: 'job-died-whilst-queueing',
+            job_id: JOB.DIED_WHILST_QUEUED,
             status: 'error',
             error: {
                 code: 666,
@@ -216,7 +182,60 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             },
         },
         {
-            job_id: 'job-died-with-error',
+            job_id: JOB.RUNNING,
+            status: 'running',
+            created: t.created,
+            queued: t.queued,
+            running: t.running,
+            updated: t.running,
+            meta: {
+                canCancel: true,
+                canRetry: true,
+                createJobStatusLines: {
+                    line: jobStrings.running,
+                    history: [jobStrings.queueHistory, jobStrings.running],
+                },
+                jobAction: jobStrings.action.cancel,
+                jobLabel: 'running',
+                niceState: {
+                    class: 'kb-job-status__summary',
+                    label: 'running',
+                },
+                terminal: false,
+                appCellFsm: { mode: 'processing', stage: 'running' },
+            },
+        },
+        {
+            job_id: JOB.TERMINATED_WHILST_RUNNING,
+            status: 'terminated',
+            created: t.created,
+            finished: t.finished,
+            queued: t.queued,
+            running: t.running,
+            updated: t.finished,
+            meta: {
+                canCancel: false,
+                canRetry: true,
+                createJobStatusLines: {
+                    line: jobStrings.termination,
+                    history: [
+                        jobStrings.queueHistory,
+                        jobStrings.runHistory,
+                        jobStrings.termination,
+                    ],
+                },
+                jobAction: jobStrings.action.retry,
+                jobLabel: 'cancelled',
+                niceState: {
+                    class: 'kb-job-status__summary--terminated',
+                    label: 'cancellation',
+                },
+                terminal: true,
+                appCellFsm: { mode: 'canceled' },
+            },
+        },
+        {
+            job_id: JOB.DIED_WHILST_RUNNING,
             status: 'error',
             error: {
                 code: -32000,
@@ -250,7 +269,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             },
         },
         {
-            job_id: 'job-finished-with-success',
+            job_id: JOB.COMPLETED,
             status: 'completed',
             created: t.created,
             finished: t.finished,
@@ -274,7 +293,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
                 appCellFsm: { mode: 'success' },
             },
             job_output: {
-                id: 'job-finished-with-success',
+                id: 'JOB_COMPLETED',
                 result: [
                     {
                         report_name: 'kb_megahit_report_33c8f76d-0aaa-4b27-a0f9-4569b69fef3e',
@@ -287,7 +306,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
     ];
 
     const unknownJob = {
-        job_id: 'unknown-job',
+        job_id: JOB.UNKNOWN,
         status: 'does_not_exist',
         other: 'key',
         another: 'key',
@@ -312,7 +331,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
         job_id: BATCH_ID,
         batch_id: BATCH_ID,
         batch_job: true,
-        child_jobs: ['unknown-job'].concat(
+        child_jobs: [unknownJob.job_id].concat(
             validJobs.map((job) => {
                 return job.job_id;
             })
@@ -372,7 +391,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
     const invalidJobStates = [
         ...invalidTypes,
         {
-            job_id: 'somejob',
+            job_id: TEST_JOB_ID,
             other: 'key',
         },
         {
@@ -380,73 +399,37 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             other: 'key',
         },
         {
-            job_id: 'baz',
+            job_id: TEST_JOB_ID,
             create: 12345,
         },
         {
-            job_id: 'whatever',
+            job_id: TEST_JOB_ID,
             status: 'running',
         },
         {
-            job_id: 'invalid job status',
+            job_id: TEST_JOB_ID,
             created: 12345678,
             status: 'who cares?',
         },
     ];
 
-    const validBackendJobStates = [
-        {
-            jobState: validJobStates[0],
-        },
-        {
-            jobState: validJobStates[1],
-            outputWidgetInfo: {},
-        },
-        {
-            jobState: validJobStates[2],
-            outputWidgetInfo: {
-                ping: 'pong',
-            },
-        },
-    ];
+    const validBackendJobStates = Object.values(ResponseData[jcm.MESSAGE_TYPE.STATUS]);
 
     const invalidBackendJobStates = [
         ...invalidJobStates,
         ...invalidJobStates.map((item) => {
             return { jobState: item };
         }),
+        {
+            jobState: validJobStates[0],
+        },
+        {
+            jobState: validJobStates[1],
+            outputWidgetInfo: null,
+        },
     ];
 
-    const validInfo = [
-        {
-            job_params: [{ this: 'that' }],
-            job_id: 'job_with_single_param',
-            app_id: 'NarrativeTest/app_sleep',
-            app_name: 'App Sleep',
-            batch_id: 'batch-parent-job',
-        },
-        {
-            job_params: [{ tag_two: 'value two', tag_three: 'value three' }],
-            job_id: 'job_with_multiple_params',
-            batch_id: null,
-            app_name: 'some app',
-            app_id: 'some/app',
-        },
-        {
-            job_id: 'batch-parent-job',
-            batch_id: 'batch-parent-job',
-            app_name: 'batch',
-            app_id: 'batch',
-            job_params: [],
-        },
-        {
-            job_id: 'some-crappy-job',
-            batch_id: null,
-            app_name: 'Some Crappy App',
-            app_id: 'some/crappy-app',
-            job_params: [{}],
-        },
-    ];
+    const validInfo = Object.values(ResponseData[jcm.MESSAGE_TYPE.INFO]);
 
     const invalidInfo = [
         ...invalidTypes,
@@ -490,24 +473,7 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
         },
     ];
 
-    const validLogs = [
-        {
-            job_id: TEST_JOB_ID,
-            batch_id: 'batch_parent_job',
-            first: 0,
-            latest: false,
-            max_lines: 0,
-            lines: [],
-        },
-        {
-            job_id: TEST_JOB_ID,
-            batch_id: 'batch_parent_job',
-            first: 500,
-            latest: true,
-            max_lines: 500,
-            lines: [],
-        },
-    ];
+    const validLogs = Object.values(ResponseData[jcm.MESSAGE_TYPE.LOGS]);
 
     const invalidLogs = [
         ...invalidTypes,
@@ -522,18 +488,8 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
         },
     ];
 
-    const validRetry = [
-        {
-            job_id: validJobStates[0].job_id,
-            job: { jobState: validJobStates[0] },
-            retry: { jobState: validJobStates[1] },
-        },
-        {
-            job_id: validJobStates[2].job_id,
-            job: { jobState: validJobStates[2] },
-            error: 'some error',
-        },
-    ];
+    const validRetry = Object.values(ResponseData[jcm.MESSAGE_TYPE.RETRY]);
+
     const invalidRetry = [
         ...invalidTypes,
         // no jobState
@@ -642,24 +598,25 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
     /**
      * output of createBatchJob:
      *
-     * batch parent: 'job-created'
+     * batch parent:
      *
      * initial children:
-     * 'job-cancelled-whilst-in-the-queue'
-     * 'job-cancelled-during-run'
-     * 'job-died-whilst-queueing'
-     * 'job-in-the-queue' --> can cancel, can retry
+     * JOB.CREATED  --> can cancel, can retry
+     * JOB.QUEUED   --> can cancel, can retry
+     * JOB.DIED_WHILST_QUEUED
+     * JOB.TERMINATED_WHILST_QUEUED
+     * JOB.TERMINATED_WHILST_RUNNING
      *
      * job retries:
-     * 'job-cancelled-whilst-in-the-queue'
-     *  - retry 1: 'job-running' --> can cancel, can retry
+     * JOB.TERMINATED_WHILST_QUEUED
+     *  - retry 1: JOB.RUNNING --> can cancel, can retry
      *
-     * 'job-cancelled-during-run'
-     *  - retry 1: 'job-finished-with-success' --> cannot cancel or retry
+     * JOB.TERMINATED_WHILST_RUNNING
+     *  - retry 1: JOB.COMPLETED --> cannot cancel or retry
      *
-     * 'job-died-whilst-queueing'
-     *  - retry 1: 'job-died-with-error'
-     *  - retry 2: 'job-estimating' (most recent retry) --> can cancel, can retry
+     * JOB.DIED_WHILST_QUEUED
+     *  - retry 1: JOB.DIED_WHILST_RUNNING
+     *  - retry 2: JOB.ESTIMATING (most recent retry) --> can cancel, can retry
      *
      * Extra metadata for batch jobs:
      * meta.currentJob: true/false -- this is the most recent job (including retries)
@@ -685,61 +642,61 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
         // add the batchParent under the index BATCH_ID and delete the old key
         jobIdIndex[BATCH_ID] = batchParent;
 
-        // no retries of 'job-in-the-queue' or 'job-created'
-        ['job-in-the-queue', 'job-created'].forEach((jobId) => {
+        // no retries of JOB.QUEUED or JOB.CREATED
+        [JOB.QUEUED, JOB.CREATED].forEach((jobId) => {
             convertToRetryParent(jobIdIndex[jobId]);
             jobIdIndex[jobId].meta.currentJob = true;
         });
 
         // these jobs have been retried
 
-        // retries of 'job-cancelled-whilst-in-the-queue'
-        parentJob = 'job-cancelled-whilst-in-the-queue';
-        convertToRetryParent(jobIdIndex[parentJob], ['job-running']);
+        // retries of JOB.TERMINATED_WHILST_QUEUED
+        parentJob = JOB.TERMINATED_WHILST_QUEUED;
+        convertToRetryParent(jobIdIndex[parentJob], [JOB.RUNNING]);
 
-        thisJob = 'job-running';
+        thisJob = JOB.RUNNING;
         convertToRetry(jobIdIndex[thisJob], parentJob);
         jobIdIndex[thisJob].meta.currentJob = true;
         passTime(jobIdIndex[thisJob], 15);
 
-        // retries of 'job-cancelled-during-run'
-        parentJob = 'job-cancelled-during-run';
-        convertToRetryParent(jobIdIndex[parentJob], ['job-cancelled-during-run']);
+        // retries of JOB.TERMINATED_WHILST_RUNNING
+        parentJob = JOB.TERMINATED_WHILST_RUNNING;
+        convertToRetryParent(jobIdIndex[parentJob], [JOB.TERMINATED_WHILST_RUNNING]);
 
-        thisJob = 'job-finished-with-success';
+        thisJob = JOB.COMPLETED;
         convertToRetry(jobIdIndex[thisJob], parentJob);
         jobIdIndex[thisJob].meta.currentJob = true;
         passTime(jobIdIndex[thisJob], 20);
 
-        // two retries of 'job-died-whilst-queueing'
-        parentJob = 'job-died-whilst-queueing';
-        convertToRetryParent(jobIdIndex[parentJob], ['job-died-with-error', 'job-estimating']);
+        // two retries of JOB.DIED_WHILST_QUEUED
+        parentJob = JOB.DIED_WHILST_QUEUED;
+        convertToRetryParent(jobIdIndex[parentJob], [JOB.DIED_WHILST_RUNNING, JOB.ESTIMATING]);
 
-        thisJob = 'job-died-with-error';
+        thisJob = JOB.DIED_WHILST_RUNNING;
         convertToRetry(jobIdIndex[thisJob], parentJob);
         passTime(jobIdIndex[thisJob], 5);
 
-        thisJob = 'job-estimating';
+        thisJob = JOB.ESTIMATING;
         convertToRetry(jobIdIndex[thisJob], parentJob);
         jobIdIndex[thisJob].meta.currentJob = true;
         passTime(jobIdIndex[thisJob], 10);
 
         const originalJobs = [
-                'job-created',
-                'job-in-the-queue',
-                'job-cancelled-whilst-in-the-queue',
-                'job-cancelled-during-run',
-                'job-died-whilst-queueing',
+                JOB.CREATED,
+                JOB.QUEUED,
+                JOB.TERMINATED_WHILST_QUEUED,
+                JOB.TERMINATED_WHILST_RUNNING,
+                JOB.DIED_WHILST_QUEUED,
             ].reduce((acc, jobId) => {
                 acc[jobId] = jobIdIndex[jobId];
                 return acc;
             }, {}),
             currentJobs = [
-                'job-created',
-                'job-in-the-queue',
-                'job-running',
-                'job-finished-with-success',
-                'job-estimating',
+                JOB.CREATED,
+                JOB.QUEUED,
+                JOB.RUNNING,
+                JOB.COMPLETED,
+                JOB.ESTIMATING,
             ].reduce((acc, jobId) => {
                 acc[jobId] = jobIdIndex[jobId];
                 return acc;
@@ -815,33 +772,33 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             // status update for the current jobs
             jobUpdateSeries.push(generateStatusMessage(childJobIds));
 
-            // retry of 'job-cancelled-whilst-in-the-queue'
-            let retry = 'job-running',
-                retryParent = 'job-cancelled-whilst-in-the-queue';
+            // retry of 'JOB_CANCELLED-WHILST-IN-THE-QUEUE'
+            let retry = JOB.RUNNING,
+                retryParent = JOB.TERMINATED_WHILST_QUEUED;
             jobUpdateSeries.push(generateRetryMessage([{ retry, retryParent }], childJobIds));
 
             // status message
             jobUpdateSeries.push(generateStatusMessage(childJobIds));
 
-            // retry 1 of 'job-died-whilst-queueing'
-            retry = 'job-died-with-error';
-            retryParent = 'job-died-whilst-queueing';
+            // retry 1 of JOB.DIED_WHILST_QUEUED
+            retry = JOB.DIED_WHILST_RUNNING;
+            retryParent = JOB.DIED_WHILST_QUEUED;
             jobUpdateSeries.push(generateRetryMessage([{ retry, retryParent }], childJobIds));
 
             // status message
             jobUpdateSeries.push(generateStatusMessage(childJobIds));
 
             // two retries at once
-            // retry of 'job-cancelled-during-run'
-            // retry 2 of 'job-died-whilst-queueing'
+            // retry of JOB.TERMINATED_WHILST_RUNNING
+            // retry 2 of JOB.DIED_WHILST_QUEUED
             jobUpdateSeries.push(
                 generateRetryMessage(
                     [
                         {
-                            retry: 'job-finished-with-success',
-                            retryParent: 'job-cancelled-during-run',
+                            retry: JOB.COMPLETED,
+                            retryParent: JOB.TERMINATED_WHILST_RUNNING,
                         },
-                        { retry: 'job-estimating', retryParent: 'job-died-whilst-queueing' },
+                        { retry: JOB.ESTIMATING, retryParent: JOB.DIED_WHILST_QUEUED },
                     ],
                     childJobIds
                 )
@@ -860,9 +817,9 @@ define(['common/format', 'common/jobCommMessages', 'testUtil'], (format, jcm, Te
             jobArray: Object.values(jobIdIndex),
             jobsById: jobIdIndex,
             jobsWithRetries: [
-                'job-cancelled-whilst-in-the-queue',
-                'job-cancelled-during-run',
-                'job-died-whilst-queueing',
+                JOB.TERMINATED_WHILST_QUEUED,
+                JOB.TERMINATED_WHILST_RUNNING,
+                JOB.DIED_WHILST_QUEUED,
             ],
             originalJobs,
             currentJobs,

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -425,10 +425,12 @@ define([
             {
                 [jcm.PARAM.JOB_ID]: retryParent.job_id,
                 job: {
+                    [jcm.PARAM.JOB_ID]: retryParent.job_id,
                     jobState: retryParent,
                 },
                 retry_id: retry.job_id,
                 retry: {
+                    [jcm.PARAM.JOB_ID]: retry.job_id,
                     jobState: retry,
                 },
             },
@@ -996,7 +998,7 @@ define([
 
                         await createJobStatusTableWithContext(
                             this,
-                            TestUtil.JSONcopy(JobsData.jobsById['job-finished-with-success'])
+                            TestUtil.JSONcopy(JobsData.jobsById['JOB_COMPLETED'])
                         );
                         container = this.container;
                     });
@@ -1011,8 +1013,8 @@ define([
                 });
 
                 const cancelRetryArgs = {
-                    cancel: 'job-in-the-queue',
-                    retry: 'job-cancelled-during-run',
+                    cancel: 'JOB_QUEUED',
+                    retry: 'JOB_TERMINATED_WHILST_RUNNING',
                 };
 
                 Object.keys(cancelRetryArgs).forEach((action) => {
@@ -1190,7 +1192,7 @@ define([
                                 code: -1,
                                 name: 'Exception',
                             },
-                            job: 'job-in-the-queue',
+                            job: 'JOB_QUEUED',
                         },
                         {
                             errorText: 'Could not retry job.',
@@ -1203,7 +1205,7 @@ define([
                                 code: -1,
                                 name: 'Exception',
                             },
-                            job: 'job-died-whilst-queueing',
+                            job: 'JOB_DIED_WHILST_QUEUED',
                         },
                     ];
 
@@ -1336,49 +1338,43 @@ define([
                         });
 
                         const estimatingUpdate = TestUtil.JSONcopy(
-                            batchJobData.jobsById['job-estimating']
+                            batchJobData.jobsById['JOB_ESTIMATING']
                         );
                         estimatingUpdate.updated += 10;
                         estimatingUpdate.status = 'queued';
 
                         const jobDiedWithErrorUpdate = TestUtil.JSONcopy(
-                            batchJobData.jobsById['job-died-with-error']
+                            batchJobData.jobsById['JOB_DIED_WHILST_RUNNING']
                         );
                         jobDiedWithErrorUpdate.updated += 15;
-                        const rowIds = [
-                            'job-created',
-                            'job-cancelled-whilst-in-the-queue',
-                            'job-died-whilst-queueing',
-                            'job-in-the-queue',
-                            'job-cancelled-during-run',
-                        ];
+                        const rowIds = Object.keys(batchJobData.originalJobs);
 
                         const updates = [
                             {
-                                // retry of 'job-cancelled-whilst-in-the-queue'
-                                retry: batchJobData.jobsById['job-running'],
+                                // retry of 'JOB_TERMINATED_WHILST_QUEUED'
+                                retry: batchJobData.jobsById['JOB_RUNNING'],
                             },
                             {
-                                // retry 1 of 'job-died-whilst-queueing'
-                                retry: batchJobData.jobsById['job-died-with-error'],
+                                // retry 1 of 'JOB_DIED_WHILST_QUEUED'
+                                retry: batchJobData.jobsById['JOB_DIED_WHILST_RUNNING'],
                             },
                             {
-                                // retry of 'job-cancelled-during-run'
-                                retry: batchJobData.jobsById['job-finished-with-success'],
+                                // retry of 'JOB_TERMINATED_WHILST_RUNNING'
+                                retry: batchJobData.jobsById['JOB_COMPLETED'],
                             },
                             {
-                                // retry 2 of 'job-died-whilst-queueing'
-                                retry: batchJobData.jobsById['job-estimating'],
+                                // retry 2 of 'JOB_DIED_WHILST_QUEUED'
+                                retry: batchJobData.jobsById['JOB_ESTIMATING'],
                             },
                             {
-                                // update of 'job-died-with-error'
-                                // this job started before job-estimating
-                                // so the table row will continue to show the job-estimating info
+                                // update of 'JOB_DIED_WHILST_RUNNING'
+                                // this job started before JOB_ESTIMATING
+                                // so the table row will continue to show the JOB_ESTIMATING info
                                 update: jobDiedWithErrorUpdate,
-                                expectedRow: batchJobData.jobsById['job-estimating'],
+                                expectedRow: batchJobData.jobsById['JOB_ESTIMATING'],
                             },
                             {
-                                // update of 'job-estimating'
+                                // update of 'JOB_ESTIMATING'
                                 update: estimatingUpdate,
                             },
                         ];

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -551,23 +551,6 @@ define([
                     ],
                 },
                 {
-                    // info for a single job
-                    type: jcm.MESSAGE_TYPE.INFO,
-                    message: (() => {
-                        const output = {};
-                        output[JobsData.example.Info.valid[0].job_id] =
-                            JobsData.example.Info.valid[0];
-                        return output;
-                    })(),
-                    expected: [
-                        JobsData.example.Info.valid[0],
-                        {
-                            channel: { [JOB_CHANNEL]: JobsData.example.Info.valid[0].job_id },
-                            key: { type: jcm.MESSAGE_TYPE.INFO },
-                        },
-                    ],
-                },
-                {
                     // info multiple jobs
                     type: jcm.MESSAGE_TYPE.INFO,
                     message: ResponseData[jcm.MESSAGE_TYPE.INFO],
@@ -584,156 +567,52 @@ define([
                     ),
                 },
                 {
-                    // log with data
-                    type: jcm.MESSAGE_TYPE.LOGS,
-                    message: {
-                        [TEST_JOB_ID]: JobsData.example.Logs.valid[0],
-                    },
-                    expected: [
-                        JobsData.example.Logs.valid[0],
-                        {
-                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                            key: { type: jcm.MESSAGE_TYPE.LOGS },
-                        },
-                    ],
+                    // status for multiple jobs
+                    type: jcm.MESSAGE_TYPE.STATUS,
+                    message: ResponseData[jcm.MESSAGE_TYPE.STATUS],
+                    expectedMultiple: Object.values(ResponseData[jcm.MESSAGE_TYPE.STATUS]).map(
+                        (status) => {
+                            return [
+                                status,
+                                {
+                                    channel: { [JOB_CHANNEL]: status.job_id },
+                                    key: { type: jcm.MESSAGE_TYPE.STATUS },
+                                },
+                            ];
+                        }
+                    ),
                 },
                 {
-                    // log with message saying that the log cannot be found
+                    // logs for multiple jobs
                     type: jcm.MESSAGE_TYPE.LOGS,
-                    message: {
-                        [TEST_JOB_ID]: {
-                            [JOB_ID]: TEST_JOB_ID,
-                            error: `Cannot find job log with id: {TEST_JOB_ID}`,
-                        },
-                    },
-                    expected: [
-                        {
-                            [JOB_ID]: TEST_JOB_ID,
-                            error: `Cannot find job log with id: {TEST_JOB_ID}`,
-                        },
-                        {
-                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                            key: { type: jcm.MESSAGE_TYPE.LOGS },
-                        },
-                    ],
+                    message: ResponseData[jcm.MESSAGE_TYPE.LOGS],
+                    expectedMultiple: Object.values(ResponseData[jcm.MESSAGE_TYPE.LOGS]).map(
+                        (logs) => {
+                            return [
+                                logs,
+                                {
+                                    channel: { [JOB_CHANNEL]: logs.job_id },
+                                    key: { type: jcm.MESSAGE_TYPE.LOGS },
+                                },
+                            ];
+                        }
+                    ),
                 },
                 {
+                    // retry multiple jobs
                     type: jcm.MESSAGE_TYPE.RETRY,
-                    message: (() => {
-                        const retryData = {};
-                        JobsData.example.Retry.valid.forEach((retry) => {
-                            retryData[retry.job.jobState.job_id] = retry;
-                        });
-                        return retryData;
-                    })(),
-                    expectedMultiple: [
-                        [
-                            JobsData.example.Retry.valid[0],
-                            {
-                                channel: {
-                                    [JOB_CHANNEL]:
-                                        JobsData.example.Retry.valid[0].job.jobState.job_id,
+                    message: ResponseData[jcm.MESSAGE_TYPE.RETRY],
+                    expectedMultiple: Object.values(ResponseData[jcm.MESSAGE_TYPE.RETRY]).map(
+                        (retry) => {
+                            return [
+                                retry,
+                                {
+                                    channel: { [JOB_CHANNEL]: retry.job_id },
+                                    key: { type: jcm.MESSAGE_TYPE.RETRY },
                                 },
-                                key: { type: jcm.MESSAGE_TYPE.RETRY },
-                            },
-                        ],
-                        [
-                            JobsData.example.Retry.valid[1],
-                            {
-                                channel: {
-                                    [JOB_CHANNEL]:
-                                        JobsData.example.Retry.valid[1].job.jobState.job_id,
-                                },
-                                key: { type: jcm.MESSAGE_TYPE.RETRY },
-                            },
-                        ],
-                    ],
-                },
-                {
-                    // single job status message
-                    type: jcm.MESSAGE_TYPE.STATUS,
-                    message: (() => {
-                        const output = {};
-                        output[JobsData.allJobs[0].job_id] = {
-                            [JOB_ID]: JobsData.allJobs[0].job_id,
-                            jobState: JobsData.allJobs[0],
-                            outputWidgetInfo: {},
-                        };
-                        return output;
-                    })(),
-                    expected: [
-                        {
-                            [JOB_ID]: JobsData.allJobs[0].job_id,
-                            jobState: JobsData.allJobs[0],
-                            outputWidgetInfo: {},
-                        },
-                        {
-                            channel: { [JOB_CHANNEL]: JobsData.allJobs[0].job_id },
-                            key: { type: jcm.MESSAGE_TYPE.STATUS },
-                        },
-                    ],
-                },
-                {
-                    // single job status message, ee2 error
-                    type: jcm.MESSAGE_TYPE.STATUS,
-                    message: {
-                        [TEST_JOB_ID]: {
-                            [JOB_ID]: TEST_JOB_ID,
-                            jobState: {
-                                job_id: TEST_JOB_ID,
-                                status: 'running',
-                            },
-                            outputWidgetInfo: {},
-                            error: ERROR_STR,
-                        },
-                    },
-                    expected: [
-                        {
-                            [JOB_ID]: TEST_JOB_ID,
-                            jobState: {
-                                job_id: TEST_JOB_ID,
-                                status: 'running',
-                            },
-                            outputWidgetInfo: {},
-                            error: ERROR_STR,
-                        },
-                        {
-                            channel: { [JOB_CHANNEL]: TEST_JOB_ID },
-                            key: { type: jcm.MESSAGE_TYPE.STATUS },
-                        },
-                    ],
-                },
-                {
-                    // more than one job, indexed by job ID
-                    type: jcm.MESSAGE_TYPE.STATUS,
-                    message: JobsData.allJobs.reduce(convertToJobState, {}),
-                    expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage),
-                },
-                {
-                    // OK job and an errored job
-                    type: jcm.MESSAGE_TYPE.STATUS,
-                    message: JobsData.allJobs
-                        .concat({
-                            job_id: '1234567890abcdef',
-                            status: 'does_not_exist',
-                        })
-                        .reduce(convertToJobState, {}),
-                    expectedMultiple: JobsData.allJobs.map(convertToJobStateBusMessage).concat([
-                        [
-                            {
-                                [JOB_ID]: '1234567890abcdef',
-                                jobState: {
-                                    job_id: '1234567890abcdef',
-                                    status: 'does_not_exist',
-                                },
-                                outputWidgetInfo: {},
-                            },
-                            {
-                                channel: { [JOB_CHANNEL]: '1234567890abcdef' },
-                                key: { type: jcm.MESSAGE_TYPE.STATUS },
-                            },
-                        ],
-                    ]),
+                            ];
+                        }
+                    ),
                 },
                 {
                     type: jcm.MESSAGE_TYPE.STATUS_ALL,
@@ -869,25 +748,6 @@ define([
                     ],
                 },
             ];
-
-            Object.keys(ResponseData).forEach((respType) => {
-                busTests.push({
-                    type: respType,
-                    message: ResponseData[respType],
-                    expectedMultiple: Object.values(ResponseData[respType]).map((response) => {
-                        if (response.jobState) {
-                            response.job_id = response.jobState.job_id;
-                        }
-                        return [
-                            response,
-                            {
-                                channel: { [JOB_CHANNEL]: response.job_id },
-                                key: { type: respType },
-                            },
-                        ];
-                    }),
-                });
-            });
 
             busTests.forEach((test) => {
                 it(`should send a ${test.type} message to the bus`, () => {

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -959,9 +959,9 @@ define([
                     return new Promise((resolve) => {
                         const message = {
                             [jcm.PARAM.JOB_ID]: this.jobId,
-                            job: { jobState: updatedJobState },
+                            job: { job_id: this.jobId, jobState: updatedJobState },
                             retry_id: retryJobState.job_id,
-                            retry: { jobState: retryJobState },
+                            retry: { job_id: retryJobState.job_id, jobState: retryJobState },
                         };
 
                         this.jobManagerInstance.addListener(

--- a/test/unit/spec/util/jobLogViewerSpec.js
+++ b/test/unit/spec/util/jobLogViewerSpec.js
@@ -724,7 +724,7 @@ define([
                 const allCalls = console.error.calls.allArgs();
                 expect(allCalls.length).toEqual(1);
                 expect(allCalls[0].length).toEqual(1);
-                expect(allCalls[0][0]).toMatch(/Error retrieving log for job.*?summat went wrong/);
+                expect(allCalls[0][0]).toMatch(/Error retrieving log for JOB_.*?summat went wrong/);
             });
 
             endStates.forEach((endState) => {
@@ -788,7 +788,7 @@ define([
                     const allCalls = console.error.calls.allArgs();
                     expect(allCalls.length).toEqual(1);
                     expect(allCalls[0].length).toEqual(1);
-                    expect(allCalls[0][0]).toMatch(/Error retrieving log for job.*?DANGER!/);
+                    expect(allCalls[0][0]).toMatch(/Error retrieving log for JOB_.*?DANGER!/);
                 });
             });
         });


### PR DESCRIPTION
# Description of PR purpose/changes

Two changes in this PR:
- update the job state object validation to include the `job_id` key (change made in the last PR)
- more edits of the JS job test data; replace the valid message samples with those from the BE response data; and use constants for the job names

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
