### PR TITLE
DATAUP-703 job channel bandwidth

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -608,7 +608,7 @@ define([
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
                 'cell_list = ' + JSON.stringify(currentCells),
                 // DATAUP-575: temporarily removing cell_list
-                'JobComm().start_job_status_loop(init_jobs=True)',
+                'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
             ].join('\n');
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2390,9 +2390,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001303",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
-            "integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
+            "version": "1.0.30001306",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
+            "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -18000,9 +18000,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001303",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
-            "integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ==",
+            "version": "1.0.30001306",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
+            "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
             "dev": true
         },
         "center-align": {

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -81,6 +81,7 @@ def _app_error_wrapper(app_func: Callable) -> any:
                     + "-----------------------------------------------------\n"
                     + e_trace
                 )
+
     return wrapper
 
 

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -1089,7 +1089,7 @@ class AppManager(object):
         return auth.get_agent_token(auth.get_auth_token(), token_name=token_name)
 
     def register_new_job(self, job: Job) -> None:
-        JobManager().register_new_job(job)
+        JobManager().register_new_job(job, refresh=False)
         self._send_comm_message("new_job", {"job_id": job.job_id})
         with exc_to_msg("appmanager"):
             JobComm().lookup_job_state(job.job_id)

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -1,7 +1,6 @@
 import copy
 import threading
 from typing import List, Union
-from xmlrpc.client import Boolean
 from ipykernel.comm import Comm
 import biokbase.narrative.jobs.jobmanager as jobmanager
 from biokbase.narrative.jobs.jobmanager import JOBS_TYPE_ERR

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -217,7 +217,6 @@ class JobComm:
                 "retry_job": self._retry_jobs,
                 "job_logs": self._get_job_logs,
             }
-        self._lookup_all_job_states(ignore_refresh_flag=True)
 
     def start_job_status_loop(
         self,

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -272,12 +272,16 @@ class JobComm:
             )
             self._lookup_timer.start()
 
-    def _lookup_all_job_states(self, req: JobRequest = None, ignore_refresh_flag: bool = False) -> dict:
+    def _lookup_all_job_states(
+        self, req: JobRequest = None, ignore_refresh_flag: bool = False
+    ) -> dict:
         """
         Fetches status of all jobs in the current workspace and sends them to the front end.
         req can be None, as it's not used.
         """
-        all_job_states = self._jm.lookup_all_job_states(ignore_refresh_flag=ignore_refresh_flag)
+        all_job_states = self._jm.lookup_all_job_states(
+            ignore_refresh_flag=ignore_refresh_flag
+        )
         self.send_comm_message("job_status_all", all_job_states)
         return all_job_states
 
@@ -502,6 +506,7 @@ class exc_to_msg:
     """
     This is a context manager to wrap around JC code
     """
+
     jc = JobComm()
 
     def __init__(self, req: Union[JobRequest, dict, str] = None):
@@ -543,7 +548,7 @@ class exc_to_msg:
                     "message": exc_value.message,
                     "error": exc_value.error,
                     "code": exc_value.code,
-                }
+                },
             )
         elif exc_type:
             self.jc.send_error_message(
@@ -552,5 +557,5 @@ class exc_to_msg:
                 {
                     "name": exc_type.__name__,
                     "message": str(exc_value),
-                }
+                },
             )

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -118,7 +118,7 @@ class JobManager(object):
             if cell_ids is not None:
                 refresh = refresh and job.in_cells(cell_ids)
 
-            self.register_new_job(job, refresh)  # int(refresh))
+            self.register_new_job(job, refresh)
 
     def _create_jobs(self, job_ids) -> dict:
         """

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -118,7 +118,7 @@ class JobManager(object):
             if cell_ids is not None:
                 refresh = refresh and job.in_cells(cell_ids)
 
-            self.register_new_job(job, refresh) #int(refresh))
+            self.register_new_job(job, refresh)  # int(refresh))
 
     def _create_jobs(self, job_ids) -> dict:
         """
@@ -243,7 +243,9 @@ class JobManager(object):
             kblogging.log_event(self._log, "list_jobs.error", {"err": str(e)})
             raise
 
-    def _construct_job_output_state_set(self, job_ids: list, states: dict = None) -> dict:
+    def _construct_job_output_state_set(
+        self, job_ids: list, states: dict = None
+    ) -> dict:
         """
         Builds a set of job states for the list of job ids.
         :param states: dict, where each value is a state is from EE2

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -147,7 +147,9 @@ class AppManagerTestCase(unittest.TestCase):
         except Exception:
             pass
 
-    def run_app_expect_error(self, comm_mock, run_func, func_name, print_error, cell_id=None):
+    def run_app_expect_error(
+        self, comm_mock, run_func, func_name, print_error, cell_id=None
+    ):
         """
         A wrapper for various versions of run_app* that'll test and verify that errors get
         1. printed to stdout and
@@ -168,7 +170,9 @@ class AppManagerTestCase(unittest.TestCase):
             )
             self.assertIn(print_error, output_str)
         else:
-            self.assertEqual('', output_str)  # if nothing gets written to a StringIO, getvalue returns an empty string
+            self.assertEqual(
+                "", output_str
+            )  # if nothing gets written to a StringIO, getvalue returns an empty string
         self._verify_comm_error(comm_mock, cell_id=cell_id)
 
     def test_reload(self):
@@ -333,9 +337,11 @@ class AppManagerTestCase(unittest.TestCase):
         # should print an error if there is no cell id
         self.run_app_expect_error(
             comm_mock,
-            lambda: self.am.run_app(self.bad_app_id, self.test_app_params, tag=self.test_tag),
+            lambda: self.am.run_app(
+                self.bad_app_id, self.test_app_params, tag=self.test_tag
+            ),
             "run_app",
-            "Unknown app id"
+            "Unknown app id",
         )
 
         comm_mock2 = MagicMock()
@@ -345,10 +351,15 @@ class AppManagerTestCase(unittest.TestCase):
         cell_id = "some_app_cell"
         self.run_app_expect_error(
             comm_mock2,
-            lambda: self.am.run_app(self.bad_app_id, self.test_app_params, tag=self.test_tag, cell_id=cell_id),
+            lambda: self.am.run_app(
+                self.bad_app_id,
+                self.test_app_params,
+                tag=self.test_tag,
+                cell_id=cell_id,
+            ),
             "run_app",
             None,
-            cell_id=cell_id
+            cell_id=cell_id,
         )
 
     ############# End tests for run_app #############
@@ -521,9 +532,11 @@ class AppManagerTestCase(unittest.TestCase):
         # should print an error if there is no cell id
         self.run_app_expect_error(
             comm_mock,
-            lambda: self.am.run_app_batch(self.bad_app_id, [self.test_app_params], tag=self.test_tag),
+            lambda: self.am.run_app_batch(
+                self.bad_app_id, [self.test_app_params], tag=self.test_tag
+            ),
             "run_app_batch",
-            "Unknown app id"
+            "Unknown app id",
         )
 
         comm_mock2 = MagicMock()
@@ -533,10 +546,15 @@ class AppManagerTestCase(unittest.TestCase):
         cell_id = "some_batch_cell"
         self.run_app_expect_error(
             comm_mock2,
-            lambda: self.am.run_app_batch(self.bad_app_id, [self.test_app_params], tag=self.test_tag, cell_id=cell_id),
+            lambda: self.am.run_app_batch(
+                self.bad_app_id,
+                [self.test_app_params],
+                tag=self.test_tag,
+                cell_id=cell_id,
+            ),
             "run_app_batch",
             None,
-            cell_id=cell_id
+            cell_id=cell_id,
         )
 
     ############# End tests for run_app_batch #############
@@ -617,9 +635,11 @@ class AppManagerTestCase(unittest.TestCase):
         # should print an error if there is no cell id
         self.run_app_expect_error(
             comm_mock,
-            lambda: self.am.run_local_app(self.bad_app_id, self.test_app_params, tag=self.test_tag),
+            lambda: self.am.run_local_app(
+                self.bad_app_id, self.test_app_params, tag=self.test_tag
+            ),
             "run_local_app",
-            "Unknown app id"
+            "Unknown app id",
         )
 
         comm_mock2 = MagicMock()
@@ -629,10 +649,15 @@ class AppManagerTestCase(unittest.TestCase):
         cell_id = "some_local_app_cell"
         self.run_app_expect_error(
             comm_mock2,
-            lambda: self.am.run_local_app(self.bad_app_id, self.test_app_params, tag=self.test_tag, cell_id=cell_id),
+            lambda: self.am.run_local_app(
+                self.bad_app_id,
+                self.test_app_params,
+                tag=self.test_tag,
+                cell_id=cell_id,
+            ),
             "run_local_app",
             None,
-            cell_id=cell_id
+            cell_id=cell_id,
         )
 
     ############# End tests for run_local_app #############
@@ -838,7 +863,7 @@ class AppManagerTestCase(unittest.TestCase):
             comm_mock,
             lambda: self.am.run_app_bulk(test_case),
             "run_app_bulk",
-            "an app_id must be of the format module_name/app_name"
+            "an app_id must be of the format module_name/app_name",
         )
 
         comm_mock2 = MagicMock()
@@ -851,7 +876,7 @@ class AppManagerTestCase(unittest.TestCase):
             lambda: self.am.run_app_bulk(test_case, cell_id=cell_id),
             "run_app_bulk",
             None,
-            cell_id=cell_id
+            cell_id=cell_id,
         )
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -245,7 +245,7 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertEqual(self.jm.get_job(self.test_job_id), new_job)
         self._verify_comm_success(c.return_value.send_comm_message, False)
 
-        self.assertEqual(1, self.jm._running_jobs[new_job.job_id]["refresh"])
+        self.assertEqual(False, self.jm._running_jobs[new_job.job_id]["refresh"])
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -429,7 +429,7 @@ class AppManagerTestCase(unittest.TestCase):
         self.assertEqual(self.jm.get_job(self.test_job_id), new_job)
         self._verify_comm_success(c.return_value.send_comm_message, False)
 
-        self.assertEqual(1, self.jm._running_jobs[new_job.job_id]["refresh"])
+        self.assertEqual(False, self.jm._running_jobs[new_job.job_id]["refresh"])
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")
@@ -731,7 +731,7 @@ class AppManagerTestCase(unittest.TestCase):
         self._verify_comm_success(c.return_value.send_comm_message, True, num_jobs=4)
 
         for job in [parent_job] + child_jobs:
-            self.assertEqual(1, self.jm._running_jobs[job.job_id]["refresh"])
+            self.assertEqual(False, self.jm._running_jobs[job.job_id]["refresh"])
 
     @mock.patch("biokbase.narrative.jobs.appmanager.clients.get", get_mock_client)
     @mock.patch("biokbase.narrative.jobs.appmanager.JobComm")

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -94,9 +94,7 @@ class JobCommTestCase(unittest.TestCase):
 
     @classmethod
     @mock.patch("biokbase.narrative.jobs.jobcomm.Comm", MockComm)
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def setUpClass(cls):
         cls.jm = biokbase.narrative.jobs.jobmanager.JobManager()
         config = ConfigTests()
@@ -105,9 +103,7 @@ class JobCommTestCase(unittest.TestCase):
         cls.jc = biokbase.narrative.jobs.jobcomm.JobComm()
         cls.jc._comm = MockComm()
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def setUp(self):
         self.jc._comm.clear_message_cache()
         self.jc._jm.initialize_jobs()
@@ -159,13 +155,9 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": "foo",
-                "content": {
-                    "source": "bar",
-                    "job_id": "aeaeae",
-                    "extra": "field"
-                }
+                "content": {"source": "bar", "job_id": "aeaeae", "extra": "field"},
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_send_error_msg__dict(self):
@@ -175,27 +167,17 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": "foo",
-                "content": {
-                    "source": "bar",
-                    "job_id": "aeaeae",
-                    "extra": "field"
-                }
+                "content": {"source": "bar", "job_id": "aeaeae", "extra": "field"},
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_send_error_msg__None(self):
         self.jc.send_error_message("foo", None, {"extra": "field"})
         msg = self.jc._comm.last_message
         self.assertEqual(
-            {
-                "msg_type": "foo",
-                "content": {
-                    "source": None,
-                    "extra": "field"
-                }
-            },
-            msg["data"]
+            {"msg_type": "foo", "content": {"source": None, "extra": "field"}},
+            msg["data"],
         )
 
     def test_send_error_msg__str(self):
@@ -203,14 +185,8 @@ class JobCommTestCase(unittest.TestCase):
         self.jc.send_error_message("foo", source, {"extra": "field"})
         msg = self.jc._comm.last_message
         self.assertEqual(
-            {
-                "msg_type": "foo",
-                "content": {
-                    "source": source,
-                    "extra": "field"
-                }
-            },
-            msg["data"]
+            {"msg_type": "foo", "content": {"source": source, "extra": "field"}},
+            msg["data"],
         )
 
     # ---------------------
@@ -219,9 +195,11 @@ class JobCommTestCase(unittest.TestCase):
     def test_req_no_inputs__succeed(self):
         msg = {
             "msg_id": "some_id",
-            "content": {"data": {
-                "request_type": "all_status",
-            }},
+            "content": {
+                "data": {
+                    "request_type": "all_status",
+                }
+            },
         }
         self.jc._handle_comm_message(msg)
         msg = self.jc._comm.last_message
@@ -230,9 +208,11 @@ class JobCommTestCase(unittest.TestCase):
     def test_req_no_inputs__fail(self):
         msg = {
             "msg_id": "some_id",
-            "content": {"data": {
-                "request_type": "job_status_batch",
-            }},
+            "content": {
+                "data": {
+                    "request_type": "job_status_batch",
+                }
+            },
         }
         err = JobIDException(JOB_NOT_PROVIDED_ERR)
         with self.assertRaisesRegex(type(err), str(err)):
@@ -241,9 +221,11 @@ class JobCommTestCase(unittest.TestCase):
 
         msg = {
             "msg_id": "some_id",
-            "content": {"data": {
-                "request_type": "retry_job",
-            }},
+            "content": {
+                "data": {
+                    "request_type": "retry_job",
+                }
+            },
         }
         err = JobIDException(JOBS_NOT_PROVIDED_ERR)
         with self.assertRaisesRegex(type(err), str(err)):
@@ -253,9 +235,7 @@ class JobCommTestCase(unittest.TestCase):
     # ---------------------
     # Start job status loop
     # ---------------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_start_stop_job_status_loop(self):
         self.assertFalse(self.jc._running_lookup_loop)
         self.assertIsNone(self.jc._lookup_timer)
@@ -276,9 +256,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertFalse(self.jc._running_lookup_loop)
         self.assertIsNone(self.jc._lookup_timer)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_start_job_status_loop__cell_ids(self):
         cell_2_jobs = get_cell_2_jobs()
         cell_ids = list(cell_2_jobs.keys())
@@ -294,15 +272,17 @@ class JobCommTestCase(unittest.TestCase):
                 self.jc.start_job_status_loop(init_jobs=True, cell_list=combo)
                 msg = self.jc._comm.last_message
 
-                exp_job_ids = [ job_id for cell_id, job_ids in cell_2_jobs.items() for job_id in job_ids if cell_id in combo and not JOBS_TERMINALITY[job_id] ]
+                exp_job_ids = [
+                    job_id
+                    for cell_id, job_ids in cell_2_jobs.items()
+                    for job_id in job_ids
+                    if cell_id in combo and not JOBS_TERMINALITY[job_id]
+                ]
                 exp_msg = {
                     "msg_type": "job_status_all",
-                    "content": get_test_job_states(exp_job_ids)
+                    "content": get_test_job_states(exp_job_ids),
                 }
-                self.assertEqual(
-                    exp_msg,
-                    msg["data"]
-                )
+                self.assertEqual(exp_msg, msg["data"])
 
                 if len(exp_job_ids):
                     self.assertTrue(self.jc._running_lookup_loop)
@@ -313,13 +293,10 @@ class JobCommTestCase(unittest.TestCase):
                     self.assertFalse(self.jc._running_lookup_loop)
                     self.assertIsNone(self.jc._lookup_timer)
 
-
     # ---------------------
     # Lookup all job states
     # ---------------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_lookup_all_job_states__ok(self):
 
         req = make_comm_msg("all_status", None, True)
@@ -354,7 +331,9 @@ class JobCommTestCase(unittest.TestCase):
             validate_job_state(state)
 
     def test_lookup_job_state__no_job(self):
-        with self.assertRaisesRegex(JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[None]}")):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[None]}")
+        ):
             self.jc.lookup_job_state(None)
 
     # -----------------------
@@ -376,9 +355,7 @@ class JobCommTestCase(unittest.TestCase):
             self.assertEqual(self.job_states[job_id], state)
             validate_job_state(state)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_lookup_job_states__2_ok(self):
         job_id_list = [JOB_COMPLETED, BATCH_PARENT]
         req = make_comm_msg("job_status", job_id_list, True)
@@ -401,9 +378,7 @@ class JobCommTestCase(unittest.TestCase):
         err = JobIDException(JOBS_MISSING_FALSY_ERR, job_id_list)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
             self.jc._handle_comm_message(req)
-        self.check_error_message(
-            "job_status", {"job_id_list": job_id_list}, err
-        )
+        self.check_error_message("job_status", {"job_id_list": job_id_list}, err)
 
     def test_lookup_job_states__ok_bad(self):
         job_id_list = ["nope", JOB_COMPLETED]
@@ -421,9 +396,7 @@ class JobCommTestCase(unittest.TestCase):
             else:
                 self.assertEqual(get_error_output_state(job_id), state)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_lookup_job_states__ee2_error(self):
         def mock_check_jobs(self, params):
             raise Exception("Test exception")
@@ -441,18 +414,16 @@ class JobCommTestCase(unittest.TestCase):
                     **{
                         job_id: get_error_output_state(job_id, "ee2_error")
                         for job_id in ACTIVE_JOBS
-                    }
-                }
+                    },
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     # -----------------------
     # Lookup batch job states
     # -----------------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_lookup_job_states_batch__ok(self):
         job_id = BATCH_PARENT
         req = make_comm_msg("job_status_batch", job_id, False)
@@ -483,9 +454,7 @@ class JobCommTestCase(unittest.TestCase):
             },
             msg["data"],
         )
-        self.check_error_message(
-            "job_status_batch", {"job_id": job_id}, err
-        )
+        self.check_error_message("job_status_batch", {"job_id": job_id}, err)
 
     def test_lookup_job_states_batch__no_job(self):
         job_id = None
@@ -493,9 +462,7 @@ class JobCommTestCase(unittest.TestCase):
         err = JobIDException(JOB_NOT_REG_ERR, job_id)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
             self.jc._handle_comm_message(req)
-        self.check_error_message(
-            "job_status_batch", {"job_id": job_id}, err
-        )
+        self.check_error_message("job_status_batch", {"job_id": job_id}, err)
 
     def test_lookup_job_states_batch__not_batch(self):
         job_id = JOB_CREATED
@@ -503,9 +470,7 @@ class JobCommTestCase(unittest.TestCase):
         err = JobIDException(JOB_NOT_BATCH_ERR, job_id)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
             self.jc._handle_comm_message(req)
-        self.check_error_message(
-            "job_status_batch", {"job_id": job_id}, err
-        )
+        self.check_error_message("job_status_batch", {"job_id": job_id}, err)
 
     # -----------------------
     # Lookup job info
@@ -529,9 +494,7 @@ class JobCommTestCase(unittest.TestCase):
         err = JobIDException(JOBS_MISSING_FALSY_ERR, job_id_list)
         with self.assertRaisesRegex(type(err), re.escape(str(err))):
             self.jc._handle_comm_message(req)
-        self.check_error_message(
-            "job_info", {"job_id_list": job_id_list}, err
-        )
+        self.check_error_message("job_info", {"job_id_list": job_id_list}, err)
 
     def test_lookup_job_info__ok_bad(self):
         job_id_list = [JOB_COMPLETED, JOB_NOT_FOUND]
@@ -552,9 +515,7 @@ class JobCommTestCase(unittest.TestCase):
     # ------------
     # Lookup batch job infos
     # ------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_lookup_job_info_batch__ok(self):
         job_id = BATCH_PARENT
         req = make_comm_msg("job_info_batch", job_id, True)
@@ -595,9 +556,7 @@ class JobCommTestCase(unittest.TestCase):
     # ------------
     # Cancel list of jobs
     # ------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_cancel_jobs__single_job_id_in(self):
         job_id = JOB_RUNNING
         req = make_comm_msg("cancel_job", job_id, False)
@@ -613,9 +572,7 @@ class JobCommTestCase(unittest.TestCase):
             msg["data"],
         )
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_cancel_jobs__1_ok(self):
         job_id_list = [JOB_RUNNING]
         req = make_comm_msg("cancel_job", job_id_list, True)
@@ -631,9 +588,7 @@ class JobCommTestCase(unittest.TestCase):
             msg["data"],
         )
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_cancel_jobs__2_ok(self):
         job_id_list = [JOB_CREATED, JOB_RUNNING, None]
         req = make_comm_msg("cancel_job", job_id_list, True)
@@ -655,7 +610,9 @@ class JobCommTestCase(unittest.TestCase):
         # Create req manually because want job_id_list to be not list
         req = {
             "msg_id": "some_id",
-            "content": {"data": {"request_type": "cancel_job", "job_id_list": job_id_list}},
+            "content": {
+                "data": {"request_type": "cancel_job", "job_id_list": job_id_list}
+            },
         }
         err = TypeError(JOBS_TYPE_ERR)
         with self.assertRaisesRegex(type(err), str(err)):
@@ -668,9 +625,7 @@ class JobCommTestCase(unittest.TestCase):
             self.jc._handle_comm_message(req)
         self.check_error_message("cancel_job", {"job_id_list": job_id_list}, err)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_cancel_jobs__some_bad_jobs(self):
         FAKE_JOB = "fake_job_id"
         job_id_list = [
@@ -734,9 +689,7 @@ class JobCommTestCase(unittest.TestCase):
     # ------------
     # Retry list of jobs
     # ------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_retry_jobs_1_ok(self):
         job_id_list = [JOB_TERMINATED]
         req = make_comm_msg("retry_job", job_id_list, True)
@@ -747,9 +700,7 @@ class JobCommTestCase(unittest.TestCase):
         )
         self.assertEqual("new_job", msg["data"]["msg_type"])
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_retry_jobs_2_ok(self):
         job_id_list = [JOB_TERMINATED, JOB_ERROR, None]
         req = make_comm_msg("retry_job", job_id_list, True)
@@ -769,9 +720,7 @@ class JobCommTestCase(unittest.TestCase):
             self.jc._handle_comm_message(req)
         self.check_error_message("retry_job", {"job_id_list": job_id_list}, err)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_retry_jobs_some_bad_jobs(self):
         job_id_list = [JOB_TERMINATED, "nope", "no"]
         req = make_comm_msg("retry_job", job_id_list, True)
@@ -782,9 +731,7 @@ class JobCommTestCase(unittest.TestCase):
         )
         self.assertEqual("new_job", msg["data"]["msg_type"])
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_retry_jobs_all_bad_jobs(self):
         job_id_list = ["nope", "no"]
         req = make_comm_msg("retry_job", job_id_list, True)
@@ -811,9 +758,7 @@ class JobCommTestCase(unittest.TestCase):
     # -----------------
     # Fetching job logs
     # -----------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_get_job_logs_ok(self):
         job_id = JOB_COMPLETED
         lines_available = 100  # just for convenience if the mock changes
@@ -888,9 +833,7 @@ class JobCommTestCase(unittest.TestCase):
     # ------------------------
     # Modify job update
     # ------------------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_modify_job_update__start__ok(self):
         job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
         req = make_comm_msg("start_job_update", job_id_list, True)
@@ -902,10 +845,7 @@ class JobCommTestCase(unittest.TestCase):
         )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    True
-                )
+                self.assertEqual(self.jm._running_jobs[job_id]["refresh"], True)
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
@@ -914,9 +854,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_modify_job_update__stop__ok(self):
         job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
         req = make_comm_msg("stop_job_update", job_id_list, True)
@@ -961,9 +899,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_modify_job_update__stop__loop_still_running(self):
         """Lookup loop should not get stopped"""
         self.jc.start_job_status_loop()
@@ -988,9 +924,7 @@ class JobCommTestCase(unittest.TestCase):
     # ------------------------
     # Modify job update batch
     # ------------------------
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_modify_job_update_batch__start__ok(self):
         job_id = BATCH_PARENT
         job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
@@ -1003,10 +937,7 @@ class JobCommTestCase(unittest.TestCase):
         )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    True
-                )
+                self.assertEqual(self.jm._running_jobs[job_id]["refresh"], True)
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
@@ -1015,9 +946,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_modify_job_update_batch__stop__ok(self):
         job_id = BATCH_PARENT
         job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
@@ -1103,9 +1032,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(msg["data"]["msg_type"], "job_status")
         validate_job_state(msg["data"]["content"][JOB_COMPLETED])
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_job_info_msg(self):
         job_id = JOB_COMPLETED
         req = make_comm_msg("job_info", job_id, False)
@@ -1116,9 +1043,7 @@ class JobCommTestCase(unittest.TestCase):
             msg["data"],
         )
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_job_status_batch_msg(self):
         job_id = BATCH_PARENT
         req = make_comm_msg("job_status_batch", job_id, False)
@@ -1132,9 +1057,7 @@ class JobCommTestCase(unittest.TestCase):
             msg["data"],
         )
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_job_info_batch_msg(self):
         job_id = BATCH_PARENT
         req = make_comm_msg("job_info_batch", job_id, False)
@@ -1148,9 +1071,7 @@ class JobCommTestCase(unittest.TestCase):
             msg["data"],
         )
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_cancel_job_msg(self):
         job_id = JOB_COMPLETED
         req = make_comm_msg("cancel_job", job_id, False)
@@ -1158,9 +1079,7 @@ class JobCommTestCase(unittest.TestCase):
         msg = self.jc._comm.last_message
         self.assertEqual(msg["data"]["msg_type"], "job_status")
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_start_job_update_msg(self):
         job_id_list = [JOB_CREATED, JOB_COMPLETED, BATCH_PARENT]
         req = make_comm_msg("start_job_update", job_id_list, False)
@@ -1184,9 +1103,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_stop_job_update_msg(self):
         job_id_list = [JOB_CREATED, JOB_COMPLETED, BATCH_PARENT]
         req = make_comm_msg("stop_job_update", job_id_list, False)
@@ -1195,7 +1112,7 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    False #not JOBS_TERMINALITY[job_id],
+                    False,  # not JOBS_TERMINALITY[job_id],
                 )
             else:
                 self.assertEqual(
@@ -1205,9 +1122,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_start_job_update_batch_msg(self):
         job_id = BATCH_PARENT
         job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
@@ -1232,9 +1147,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_stop_job_update_batch_msg(self):
         job_id = BATCH_PARENT
         job_id_list = [BATCH_PARENT] + BATCH_CHILDREN
@@ -1242,10 +1155,7 @@ class JobCommTestCase(unittest.TestCase):
         self.jc._handle_comm_message(req)
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    False
-                )
+                self.assertEqual(self.jm._running_jobs[job_id]["refresh"], False)
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
@@ -1254,9 +1164,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_latest_job_logs_msg(self):
         job_id = JOB_COMPLETED
         req = make_comm_msg(
@@ -1271,9 +1179,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(msg["data"]["content"]["max_lines"], 100)
         self.assertEqual(len(msg["data"]["content"]["lines"]), 10)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_job_logs_msg(self):
         job_id = JOB_COMPLETED
         req = make_comm_msg(
@@ -1288,9 +1194,7 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(msg["data"]["content"]["max_lines"], 100)
         self.assertEqual(len(msg["data"]["content"]["lines"]), 10)
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_mock_client)
     def test_handle_cancel_job_msg_with_job_id_list(self):
         job_id_list = [JOB_COMPLETED]
         req = make_comm_msg("cancel_job", job_id_list, False)
@@ -1338,11 +1242,13 @@ class JobRequestTestCase(unittest.TestCase):
     def test_request_both_inputs(self):
         msg = {
             "msg_id": "some_id",
-            "content": {"data": {
-                "request_type": "job_status",
-                "job_id": "ababab",
-                "job_id_list": []
-            }},
+            "content": {
+                "data": {
+                    "request_type": "job_status",
+                    "job_id": "ababab",
+                    "job_id_list": [],
+                }
+            },
         }
         with self.assertRaisesRegex(ValueError, "Both job_id and job_id_list present"):
             JobRequest(msg)
@@ -1350,9 +1256,11 @@ class JobRequestTestCase(unittest.TestCase):
     def test_request__no_input(self):
         msg = {
             "msg_id": "some_id",
-            "content": {"data": {
-                "request_type": "job_status",
-            }},
+            "content": {
+                "data": {
+                    "request_type": "job_status",
+                }
+            },
         }
         req = JobRequest(msg)
 
@@ -1426,18 +1334,19 @@ class JobRequestTestCase(unittest.TestCase):
     def test_translate_both_inputs(self):
         msg = {
             "msg_id": "some_id",
-            "content": {"data": {
-                "request_type": "job_status",
-                "job_id": "ababab",
-                "job_id_list": []
-            }},
+            "content": {
+                "data": {
+                    "request_type": "job_status",
+                    "job_id": "ababab",
+                    "job_id_list": [],
+                }
+            },
         }
         with self.assertRaisesRegex(ValueError, "Both job_id and job_id_list present"):
             JobRequest.translate(msg)
 
 
 class exc_to_msgTestCase(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.maxDiff = None
@@ -1490,9 +1399,9 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "job_id_list": job_id_list,
                     "name": "RuntimeError",
                     "message": message,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_with_nested_try__succeed(self):
@@ -1543,9 +1452,9 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "message": message,
                     "error": error,
                     "code": -1,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_JobIDException(self):
@@ -1573,9 +1482,9 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "job_id": job_id,
                     "name": "JobIDException",
                     "message": f"{message}: a0a0a0",
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_ValueError(self):
@@ -1603,9 +1512,9 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "job_id_list": job_id_list,
                     "name": "ValueError",
                     "message": message,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_dict_req__no_err(self):
@@ -1656,9 +1565,9 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "job_id": job_id,
                     "name": "ValueError",
                     "message": message,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_dict_req__both_inputs(self):
@@ -1689,9 +1598,9 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "job_id_list": job_id_list,
                     "name": "ValueError",
                     "message": message,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_None_req(self):
@@ -1712,9 +1621,9 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "source": source,
                     "name": "ValueError",
                     "message": message,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )
 
     def test_str_req(self):
@@ -1735,7 +1644,7 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "source": source,
                     "name": "ValueError",
                     "message": message,
-                }
+                },
             },
-            msg["data"]
+            msg["data"],
         )

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -158,9 +158,7 @@ class JobManagerTest(unittest.TestCase):
             return False
         return True
 
-    @mock.patch(
-        "biokbase.narrative.clients.get", get_failing_mock_client
-    )
+    @mock.patch("biokbase.narrative.clients.get", get_failing_mock_client)
     def test_initialize_jobs_ee2_fail(self):
         # init jobs should fail. specifically, ee2.check_workspace_jobs should error.
         with self.assertRaises(NarrativeException) as e:
@@ -230,17 +228,23 @@ class JobManagerTest(unittest.TestCase):
         with self.assertRaisesRegex(JobIDException, f"{JOB_NOT_REG_ERR}: {None}"):
             self.jm._check_job(None)
 
-        with self.assertRaisesRegex(JobIDException, f"{JOB_NOT_REG_ERR}: {JOB_NOT_FOUND}"):
+        with self.assertRaisesRegex(
+            JobIDException, f"{JOB_NOT_REG_ERR}: {JOB_NOT_FOUND}"
+        ):
             self.jm._check_job(JOB_NOT_FOUND)
 
     def test__check_job_list_fail(self):
         with self.assertRaisesRegex(TypeError, f"{JOBS_TYPE_ERR}: {None}"):
             self.jm._check_job_list(None)
 
-        with self.assertRaisesRegex(JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+        ):
             self.jm._check_job_list([])
 
-        with self.assertRaisesRegex(JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')
+        ):
             self.jm._check_job_list(["", "", None])
 
     def test__check_job_list(self):
@@ -305,9 +309,9 @@ class JobManagerTest(unittest.TestCase):
                 **{
                     job_id: get_error_output_state(job_id, "ee2_error")
                     for job_id in ACTIVE_JOBS
-                }
+                },
             },
-            job_states
+            job_states,
         )
 
     def test__create_jobs__empty_list(self):
@@ -324,9 +328,7 @@ class JobManagerTest(unittest.TestCase):
         self.assertIsInstance(job, Job)
 
     def test_get_job_bad(self):
-        with self.assertRaisesRegex(
-            JobIDException, f"{JOB_NOT_REG_ERR}: not_a_job_id"
-        ):
+        with self.assertRaisesRegex(JobIDException, f"{JOB_NOT_REG_ERR}: not_a_job_id"):
             self.jm.get_job("not_a_job_id")
 
     @mock.patch("biokbase.narrative.clients.get", get_mock_client)
@@ -351,9 +353,7 @@ class JobManagerTest(unittest.TestCase):
             self.assertEqual(self.jm.list_jobs(), expected)
 
         # with some jobs
-        with mock.patch(
-            "biokbase.narrative.clients.get", get_mock_client
-        ):
+        with mock.patch("biokbase.narrative.clients.get", get_mock_client):
             jobs_html_0 = self.jm.list_jobs().data
             jobs_html_1 = self.jm.list_jobs().data
 
@@ -369,14 +369,20 @@ class JobManagerTest(unittest.TestCase):
                 self.assertEqual(jobs_html_0, jobs_html_1)
 
     def test_cancel_jobs__bad_inputs(self):
-        with self.assertRaisesRegex(JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+        ):
             self.jm.cancel_jobs([])
 
-        with self.assertRaisesRegex(JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')
+        ):
             self.jm.cancel_jobs(["", "", None])
 
         job_states = self.jm.cancel_jobs([JOB_NOT_FOUND])
-        self.assertEqual({JOB_NOT_FOUND: get_error_output_state(JOB_NOT_FOUND)}, job_states)
+        self.assertEqual(
+            {JOB_NOT_FOUND: get_error_output_state(JOB_NOT_FOUND)}, job_states
+        )
 
     def test_cancel_jobs__job_already_finished(self):
         self.assertEqual(get_test_job(JOB_COMPLETED)["status"], "completed")
@@ -613,10 +619,14 @@ class JobManagerTest(unittest.TestCase):
         self._check_retry_jobs(expected, retry_results)
 
     def test_retry_jobs__bad_inputs(self):
-        with self.assertRaisesRegex(JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+        ):
             self.jm.retry_jobs([])
 
-        with self.assertRaisesRegex(JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f'{JOBS_MISSING_FALSY_ERR}: {["", "", None]}')
+        ):
             self.jm.retry_jobs(["", "", None])
 
     @mock.patch("biokbase.narrative.clients.get", get_mock_client)
@@ -720,7 +730,9 @@ class JobManagerTest(unittest.TestCase):
         self.assertEqual(exp, res)
 
     def test_get_job_states__empty(self):
-        with self.assertRaisesRegex(JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")):
+        with self.assertRaisesRegex(
+            JobIDException, re.escape(f"{JOBS_MISSING_FALSY_ERR}: {[]}")
+        ):
             self.jm.get_job_states([])
 
     def test_update_batch_job__dne(self):
@@ -730,10 +742,14 @@ class JobManagerTest(unittest.TestCase):
             self.jm.update_batch_job(JOB_NOT_FOUND)
 
     def test_update_batch_job__not_batch(self):
-        with self.assertRaisesRegex(JobIDException, f"{JOB_NOT_BATCH_ERR}: {JOB_CREATED}"):
+        with self.assertRaisesRegex(
+            JobIDException, f"{JOB_NOT_BATCH_ERR}: {JOB_CREATED}"
+        ):
             self.jm.update_batch_job(JOB_CREATED)
 
-        with self.assertRaisesRegex(JobIDException, f"{JOB_NOT_BATCH_ERR}: {BATCH_TERMINATED}"):
+        with self.assertRaisesRegex(
+            JobIDException, f"{JOB_NOT_BATCH_ERR}: {BATCH_TERMINATED}"
+        ):
             self.jm.update_batch_job(BATCH_TERMINATED)
 
     @mock.patch("biokbase.narrative.clients.get", get_mock_client)
@@ -799,9 +815,7 @@ class JobManagerTest(unittest.TestCase):
 
     def test_modify_job_refresh(self):
         for job_id, terminality in JOBS_TERMINALITY.items():
-            self.assertEqual(
-                self.jm._running_jobs[job_id]["refresh"], not terminality
-            )
+            self.assertEqual(self.jm._running_jobs[job_id]["refresh"], not terminality)
             self.jm.modify_job_refresh([job_id], False)  # stop
             self.assertEqual(self.jm._running_jobs[job_id]["refresh"], False)
             self.jm.modify_job_refresh([job_id], False)  # stop harder

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -116,9 +116,7 @@ define([
             expect(jobCommInitString.split('\n')).toEqual([
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
                 'cell_list = ["12345","abcde","who cares?"]',
-                // DATAUP-575: temporary disabling of cell_list
-                // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
-                'JobComm().start_job_status_loop(init_jobs=True)',
+                'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
             ]);
         });
 
@@ -129,9 +127,7 @@ define([
             expect(jobCommInitString.split('\n')).toEqual([
                 'from biokbase.narrative.jobs.jobcomm import JobComm',
                 'cell_list = []',
-                // DATAUP-575: temporary disabling of cell_list
-                // 'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
-                'JobComm().start_job_status_loop(init_jobs=True)',
+                'JobComm().start_job_status_loop(cell_list=cell_list, init_jobs=True)',
             ]);
         });
 


### PR DESCRIPTION
# Description of PR purpose/changes

It was noticed that the job channel of the websocket was using a fairly colossal amount of bandwidth. This wound up being due to all job status being returned from an `all_job_status` call in the kernel-side job monitoring thread, even if all of those jobs were complete and nothing on the front end was tracking them.

After some discussion, we decided that one of the cores of the problem was using the "refresh" flag for each job as an integer. This would represent the number of front end things (widgets, viewers, etc.) that wanted to receive continual job status. As those things were created or destroyed, the count would go up and down, and as long as one thing wanted job status, it would get returned on each turn of the cycle.

This is horribly confusing and inefficient and led to the tracking count being very brittle and prone to losing synchronicity. 

Instead, we decided to flip that to a boolean. If `True`, we return the latest job status on each cycle. This will work better as we're now in a position where there is effectively only one widget up at a time that will want job status. There's some internal developer debugging tools that also might want this, but they can be managed in other ways and aren't relevant for most, if not all, users.

An additional issue was uncovered where whenever a new job was created - whether by an app cell or by a direct code execution of `AppManager.run_app` - that job was set to always return its status. Thus, if you were to, say, write a short loop that generates 2000+ jobs, their status would always be returned, even long after all jobs were complete. The refresh value for them would also get set to 1 whenever the kernel restarted, or the page reloaded.

All of these together have the potential to gobble up all of a user's bandwidth pretty quickly, and might cause other problems in a narrative where there's 100s or 1000s of cells, due to network lag and such.

This PR, then, adds the following changes:
1. Turn that `refresh` int into a boolean.
2. On job creation, leave `refresh=False` until requested by a front end element (already built in to App Cells)
3. On kernel start or restart, if given a list of cell ids, turn `refresh=True` for those jobs that are incomplete AND associated with a cell.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-703
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Effectively there should be no visual changes
  * starting up new single app cells should work as expected
    * newly run app cells should get data until they stop running
    * running a new app cell, then refreshing the page should still get job status
    * running a new app cell, then restarting the kernel, should still get job status
  * all of the above should apply to bulk import cells as well
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
