### PR TITLE
DATAUP-497: Moving all bus message sending to the TestUtils file

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -276,18 +276,18 @@ define([
             }
 
             channelList
-                .filter((channel) => {
-                    return channel && channel.length > 0 ? 1 : 0;
+                .filter((channelId) => {
+                    return channelId && channelId.length > 0 ? 1 : 0;
                 })
-                .forEach((channel) => {
-                    if (!this.listeners[channel]) {
-                        this.listeners[channel] = {};
+                .forEach((channelId) => {
+                    if (!this.listeners[channelId]) {
+                        this.listeners[channelId] = {};
                     }
-                    if (!this.listeners[channel][msgType]) {
-                        const channelObject = { [channelType]: channel };
+                    if (!this.listeners[channelId][msgType]) {
+                        const channelObject = { [channelType]: channelId };
 
                         // listen for job-related bus messages
-                        this.listeners[channel][msgType] = this.bus.listen({
+                        this.listeners[channelId][msgType] = this.bus.listen({
                             channel: channelObject,
                             key: {
                                 type: msgType,
@@ -298,7 +298,7 @@ define([
                                 }
                                 this.runHandler(msgType, message, {
                                     channelType,
-                                    channelId: channel,
+                                    channelId,
                                 });
                             },
                         });
@@ -314,13 +314,13 @@ define([
         /**
          * Remove the listener for ${msgType} messages for a channel
          *
-         * @param {string} channel
+         * @param {string} channelId
          * @param {string} msgType - the msgType of the listener
          */
-        removeListener(channel, msgType) {
+        removeListener(channelId, msgType) {
             try {
-                this.bus.removeListener(this.listeners[channel][msgType]);
-                delete this.listeners[channel][msgType];
+                this.bus.removeListener(this.listeners[channelId][msgType]);
+                delete this.listeners[channelId][msgType];
             } catch (err) {
                 // do nothing
             }
@@ -328,14 +328,14 @@ define([
 
         /**
          * Remove all listeners associated with a certain channel ID
-         * @param {string} channel
+         * @param {string} channelId
          */
-        removeChannelListeners(channel) {
-            if (this.listeners[channel] && Object.keys(this.listeners[channel]).length) {
-                Object.keys(this.listeners[channel]).forEach((msgType) => {
-                    this.removeListener(channel, msgType);
+        removeChannelListeners(channelId) {
+            if (this.listeners[channelId] && Object.keys(this.listeners[channelId]).length) {
+                Object.keys(this.listeners[channelId]).forEach((msgType) => {
+                    this.removeListener(channelId, msgType);
                 });
-                delete this.listeners[channel];
+                delete this.listeners[channelId];
             }
         }
 

--- a/test/unit/testUtil.js
+++ b/test/unit/testUtil.js
@@ -1,8 +1,9 @@
-define('testUtil', ['bluebird', 'util/stagingFileCache', 'json!/test/testConfig.json'], (
-    Promise,
-    StagingFileCache,
-    TestConfig
-) => {
+define('testUtil', [
+    'bluebird',
+    'util/stagingFileCache',
+    'common/jobCommMessages',
+    'json!/test/testConfig.json',
+], (Promise, StagingFileCache, jcm, TestConfig) => {
     'use strict';
 
     let token = null,
@@ -186,6 +187,169 @@ define('testUtil', ['bluebird', 'util/stagingFileCache', 'json!/test/testConfig.
         StagingFileCache.clearCache();
     }
 
+    /**
+     * send a jcm.MESSAGE_TYPE.INFO message over the bus
+     *
+     * @param {object} ctx - `this` context, containing keys
+     *      {object} bus
+     *      {object} jobInfo
+     */
+    function send_INFO(ctx) {
+        const { bus, jobInfo } = ctx;
+        const jobId = jobInfo.job_id;
+        sendBusMessage({
+            bus,
+            message: { ...jobInfo, [jcm.PARAM.JOB_ID]: jobId },
+            channelType: jcm.CHANNEL.JOB,
+            channelId: jobId,
+            type: jcm.MESSAGE_TYPE.INFO,
+        });
+    }
+
+    /**
+     * send a jcm.MESSAGE_TYPE.LOGS message over the bus
+     *
+     * @param {object} ctx - `this` context, containing keys
+     *      {object} bus
+     *      {object} message - partial log message; missing keys will be filled in
+     */
+    function send_LOGS(ctx) {
+        const { bus, message } = ctx;
+        if (message.lines) {
+            message.first = 0;
+            message.max_lines = message.lines.length;
+        }
+        sendBusMessage({
+            bus,
+            message,
+            channelType: jcm.CHANNEL.JOB,
+            channelId: message[jcm.PARAM.JOB_ID],
+            type: jcm.MESSAGE_TYPE.LOGS,
+        });
+    }
+
+    /**
+     * send a jcm.MESSAGE_TYPE.RETRY message over the bus
+     *
+     * @param {object} ctx - `this` context, containing keys
+     *      {object} retryParent    - the parent of the retried job
+     *      {object} retry          - the new job
+     *      {object} bus            - the bus to send the message on
+     */
+    function send_RETRY(ctx) {
+        const { bus, retryParent, retry } = ctx;
+        // send the retry response and the update for the batch parent
+        sendBusMessage({
+            bus,
+            message: {
+                [jcm.PARAM.JOB_ID]: retryParent.job_id,
+                job: {
+                    [jcm.PARAM.JOB_ID]: retryParent.job_id,
+                    jobState: retryParent,
+                },
+                retry_id: retry.job_id,
+                retry: {
+                    [jcm.PARAM.JOB_ID]: retry.job_id,
+                    jobState: retry,
+                },
+            },
+            channelType: jcm.CHANNEL.JOB,
+            channelId: retryParent.job_id,
+            type: jcm.MESSAGE_TYPE.RETRY,
+        });
+    }
+
+    /**
+     * send a jcm.MESSAGE_TYPE.ERROR message over the bus
+     *
+     * @param {object} ctx - `this` context, containing keys
+     *      {object} jobId          - the job in question
+     *      {object} error          - error object from the backend
+     *      {object} bus            - the bus to send the message on
+     */
+    function send_ERROR(ctx) {
+        const { bus, jobId, error } = ctx;
+        sendBusMessage({
+            bus,
+            message: {
+                [jcm.PARAM.JOB_ID]: jobId,
+                error,
+                request: error.source,
+            },
+            channelType: jcm.CHANNEL.JOB,
+            channelId: jobId,
+            type: jcm.MESSAGE_TYPE.ERROR,
+        });
+    }
+
+    /**
+     * send a jcm.MESSAGE_TYPE.RUN_STATUS message over the bus
+     *
+     * @param {object} ctx - `this` context, containing keys
+     *      {object} runStatusArgs - object with keys for a valid run_status message
+     *      {object} bus
+     */
+    function send_RUN_STATUS(ctx) {
+        const { bus, runStatusArgs } = ctx;
+        if (!runStatusArgs.cell_id) {
+            throw new Error('No cell_id supplied for RUN_STATUS message');
+        }
+        sendBusMessage({
+            bus,
+            message: { event_at: 1234567890, ...runStatusArgs },
+            channelType: [jcm.CHANNEL.CELL],
+            channelId: runStatusArgs.cell_id,
+            type: jcm.MESSAGE_TYPE.RUN_STATUS,
+        });
+    }
+
+    /**
+     * send a jcm.MESSAGE_TYPE.STATUS message over the bus
+     *
+     * @param {object} ctx - `this` context, containing keys
+     *      {object} bus      - message bus
+     *      {object} jobState - the jobState object to be sent
+     */
+    function send_STATUS(ctx) {
+        const { bus, jobState } = ctx;
+        const jobId = jobState.job_id;
+        sendBusMessage({
+            bus,
+            message: {
+                [jcm.PARAM.JOB_ID]: jobId,
+                jobState,
+            },
+            channelType: jcm.CHANNEL.JOB,
+            channelId: jobId,
+            type: jcm.MESSAGE_TYPE.STATUS,
+        });
+    }
+
+    /**
+     * send a jcm.MESSAGE_TYPE.<type> message over the bus
+     *
+     * @param {object} args with key value pairs:
+     * @param {object} bus
+     * @param {object} message
+     * @param {string} channelType    - jcm.CHANNEL.<type>
+     * @param {string} channelId      - ID for the channel
+     * @param {string} type           - jcm.MESSAGE_TYPE.<type>
+     */
+    function sendBusMessage(args) {
+        const keys = ['bus', 'message', 'channelType', 'channelId', 'type'].filter((key) => {
+            return !args[key];
+        });
+        if (keys.length) {
+            throw new Error('Missing required keys for sendBusMessage: ' + keys.join(', '));
+        }
+
+        const { bus, message, channelType, channelId, type } = args;
+
+        bus.send(message, { channel: { [channelType]: channelId }, key: { type } });
+
+        // bus.send({ [channelId]: message }, { channel: { [channelType]: channelId }, key: { type } });
+    }
+
     return {
         make,
         getAuthToken,
@@ -197,6 +361,13 @@ define('testUtil', ['bluebird', 'util/stagingFileCache', 'json!/test/testConfig.
         waitForElement,
         waitForElementState,
         waitForElementChange,
+        send_ERROR,
+        send_INFO,
+        send_LOGS,
+        send_RETRY,
+        send_RUN_STATUS,
+        send_STATUS,
+        sendBusMessage,
         clearRuntime,
     };
 });


### PR DESCRIPTION
# Description of PR purpose/changes

Centralising all bus message sends in the TestUtils files for ease of manipulation.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
