### PR TITLE
DATAUP-497: Adding a simple looper module for scheduling function execution

### DIFF
--- a/kbase-extension/static/kbase/js/common/looper.js
+++ b/kbase-extension/static/kbase/js/common/looper.js
@@ -1,0 +1,24 @@
+define([], () => {
+    'use strict';
+
+    class Looper {
+        constructor(config = {}) {
+            this.requestLoop = null;
+            this.pollInterval = config.pollInterval || 2500;
+        }
+
+        scheduleRequest(fn, ...args) {
+            this.requestLoop = window.setTimeout(() => {
+                fn(...args);
+            }, this.pollInterval);
+        }
+
+        clearRequest() {
+            if (this.requestLoop) {
+                window.clearTimeout(this.requestLoop);
+                this.requestLoop = null;
+            }
+        }
+    }
+    return Looper;
+});

--- a/test/unit/spec/common/looper-spec.js
+++ b/test/unit/spec/common/looper-spec.js
@@ -1,0 +1,49 @@
+define(['common/looper'], (Looper) => {
+    'use strict';
+
+    describe('the Looper instance', () => {
+        beforeEach(() => {
+            jasmine.clock().install();
+        });
+        afterEach(() => {
+            jasmine.clock().uninstall();
+        });
+
+        it('can be instantiated', () => {
+            const looperInstance = new Looper();
+            ['scheduleRequest', 'clearRequest'].forEach((fn) => {
+                expect(looperInstance[fn]).toEqual(jasmine.any(Function));
+            });
+        });
+
+        it('has a default poll interval', () => {
+            const looperInstance = new Looper();
+            expect(looperInstance.pollInterval).toBeGreaterThan(0);
+        });
+
+        it('can have a poll interval set', () => {
+            const looperInstance = new Looper({ pollInterval: 500 });
+            expect(looperInstance.pollInterval).toEqual(500);
+        });
+
+        it('executes a function after a delay', () => {
+            const looperInstance = new Looper({ pollInterval: 10000 });
+            spyOn(console, 'error');
+            looperInstance.scheduleRequest(console.error, 'ZOMG!');
+            expect(console.error).not.toHaveBeenCalled();
+            jasmine.clock().tick(10001);
+            expect(console.error.calls.allArgs()).toEqual([['ZOMG!']]);
+        });
+
+        it('can have the function cleared', () => {
+            const looperInstance = new Looper({ pollInterval: 10000 });
+            spyOn(console, 'error');
+            looperInstance.scheduleRequest(console.error, 'ZOMG!');
+            expect(console.error).not.toHaveBeenCalled();
+            jasmine.clock().tick(1000);
+            looperInstance.clearRequest();
+            jasmine.clock().tick(10000);
+            expect(console.error).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
# Description of PR purpose/changes

A simple module to execute a function after a configurable delay.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
