### PR TITLE
DATAUP-497: Simplifying the kernel error message structure

### DIFF
--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -437,21 +437,21 @@ class JobComm:
 
         This sends a packet that looks like:
         {
-            raw_request: the original JobRequest object, function params, or function name
+            request: the original JobRequest data object, function params, or function name
             source: the function request that spawned the error
             other fields about the error, dependent on the content.
         }
         """
         error_content = dict()
         if isinstance(req, JobRequest):
-            error_content["raw_request"] = req.raw_request
+            error_content["request"] = req.rq_data
             error_content["source"] = req.request_type
         elif isinstance(req, dict):
             data = req.get("content", {}).get("data", {})
-            error_content["raw_request"] = req
+            error_content["request"] = data
             error_content["source"] = data.get("request_type")
         elif isinstance(req, str) or req is None:
-            error_content["raw_request"] = req
+            error_content["request"] = req
             error_content["source"] = req
 
         if content is not None:

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -162,20 +162,20 @@ class JobCommTestCase(unittest.TestCase):
             err: the error object produced
 
         error message produced will contain:
-            raw_request: the input that generated the error
+            request: the input that generated the error
             source: the request that was called
             extra_params
             name: the type of exception
             message: the error message
         """
         if isinstance(req, JobRequest):
-            raw_request = req.raw_request
+            request = req.rq_data
             source = req.request_type
         elif isinstance(req, dict):
-            raw_request = req
+            request = req["content"]["data"]
             source = req["content"]["data"]["request_type"]
         elif isinstance(req, str):
-            raw_request = req
+            request = req
             source = req
 
         msg = self.jc._comm.last_message
@@ -183,7 +183,7 @@ class JobCommTestCase(unittest.TestCase):
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": raw_request,
+                    "request": request,
                     "source": source,
                     **extra_params,
                     "name": type(err).__name__,
@@ -290,7 +290,7 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     "source": "bar",
                     "extra": "field",
-                    "raw_request": req.raw_request,
+                    "request": req.rq_data,
                 },
             },
             msg,
@@ -306,7 +306,7 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     "source": "bar",
                     "extra": "field",
-                    "raw_request": req_dict,
+                    "request": req_dict["content"]["data"],
                 },
             },
             msg,
@@ -321,7 +321,7 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     "source": None,
                     "extra": "field",
-                    "raw_request": None,
+                    "request": None,
                 },
             },
             msg,
@@ -337,7 +337,7 @@ class JobCommTestCase(unittest.TestCase):
                 "content": {
                     "source": source,
                     "extra": "field",
-                    "raw_request": source,
+                    "request": source,
                 },
             },
             msg,
@@ -919,7 +919,7 @@ class JobCommTestCase(unittest.TestCase):
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req_dict,
+                    "request": req_dict["content"]["data"],
                     "source": RETRY,
                     "name": "JSONRPCError",
                     "error": "Unable to retry job(s)",
@@ -1406,7 +1406,7 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "source": req_type,
                     "name": "RuntimeError",
                     "message": message,
-                    "raw_request": req.raw_request,
+                    "request": req.rq_data,
                 },
             },
             msg,
@@ -1453,7 +1453,7 @@ class exc_to_msgTestCase(unittest.TestCase):
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req.raw_request,
+                    "request": req.rq_data,
                     "source": req_type,
                     # Below are from transform_job_exception
                     "name": "Exception",
@@ -1486,7 +1486,7 @@ class exc_to_msgTestCase(unittest.TestCase):
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req.raw_request,
+                    "request": req.rq_data,
                     "source": req_type,
                     "name": "JobRequestException",
                     "message": f"{message}: a0a0a0",
@@ -1516,7 +1516,7 @@ class exc_to_msgTestCase(unittest.TestCase):
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req.raw_request,
+                    "request": req.rq_data,
                     "source": req_type,
                     "name": "ValueError",
                     "message": message,
@@ -1569,7 +1569,7 @@ class exc_to_msgTestCase(unittest.TestCase):
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req_dict,
+                    "request": req_dict["content"]["data"],
                     "source": req_type,
                     "name": "ValueError",
                     "message": message,
@@ -1600,7 +1600,7 @@ class exc_to_msgTestCase(unittest.TestCase):
             {
                 "msg_type": ERROR,
                 "content": {
-                    "raw_request": req_dict,
+                    "request": req_dict["content"]["data"],
                     "source": req_type,
                     "name": "ValueError",
                     "message": message,
@@ -1627,7 +1627,7 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "source": source,
                     "name": "ValueError",
                     "message": message,
-                    "raw_request": None,
+                    "request": None,
                 },
             },
             msg,
@@ -1651,7 +1651,7 @@ class exc_to_msgTestCase(unittest.TestCase):
                     "source": source,
                     "name": "ValueError",
                     "message": message,
-                    "raw_request": source,
+                    "request": source,
                 },
             },
             msg,


### PR DESCRIPTION
# Description of PR purpose/changes

Removing some unnecessary nesting to make error messages from the kernel easier to parse

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-497
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
