### PR TITLE
fix a few other cases where user-created text was mangled

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseDataCard.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseDataCard.js
@@ -58,7 +58,7 @@ define([
         //shorten name if applicable
         const $name = $('<span>').addClass('kb-data-list-name');
         if (maxNameLength && name && name.length > maxNameLength) {
-            $name.append(name.substring(0, maxNameLength - 3) + '...');
+            $name.text(name.substring(0, maxNameLength - 3) + '...');
             $name.tooltip({
                 title: name,
                 placement: 'bottom',
@@ -68,7 +68,7 @@ define([
                 },
             });
         } else {
-            $name.append(name);
+            $name.text(name);
         }
 
         const $logo = $('<div>');
@@ -80,7 +80,7 @@ define([
 
         //no default
         const $byUser = $('<span>').addClass('kb-data-list-edit-by').append(editBy),
-            $narrative = $('<div>').addClass('kb-data-list-narrative').append(entry.narrative),
+            $narrative = $('<div>').addClass('kb-data-list-narrative').text(entry.narrative),
             $title = $('<div>').append($name),
             $subcontent = $('<div>').addClass('narrative-data-list-subcontent');
 
@@ -177,7 +177,7 @@ define([
             }
 
             DataProvider.getDataByName().then((data) => {
-                if (data.hasOwnProperty(objectInfo[1])) {
+                if (objectInfo[1] in data) {
                     showCopyWarningDialog();
                 } else {
                     doObjectCopy();


### PR DESCRIPTION
User-created text (like narrative names, also object type names and object names) was possibly being mangled in the slideout data browser. This converts a few auld jquery `.append` calls to `.text` to fix that.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [n/a] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a - previous PR notes apply] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
