### PR TITLE
DATAUP-678: job manager updates

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -471,7 +471,10 @@ define([
             this.jobsByRetryParent[rowIx].jobs[currentJobIx] = jobState;
             // do we have job info for it?
             if (!this.jobManager.model.getItem(`exec.jobs.info.${rowIx}`)) {
-                this.jobManager.requestJobInfo([rowIx]);
+                // TODO: move this to the Job Manager
+                this.jobManager.bus.emit(jcm.MESSAGE_TYPE.INFO, {
+                    [jcm.PARAM.JOB_ID_LIST]: [rowIx],
+                });
             }
 
             // is this a job that has been retried?

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -563,7 +563,7 @@ define([
         return acc;
     }, {});
 
-    const jobsById = allJobs.reduce((acc, curr) => {
+    const jobsById = allJobsWithBatchParent.reduce((acc, curr) => {
         acc[curr.job_id] = curr;
         return acc;
     }, {});

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -584,7 +584,8 @@ define([
                 // this table already has the info populated, so the job info
                 // listener is not required
                 jobIdList.forEach((jobId) => {
-                    expect(Object.keys(this.jobManager.listeners[jobId])).toEqual(
+                    const channelString = JSON.stringify({ [jcm.CHANNEL.JOB]: jobId });
+                    expect(Object.keys(this.jobManager.listeners[channelString])).toEqual(
                         jasmine.arrayWithExactContents([
                             jcm.MESSAGE_TYPE.STATUS,
                             jcm.MESSAGE_TYPE.ERROR,
@@ -624,8 +625,9 @@ define([
                 ]);
                 // job info listeners only required for some jobs
                 jobIdList.forEach((jobId) => {
+                    const channelString = JSON.stringify({ [jcm.CHANNEL.JOB]: jobId });
                     if (missingJobIds.includes(jobId)) {
-                        expect(Object.keys(this.jobManager.listeners[jobId])).toEqual(
+                        expect(Object.keys(this.jobManager.listeners[channelString])).toEqual(
                             jasmine.arrayWithExactContents([
                                 jcm.MESSAGE_TYPE.STATUS,
                                 jcm.MESSAGE_TYPE.ERROR,
@@ -633,7 +635,7 @@ define([
                             ])
                         );
                     } else {
-                        expect(Object.keys(this.jobManager.listeners[jobId])).toEqual(
+                        expect(Object.keys(this.jobManager.listeners[channelString])).toEqual(
                             jasmine.arrayWithExactContents([
                                 jcm.MESSAGE_TYPE.STATUS,
                                 jcm.MESSAGE_TYPE.ERROR,
@@ -1020,20 +1022,26 @@ define([
                             // we expect the job-status listener to be removed
                             if (this.input.status === 'does_not_exist') {
                                 expect(Object.keys(this.jobManager.listeners)).toEqual([
-                                    BATCH_PARENT_ID,
+                                    JSON.stringify({ [jcm.CHANNEL.JOB]: BATCH_PARENT_ID }),
                                 ]);
                             } else if (
                                 Jobs.isTerminalStatus(this.input.status) &&
                                 !this.input.meta.canRetry
                             ) {
+                                const channelString = JSON.stringify({
+                                    [jcm.CHANNEL.JOB]: this.job.job_id,
+                                });
                                 expect(
-                                    this.jobManager.listeners[this.job.job_id][
+                                    this.jobManager.listeners[channelString][
                                         jcm.MESSAGE_TYPE.STATUS
                                     ]
                                 ).toBeUndefined();
                             } else {
+                                const channelString = JSON.stringify({
+                                    [jcm.CHANNEL.JOB]: this.job.job_id,
+                                });
                                 expect(
-                                    this.jobManager.listeners[this.job.job_id][
+                                    this.jobManager.listeners[channelString][
                                         jcm.MESSAGE_TYPE.STATUS
                                     ]
                                 ).toBeDefined();

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -680,8 +680,10 @@ define([
         });
 
         it('current jobs, no retries', () => {
-            const jobsByOriginalId = Jobs.getCurrentJobs(JobsData.allJobs);
-            expect(jobsByOriginalId).toEqual(JobsData.jobsById);
+            const jobsByOriginalId = Jobs.getCurrentJobs(JobsData.allJobsWithBatchParent);
+            const expectedJobsById = TestUtil.JSONcopy(JobsData.jobsById);
+            delete expectedJobsById[JobsData.batchParentJob.job_id];
+            expect(jobsByOriginalId).toEqual(expectedJobsById);
         });
 
         it('can retrieve current jobs, with retries', () => {


### PR DESCRIPTION
# Description of PR purpose/changes

Minor changes to the job manager: update listener indexing to allow both JOB and CHANNEL listeners for a single ID; a couple of minor efficiency fixes for default job handlers

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
