### PR TITLE
DATAUP-678: universal batch listening for the job manager and the batch table

### DIFF
--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -658,6 +658,7 @@ define([
                                         jcm.MESSAGE_TYPE.START_UPDATE,
                                         { [jcm.PARAM.BATCH_ID]: batchId },
                                     ],
+                                    [jcm.MESSAGE_TYPE.INFO, { [jcm.PARAM.BATCH_ID]: batchId }],
                                     [
                                         jcm.MESSAGE_TYPE.CANCEL,
                                         { [jcm.PARAM.JOB_ID_LIST]: [batchId] },


### PR DESCRIPTION

# Description of PR purpose/changes

Updating job manager to add all relevant listeners for batch jobs, and convert the job status table over to using the batch channel to receive messages

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-678
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
