### PR TITLE
DATAUP-678: Adding a looped job status request to the batch job manager

### DIFF
--- a/kbase-extension/static/kbase/js/common/looper.js
+++ b/kbase-extension/static/kbase/js/common/looper.js
@@ -1,4 +1,4 @@
-define([], () => {
+define(['util/developerMode'], (Developer) => {
     'use strict';
 
     const debugFn = (...args) => {
@@ -10,7 +10,7 @@ define([], () => {
         constructor(config = {}) {
             this.requestLoop = null;
             this.pollInterval = config.pollInterval || 2500;
-            this.devMode = config.devMode || false;
+            this.devMode = config.devMode || Developer.mode;
             this.debug = this.devMode
                 ? debugFn
                 : () => {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -660,18 +660,11 @@ define([
                                 const allEmissions =
                                     bulkImportCellInstance.jobManager.bus.emit.calls.allArgs();
                                 expect([
-                                    [
-                                        jcm.MESSAGE_TYPE.START_UPDATE,
-                                        { [jcm.PARAM.BATCH_ID]: batchId },
-                                    ],
+                                    [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.BATCH_ID]: batchId }],
                                     [jcm.MESSAGE_TYPE.INFO, { [jcm.PARAM.BATCH_ID]: batchId }],
                                     [
                                         jcm.MESSAGE_TYPE.CANCEL,
                                         { [jcm.PARAM.JOB_ID_LIST]: [batchId] },
-                                    ],
-                                    [
-                                        jcm.MESSAGE_TYPE.STOP_UPDATE,
-                                        { [jcm.PARAM.BATCH_ID]: batchId },
                                     ],
                                     [
                                         'reset-cell',
@@ -775,10 +768,9 @@ define([
                 expect(bulkImportCellInstance.jobManager.initBatchJob).toHaveBeenCalledTimes(1);
                 // bus calls to init jobs, request info, cancel jobs, and stop updates
                 const callArgs = [
-                    [jcm.MESSAGE_TYPE.START_UPDATE, { [jcm.PARAM.BATCH_ID]: batchId }],
+                    [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.BATCH_ID]: batchId }],
                     [jcm.MESSAGE_TYPE.INFO, { [jcm.PARAM.BATCH_ID]: batchId }],
                     [jcm.MESSAGE_TYPE.CANCEL, { [jcm.PARAM.JOB_ID_LIST]: [batchId] }],
-                    [jcm.MESSAGE_TYPE.STOP_UPDATE, { [jcm.PARAM.BATCH_ID]: batchId }],
                 ];
                 expect(Jupyter.narrative.saveNarrative.calls.allArgs()).toEqual([[]]);
                 expect(bulkImportCellInstance.jobManager.bus.emit.calls.allArgs()).toEqual(


### PR DESCRIPTION
# Description of PR purpose/changes

Rather than having the backend run the job status lookup loop, the frontend now requests job status updates when it desires them. It's strong and independent and empowered like that!

TODO: 
- add the request loop to the app cell and narrative job status widget
- do we need a fallback in case the request is not fulfilled?

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-678
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
