### PR TITLE
DATAUP-678: minor job manager edits

### DIFF
--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -514,8 +514,8 @@ class JobManagerTest(unittest.TestCase):
             self.jm.retry_jobs(["", "", None])
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_all_job_states(self):
-        states = self.jm.lookup_all_job_states()
+    def test_get_all_job_states(self):
+        states = self.jm.get_all_job_states()
         self.assertEqual(set(ACTIVE_JOBS), set(states.keys()))
         self.assertEqual(
             states,
@@ -523,39 +523,39 @@ class JobManagerTest(unittest.TestCase):
         )
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_all_job_states__ignore_refresh_flag(self):
-        states = self.jm.lookup_all_job_states(ignore_refresh_flag=True)
+    def test_get_all_job_states__ignore_refresh_flag(self):
+        states = self.jm.get_all_job_states(ignore_refresh_flag=True)
         self.assertEqual(set(ALL_JOBS), set(states.keys()))
         self.assertEqual(
             {id: ALL_RESPONSE_DATA[MESSAGE_TYPE["STATUS"]][id] for id in ALL_JOBS},
             states,
         )
 
-    ## lookup_job_states_by_cell_id
+    ## get_job_states_by_cell_id
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list_None(self):
+    def test_get_job_states_by_cell_id__cell_id_list_None(self):
         with self.assertRaisesRegex(JobRequestException, CELLS_NOT_PROVIDED_ERR):
-            self.jm.lookup_job_states_by_cell_id(cell_id_list=None)
+            self.jm.get_job_states_by_cell_id(cell_id_list=None)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list_empty(self):
+    def test_get_job_states_by_cell_id__cell_id_list_empty(self):
         with self.assertRaisesRegex(JobRequestException, CELLS_NOT_PROVIDED_ERR):
-            self.jm.lookup_job_states_by_cell_id(cell_id_list=[])
+            self.jm.get_job_states_by_cell_id(cell_id_list=[])
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list_no_results(self):
-        result = self.jm.lookup_job_states_by_cell_id(cell_id_list=["a", "b", "c"])
+    def test_get_job_states_by_cell_id__cell_id_list_no_results(self):
+        result = self.jm.get_job_states_by_cell_id(cell_id_list=["a", "b", "c"])
         self.assertEqual(
             {"jobs": {}, "mapping": {"a": set(), "b": set(), "c": set()}}, result
         )
 
-    def check_lookup_job_states_by_cell_id_results(self, cell_ids, expected_ids):
+    def check_get_job_states_by_cell_id_results(self, cell_ids, expected_ids):
         expected_states = {
             id: ALL_RESPONSE_DATA[MESSAGE_TYPE["STATUS"]][id]
             for id in ALL_RESPONSE_DATA[MESSAGE_TYPE["STATUS"]].keys()
             if id in expected_ids
         }
-        result = self.jm.lookup_job_states_by_cell_id(cell_id_list=cell_ids)
+        result = self.jm.get_job_states_by_cell_id(cell_id_list=cell_ids)
         self.assertEqual(set(expected_ids), set(result["jobs"].keys()))
         self.assertEqual(expected_states, result["jobs"])
         self.assertEqual(set(cell_ids), set(result["mapping"].keys()))
@@ -563,49 +563,49 @@ class JobManagerTest(unittest.TestCase):
             self.assertEqual(set(TEST_CELL_IDs[key]), set(result["mapping"][key]))
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list_all_results(self):
+    def test_get_job_states_by_cell_id__cell_id_list_all_results(self):
         cell_ids = TEST_CELL_ID_LIST
-        self.check_lookup_job_states_by_cell_id_results(cell_ids, ALL_JOBS)
+        self.check_get_job_states_by_cell_id_results(cell_ids, ALL_JOBS)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list__batch_job__one_cell(self):
+    def test_get_job_states_by_cell_id__cell_id_list__batch_job__one_cell(self):
         cell_ids = [TEST_CELL_ID_LIST[2]]
         expected_ids = TEST_CELL_IDs[TEST_CELL_ID_LIST[2]]
-        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
+        self.check_get_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list__batch_job__two_cells(self):
+    def test_get_job_states_by_cell_id__cell_id_list__batch_job__two_cells(self):
         cell_ids = [TEST_CELL_ID_LIST[2], TEST_CELL_ID_LIST[3]]
         expected_ids = (
             TEST_CELL_IDs[TEST_CELL_ID_LIST[2]] + TEST_CELL_IDs[TEST_CELL_ID_LIST[3]]
         )
-        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
+        self.check_get_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list__batch_job__one_ok_one_invalid(
+    def test_get_job_states_by_cell_id__cell_id_list__batch_job__one_ok_one_invalid(
         self,
     ):
         cell_ids = [TEST_CELL_ID_LIST[1], TEST_CELL_ID_LIST[4]]
         expected_ids = TEST_CELL_IDs[TEST_CELL_ID_LIST[1]]
-        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
+        self.check_get_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list__batch_and_other_job(self):
+    def test_get_job_states_by_cell_id__cell_id_list__batch_and_other_job(self):
         cell_ids = [TEST_CELL_ID_LIST[0], TEST_CELL_ID_LIST[2]]
         expected_ids = (
             TEST_CELL_IDs[TEST_CELL_ID_LIST[0]] + TEST_CELL_IDs[TEST_CELL_ID_LIST[2]]
         )
-        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
+        self.check_get_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
-    def test_lookup_job_states_by_cell_id__cell_id_list__batch_in_many_cells(self):
+    def test_get_job_states_by_cell_id__cell_id_list__batch_in_many_cells(self):
         cell_ids = [TEST_CELL_ID_LIST[0], TEST_CELL_ID_LIST[2], TEST_CELL_ID_LIST[3]]
         expected_ids = (
             TEST_CELL_IDs[TEST_CELL_ID_LIST[0]]
             + TEST_CELL_IDs[TEST_CELL_ID_LIST[2]]
             + TEST_CELL_IDs[TEST_CELL_ID_LIST[3]]
         )
-        self.check_lookup_job_states_by_cell_id_results(cell_ids, expected_ids)
+        self.check_get_job_states_by_cell_id_results(cell_ids, expected_ids)
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_get_job_states(self):


### PR DESCRIPTION
# Description of PR purpose/changes

Extremely minor PR, reordering methods in the py job manager and changing the names of some methods to be `get(_all)*_job` instead of `lookup(_all)*_job` for internal consistency in the module.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-678
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
