### PR TITLE
DATAUP-641 - add check for bad select box input from an xsv spec

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Unreleased
+- DATAUP-641 - Adds custom error messages when app cell dropdown menu inputs are incorrect in various different ways.
+
 ### Version 5.0.2
 - SAM-73 - Extends the ability to use app params as arguments for dynamic dropdown calls to inputs that are part of a struct or sequence.
 - DATAUP-696 - Prevent import specifications from being imported with either unknown data types, or data types not currently registered as using the bulk import cell.

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
@@ -9,7 +9,7 @@ define([
     '../validators/constants',
     'select2',
     'bootstrap',
-], ($, Promise, html, UI, Runtime, Validation, Constants, inputUtils) => {
+], ($, Promise, html, UI, Runtime, Validation, inputUtils, Constants) => {
     'use strict';
 
     // Constants
@@ -70,10 +70,20 @@ define([
 
         function validate(value) {
             return Promise.try(() => {
-                return Validation.validateTextString(value, spec.data.constraints, {
-                    invalidValues: model.invalidValues,
-                    invalidError,
-                });
+                const defaultInvalidMessage = `Invalid ${spec.ui.label}: ${value}. Please select a value from the dropdown.`;
+                const validation = Validation.validateTextString(
+                    value || '',
+                    spec.data.constraints,
+                    {
+                        invalidValues: model.invalidValues,
+                        invalidError: invalidError || defaultInvalidMessage,
+                        validValues: model.availableValuesSet,
+                    }
+                );
+                if (validation.diagnosis === Constants.DIAGNOSIS.REQUIRED_MISSING) {
+                    validation.errorMessage = 'Please select a value from the dropdown.';
+                }
+                return validation;
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
@@ -422,6 +422,8 @@ define([
          * @param {object} options (optional). if present, optional values are
          * - invalidValues {Set<string>} set of values that are always invalid
          * - invalidError {string} string to respond with if an invalid value is present
+         * - validValues {Set<string>} set of allowed values - if present, and the value doesn't
+         *   match one of these, it will resolve to invalid.
          */
         function validateTextString(value, constraints, options = {}) {
             let parsedValue,
@@ -448,6 +450,9 @@ define([
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = 'value must be a string (it is of type "' + typeof value + '")';
             } else if (options.invalidValues && options.invalidValues.has(value)) {
+                diagnosis = Constants.DIAGNOSIS.INVALID;
+                errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
+            } else if (options.validValues && !options.validValues.has(value)) {
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
             } else {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
@@ -449,10 +449,10 @@ define([
             } else if (typeof value !== 'string') {
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = 'value must be a string (it is of type "' + typeof value + '")';
-            } else if (options.invalidValues && options.invalidValues.has(value)) {
-                diagnosis = Constants.DIAGNOSIS.INVALID;
-                errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
-            } else if (options.validValues && !options.validValues.has(value)) {
+            } else if (
+                (options.invalidValues && options.invalidValues.has(value)) ||
+                (options.validValues && !options.validValues.has(value))
+            ) {
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
             } else {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -263,7 +263,7 @@ define([
             data.types[dataType] = data.types[dataType].map((parameterSet) => {
                 Object.keys(parameterSet).forEach((paramId) => {
                     const value = parameterSet[paramId];
-                    if (specParams[paramId]) {
+                    if (specParams[paramId] && value in specParams[paramId]) {
                         parameterSet[paramId] = specParams[paramId][value];
                     }
                 });


### PR DESCRIPTION
# Description of PR purpose/changes

Actually adding error checks now! This one shows an error in select box dropdowns if an xsv file has an invalid entry (or, really, if any value is set that isn't one of the options).

Design from https://kbase-jira.atlassian.net/browse/DATAUP-408
![Z3 In-app error - bad param for static dropdown](https://user-images.githubusercontent.com/2152243/154733123-36318459-4c96-4c22-b37f-b8ee21116cbd.png)

Working example:
![Screen Shot 2022-02-18 at 12 32 36 PM](https://user-images.githubusercontent.com/2152243/154733232-8bd97200-f12f-4643-87f2-3f6a98e684ad.png)

Another example with custom error text in different cases:
![Screen Shot 2022-02-18 at 12 32 48 PM](https://user-images.githubusercontent.com/2152243/154733274-bbae5edb-f898-4c25-84cb-e8a1e44a3bac.png)

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-641
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
