### PR TITLE
DATAUP-678: Remove batch jobs from the job lookup loop

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -163,7 +163,8 @@ class JobManager(object):
 
             # Set to refresh when job is not in terminal state
             # and when job is present in cells (if given)
-            refresh = not job.was_terminal()
+            # and when it is not part of a batch
+            refresh = not job.was_terminal() and not job.batch_id
             if cell_ids is not None:
                 refresh = refresh and job.in_cells(cell_ids)
 

--- a/src/biokbase/narrative/tests/job_test_constants.py
+++ b/src/biokbase/narrative/tests/job_test_constants.py
@@ -94,12 +94,17 @@ JOBS_TERMINALITY = {
 
 TERMINAL_JOBS = []
 ACTIVE_JOBS = []
+REFRESH_STATE = {}
 for key, value in JOBS_TERMINALITY.items():
     if value:
         TERMINAL_JOBS.append(key)
     else:
         ACTIVE_JOBS.append(key)
-
+    # job refresh state
+    if key in BATCH_PARENT_CHILDREN:
+        REFRESH_STATE[key] = False
+    else:
+        REFRESH_STATE[key] = not value
 
 READS_OBJ_1 = "rhodobacterium.art.q20.int.PE.reads"
 READS_OBJ_2 = "rhodobacterium.art.q10.PE.reads"

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -56,6 +56,7 @@ from biokbase.narrative.tests.job_test_constants import (
     ALL_JOBS,
     BAD_JOBS,
     ACTIVE_JOBS,
+    REFRESH_STATE,
     BATCH_PARENT_CHILDREN,
     BATCH_CHILDREN,
     generate_error,
@@ -383,7 +384,11 @@ class JobCommTestCase(unittest.TestCase):
         self.assertEqual(
             {
                 "msg_type": STATUS_ALL,
-                "content": {id: ALL_RESPONSE_DATA[STATUS][id] for id in ACTIVE_JOBS},
+                "content": {
+                    id: ALL_RESPONSE_DATA[STATUS][id]
+                    for id in REFRESH_STATE
+                    if REFRESH_STATE[id]
+                },
             },
             msg,
         )
@@ -413,7 +418,7 @@ class JobCommTestCase(unittest.TestCase):
                     job_id
                     for cell_id, job_ids in JOBS_BY_CELL_ID.items()
                     for job_id in job_ids
-                    if cell_id in combo and not JOBS_TERMINALITY[job_id]
+                    if cell_id in combo and REFRESH_STATE[job_id]
                 ]
                 exp_msg = {
                     "msg_type": "job_status_all",
@@ -1108,7 +1113,7 @@ class JobCommTestCase(unittest.TestCase):
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    not JOBS_TERMINALITY[job_id],
+                    REFRESH_STATE[job_id],
                 )
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
@@ -1125,12 +1130,12 @@ class JobCommTestCase(unittest.TestCase):
             if job_id in job_id_list:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0),
+                    False,
                 )
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
+                    REFRESH_STATE[job_id],
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
@@ -1154,14 +1159,11 @@ class JobCommTestCase(unittest.TestCase):
 
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0),
-                )
+                self.assertEqual(self.jm._running_jobs[job_id]["refresh"], False)
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
+                    REFRESH_STATE[job_id],
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)
@@ -1179,14 +1181,11 @@ class JobCommTestCase(unittest.TestCase):
         )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0),
-                )
+                self.assertEqual(self.jm._running_jobs[job_id]["refresh"], False)
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
+                    REFRESH_STATE[job_id],
                 )
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
@@ -1209,7 +1208,7 @@ class JobCommTestCase(unittest.TestCase):
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    not JOBS_TERMINALITY[job_id],
+                    REFRESH_STATE[job_id],
                 )
         self.assertTrue(self.jc._lookup_timer)
         self.assertTrue(self.jc._running_lookup_loop)
@@ -1225,14 +1224,11 @@ class JobCommTestCase(unittest.TestCase):
         )
         for job_id in ALL_JOBS:
             if job_id in job_id_list:
-                self.assertEqual(
-                    self.jm._running_jobs[job_id]["refresh"],
-                    max(int(not JOBS_TERMINALITY[job_id]) - 1, 0),
-                )
+                self.assertEqual(self.jm._running_jobs[job_id]["refresh"], False)
             else:
                 self.assertEqual(
                     self.jm._running_jobs[job_id]["refresh"],
-                    int(not JOBS_TERMINALITY[job_id]),
+                    REFRESH_STATE[job_id],
                 )
         self.assertIsNone(self.jc._lookup_timer)
         self.assertFalse(self.jc._running_lookup_loop)


### PR DESCRIPTION
# Description of PR purpose/changes

This edit stops the backend from adding any batch jobs to the backend lookup loop; as it is, the BE sends all batch parent jobs to the frontend, even those that finished long ago.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-678
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
