### PR TITLE
DATAUP-641 parameter errors 6 - fix numerical inputs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Unreleased
+- DATAUP-641 - Adds custom error messages when app cell dropdown menu inputs are incorrect in various different ways.
+
 ### Version 5.0.2
 - SAM-73 - Extends the ability to use app params as arguments for dynamic dropdown calls to inputs that are part of a struct or sequence.
 - DATAUP-696 - Prevent import specifications from being imported with either unknown data types, or data types not currently registered as using the bulk import cell.

--- a/kbase-extension/static/buildTools/loadAppWidgets.js
+++ b/kbase-extension/static/buildTools/loadAppWidgets.js
@@ -42,7 +42,6 @@ define([
     'widgets/appWidgets2/subdataMethods/samplePropertyHistogram',
     'widgets/appWidgets2/validators/customSubdata',
     'widgets/appWidgets2/validators/float',
-    'widgets/appWidgets2/validators/int',
     'widgets/appWidgets2/validators/resolver',
     'widgets/appWidgets2/validators/sequence',
     'widgets/appWidgets2/validators/struct',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/floatInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/floatInput.js
@@ -1,6 +1,6 @@
 define([
     'bluebird',
-    'kb_common/html',
+    'common/html',
     'common/events',
     'common/ui',
     'common/props',
@@ -158,6 +158,18 @@ define([
                 initialControlValue = String(currentValue);
             }
 
+            function boundaryDiv(value, isMin) {
+                value = String(value);
+                const text = isMin ? `${value} &#8804; ` : ` &#8804; ${value}`;
+                return div(
+                    {
+                        class: 'input-group-addon kb-input-group-addon',
+                        fontFamily: 'monospace',
+                    },
+                    text
+                );
+            }
+
             return div(
                 {
                     style: { width: '100%' },
@@ -170,15 +182,7 @@ define([
                             style: { width: '100%' },
                         },
                         [
-                            typeof min === 'number'
-                                ? div(
-                                      {
-                                          class: 'input-group-addon kb-input-group-addon',
-                                          fontFamily: 'monospace',
-                                      },
-                                      String(min) + ' &#8804; '
-                                  )
-                                : '',
+                            typeof min === 'number' ? boundaryDiv(min, true) : '',
                             input({
                                 id: events.addEvents({
                                     events: [handleChanged(), handleTouched()],
@@ -191,15 +195,7 @@ define([
                                 },
                                 value: initialControlValue,
                             }),
-                            typeof max === 'number'
-                                ? div(
-                                      {
-                                          class: 'input-group-addon kb-input-group-addon',
-                                          fontFamily: 'monospace',
-                                      },
-                                      ' &#8804; ' + String(max)
-                                  )
-                                : '',
+                            typeof max === 'number' ? boundaryDiv(max, false) : '',
                         ]
                     ),
                     div({

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
@@ -9,7 +9,7 @@ define([
     '../validators/constants',
     'select2',
     'bootstrap',
-], ($, Promise, html, UI, Runtime, Validation, Constants, inputUtils) => {
+], ($, Promise, html, UI, Runtime, Validation, inputUtils, Constants) => {
     'use strict';
 
     // Constants
@@ -70,10 +70,20 @@ define([
 
         function validate(value) {
             return Promise.try(() => {
-                return Validation.validateTextString(value, spec.data.constraints, {
-                    invalidValues: model.invalidValues,
-                    invalidError,
-                });
+                const defaultInvalidMessage = `Invalid ${spec.ui.label}: ${value}. Please select a value from the dropdown.`;
+                const validation = Validation.validateTextString(
+                    value || '',
+                    spec.data.constraints,
+                    {
+                        invalidValues: model.invalidValues,
+                        invalidError: invalidError || defaultInvalidMessage,
+                        validValues: model.availableValuesSet,
+                    }
+                );
+                if (validation.diagnosis === Constants.DIAGNOSIS.REQUIRED_MISSING) {
+                    validation.errorMessage = 'Please select a value from the dropdown.';
+                }
+                return validation;
             });
         }
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
@@ -422,6 +422,8 @@ define([
          * @param {object} options (optional). if present, optional values are
          * - invalidValues {Set<string>} set of values that are always invalid
          * - invalidError {string} string to respond with if an invalid value is present
+         * - validValues {Set<string>} set of allowed values - if present, and the value doesn't
+         *   match one of these, it will resolve to invalid.
          */
         function validateTextString(value, constraints, options = {}) {
             let parsedValue,
@@ -448,6 +450,9 @@ define([
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = 'value must be a string (it is of type "' + typeof value + '")';
             } else if (options.invalidValues && options.invalidValues.has(value)) {
+                diagnosis = Constants.DIAGNOSIS.INVALID;
+                errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
+            } else if (options.validValues && !options.validValues.has(value)) {
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
             } else {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
@@ -449,10 +449,10 @@ define([
             } else if (typeof value !== 'string') {
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = 'value must be a string (it is of type "' + typeof value + '")';
-            } else if (options.invalidValues && options.invalidValues.has(value)) {
-                diagnosis = Constants.DIAGNOSIS.INVALID;
-                errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
-            } else if (options.validValues && !options.validValues.has(value)) {
+            } else if (
+                (options.invalidValues && options.invalidValues.has(value)) ||
+                (options.validValues && !options.validValues.has(value))
+            ) {
                 diagnosis = Constants.DIAGNOSIS.INVALID;
                 errorMessage = options.invalidError ? options.invalidError : 'value is invalid';
             } else {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/resolver.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/resolver.js
@@ -3,10 +3,10 @@ define(['require', 'bluebird', '../validation'], (require, Promise, Validator) =
 
     const typeToValidator = {
         string: Validator.validateTextString,
+        int: Validator.validateIntString,
     };
 
     const typeToValidatorModule = {
-        int: 'int',
         float: 'float',
         sequence: 'sequence',
         struct: 'struct',

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/intView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/intView.js
@@ -1,14 +1,13 @@
 define([
     'bluebird',
-    'kb_common/html',
-    '../validators/int',
+    'common/html',
     'common/events',
     'common/ui',
     'common/props',
     '../inputUtils',
 
     'bootstrap',
-], (Promise, html, Validation, Events, UI, Props) => {
+], (Promise, html, Events, UI, Props) => {
     'use strict';
 
     // Constants
@@ -17,12 +16,16 @@ define([
         input = t('input');
 
     function factory(config) {
-        let spec = config.parameterSpec,
+        const spec = config.parameterSpec,
             bus = config.bus,
-            parent,
-            container,
-            model,
-            ui;
+            model = Props.make({
+                data: {
+                    value: spec.data.nullValue,
+                },
+                onUpdate: function () {},
+            });
+
+        let parent, container, ui;
 
         // MODEL
 
@@ -44,23 +47,25 @@ define([
 
         function makeViewControl(currentValue) {
             // CONTROL
-            let initialControlValue,
+            const initialControlValue = String(currentValue),
                 min = spec.data.constraints.min,
                 max = spec.data.constraints.max;
-            if (typeof currentValue === 'number') {
-                initialControlValue = String(currentValue);
+
+            function boundaryDiv(value, isMin) {
+                value = String(value);
+                const text = isMin ? `${value} &#8804; ` : ` &#8804; ${value}`;
+                return div(
+                    {
+                        class: 'input-group-addon kb-input-group-addon',
+                        fontFamily: 'monospace',
+                    },
+                    text
+                );
             }
+
             return div({ style: { width: '100%' }, dataElement: 'input-wrapper' }, [
                 div({ class: 'input-group', style: { width: '100%' } }, [
-                    typeof min === 'number'
-                        ? div(
-                              {
-                                  class: 'input-group-addon kb-input-group-addon',
-                                  fontFamily: 'monospace',
-                              },
-                              String(min) + ' &#8804; '
-                          )
-                        : '',
+                    typeof min === 'number' ? boundaryDiv(min, true) : '',
                     input({
                         class: 'form-control',
                         dataElement: 'input',
@@ -71,15 +76,7 @@ define([
                             textAlign: 'right',
                         },
                     }),
-                    typeof max === 'number'
-                        ? div(
-                              {
-                                  class: 'input-group-addon kb-input-group-addon',
-                                  fontFamily: 'monospace',
-                              },
-                              ' &#8804; ' + String(max)
-                          )
-                        : '',
+                    typeof max === 'number' ? boundaryDiv(max, false) : '',
                 ]),
                 div({ dataElement: 'message', style: { backgroundColor: 'red', color: 'white' } }),
             ]);
@@ -141,19 +138,12 @@ define([
 
         // INIT
 
-        model = Props.make({
-            data: {
-                value: spec.data.nullValue,
-            },
-            onUpdate: function () {},
-        });
-
         setModelValue(config.initialValue);
 
         return {
-            start: start,
-            stop: stop,
-            bus: bus,
+            start,
+            stop,
+            bus,
         };
     }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/importSetup.js
@@ -263,7 +263,7 @@ define([
             data.types[dataType] = data.types[dataType].map((parameterSet) => {
                 Object.keys(parameterSet).forEach((paramId) => {
                     const value = parameterSet[paramId];
-                    if (specParams[paramId]) {
+                    if (specParams[paramId] && value in specParams[paramId]) {
                         parameterSet[paramId] = specParams[paramId][value];
                     }
                 });

--- a/test/unit/spec/appWidgets/input/intInputSpec.js
+++ b/test/unit/spec/appWidgets/input/intInputSpec.js
@@ -56,133 +56,135 @@ define(['widgets/appWidgets2/input/intInput', 'common/runtime', 'testUtil'], (
             });
         });
 
-        it('should start and stop properly without initial value', (done) => {
+        it('should start and stop properly without initial value', async () => {
             const widget = IntInput.make(testConfig);
-            widget
-                .start({ node: container })
-                .then(() => {
-                    expect(container.childElementCount).toBeGreaterThan(0);
-                    const input = container.querySelector('input[data-type="int"]');
-                    expect(input).toBeDefined();
-                    expect(input.getAttribute('value')).toBeNull();
-                    return widget.stop();
-                })
-                .then(() => {
-                    expect(container.childElementCount).toBe(0);
-                    done();
-                });
+            await widget.start({ node: container });
+            expect(container.childElementCount).toBeGreaterThan(0);
+            const input = container.querySelector('input[data-type="int"]');
+            expect(input).toBeDefined();
+            expect(input.getAttribute('value')).toBe(testConfig.parameterSpec.data.nullValue);
+            await widget.stop();
+            expect(container.childElementCount).toBe(0);
         });
 
-        it('should start and stop properly with initial value', (done) => {
+        it('should start and stop properly with initial value', async () => {
             testConfig.initialValue = 10;
             const widget = IntInput.make(testConfig);
-            widget
-                .start({ node: container })
-                .then(() => {
-                    expect(container.childElementCount).toBeGreaterThan(0);
-                    const input = container.querySelector('input[data-type="int"]');
-                    expect(input).toBeDefined();
-                    expect(input.getAttribute('value')).toBe(String(testConfig.initialValue));
-                    return widget.stop();
-                })
-                .then(() => {
-                    expect(container.childElementCount).toBe(0);
-                    done();
-                });
+            await widget.start({ node: container });
+            expect(container.childElementCount).toBeGreaterThan(0);
+            const input = container.querySelector('input[data-type="int"]');
+            expect(input).toBeDefined();
+            expect(input.getAttribute('value')).toBe(String(testConfig.initialValue));
+            await widget.stop();
+            expect(container.childElementCount).toBe(0);
         });
 
-        it('should update model properly with change event', (done) => {
+        it('should update model properly with change event', async () => {
+            const widget = IntInput.make(testConfig);
+            let changeMsg;
             bus.on('changed', (value) => {
-                expect(value).toEqual({ newValue: 1 });
-                done();
+                changeMsg = value;
             });
-            const widget = IntInput.make(testConfig);
-            widget.start({ node: container }).then(() => {
-                const input = container.querySelector('input[data-type="int"]');
-                input.setAttribute('value', 1);
-                input.dispatchEvent(new Event('change'));
-            });
+            await widget.start({ node: container });
+            const input = container.querySelector('input[data-type="int"]');
+            input.setAttribute('value', 1);
+            input.dispatchEvent(new Event('change'));
+            await TestUtil.wait(500);
+            expect(changeMsg).toEqual({ newValue: 1 });
+            await widget.stop();
         });
 
-        xit('should update model properly with keyup/touch event', (done) => {
+        it('should update model properly with keyup event', async () => {
             const widget = IntInput.make(testConfig);
+            let validMsg;
             bus.on('validation', (message) => {
-                expect(message.isValid).toBeFalsy();
-                done();
+                validMsg = message;
             });
-            widget.start({ node: container }).then(() => {
-                const input = container.querySelector('input[data-type="int"]');
-                input.value = 'foo';
-                input.setAttribute('value', 'foo');
-                input.dispatchEvent(new KeyboardEvent('keyup', { key: 3 }));
-            });
+            await widget.start({ node: container });
+            const input = container.querySelector('input[data-type="int"]');
+            input.value = 'foo';
+            input.setAttribute('value', 'foo');
+            input.dispatchEvent(new KeyboardEvent('keyup', { key: 3 }));
+            await TestUtil.wait(500);
+            expect(validMsg.isValid).toBeFalsy();
+            await widget.stop();
         });
 
-        it('should catch invalid string input', (done) => {
+        it('should catch invalid string input', async () => {
             const widget = IntInput.make(testConfig);
+            let validMsg;
             bus.on('validation', (msg) => {
-                expect(msg.isValid).toBeFalsy();
-                expect(msg.diagnosis).toBe('invalid');
-                done();
+                validMsg = msg;
             });
-            widget.start({ node: container }).then(() => {
-                const input = container.querySelector('input[data-type="int"]');
-                input.setAttribute('value', 'abracadabra');
-                input.dispatchEvent(new Event('change'));
-            });
+            await widget.start({ node: container });
+
+            const input = container.querySelector('input[data-type="int"]');
+            input.setAttribute('value', 'abracadabra');
+            input.dispatchEvent(new Event('change'));
+            await TestUtil.wait(500);
+            expect(validMsg.isValid).toBeFalsy();
+            expect(validMsg.diagnosis).toBe('invalid');
+            await widget.stop();
         });
 
-        it('should catch invalid float input', (done) => {
+        it('should catch invalid float input', async () => {
             const widget = IntInput.make(testConfig);
+            let validMsg;
             bus.on('validation', (msg) => {
-                expect(msg.isValid).toBeFalsy();
-                expect(msg.diagnosis).toBe('invalid');
-                done();
+                validMsg = msg;
             });
-            widget.start({ node: container }).then(() => {
-                const input = container.querySelector('input[data-type="int"]');
-                input.setAttribute('value', 12345.6);
-                input.dispatchEvent(new Event('change'));
-            });
+            await widget.start({ node: container });
+            const input = container.querySelector('input[data-type="int"]');
+            input.setAttribute('value', 12345.6);
+            input.dispatchEvent(new Event('change'));
+            await TestUtil.wait(500);
+            expect(validMsg.isValid).toBeFalsy();
+            expect(validMsg.diagnosis).toBe('invalid');
+            await widget.stop();
         });
 
-        it('should show message when configured, valid input', (done) => {
+        it('should show message when configured, valid input', async () => {
             testConfig.showOwnMessages = true;
             const widget = IntInput.make(testConfig);
+            let changeMsg;
             bus.on('changed', (value) => {
-                expect(value).toEqual({ newValue: 5 });
-                // message node will be empty
-                const errorMsg = container.querySelector('[data-element="message"]');
-                expect(errorMsg.innerHTML).toBe('');
-                done();
+                changeMsg = value;
             });
-            widget.start({ node: container }).then(() => {
-                const input = container.querySelector('input[data-type="int"]');
-                input.setAttribute('value', 5);
-                input.dispatchEvent(new Event('change'));
-            });
+            await widget.start({ node: container });
+            const input = container.querySelector('input[data-type="int"]');
+            input.setAttribute('value', 5);
+            input.dispatchEvent(new Event('change'));
+            await TestUtil.wait(500);
+            expect(changeMsg).toEqual({ newValue: 5 });
+            // message node will be empty
+            const errorMsg = container.querySelector('[data-element="message"]');
+            expect(errorMsg.innerHTML).toBe('');
+            await widget.stop();
         });
 
-        it('should show message when configured, invalid input', (done) => {
+        it('should show message when configured, invalid input', async () => {
             testConfig.showOwnMessages = true;
             const widget = IntInput.make(testConfig);
+            let changeMsg;
             bus.on('changed', (value) => {
-                expect(value).toEqual({ newValue: 123456 });
-                // check for an error message in the node
-                const errorMsg = container.querySelector('[data-element="message"]');
-                expect(errorMsg.innerHTML).toContain('ERROR');
+                changeMsg = value;
             });
+            let validMsg;
             bus.on('validation', (msg) => {
-                expect(msg.isValid).toBeFalsy();
-                expect(msg.diagnosis).toBe('invalid');
-                done();
+                validMsg = msg;
             });
-            widget.start({ node: container }).then(() => {
-                const input = container.querySelector('input[data-type="int"]');
-                // this value is out of the allowed range
-                input.setAttribute('value', 123456);
-                input.dispatchEvent(new Event('change'));
-            });
+            await widget.start({ node: container });
+            const input = container.querySelector('input[data-type="int"]');
+            // this value is out of the allowed range
+            input.setAttribute('value', 123456);
+            input.dispatchEvent(new Event('change'));
+            await TestUtil.wait(1000);
+            expect(changeMsg).toEqual({ newValue: 123456 });
+            // check for an error message in the node
+            const errorMsg = container.querySelector('[data-element="message"]');
+            expect(errorMsg.innerHTML).toContain('ERROR');
+            expect(validMsg.isValid).toBeFalsy();
+            expect(validMsg.diagnosis).toBe('invalid');
         });
 
         // this sets the model values but does nothing to the UI

--- a/test/unit/spec/appWidgets/validationSpec.js
+++ b/test/unit/spec/appWidgets/validationSpec.js
@@ -654,7 +654,7 @@ define([
             runTests('validateFloatString', tests);
         })();
 
-        // INTS
+        // INTEGERS
         (function () {
             const emptyValues = [
                     {
@@ -778,7 +778,8 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: Constants.DIAGNOSIS.INVALID,
-                            errorMessage: 'value must be a string (it is of type "undefined")',
+                            errorMessage:
+                                'value must be a string or number (it is of type "undefined")',
                             value: undefined,
                             pasedValue: undefined,
                         },
@@ -790,7 +791,8 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: Constants.DIAGNOSIS.INVALID,
-                            errorMessage: 'value must be a string (it is of type "object")',
+                            errorMessage:
+                                'value must be a string or number (it is of type "object")',
                             value: [],
                             parsedValue: undefined,
                         },
@@ -802,7 +804,8 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: Constants.DIAGNOSIS.INVALID,
-                            errorMessage: 'value must be a string (it is of type "object")',
+                            errorMessage:
+                                'value must be a string or number (it is of type "object")',
                             value: {},
                             parsedValue: undefined,
                         },
@@ -814,7 +817,8 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: Constants.DIAGNOSIS.INVALID,
-                            errorMessage: 'value must be a string (it is of type "object")',
+                            errorMessage:
+                                'value must be a string or number (it is of type "object")',
                             value: new Date(0),
                             parsedValue: undefined,
                         },

--- a/test/unit/spec/common/validate2-Spec.js
+++ b/test/unit/spec/common/validate2-Spec.js
@@ -1,11 +1,10 @@
 define([
     'bluebird',
     'widgets/appWidgets2/validation',
-    'widgets/appWidgets2/validators/int',
     'widgets/appWidgets2/validators/resolver',
     'widgets/appWidgets2/validators/constants',
     'testUtil',
-], (Promise, Validation, IntValidation, ValidationResolver, Constants, TestUtil) => {
+], (Promise, Validation, ValidationResolver, Constants, TestUtil) => {
     'use strict';
 
     describe('Validator2 core functions', () => {
@@ -99,144 +98,6 @@ define([
                     max_length: 10,
                 })
             ).then((result) => {
-                expect(result.isValid).toEqual(false);
-                done();
-            });
-        });
-
-        // INTEGER
-        it('Validate an integer without constraints', (done) => {
-            const spec = {
-                data: {
-                    constraints: {},
-                },
-            };
-            wrap(IntValidation.validate(42, spec)).then((result) => {
-                expect(result.isValid).toEqual(true);
-                done();
-            });
-        });
-        it('Validate an integer, required, valid value', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(42, spec)).then((result) => {
-                expect(result.isValid).toEqual(true);
-                done();
-            });
-        });
-        it('Validate an integer, required, empty string value', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                    },
-                },
-            };
-            wrap(IntValidation.validate('', spec)).then((result) => {
-                expect(result.isValid).toEqual(false);
-                done();
-            });
-        });
-        it('Validate an integer, required, null value', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(null, spec)).then((result) => {
-                expect(result.isValid).toEqual(false);
-                done();
-            });
-        });
-        it('Validate an integer, required, NaN value', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(0 / 0, spec)).then((result) => {
-                expect(result.isValid).toEqual(false);
-                done();
-            });
-        });
-        it('Validate an integer, required, float value', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(1.23, spec)).then((result) => {
-                expect(result.isValid).toEqual(false);
-                done();
-            });
-        });
-        it('Validate an integer, required, range given, within range', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                        min_int: 5,
-                        max_int: 10,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(7, spec)).then((result) => {
-                expect(result.isValid).toEqual(true);
-                done();
-            });
-        });
-        it('Validate an integer, required, range given, below range', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                        min_int: 5,
-                        max_int: 10,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(3, spec)).then((result) => {
-                expect(result.isValid).toEqual(true);
-                done();
-            });
-        });
-        it('Validate an integer, required, range given, above range', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                        min_int: 5,
-                        max_int: 10,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(24, spec)).then((result) => {
-                expect(result.isValid).toEqual(true);
-                done();
-            });
-        });
-        it('Validate an integer, required, range given, wrong type (date)', (done) => {
-            const spec = {
-                data: {
-                    constraints: {
-                        required: true,
-                        min_int: 5,
-                        max_int: 10,
-                    },
-                },
-            };
-            wrap(IntValidation.validate(new Date(), spec)).then((result) => {
                 expect(result.isValid).toEqual(false);
                 done();
             });
@@ -383,7 +244,7 @@ define([
                         result: {
                             isValid: false,
                             diagnosis: Constants.DIAGNOSIS.INVALID,
-                            errorMessage: 'value must be numeric',
+                            errorMessage: 'Invalid integer format',
                         },
                     },
                 ],


### PR DESCRIPTION
## DO NOT MERGE
# Description of PR purpose/changes

The goal here is to change app cell numerical input fields to show errors from the XSV inputs. This means:
1. showing invalid text that users put in spreadsheets
2. showing a more readable error string

From the mockup:
![Z4 In-app error - bad param for typed field](https://user-images.githubusercontent.com/2152243/154773422-e7127fff-7dbd-4e68-9517-998377677aea.png)

It's proving a bit more challenging to show that an input's a float instead of an integer (implied in the "received string") vs. a string, so I tweaked it a bit to look like this:
![Screen Shot 2022-02-18 at 6 16 59 PM](https://user-images.githubusercontent.com/2152243/154773567-0fa2874b-a6ec-4c98-9d62-2e9aaab75422.png)

Still todo: 
* adjust error layout (size, padding, orientation)
* apply changes to the floatInput widget

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
