### PR TITLE
DATAUP-678: Adding mixin for using job manager with single jobs

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobCommChannel.js
+++ b/kbase-extension/static/kbase/js/common/jobCommChannel.js
@@ -195,7 +195,7 @@ define([
          * If a batch ID does not exist, a job ID mapping is made instead:
          *
          * _jobMapping: {
-         *      [job_id]: { [jcm.PARAM.JOB_ID: job_id }
+         *      [job_id]: { [jcm.PARAM.JOB_ID]: job_id }
          * }
          *
          * @param {object} jobStateObj
@@ -248,6 +248,7 @@ define([
             // if there is no valid data, abort
             if (!('valid' in validated)) {
                 this.debug('no valid data in backend message');
+                console.error(msgType, msgData);
                 return;
             }
 

--- a/kbase-extension/static/kbase/js/common/jobManager.js
+++ b/kbase-extension/static/kbase/js/common/jobManager.js
@@ -15,6 +15,9 @@ define([
         retry: jcm.MESSAGE_TYPE.RETRY,
     };
 
+    // how soon after receiving job status updates from the backend to send the next status request
+    const DEFAULT_STATUS_REQUEST_INTERVAL = 2500;
+
     class JobManagerCore {
         /**
          * Initialise the job manager
@@ -374,34 +377,94 @@ define([
                 this.removeChannelListeners(channelType, channelId);
             });
         }
-
-        /**
-         * Update the model with the supplied jobState objects
-         * @param {array} jobArray list of jobState objects to update the model with
-         */
-        updateModel(jobArray) {
-            const jobIndex = this.model.getItem('exec.jobs');
-            const batchId = this.model.getItem('exec.jobState.job_id');
-            let batchJob;
-            jobArray.forEach((jobState) => {
-                // update the job object
-                jobIndex.byId[jobState.job_id] = jobState;
-                if (jobState.job_id === batchId) {
-                    batchJob = jobState;
-                }
-            });
-            this.model.setItem('exec.jobs', jobIndex);
-            // check whether the batch parent needs updating
-            if (batchJob) {
-                this.model.setItem('exec.jobState', batchJob);
-            }
-            this.runHandler('modelUpdate', jobArray);
-            return this.model;
-        }
     }
 
+    const SingleJobMixin = (Base) =>
+        class extends Base {
+            constructor(config) {
+                // run the constructor for the base class
+                super(config);
+                this.pollInterval = config.pollInterval || DEFAULT_STATUS_REQUEST_INTERVAL;
+            }
+
+            init() {
+                const job = this.model.getItem('exec.jobState');
+                if (!job) {
+                    throw new Error('Cannot init without a job');
+                }
+
+                const self = this;
+                ['ERROR', 'INFO', 'LOGS', 'STATUS'].forEach((msgType) => {
+                    this.addListener(jcm.MESSAGE_TYPE[msgType], jcm.CHANNEL.JOB, job.job_id);
+                });
+
+                if (!this.looper) {
+                    this.looper = new Looper({ pollInterval: this.pollInterval });
+                }
+
+                this.addEventHandler(jcm.MESSAGE_TYPE.STATUS, {
+                    // default job status handler
+                    [`__default_${jcm.MESSAGE_TYPE.STATUS}`]: self.handleJobStatus.bind(self),
+
+                    // set up a delayed request for job status, executed after this.pollInterval ms
+                    jobStatusLooper: () => {
+                        self.looper.scheduleRequest(self.requestJobStatus.bind(self));
+                    },
+                });
+                this.bus.emit(jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: job.job_id });
+            }
+
+            /**
+             * Update the stored jobState object and run the 'modelUpdate' handler
+             *
+             * @param {object} jobState
+             * @returns this.model
+             */
+            updateModel(jobState) {
+                this.model.setItem('exec.jobState', jobState);
+                this.runHandler('modelUpdate', [jobState]);
+                return this.model;
+            }
+
+            /**
+             * Request the status of the stored job
+             */
+            requestJobStatus() {
+                const job = this.model.getItem('exec.jobState');
+
+                if (Jobs.isTerminalStatus(job.status)) {
+                    // no more updates. Remove the looping request handler
+                    this.looper.clearRequest();
+                    this.removeEventHandler(jcm.MESSAGE_TYPE.STATUS, 'jobStatusLooper');
+                    return;
+                }
+
+                this.bus.emit(jcm.MESSAGE_TYPE.STATUS, {
+                    [jcm.PARAM.JOB_ID]: job.job_id,
+                });
+            }
+
+            /**
+             * Default handler for a job status message, which updates the stored job if applicable
+             *
+             * @param {Object} message
+             */
+            handleJobStatus(self, message) {
+                const job = this.model.getItem('exec.jobState');
+                if (message[job.job_id]) {
+                    const jobState = message[job.job_id].jobState;
+                    if (_.isEqual(jobState, job)) {
+                        // no update required
+                        return;
+                    }
+                    // update the model
+                    self.updateModel(jobState);
+                }
+            }
+        };
+
     /**
-     * A set of generic message handlers
+     * A set of generic message handlers for batch jobs
      *
      * @param {class} Base
      * @returns
@@ -426,6 +489,30 @@ define([
                     toAdd[`__default_${jcm.MESSAGE_TYPE[event]}`] = defaultHandlers[event];
                     this.addEventHandler(jcm.MESSAGE_TYPE[event], toAdd);
                 }, this);
+            }
+
+            /**
+             * Update the model with the supplied jobState objects
+             * @param {array} jobArray list of jobState objects to update the model with
+             */
+            updateModel(jobArray) {
+                const jobIndex = this.model.getItem('exec.jobs');
+                const batchId = this.model.getItem('exec.jobState.job_id');
+                let batchJob;
+                jobArray.forEach((jobState) => {
+                    // update the job object
+                    jobIndex.byId[jobState.job_id] = jobState;
+                    if (jobState.job_id === batchId) {
+                        batchJob = jobState;
+                    }
+                });
+                this.model.setItem('exec.jobs', jobIndex);
+                // check whether the batch parent needs updating
+                if (batchJob) {
+                    this.model.setItem('exec.jobState', batchJob);
+                }
+                this.runHandler('modelUpdate', jobArray);
+                return this.model;
             }
 
             /**
@@ -744,6 +831,11 @@ define([
 
     const BatchMixin = (Base) =>
         class extends Base {
+            constructor(config) {
+                // run the constructor for the base class
+                super(config);
+                this.pollInterval = config.pollInterval || DEFAULT_STATUS_REQUEST_INTERVAL;
+            }
             /**
              * set up the job manager to handle a batch job
              *
@@ -798,7 +890,7 @@ define([
                 });
 
                 if (!this.looper) {
-                    this.looper = new Looper();
+                    this.looper = new Looper({ pollInterval: this.pollInterval });
                 }
 
                 // set up repeated requests for batch status
@@ -836,20 +928,22 @@ define([
             }
 
             /**
-             * send a message requesting status updates for all
-             * non-terminal jobs in the batch
+             * Examine the jobs in the model and create an array of job IDs to be updated
+             *
+             * @returns {array} jobsToUpdate
              */
-            requestBatchStatus() {
+
+            _getJobsToUpdate() {
                 const jobsById = this.model.getItem('exec.jobs.byId'),
                     batchJob = this.model.getItem('exec.jobState');
 
                 // no stored jobs
                 if (!jobsById || !batchJob || !Object.keys(jobsById).length) {
-                    return;
+                    return [];
                 }
                 // terminal batch job ==> no updates to child jobs
                 if (Jobs.isTerminalStatus(batchJob.status)) {
-                    return;
+                    return [];
                 }
 
                 const batchId = batchJob.job_id;
@@ -866,19 +960,31 @@ define([
                         return job.job_id;
                     });
 
-                if (jobsToUpdate.length) {
-                    // if the only job to update is the batch job, skip the request
-                    if (jobsToUpdate.length === 1 && jobsToUpdate[0] === batchId) {
-                        return;
-                    }
-                    const args = {
-                        [jcm.PARAM.JOB_ID_LIST]: jobsToUpdate,
-                    };
-                    if (this.lastUpdate) {
-                        args.timestamp = this.lastUpdate;
-                    }
-                    this.bus.emit(jcm.MESSAGE_TYPE.STATUS, args);
+                // if the only job to update is the batch job, skip the request
+                if (jobsToUpdate.length === 1 && jobsToUpdate[0] === batchId) {
+                    return [];
                 }
+                return jobsToUpdate;
+            }
+
+            /**
+             * send a message requesting status updates for all
+             * non-terminal jobs in the batch
+             */
+            requestBatchStatus() {
+                const jobsToUpdate = this._getJobsToUpdate();
+
+                if (!jobsToUpdate.length) {
+                    return;
+                }
+
+                const args = {
+                    [jcm.PARAM.JOB_ID_LIST]: jobsToUpdate,
+                };
+                if (this.lastUpdate) {
+                    args.timestamp = this.lastUpdate;
+                }
+                this.bus.emit(jcm.MESSAGE_TYPE.STATUS, args);
             }
 
             /**
@@ -942,11 +1048,15 @@ define([
 
     class JobManager extends BatchMixin(JobActionsMixin(DefaultHandlerMixin(JobManagerCore))) {}
 
+    class SingleJobManager extends SingleJobMixin(JobManagerCore) {}
+
     return {
         JobManagerCore,
         DefaultHandlerMixin,
         JobActionsMixin,
         BatchMixin,
+        SingleJobMixin,
+        SingleJobManager,
         JobManager,
     };
 });

--- a/test/data/jobsData.js
+++ b/test/data/jobsData.js
@@ -903,29 +903,30 @@ define([
         return [
             {
                 ...jobsById[JOB.CREATED],
-                job_id: TEST_JOB_ID,
+                job_id: JOB.CREATED,
             },
             {
                 ...jobsById[JOB.ESTIMATING],
-                job_id: TEST_JOB_ID,
+                job_id: JOB.CREATED,
             },
             {
                 ...jobsById[JOB.QUEUED],
-                job_id: TEST_JOB_ID,
+                job_id: JOB.CREATED,
             },
             {
                 ...jobsById[JOB.RUNNING],
-                job_id: TEST_JOB_ID,
+                job_id: JOB.CREATED,
             },
             {
                 ...jobsById[JOB.COMPLETED],
-                job_id: TEST_JOB_ID,
+                job_id: JOB.CREATED,
             },
         ];
     }
 
     return {
         TEST_JOB_ID,
+        JOB_NAMES: JOB,
         validJobs,
         unknownJob,
         batchParentJob,

--- a/test/unit/spec/common/jobCommChannel-spec.js
+++ b/test/unit/spec/common/jobCommChannel-spec.js
@@ -13,14 +13,9 @@ define([
     // allow spies to be overwritten
     jasmine.getEnv().allowRespy(true);
 
-    const TEST_JOB_ID = 'someJob',
+    const { TEST_JOB_ID } = JobsData,
         TEST_JOB_LIST = [TEST_JOB_ID, 'anotherJob', 'aThirdJob'],
         ERROR_STR = 'Some error string';
-
-    const { JOB_ID, JOB_ID_LIST, BATCH_ID } = jcm.PARAM,
-        JOB_CHANNEL = jcm.CHANNEL.JOB,
-        CELL_CHANNEL = jcm.CHANNEL.CELL,
-        BATCH_CHANNEL = jcm.CHANNEL.BATCH;
 
     const responseDataJobMapping = {};
     const batchJobs = {};
@@ -156,9 +151,9 @@ define([
             });
 
             const messagesToSend = [
-                [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 0 }],
-                [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 1 }],
-                [jcm.MESSAGE_TYPE.STATUS, { [JOB_ID]: 2 }],
+                [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: 0 }],
+                [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: 1 }],
+                [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: 2 }],
             ];
             const messagesInQueue = messagesToSend.map((arg) => {
                 return {
@@ -171,7 +166,7 @@ define([
                     {
                         target_name: 'KBaseJobs',
                         request_type: jcm.MESSAGE_TYPE.STATUS,
-                        [JOB_ID]: num,
+                        [jcm.PARAM.JOB_ID]: num,
                     },
                 ];
             });
@@ -191,7 +186,7 @@ define([
                             'ERROR sending comm message: ' + comm.ERROR_COMM_CHANNEL_NOT_INIT
                         );
                         // resolve the promise on receiving the last message
-                        if (args[1][JOB_ID] === 2) {
+                        if (args[1][jcm.PARAM.JOB_ID] === 2) {
                             resolve();
                         }
                     });
@@ -223,7 +218,7 @@ define([
                             }
                             return comm.sendCommMessage.and.originalFn.call(comm, ...args);
                         }
-                        const jobId = args[1][JOB_ID];
+                        const jobId = args[1][jcm.PARAM.JOB_ID];
                         // original function should throw an error
                         await expectAsync(
                             comm.sendCommMessage.and.originalFn.call(comm, ...args)
@@ -274,7 +269,7 @@ define([
                             }
                             return comm.sendCommMessage.and.originalFn.call(comm, ...args);
                         }
-                        const jobId = args[1][JOB_ID];
+                        const jobId = args[1][jcm.PARAM.JOB_ID];
                         if (jobId < 2) {
                             // original function should throw an error
                             await expectAsync(
@@ -331,68 +326,68 @@ define([
             const busMsgCases = [
                 {
                     channel: jcm.MESSAGE_TYPE.LOGS,
-                    message: { [JOB_ID]: TEST_JOB_ID },
+                    message: { [jcm.PARAM.JOB_ID]: TEST_JOB_ID },
                     expected: {
                         request_type: jcm.MESSAGE_TYPE.LOGS,
-                        [JOB_ID]: TEST_JOB_ID,
+                        [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                     },
                 },
                 {
                     channel: jcm.MESSAGE_TYPE.LOGS,
                     message: {
-                        [JOB_ID]: TEST_JOB_ID,
+                        [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                         latest: true,
                     },
                     expected: {
                         request_type: jcm.MESSAGE_TYPE.LOGS,
-                        [JOB_ID]: TEST_JOB_ID,
+                        [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                         latest: true,
                     },
                 },
                 {
                     channel: jcm.MESSAGE_TYPE.LOGS,
                     message: {
-                        [JOB_ID]: TEST_JOB_ID,
+                        [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                         first_line: 2000,
                         latest: true,
                     },
                     expected: {
                         request_type: jcm.MESSAGE_TYPE.LOGS,
-                        [JOB_ID]: TEST_JOB_ID,
+                        [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                         first_line: 2000,
                         latest: true,
                     },
                 },
                 {
                     channel: jcm.MESSAGE_TYPE.CANCEL,
-                    message: { [JOB_ID]: TEST_JOB_ID },
+                    message: { [jcm.PARAM.JOB_ID]: TEST_JOB_ID },
                     expected: {
                         request_type: jcm.MESSAGE_TYPE.CANCEL,
-                        [JOB_ID]: TEST_JOB_ID,
+                        [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                     },
                 },
                 {
                     channel: jcm.MESSAGE_TYPE.CANCEL,
-                    message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                    message: { [jcm.PARAM.JOB_ID_LIST]: TEST_JOB_LIST },
                     expected: {
                         request_type: jcm.MESSAGE_TYPE.CANCEL,
-                        [JOB_ID_LIST]: TEST_JOB_LIST,
+                        [jcm.PARAM.JOB_ID_LIST]: TEST_JOB_LIST,
                     },
                 },
                 {
                     channel: jcm.MESSAGE_TYPE.RETRY,
-                    message: { [JOB_ID]: TEST_JOB_ID },
+                    message: { [jcm.PARAM.JOB_ID]: TEST_JOB_ID },
                     expected: {
                         request_type: jcm.MESSAGE_TYPE.RETRY,
-                        [JOB_ID]: TEST_JOB_ID,
+                        [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                     },
                 },
                 {
                     channel: jcm.MESSAGE_TYPE.RETRY,
-                    message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                    message: { [jcm.PARAM.JOB_ID_LIST]: TEST_JOB_LIST },
                     expected: {
                         request_type: jcm.MESSAGE_TYPE.RETRY,
-                        [JOB_ID_LIST]: TEST_JOB_LIST,
+                        [jcm.PARAM.JOB_ID_LIST]: TEST_JOB_LIST,
                     },
                 },
             ];
@@ -403,26 +398,26 @@ define([
                 busMsgCases.push(
                     {
                         channel: jcm.MESSAGE_TYPE[type],
-                        message: { [JOB_ID]: TEST_JOB_ID },
+                        message: { [jcm.PARAM.JOB_ID]: TEST_JOB_ID },
                         expected: {
                             request_type: jcm.MESSAGE_TYPE[type],
-                            [JOB_ID]: TEST_JOB_ID,
+                            [jcm.PARAM.JOB_ID]: TEST_JOB_ID,
                         },
                     },
                     {
                         channel: jcm.MESSAGE_TYPE[type],
-                        message: { [JOB_ID_LIST]: TEST_JOB_LIST },
+                        message: { [jcm.PARAM.JOB_ID_LIST]: TEST_JOB_LIST },
                         expected: {
                             request_type: jcm.MESSAGE_TYPE[type],
-                            [JOB_ID_LIST]: TEST_JOB_LIST,
+                            [jcm.PARAM.JOB_ID_LIST]: TEST_JOB_LIST,
                         },
                     },
                     {
                         channel: jcm.MESSAGE_TYPE[type],
-                        message: { [BATCH_ID]: 'batch_job' },
+                        message: { [jcm.PARAM.BATCH_ID]: 'batch_job' },
                         expected: {
                             request_type: `${jcm.MESSAGE_TYPE[type]}`,
-                            [BATCH_ID]: 'batch_job',
+                            [jcm.PARAM.BATCH_ID]: 'batch_job',
                         },
                     }
                 );
@@ -464,7 +459,7 @@ define([
                 await comm.initCommChannel();
 
                 await expectAsync(
-                    comm.sendCommMessage('unknown', { [JOB_CHANNEL]: TEST_JOB_ID })
+                    comm.sendCommMessage('unknown', { [jcm.CHANNEL.JOB]: TEST_JOB_ID })
                 ).toBeRejectedWithError(
                     'ERROR sending comm message: Ignoring unknown message type "unknown"'
                 );
@@ -526,12 +521,12 @@ define([
                 const channelOutput = [];
                 Object.keys(output).forEach((jobId) => {
                     const address = {
-                        channel: { [JOB_CHANNEL]: jobId },
+                        channel: { [jcm.CHANNEL.JOB]: jobId },
                         key: { type: messageType },
                     };
 
                     if (jobId in batchJobs) {
-                        address.channel = { [BATCH_CHANNEL]: jobId };
+                        address.channel = { [jcm.CHANNEL.BATCH]: jobId };
                     }
                     channelOutput.push([output[jobId], address]);
                 });
@@ -558,7 +553,7 @@ define([
                                 run_id: 54321,
                             },
                             {
-                                channel: { [CELL_CHANNEL]: 'bar' },
+                                channel: { [jcm.CHANNEL.CELL]: 'bar' },
                                 key: { type: jcm.MESSAGE_TYPE.RUN_STATUS },
                             },
                         ],


### PR DESCRIPTION
# Description of PR purpose/changes

Adding a mixin to allow the job manager to be used with single jobs, not just batches.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-678
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
