### PR TITLE
DATAUP-678: split job log viewer into job state viewer and simple log viewer

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobStateViewer.js
+++ b/kbase-extension/static/kbase/js/common/jobStateViewer.js
@@ -98,7 +98,7 @@ define([
                 this.addEventHandlers();
 
                 // check whether a jobState is available
-                this.lastJobState = this.jobManager.model.getItem(`exec.jobs.byId.${this.jobId}`);
+                this.lastJobState = this.jobManager.getJob(this.jobId);
                 this.renderJobState(this.lastJobState || { job_id: this.jobId });
 
                 this.bus.emit(jcm.MESSAGE_TYPE.STATUS, {
@@ -313,10 +313,10 @@ define([
             }
         };
 
-    class ManagedJobStateViewer extends EventListenerMixin(JobStateViewerCore) {}
+    class JobStateViewer extends EventListenerMixin(JobStateViewerCore) {}
 
     return {
-        ManagedJobStateViewer,
+        JobStateViewer,
         cssBaseClass,
     };
 });

--- a/kbase-extension/static/kbase/js/common/jobStateViewer.js
+++ b/kbase-extension/static/kbase/js/common/jobStateViewer.js
@@ -1,0 +1,322 @@
+/**
+ *
+ * Usage:
+ * const viewer = new JobStateViewer({
+ *      jobManager,
+ *      showHistory: true,
+ * });
+ * viewer.start({
+ *     jobId: <some job id>,
+ *     node: <a DOM node>
+ * })
+ *
+ * viewer.stop()
+ */
+define([
+    'bluebird',
+    'common/errorDisplay',
+    'common/html',
+    'common/jobs',
+    'common/jobCommMessages',
+    'common/props',
+    'common/runClock',
+    'common/ui',
+    'util/developerMode',
+], (Promise, ErrorDisplay, html, Jobs, jcm, Props, RunClock, UI, devMode) => {
+    'use strict';
+
+    const t = html.tag,
+        div = t('div'),
+        span = t('span'),
+        devContainerCssBaseClass = 'kb-dev__container',
+        cssBaseClass = 'kb-job-state-viewer';
+
+    /**
+     * The entrypoint to this widget. This creates the job state viewer and initializes it.
+     * Starting it is left as a lifecycle method for the caller.
+     *
+     * config options:
+     *  jobManager    {object}  - required
+     *  showHistory   {boolean} - whether job status lines should include history
+     *                            (queue and run times)
+     *  developerMode {boolean} - whether or not to enable developer mode, which
+     *                            prints out extra debugging information
+     */
+
+    class JobStateViewerCore {
+        constructor(config = {}) {
+            this._init(config);
+        }
+
+        /**
+         * Set up the Job State Viewer class
+         * @param {object} config
+         */
+        _init(config) {
+            if (!config.jobManager) {
+                throw new Error('Requires a valid JobManager for initialisation');
+            }
+            this.jobManager = config.jobManager;
+            this.bus = this.jobManager.bus;
+            this.showHistory = config.showHistory || false;
+            this.developerMode = config.devMode || devMode.mode;
+            this.lastJobState = {};
+        }
+
+        /**
+         * The main lifecycle event, called when its container node exists, and we want to start
+         * running this widget.
+         * This detaches itself first, if it exists, then recreates itself in its host node.
+         * @param {object} arg - should have attributes:
+         *   - node - a DOM node where it will be hosted.
+         *   - jobId - string, a job id for this widget to track
+         */
+        start(arg) {
+            return Promise.try(() => {
+                this.stop(); // if the state viewer had already been instantiated, shut it down
+
+                this.container = arg.node;
+                if (!this.container) {
+                    throw new Error('Requires a node to start');
+                }
+                this.jobId = arg.jobId;
+                if (!this.jobId) {
+                    throw new Error('Requires a job id to start');
+                }
+
+                if (
+                    !this.jobManager ||
+                    !('bus' in this.jobManager) ||
+                    !('model' in this.jobManager)
+                ) {
+                    throw new Error('Requires a valid JobManager to start');
+                }
+
+                this.ui = UI.make({ node: this.container });
+                this.container.innerHTML = this.renderLayout();
+
+                this.addEventHandlers();
+
+                // check whether a jobState is available
+                this.lastJobState = this.jobManager.model.getItem(`exec.jobs.byId.${this.jobId}`);
+                this.renderJobState(this.lastJobState || { job_id: this.jobId });
+
+                this.bus.emit(jcm.MESSAGE_TYPE.STATUS, {
+                    [jcm.PARAM.JOB_ID]: this.jobId,
+                });
+            }).catch((err) => {
+                throw err;
+            });
+        }
+
+        /**
+         * stop the widget, cancel any pending requests, and
+         * empty the widget container
+         */
+        stop() {
+            this.removeEventHandlers();
+            if (this.runClock) {
+                this.runClock.stop();
+            }
+            if (this.container) {
+                this.container.innerHTML = '';
+            }
+        }
+
+        /**
+         * builds contents of panel-body class
+         */
+        renderLayout() {
+            let content = div(
+                {
+                    class: `${cssBaseClass}__container`,
+                },
+                [
+                    div({
+                        class: `${cssBaseClass}__status_line`,
+                        dataElement: 'status-line',
+                    }),
+                ]
+            );
+
+            if (this.developerMode) {
+                const devDiv = div(
+                    {
+                        dataElement: 'dev',
+                        class: devContainerCssBaseClass,
+                    },
+                    [
+                        div(
+                            {
+                                class: `${devContainerCssBaseClass}--jobId`,
+                            },
+                            [
+                                'Job ID: ' +
+                                    span(
+                                        {
+                                            dataElement: 'job-id',
+                                        },
+                                        this.jobId
+                                    ),
+                            ]
+                        ),
+                        div(
+                            {
+                                class: `${devContainerCssBaseClass}--jobState`,
+                            },
+                            [
+                                'Job state: ' +
+                                    span({
+                                        dataElement: 'job-state',
+                                    }),
+                            ]
+                        ),
+                    ]
+                );
+                content = div([devDiv, content]);
+            }
+
+            return content;
+        }
+
+        /**
+         * Generate lines describing the job status
+         *
+         * @param {object} jobState
+         * @returns {array[string]} array of HTML strings describing the job state
+         */
+        renderJobStatusLines(jobState) {
+            const lines = Jobs.createJobStatusLines(jobState, this.showHistory);
+
+            return lines.map((line) =>
+                div(
+                    {
+                        class: `${cssBaseClass}__job_status_detail`,
+                    },
+                    line
+                )
+            );
+        }
+
+        /**
+         * Render a div containing the current job status and error information
+         *
+         * @param {object} jobState
+         */
+        renderJobState(jobState) {
+            const isError = jobState.status === 'error';
+
+            if (this.runClock) {
+                this.runClock.stop();
+            }
+
+            this.ui.setContent(
+                'status-line',
+                [
+                    div(
+                        {
+                            class: `${cssBaseClass}__job_status_detail_container`,
+                        },
+                        this.renderJobStatusLines(jobState)
+                    ),
+                    div({
+                        class: `${cssBaseClass}__error_container`,
+                        dataElement: 'error-container',
+                    }),
+                ].join('\n')
+            );
+
+            if (this.developerMode) {
+                this.ui.setContent('dev.job-state', JSON.stringify(jobState, null, 1));
+            }
+
+            if (jobState.status === 'running') {
+                this.runClock = RunClock.make({
+                    prefix: ', ',
+                    suffix: ' ago',
+                });
+                this.runClock
+                    .start({
+                        node: this.ui.getElement('status-line.clock'),
+                        startTime: jobState.running,
+                    })
+                    .catch((err) => {
+                        console.warn('Clock problem:', err);
+                        this.ui.setContent('status-line.clock', '');
+                    });
+                return;
+            }
+
+            if (isError) {
+                const errorModel = Props.make({
+                    data: {
+                        exec: {
+                            jobState,
+                        },
+                    },
+                });
+                const errorContent = ErrorDisplay.make({
+                    model: errorModel,
+                });
+                errorContent.start({
+                    node: this.ui.getElement('status-line.error-container'),
+                });
+            }
+        }
+    }
+
+    const EventListenerMixin = (Base) =>
+        class extends Base {
+            /**
+             * set up the event handlers for the state viewer
+             */
+            addEventHandlers() {
+                const self = this;
+                this.jobManager.addEventHandler(jcm.MESSAGE_TYPE.STATUS, {
+                    [`jobStateViewer_status_${this.jobId}`]: (_, message) => {
+                        if (message[this.jobId]) {
+                            self.handleJobStatus.bind(self)(message[this.jobId]);
+                        }
+                    },
+                });
+            }
+
+            /**
+             * Remove all active event handlers from the job manager.
+             */
+            removeEventHandlers() {
+                this.jobManager.removeEventHandler(
+                    jcm.MESSAGE_TYPE.STATUS,
+                    `jobLogViewer_status_${self.jobId}`
+                );
+            }
+
+            handleJobStatus(message) {
+                const { jobState } = message;
+                // can't do anything unless there is a job state object
+                if (!jobState) {
+                    return;
+                }
+                const { status } = jobState;
+
+                // nothing has changed since last time.
+                if (
+                    this.lastJobState &&
+                    this.lastJobState.status &&
+                    status === this.lastJobState.status
+                ) {
+                    return;
+                }
+
+                this.lastJobState = jobState;
+                this.renderJobState(this.lastJobState);
+            }
+        };
+
+    class ManagedJobStateViewer extends EventListenerMixin(JobStateViewerCore) {}
+
+    return {
+        ManagedJobStateViewer,
+        cssBaseClass,
+    };
+});

--- a/kbase-extension/static/kbase/js/common/simpleLogViewer.js
+++ b/kbase-extension/static/kbase/js/common/simpleLogViewer.js
@@ -1,0 +1,745 @@
+define([
+    'bluebird',
+    'common/html',
+    'common/jobCommMessages',
+    'common/jobs',
+    'common/looper',
+    'common/props',
+    'common/ui',
+], (Promise, html, jcm, Jobs, Looper, Props, UI) => {
+    'use strict';
+
+    const t = html.tag,
+        div = t('div'),
+        button = t('button'),
+        span = t('span'),
+        p = t('p'),
+        cssBaseClass = 'kb-log',
+        logContentStandardClass = `${cssBaseClass}__content`,
+        logContentExpandedClass = `${logContentStandardClass}--expanded`,
+        LOG_CONTAINER = 'log-container', // container for the whole widget
+        LOG_PANEL = 'log-panel', // panel displayed by clicking on the "Logs" title
+        LOG_LINES = 'log-lines'; // numbered list of log lines
+
+    let logContentClass = logContentStandardClass;
+
+    /**
+     * The entrypoint to this widget. This creates the job log viewer and initializes it.
+     *
+     * config options:
+     *  {object} jobManager -
+     *  {int}    logPollInterval - time in ms for how frequently to check for new logs (optional)
+     */
+
+    class JobLogViewerCore {
+        constructor(config = {}) {
+            this._init(config);
+        }
+
+        /**
+         * Set up the Job Log Viewer class
+         * @param {object} config
+         */
+        _init(config) {
+            this.element = {
+                LOG_CONTAINER, // container for the whole widget
+                LOG_PANEL, // panel displayed by clicking on the "Logs" title
+                LOG_LINES, // numbered list of log lines
+            };
+
+            this.messages = {
+                REQUIRES_JOB_MANAGER: 'Requires a valid JobManager',
+                REQUIRES_NODE: 'Requires a node to start',
+                REQUIRES_JOB_ID: 'Requires a job ID to start',
+                JOB_QUEUED: 'Job is queued; logs will be available when the job is running.',
+                JOB_NOT_FOUND: 'Job not found',
+                JOB_STATUS_UNKNOWN: Jobs.jobStatusUnknown,
+                BATCH_JOB: 'Job logs are not available for batch jobs',
+            };
+
+            // UI buttons states
+            this.buttonsByJobState = {
+                default: {
+                    buttons: {
+                        enabled: [],
+                        disabled: ['expand', 'play', 'stop', 'top', 'bottom'],
+                    },
+                },
+                running_scrolling: {
+                    buttons: {
+                        enabled: ['expand', 'stop', 'top', 'bottom'],
+                        disabled: ['play'],
+                    },
+                },
+                running: {
+                    buttons: {
+                        enabled: ['expand', 'play', 'top', 'bottom'],
+                        disabled: ['stop'],
+                    },
+                },
+                terminal: {
+                    buttons: {
+                        enabled: ['top', 'bottom', 'expand'],
+                        disabled: ['play', 'stop'],
+                    },
+                },
+            };
+
+            /* The data model for this widget contains all lines currently being shown, along with the indices for
+             * the first and last lines known.
+             * It also tracks the total lines currently available for the app, if returned.
+             * Lines is a list of small objects. Each object
+             * lines - list, each is a small object with keys (these are all post-processed after fetching):
+             *      line - string, the line text
+             *      is_error - 0 / 1; whether the line denotes an error
+             *      ts - int timestamp
+             *      linepos - int, what line this is
+             * firstLine - int, the first line we're tracking (inclusive)
+             * lastLine - int, the last line we're tracking (inclusive)
+             * totalLines - int, the total number of lines available from the server as of the last message.
+             */
+
+            this.model = Props.make({
+                data: {
+                    lines: [],
+                    firstLine: null,
+                    lastLine: null,
+                    totalLines: null,
+                },
+            });
+
+            if (!config.jobManager) {
+                throw new Error(this.messages.REQUIRES_JOB_MANAGER);
+            }
+            this.jobManager = config.jobManager;
+            this.bus = this.jobManager.bus;
+            this.logPollInterval = config.logPollInterval || 2500;
+            this.looper = new Looper({ pollInterval: this.logPollInterval });
+            this._resetVariables();
+        }
+
+        _resetVariables() {
+            this.lastJobState = null;
+            this.state = {
+                looping: false, // if true, the log viewer is automatically requesting log updates
+                awaitingLog: false, // if true, there's a log request fired that we're awaiting
+                scrollToEndOnNext: true, // if true, the log viewer scrolls to keep up with incoming logs
+            };
+        }
+
+        // convert a job status into a 'mode'
+        _statusToMode(status) {
+            switch (status) {
+                case 'created':
+                case 'estimating':
+                case 'queued':
+                    return 'queued';
+
+                case 'running':
+                    return status;
+
+                case 'completed':
+                case 'error':
+                case 'terminated':
+                    return 'terminal';
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+    /**
+     * UI mixin: accessing and rendering various elements of the log viewer
+     *
+     * @param {object} Base
+     */
+    const UIMixin = (Base) =>
+        class extends Base {
+            // element access
+            getLogPanel() {
+                return this.ui.getElement(LOG_PANEL);
+            }
+
+            getLastLogLine() {
+                return this.ui.getElement(LOG_LINES).lastChild;
+            }
+
+            doScrollToTop() {
+                this.getLogPanel().scrollTo(0, 0);
+            }
+
+            doScrollToBottom() {
+                this.getLogPanel().scrollTo(0, this.getLastLogLine().offsetTop);
+            }
+
+            // UI Rendering
+
+            /**
+             * toggle the viewer class to switch between standard and expanded versions
+             */
+            toggleViewerSize() {
+                const logContentClassList = this.getLogPanel().classList;
+                let inactiveClass;
+                if (logContentClassList.contains(logContentStandardClass)) {
+                    logContentClass = logContentExpandedClass;
+                    inactiveClass = logContentStandardClass;
+                } else {
+                    logContentClass = logContentStandardClass;
+                    inactiveClass = logContentExpandedClass;
+                }
+                logContentClassList.add(logContentClass);
+                logContentClassList.remove(inactiveClass);
+            }
+
+            /**
+             * builds contents of panel-heading div with the log controls in it
+             */
+            renderControls() {
+                const buttons = [
+                    {
+                        action: 'expand',
+                        title: 'Toggle log viewer size',
+                        icon: 'expand',
+                    },
+                    {
+                        action: 'play',
+                        title: 'Auto-scroll to newest log messages',
+                        icon: 'play',
+                    },
+                    {
+                        action: 'stop',
+                        title: 'Stop auto-scrolling',
+                        icon: 'stop',
+                    },
+                    {
+                        action: 'top',
+                        title: 'Jump to the top',
+                        icon: 'angle-double-up',
+                    },
+                    {
+                        action: 'bottom',
+                        title: 'Jump to the end',
+                        icon: 'angle-double-down',
+                    },
+                ];
+
+                return div(
+                    {
+                        dataElement: 'header',
+                        class: `${cssBaseClass}__controls`,
+                    },
+                    [
+                        buttons.map((b) => {
+                            return button(
+                                {
+                                    class: `btn btn-sm btn-default ${cssBaseClass}__log_button--${b.action}`,
+                                    dataToggle: 'tooltip',
+                                    dataPlacement: 'top',
+                                    title: b.title,
+                                    dataButton: b.action,
+                                },
+                                [span({ class: `fa fa-${b.icon}` })]
+                            );
+                        }),
+                        div(
+                            {
+                                dataElement: 'spinner',
+                                class: `pull-right hidden ${cssBaseClass}__spinner`,
+                            },
+                            [
+                                span({ class: 'fa fa-spinner fa-pulse fa-ex fa-fw' }),
+                                'Fetching logs...',
+                            ]
+                        ),
+                    ]
+                );
+            }
+
+            /**
+             * builds contents of panel-body class
+             */
+            renderLayout() {
+                const uniqueID = html.genId();
+                return div(
+                    {
+                        class: `${cssBaseClass}__container`,
+                    },
+                    [
+                        div(
+                            {
+                                class: `${cssBaseClass}__logs_container`,
+                                dataElement: LOG_CONTAINER,
+                            },
+                            [
+                                div(
+                                    {
+                                        class: `${cssBaseClass}__logs_title collapsed`,
+                                        role: 'button',
+                                        dataToggle: 'collapse',
+                                        dataTarget: '#' + uniqueID,
+                                        ariaExpanded: 'false',
+                                        ariaControls: uniqueID,
+                                    },
+                                    [span({}, ['Logs'])]
+                                ),
+                                div(
+                                    {
+                                        class: `${cssBaseClass}__logs_content_panel collapse`,
+                                        id: uniqueID,
+                                    },
+                                    [
+                                        this.renderControls(),
+                                        div({
+                                            dataElement: LOG_PANEL,
+                                            class: logContentClass,
+                                        }),
+                                    ]
+                                ),
+                            ]
+                        ),
+                    ]
+                );
+            }
+
+            /**
+             * render the HTML structure that displays
+             * an individual job log line
+             * <ol class="${cssBaseClass}__log_line_container">
+             *    <li class="${cssBaseClass}__line_text">starting job</div>
+             *    <li class="${cssBaseClass}__line_text">initialising variables</div>
+             *    ...
+             * </ol>
+             * @param {object} line
+             */
+            renderLogLine(line) {
+                const errorSuffix = line.is_error ? '--error' : '';
+                return t('li')(
+                    {
+                        class: `${cssBaseClass}__line_text${errorSuffix}`,
+                    },
+                    line.line
+                );
+            }
+
+            /**
+             * Render the log
+             *
+             * This adds any new content in model.getItem('lines') to rendered lines from the DOM.
+             */
+            renderLog() {
+                const lines = this.model.getItem('lines');
+                if (!lines || lines.length === 0) {
+                    this.ui.setContent(LOG_PANEL, 'No log entries to show.');
+                    this.renderButtons();
+                    return;
+                }
+
+                const panel = this.getLogPanel();
+                const renderedLines = panel.querySelectorAll('ol li');
+                if (renderedLines && renderedLines.length) {
+                    const olElement = panel.querySelector('ol');
+                    // append the new lines to the existing log lines
+                    const newLines = lines
+                        .slice(renderedLines.length)
+                        .map((line) => this.renderLogLine(line))
+                        .join('\n');
+                    olElement.innerHTML += newLines;
+                } else {
+                    panel.innerHTML = t('ol')(
+                        {
+                            class: `${cssBaseClass}__log_line_container`,
+                            dataElement: LOG_LINES,
+                        },
+                        lines.map((line) => this.renderLogLine(line)).join('\n')
+                    );
+                }
+
+                // if we're autoscrolling, scroll to the bottom
+                if (this.state.scrollToEndOnNext) {
+                    this.doScrollToBottom();
+                }
+                this.renderButtons();
+            }
+
+            /**
+             * Update the log control buttons
+             */
+            renderButtons() {
+                const previousStatus = (this.lastJobState && this.lastJobState.status) || null;
+                let mode = this._statusToMode(previousStatus) || 'default';
+                if (mode === 'running' && this.state.scrollToEndOnNext) {
+                    mode = 'running_scrolling';
+                }
+                this._renderButtonState(mode);
+            }
+
+            _renderButtonState(mode) {
+                // Button state
+                const { buttons } = this.buttonsByJobState[mode];
+                // the log controls section may have been removed
+                // so use try/catch to suppress any errors
+                buttons.enabled.forEach((_button) => {
+                    try {
+                        this.ui.enableButton(_button);
+                    } catch (err) {
+                        // eslint-disable-next-line no-empty
+                    }
+                });
+                buttons.disabled.forEach((_button) => {
+                    try {
+                        this.ui.disableButton(_button);
+                    } catch (err) {
+                        // eslint-disable-next-line no-empty
+                    }
+                });
+            }
+        };
+
+    const ControllerMixin = (Base) =>
+        class extends Base {
+            /* Job requests */
+
+            /**
+             * Requests log lines starting from the last line
+             * in the stored logs
+             */
+            requestJobLog() {
+                this.ui.showElement('spinner');
+                this.state.awaitingLog = true;
+                const requestParams = {
+                    [jcm.PARAM.JOB_ID]: this.jobId,
+                };
+                const lastLine = this.model.getItem('lastLine');
+                if (lastLine) {
+                    requestParams.first_line = lastLine;
+                }
+                this.bus.emit(jcm.MESSAGE_TYPE.LOGS, requestParams);
+            }
+
+            /**
+             * Add a job log request to the request loop
+             */
+            scheduleLogRequest() {
+                if (!this.state.looping) {
+                    return;
+                }
+                const self = this;
+                this.looper.scheduleRequest(self.requestJobLog.bind(self));
+            }
+
+            /**
+             * Starts the autofetch loop. After the first request, this starts a timeout that calls it again.
+             */
+            startLogAutoFetch() {
+                if (this.state.looping) {
+                    // already dealt with; no changes needed
+                    return;
+                }
+                const { status } = this.lastJobState;
+                if (status && status === 'running') {
+                    this.state.looping = true;
+
+                    // clear any pending requests and request logs now
+                    this.looper.clearRequest();
+                    this.requestJobLog();
+                }
+            }
+
+            /**
+             * Stop automatically fetching the log
+             */
+            stopLogAutoFetch() {
+                this.state.looping = false;
+                if (this.ui) {
+                    this.ui.hideElement('spinner');
+                }
+            }
+
+            /**
+             * Turn on log window auto-scrolling to newest lines
+             */
+            doPlayLogs() {
+                this.state.scrollToEndOnNext = true;
+                this.startLogAutoFetch();
+            }
+
+            /**
+             * Stop log window auto-scrolling to newest update
+             */
+            doStopLogs() {
+                this.state.scrollToEndOnNext = false;
+            }
+        };
+
+    const EventMixin = (Base) =>
+        class extends Base {
+            handleJobStatus(message) {
+                const { jobState } = message;
+                // can't do anything unless there is a job state object
+                if (!jobState || !jobState.status) {
+                    return;
+                }
+
+                // check if this is a batch job
+                if (jobState.batch_job) {
+                    this.lastJobState = jobState;
+                    this.ui.setContent(LOG_PANEL, p(this.messages.BATCH_JOB));
+                    this._renderButtonState('default');
+                    return;
+                }
+
+                const { status } = jobState,
+                    previousStatus =
+                        this.lastJobState && this.lastJobState.status
+                            ? this.lastJobState.status
+                            : null;
+
+                this.lastJobState = jobState;
+
+                if (status === 'does_not_exist') {
+                    this.ui.setContent(LOG_PANEL, p([this.messages.JOB_NOT_FOUND]));
+                    this._renderButtonState('default');
+                    this.stopLogAutoFetch();
+                    this.state.awaitingLog = false;
+                    this.looper.clearRequest();
+                    return;
+                }
+
+                // nothing has changed since last time.
+                if (status === previousStatus) {
+                    return;
+                }
+
+                const newMode = this._statusToMode(status);
+                const previousMode = this._statusToMode(previousStatus);
+
+                if (newMode !== previousMode) {
+                    switch (newMode) {
+                        case 'queued':
+                            this.ui.setContent(LOG_PANEL, p([this.messages.JOB_QUEUED]));
+                            this._renderButtonState('default');
+                            break;
+                        case 'running':
+                            // clear the content of the job panel to make way for logs
+                            this.ui.setContent(LOG_PANEL, '');
+                            this.startLogAutoFetch();
+                            this._renderButtonState('running_scrolling');
+                            break;
+                        case 'terminal':
+                            this.stopLogAutoFetch();
+                            this.requestJobLog();
+                            this._renderButtonState('terminal');
+                            break;
+                        // this should never happen
+                        default:
+                            console.error('Unknown job status', status, message);
+                            throw new Error(`Unknown job status ${status}`);
+                    }
+                }
+            }
+
+            handleJobLogs(message) {
+                if (!this.state.awaitingLog) {
+                    return;
+                }
+
+                this.ui.hideElement('spinner');
+                /* message has structure:
+                 * {
+                 *      first: int (first line of the log batch), 0-indexed
+                 *      job_id: string,
+                 *      latest: bool,
+                 *      max_lines: int (total logs available - if job is done, so is this),
+                 *      lines: [{
+                 *          is_error: 0 or 1,
+                 *          line: string,
+                 *          linepos: int, position in log. helpful!
+                 *          ts: timestamp
+                 *      }]
+                 * }
+                 */
+                this.state.awaitingLog = false;
+
+                if (message.error) {
+                    return this.handleLogError(message);
+                }
+                if (this.state.looping) {
+                    this.scheduleLogRequest();
+                }
+
+                if (message.lines.length !== 0) {
+                    const savedLogs = this.model.getRawObject();
+                    // ensure that message.first is equal to or less than savedLogs.lastLine
+                    if (!savedLogs.lastLine || message.first <= savedLogs.lastLine) {
+                        // no need to update if we already have all the lines
+                        if (message.first + message.lines.length <= savedLogs.lastLine) {
+                            return;
+                        }
+                        savedLogs.lines.splice(
+                            message.first,
+                            message.lines.length,
+                            ...message.lines
+                        );
+                        if (!savedLogs.firstLine) {
+                            this.model.setItem('firstLine', message.first + 1);
+                        }
+                        this.model.setItem('lastLine', message.first + message.lines.length);
+                        this.model.setItem('totalLines', message.max_lines);
+                        this.model.setItem('lines', savedLogs.lines);
+                        this.renderLog();
+                    } else {
+                        console.warn(
+                            `ignoring log message with first line ${message.first}; saved logs from ${savedLogs.firstLine} to ${savedLogs.lastLine}`
+                        );
+                    }
+                }
+            }
+
+            handleLogError(message) {
+                this.stopLogAutoFetch();
+                this.renderLog();
+                this.state.awaitingLog = false;
+                console.error(
+                    `Error retrieving log for ${this.jobId}: ${JSON.stringify(
+                        message.error,
+                        null,
+                        1
+                    )}`
+                );
+            }
+
+            /**
+             * set up the event handlers for the log viewer
+             */
+            addEventHandlers() {
+                const self = this;
+
+                this.jobManager.addEventHandler(jcm.MESSAGE_TYPE.STATUS, {
+                    [`jobLogViewer_status_${self.jobId}`]: (_, message) => {
+                        if (message[this.jobId]) {
+                            self.handleJobStatus.bind(self)(message[this.jobId]);
+                        }
+                    },
+                });
+
+                this.jobManager.addEventHandler(jcm.MESSAGE_TYPE.LOGS, {
+                    [`jobLogViewer_logs_${self.jobId}`]: (_, message) => {
+                        if (message[this.jobId]) {
+                            self.handleJobLogs.bind(self)(message[this.jobId]);
+                        }
+                    },
+                });
+            }
+
+            /**
+             * Remove all active event handlers from the job manager.
+             */
+            removeEventHandlers() {
+                this.jobManager.removeEventHandler(
+                    jcm.MESSAGE_TYPE.LOGS,
+                    `jobLogViewer_logs_${self.jobId}`
+                );
+                this.jobManager.removeEventHandler(
+                    jcm.MESSAGE_TYPE.STATUS,
+                    `jobLogViewer_status_${self.jobId}`
+                );
+            }
+
+            /**
+             * The main lifecycle event, called when its container node exists, and we want to start
+             * running this widget.
+             * This detaches itself first, if it exists, then recreates itself in its host node.
+             * @param {object} arg - should have attributes:
+             *   - node - a DOM node where it will be hosted.
+             *   - jobId - string, a job id for this log
+             */
+            start(arg) {
+                const self = this;
+                return Promise.try(() => {
+                    this.stop(); // if the log viewer had already been instantiated, shut it down
+                    this._resetVariables();
+
+                    this.container = arg.node;
+                    if (!this.container) {
+                        throw new Error(this.messages.REQUIRES_NODE);
+                    }
+                    this.jobId = arg.jobId;
+                    if (!this.jobId) {
+                        throw new Error(this.messages.REQUIRES_JOB_ID);
+                    }
+
+                    if (
+                        !this.jobManager ||
+                        !('bus' in this.jobManager) ||
+                        !('model' in this.jobManager)
+                    ) {
+                        throw new Error(this.messages.REQUIRES_JOB_MANAGER);
+                    }
+
+                    this.ui = UI.make({ node: this.container });
+                    this.container.innerHTML = this.renderLayout();
+
+                    // add event listeners to log control buttons
+                    this.container.querySelectorAll(`.kb-log__controls button`).forEach((el) => {
+                        el.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            const dataButton = e.currentTarget.getAttribute('data-button');
+                            const actions = {
+                                expand: self.toggleViewerSize,
+                                play: self.doPlayLogs,
+                                stop: self.doStopLogs,
+                                top: self.doScrollToTop,
+                                bottom: self.doScrollToBottom,
+                            };
+                            if (actions[dataButton]) {
+                                actions[dataButton].bind(self)();
+                            }
+                        });
+                    });
+                    this.addEventHandlers();
+
+                    // check whether a jobState is available
+                    const jobState = this.jobManager.model.getItem(
+                        `exec.jobs.byId.${this.jobId}`
+                    ) || { job_id: this.jobId };
+
+                    // initial render
+                    if (jobState && jobState.status) {
+                        this.handleJobStatus({ jobState });
+                    } else {
+                        // some kind of 'await job info' message
+                        this.ui.setContent(LOG_PANEL, p([this.messages.JOB_STATUS_UNKNOWN]));
+                        this._renderButtonState('default');
+                    }
+
+                    this.bus.emit(jcm.MESSAGE_TYPE.STATUS, {
+                        [jcm.PARAM.JOB_ID]: this.jobId,
+                    });
+                }).catch((err) => {
+                    throw err;
+                });
+            }
+
+            /**
+             * stop the widget, cancel any pending requests, and
+             * empty the widget container
+             */
+            stop() {
+                this.removeEventHandlers();
+                this.stopLogAutoFetch();
+                this.looper.clearRequest();
+                if (this.container) {
+                    this.container.innerHTML = '';
+                }
+                return this.container;
+            }
+        };
+
+    class SimpleLogViewer extends EventMixin(ControllerMixin(UIMixin(JobLogViewerCore))) {}
+
+    return {
+        SimpleLogViewer,
+        cssBaseClass,
+    };
+});

--- a/kbase-extension/static/kbase/js/common/simpleLogViewer.js
+++ b/kbase-extension/static/kbase/js/common/simpleLogViewer.js
@@ -700,9 +700,7 @@ define([
                     this.addEventHandlers();
 
                     // check whether a jobState is available
-                    const jobState = this.jobManager.model.getItem(
-                        `exec.jobs.byId.${this.jobId}`
-                    ) || { job_id: this.jobId };
+                    const jobState = this.jobManager.getJob(this.jobId) || { job_id: this.jobId };
 
                     // initial render
                     if (jobState && jobState.status) {

--- a/test/unit/spec/common/jobStateViewer-spec.js
+++ b/test/unit/spec/common/jobStateViewer-spec.js
@@ -1,0 +1,348 @@
+define([
+    'jquery',
+    'bluebird',
+    'common/jobStateViewer',
+    'common/jobs',
+    'common/jobCommMessages',
+    'common/jobManager',
+    'common/props',
+    'common/runtime',
+    '/test/data/jobsData',
+    'testUtil',
+], (
+    $,
+    Promise,
+    JobStateViewerModule,
+    Jobs,
+    jcm,
+    JobManagerModule,
+    Props,
+    Runtime,
+    JobsData,
+    TestUtil
+) => {
+    'use strict';
+
+    const { cssBaseClass, ManagedJobStateViewer } = JobStateViewerModule;
+
+    const { JobManager } = JobManagerModule;
+
+    const BATCH_ID = JobsData.batchParentJob.batch_id;
+
+    function createJobManager(context) {
+        context.bus = Runtime.make().bus();
+        context.model = Props.make({
+            data: {},
+        });
+        Jobs.populateModelFromJobArray(
+            context.model,
+            TestUtil.JSONcopy(JobsData.allJobsWithBatchParent)
+        );
+
+        context.jobManager = new JobManager({
+            bus: context.bus,
+            model: context.model,
+        });
+
+        context.jobManager.addListener(
+            jcm.MESSAGE_TYPE.STATUS,
+            jcm.CHANNEL.JOB,
+            JobsData.allJobsWithBatchParent.map((job) => {
+                return job.job_id;
+            })
+        );
+        context.jobManager.addListener(jcm.MESSAGE_TYPE.STATUS, jcm.CHANNEL.BATCH, BATCH_ID);
+
+        return context.jobManager;
+    }
+
+    function createStateViewer(context, showHistory = false) {
+        context.node = document.createElement('div');
+
+        createJobManager(context);
+
+        const args = { showHistory, jobManager: context.jobManager, devMode: true };
+        context.jobStateViewerInstance = new ManagedJobStateViewer(args);
+    }
+
+    /**
+     *
+     * @param {object} context `this` context, including the node to search for the job status lines
+     * @param {boolean} includeHistory whether or not history mode is on
+     */
+
+    function testJobStatus(context, includeHistory = false) {
+        const statusNode = context.node.querySelector(`.${cssBaseClass}__container`);
+        const errorNode = context.node.querySelector(`.${cssBaseClass}__error_container`);
+
+        const statusLine = context.jobState
+            ? context.jobState.meta.createJobStatusLines.line
+            : Jobs.jobStatusUnknown[0];
+
+        const errorLine = context.jobState ? context.jobState.meta.errorString || null : null;
+
+        if (!statusNode) {
+            fail('tests failed: status node not found');
+            return;
+        }
+        expect(statusNode.textContent).toContain(statusLine);
+
+        if (includeHistory) {
+            const history = context.jobState
+                ? context.jobState.meta.createJobStatusLines.history
+                : Jobs.jobStatusUnknown;
+            history.forEach((line) => {
+                expect(statusNode.textContent).toContain(line);
+            });
+        }
+
+        if (errorLine) {
+            expect(errorNode.textContent).toContain(errorLine);
+        } else {
+            expect(errorNode.textContent).toBe('');
+        }
+    }
+
+    function itHasJobStatus() {
+        it('has job status', function () {
+            testJobStatus(this);
+        });
+    }
+
+    function itHasJobStatusHistory() {
+        it('has job status history', function () {
+            testJobStatus(this, true);
+        });
+    }
+
+    describe('The managed job state viewer module', () => {
+        it('Should load the module code successfully', () => {
+            expect(ManagedJobStateViewer).toEqual(jasmine.any(Function));
+        });
+
+        it('Should have a css base class', () => {
+            expect(cssBaseClass).toEqual(jasmine.any(String));
+            expect(cssBaseClass).toEqual('kb-job-state-viewer');
+        });
+    });
+
+    describe('The managed job state viewer instance', () => {
+        beforeAll(() => {
+            TestUtil.clearRuntime();
+        });
+
+        afterEach(() => {
+            TestUtil.clearRuntime();
+        });
+
+        describe('starting and then stopping', () => {
+            beforeEach(function () {
+                createStateViewer(this);
+            });
+
+            it('should have methods defined', function () {
+                ['start', 'stop'].forEach((fn) => {
+                    expect(this.jobStateViewerInstance[fn]).toEqual(jasmine.any(Function));
+                });
+            });
+
+            it('should fail to init without a job manager', () => {
+                expect(() => {
+                    new ManagedJobStateViewer();
+                }).toThrowError(Error, 'Requires a valid JobManager for initialisation');
+            });
+
+            it('Should fail to start without a node', async () => {
+                const jobStateViewerInstance = new ManagedJobStateViewer({
+                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                });
+                await expectAsync(
+                    jobStateViewerInstance.start({ jobId: 'fakeJob' })
+                ).toBeRejectedWithError(/Requires a node to start/);
+            });
+
+            it('Should fail to start without a jobId', async function () {
+                const jobStateViewerInstance = new ManagedJobStateViewer({
+                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                });
+                await expectAsync(
+                    jobStateViewerInstance.start({ node: this.node })
+                ).toBeRejectedWithError(/Requires a job id to start/);
+            });
+
+            it('Should start as expected with inputs, and be stoppable', async function () {
+                const arg = {
+                    node: this.node,
+                    jobId: 'test_job_start',
+                };
+                await this.jobStateViewerInstance.start(arg);
+                expect(this.node.querySelector('div[data-element="status-line"]')).toBeDefined();
+                this.jobStateViewerInstance.stop();
+                expect(this.node.innerHTML).toBe('');
+            });
+
+            it('Should send bus messages requesting job status information at startup', async function () {
+                const jobId = 'test_bus_request';
+                const arg = {
+                    node: this.node,
+                    jobId,
+                };
+                await this.jobStateViewerInstance.start(arg);
+
+                return new Promise((resolve) => {
+                    this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                        resolve();
+                    });
+                });
+            });
+        });
+
+        describe('initial widget state', () => {
+            beforeEach(function () {
+                createStateViewer(this);
+            });
+
+            describe('should be awaiting job data with no job object', () => {
+                beforeEach(async function () {
+                    await this.jobStateViewerInstance.start({
+                        node: this.node,
+                        jobId: 'no state set',
+                    });
+                });
+                itHasJobStatus();
+            });
+
+            JobsData.allJobs.forEach((jobState) => {
+                describe(`should create a string for status ${jobState.status}`, () => {
+                    beforeEach(async function () {
+                        this.jobState = jobState;
+                        await this.jobStateViewerInstance.start({
+                            node: this.node,
+                            jobId: jobState.job_id,
+                            jobState,
+                        });
+                    });
+                    itHasJobStatus();
+                });
+            });
+        });
+
+        describe('initial state, history mode on', () => {
+            beforeEach(function () {
+                createStateViewer(this, true);
+            });
+
+            describe('should be awaiting job data with no job object', () => {
+                beforeEach(async function () {
+                    await this.jobStateViewerInstance.start({
+                        node: this.node,
+                        jobId: 'no state set, history',
+                    });
+                });
+                itHasJobStatusHistory();
+            });
+
+            JobsData.allJobs.forEach((jobState) => {
+                describe(`should create an array in history mode for status ${jobState.status}`, () => {
+                    beforeEach(async function () {
+                        this.jobState = jobState;
+                        await this.jobStateViewerInstance.start({
+                            node: this.node,
+                            jobId: jobState.job_id,
+                            jobState,
+                        });
+                    });
+                    itHasJobStatusHistory();
+                });
+            });
+        });
+
+        const allJobStateMessages = JobsData.allJobs.reduce((acc, jobState) => {
+            acc[jobState.job_id] = {
+                [jcm.PARAM.JOB_ID]: jobState.job_id,
+                jobState,
+            };
+            return acc;
+        }, {});
+
+        describe('response to update', () => {
+            [true, false].forEach((mode) => {
+                beforeEach(function () {
+                    if (mode) {
+                        createStateViewer(this, mode);
+                    }
+                });
+                JobsData.allJobs.forEach((jobState) => {
+                    const input = {
+                        'by job ID': {
+                            message: { [jobState.job_id]: allJobStateMessages[jobState.job_id] },
+                            channelType: jcm.CHANNEL.JOB,
+                            channelId: jobState.job_id,
+                        },
+                        'by batch ID': {
+                            message: allJobStateMessages,
+                            channelType: jcm.CHANNEL.BATCH,
+                            channelId: BATCH_ID,
+                        },
+                    };
+
+                    ['by job ID', 'by batch ID'].forEach((inputType) => {
+                        it(`should create a string for status ${jobState.status}, history mode ${
+                            mode ? 'on' : 'off'
+                        }, ${inputType}`, async function () {
+                            // remove the job data so the status viewer says 'Awaiting job information'
+                            this.jobManager.model.setItem(`exec.jobs.byId.${jobState.job_id}`, {
+                                job_id: jobState.job_id,
+                            });
+                            const { message, channelType, channelId } = input[inputType];
+                            // test the status lines when the widget requests a status update (on start up)
+                            this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                                testJobStatus(this, mode);
+                                expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobState.job_id });
+                                TestUtil.sendBusMessage({
+                                    bus: this.bus,
+                                    message,
+                                    channelType,
+                                    channelId,
+                                    type: jcm.MESSAGE_TYPE.STATUS,
+                                });
+                            });
+
+                            await this.jobStateViewerInstance.start({
+                                node: this.node,
+                                jobId: jobState.job_id,
+                            });
+
+                            await TestUtil.waitFor({
+                                documentElement: this.node.querySelector(
+                                    '[data-element="status-line"]'
+                                ),
+                                domStateFunction: (mutations) => {
+                                    if (!mutations || !mutations.length) {
+                                        return false;
+                                    }
+                                    const result = mutations.some((mut) => {
+                                        return Array.from(mut.addedNodes).some((domEl) => {
+                                            return (
+                                                domEl.classList &&
+                                                domEl.classList.contains(
+                                                    `${cssBaseClass}__job_status_detail_container`
+                                                )
+                                            );
+                                        });
+                                    });
+                                    return result ? true : false;
+                                },
+                                config: { childList: true },
+                            });
+
+                            this.jobState = jobState;
+                            testJobStatus(this, mode);
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/unit/spec/common/jobStateViewer-spec.js
+++ b/test/unit/spec/common/jobStateViewer-spec.js
@@ -23,7 +23,7 @@ define([
 ) => {
     'use strict';
 
-    const { cssBaseClass, ManagedJobStateViewer } = JobStateViewerModule;
+    const { cssBaseClass, JobStateViewer } = JobStateViewerModule;
 
     const { JobManager } = JobManagerModule;
 
@@ -62,7 +62,7 @@ define([
         createJobManager(context);
 
         const args = { showHistory, jobManager: context.jobManager, devMode: true };
-        context.jobStateViewerInstance = new ManagedJobStateViewer(args);
+        context.jobStateViewerInstance = new JobStateViewer(args);
     }
 
     /**
@@ -115,9 +115,9 @@ define([
         });
     }
 
-    describe('The managed job state viewer module', () => {
+    describe('The job state viewer module', () => {
         it('Should load the module code successfully', () => {
-            expect(ManagedJobStateViewer).toEqual(jasmine.any(Function));
+            expect(JobStateViewer).toEqual(jasmine.any(Function));
         });
 
         it('Should have a css base class', () => {
@@ -126,7 +126,7 @@ define([
         });
     });
 
-    describe('The managed job state viewer instance', () => {
+    describe('The job state viewer instance', () => {
         beforeAll(() => {
             TestUtil.clearRuntime();
         });
@@ -148,13 +148,14 @@ define([
 
             it('should fail to init without a job manager', () => {
                 expect(() => {
-                    new ManagedJobStateViewer();
+                    new JobStateViewer();
                 }).toThrowError(Error, 'Requires a valid JobManager for initialisation');
             });
 
             it('Should fail to start without a node', async () => {
-                const jobStateViewerInstance = new ManagedJobStateViewer({
-                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                createJobManager(this);
+                const jobStateViewerInstance = new JobStateViewer({
+                    jobManager: this.jobManager,
                 });
                 await expectAsync(
                     jobStateViewerInstance.start({ jobId: 'fakeJob' })
@@ -162,8 +163,8 @@ define([
             });
 
             it('Should fail to start without a jobId', async function () {
-                const jobStateViewerInstance = new ManagedJobStateViewer({
-                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                const jobStateViewerInstance = new JobStateViewer({
+                    jobManager: this.jobManager,
                 });
                 await expectAsync(
                     jobStateViewerInstance.start({ node: this.node })

--- a/test/unit/spec/common/simpleLogViewer-spec.js
+++ b/test/unit/spec/common/simpleLogViewer-spec.js
@@ -1,0 +1,1070 @@
+define([
+    'jquery',
+    'bluebird',
+    'common/simpleLogViewer',
+    'common/jobs',
+    'common/jobCommMessages',
+    'common/jobManager',
+    'common/props',
+    'common/runtime',
+    '/test/data/jobsData',
+    'testUtil',
+], (
+    $,
+    Promise,
+    SimpleLogViewerModule,
+    Jobs,
+    jcm,
+    JobManagerModule,
+    Props,
+    Runtime,
+    JobsData,
+    TestUtil
+) => {
+    'use strict';
+
+    const TEST_POLL_INTERVAL = 10;
+    const { cssBaseClass, SimpleLogViewer } = SimpleLogViewerModule;
+
+    const { JobManager } = JobManagerModule;
+
+    const jobsByStatus = JobsData.jobsByStatus;
+    const BATCH_ID = JobsData.batchParentJob.batch_id;
+    const TEST_JOB_ID = 'TEST_JOB_ID';
+    const endStates = ['completed', 'error', 'terminated'];
+    const queueStates = ['created', 'estimating', 'queued'];
+    const allJobStateMessages = JobsData.allJobs.reduce((acc, jobState) => {
+        acc[jobState.job_id] = {
+            [jcm.PARAM.JOB_ID]: jobState.job_id,
+            jobState,
+        };
+        return acc;
+    }, {});
+
+    const lotsOfLogLines = [];
+    let n = 0;
+    while (n < 10) {
+        n++;
+        lotsOfLogLines.push({
+            is_error: 0,
+            line: `log line ${n}`,
+            linepos: n,
+        });
+    }
+
+    function generateInput(jobId) {
+        return {
+            job: {
+                message: { [jobId]: allJobStateMessages[jobId] },
+                channelType: jcm.CHANNEL.JOB,
+                channelId: jobId,
+            },
+            batch: {
+                message: allJobStateMessages,
+                channelType: jcm.CHANNEL.BATCH,
+                channelId: BATCH_ID,
+            },
+        };
+    }
+
+    function createJobManager(context) {
+        context.bus = Runtime.make().bus();
+        context.model = Props.make({
+            data: {},
+        });
+        Jobs.populateModelFromJobArray(
+            context.model,
+            TestUtil.JSONcopy(JobsData.allJobsWithBatchParent)
+        );
+        context.pollInterval = TEST_POLL_INTERVAL;
+        context.jobManager = new JobManager(context);
+
+        ['LOGS', 'STATUS'].forEach((type) => {
+            context.jobManager.addListener(
+                jcm.MESSAGE_TYPE[type],
+                jcm.CHANNEL.JOB,
+                JobsData.allJobsWithBatchParent.map((job) => {
+                    return job.job_id;
+                })
+            );
+            context.jobManager.addListener(jcm.MESSAGE_TYPE[type], jcm.CHANNEL.BATCH, BATCH_ID);
+        });
+        return context.jobManager;
+    }
+
+    function createLogViewer(context, logPollInterval = null) {
+        context.node = document.createElement('div');
+
+        createJobManager(context);
+
+        const args = { jobManager: context.jobManager, devMode: true };
+        if (logPollInterval) {
+            args.logPollInterval = logPollInterval;
+        }
+        context.simpleLogViewerInstance = new SimpleLogViewer(args);
+    }
+
+    const logLines = [
+        {
+            is_error: 0,
+            line: 'line 1 - log',
+            linepos: 1,
+            ts: 1234567891,
+        },
+        {
+            is_error: 1,
+            line: 'line 2 - error',
+            linepos: 2,
+            ts: 1234567892,
+        },
+        {
+            is_error: 0,
+            line: 'line 3 - more logs',
+            linepos: 3,
+            ts: 1234567893,
+        },
+        {
+            is_error: 0,
+            line: 'line 4 - last log',
+            linepos: 4,
+            ts: 1234567894,
+        },
+        {
+            is_error: 1,
+            line: 'line 5 - error',
+            linepos: 5,
+            ts: 1234567895,
+        },
+        {
+            is_error: 1,
+            line: 'line 6 - TOTAL BREAKDOWN!',
+            linepos: 6,
+            ts: 1234567896,
+        },
+    ];
+
+    // lines to return each time there is a request for the latest logs
+    const messageSeries = [
+        {
+            // expected model 'lines' content at the time of the request
+            model: [],
+            // expected request params
+            request: {},
+            // response: 0 log lines
+            lines: [],
+            first: 0,
+            max_lines: 0,
+        },
+        {
+            model: [],
+            request: {},
+            // two lines
+            lines: logLines.slice(0, 3),
+            first: 0,
+            max_lines: 3,
+        },
+        {
+            model: logLines.slice(0, 3),
+            request: { first_line: 3 },
+            // no new lines
+            lines: logLines.slice(2, 3),
+            first: 2,
+            max_lines: 3,
+        },
+        {
+            model: logLines.slice(0, 3),
+            request: { first_line: 3 },
+            // one new line
+            lines: logLines.slice(1, 4),
+            first: 1,
+            max_lines: 4,
+        },
+        {
+            model: logLines.slice(0, 4),
+            request: { first_line: 4 },
+            // the remaining lines
+            lines: logLines.slice(2),
+            first: 2,
+            max_lines: logLines.length,
+        },
+    ];
+
+    /**
+     * Ensure that the log lines are as they should be
+     * @param {object} ctx `this` context, including the log viewer instance and the DOM node
+     * @param {array} accumulatedLogLines all log lines posted so far (not just the most recent lines)
+     */
+
+    function testJobLogs(ctx, accumulatedLogLines) {
+        const node = ctx.node;
+
+        const modelLogLines = ctx.simpleLogViewerInstance.model.getItem('lines');
+        expect(modelLogLines).toEqual(accumulatedLogLines);
+
+        if (!accumulatedLogLines.length) {
+            // no log lines element
+            expect(node.querySelector('[data-element="log-lines"]')).toBeNull();
+            // no children of the log panel
+            expect(node.querySelector('[data-element="log-panel"]').children.length).toEqual(0);
+            expect(modelLogLines).toEqual([]);
+            return;
+        }
+
+        const logLinesList = node.querySelector('[data-element="log-lines"]');
+        try {
+            expect(logLinesList.children.length).toEqual(accumulatedLogLines.length);
+            Array.from(logLinesList.children).forEach((line, ix) => {
+                const expectedClass = accumulatedLogLines[ix].is_error
+                    ? `${cssBaseClass}__line_text--error`
+                    : `${cssBaseClass}__line_text`;
+                expect(line).toHaveClass(expectedClass);
+                expect(line.textContent).toContain(accumulatedLogLines[ix].line);
+            });
+        } catch (error) {
+            console.error('testJobLogs failed: ', error, 'logLinesList: ' + logLinesList.outerHTML);
+            fail(error);
+        }
+    }
+
+    // check that the log viewer is in the appropriate state for having made a log request
+    function expectLogRequested(ctx) {
+        expect(ctx.simpleLogViewerInstance.ui.getElement('spinner')).not.toHaveClass('hidden');
+        expect(ctx.simpleLogViewerInstance.state.awaitingLog).toBeTrue();
+    }
+
+    // check that the log viewer is not waiting for a log message
+    function expectNotAwaitingLog(ctx) {
+        expect(ctx.simpleLogViewerInstance.ui.getElement('spinner')).toHaveClass('hidden');
+        expect(ctx.simpleLogViewerInstance.state.awaitingLog).toBeFalse();
+    }
+
+    // expected layout when waiting for job data
+    function expectAwaitingDataMessage(ctx) {
+        expect(ctx.simpleLogViewerInstance.getLogPanel().textContent).toContain(
+            ctx.simpleLogViewerInstance.messages.JOB_STATUS_UNKNOWN
+        );
+    }
+
+    // expected layout when the job is queued
+    function expectQueuedMessage(ctx) {
+        expect(ctx.simpleLogViewerInstance.getLogPanel().textContent).toContain(
+            ctx.simpleLogViewerInstance.messages.JOB_QUEUED
+        );
+    }
+
+    // expected layout when the job is not found
+    function expectJobNotFound(ctx) {
+        expect(ctx.node.querySelector('[data-element="log-panel"]').textContent).toBe(
+            ctx.simpleLogViewerInstance.messages.JOB_NOT_FOUND
+        );
+    }
+
+    // check the state of the UI buttons is as expected
+    function checkButtons(ctx, expectedState) {
+        const buttonsExpected =
+            ctx.simpleLogViewerInstance.buttonsByJobState[expectedState].buttons;
+        const btns = ctx.node.querySelectorAll('div[data-element="header"] button');
+        btns.forEach((btn) => {
+            const action = btn.getAttribute('data-button');
+            expect(buttonsExpected.disabled.includes(action)).toEqual(btn.disabled);
+        });
+    }
+
+    describe('The simple log viewer module', () => {
+        it('Should load the module code successfully', () => {
+            expect(SimpleLogViewer).toEqual(jasmine.any(Function));
+        });
+
+        it('Should have a css base class', () => {
+            expect(cssBaseClass).toEqual(jasmine.any(String));
+            expect(cssBaseClass).toEqual('kb-log');
+        });
+    });
+
+    describe('The simple log viewer instance', () => {
+        beforeAll(() => {
+            TestUtil.clearRuntime();
+        });
+
+        afterEach(() => {
+            TestUtil.clearRuntime();
+        });
+
+        describe('starting and then stopping', () => {
+            beforeEach(function () {
+                createLogViewer(this);
+            });
+
+            it('should have methods defined', function () {
+                ['start', 'stop'].forEach((fn) => {
+                    expect(this.simpleLogViewerInstance[fn]).toEqual(jasmine.any(Function));
+                });
+            });
+
+            it('should fail to init without a job manager', () => {
+                expect(() => {
+                    new SimpleLogViewer();
+                }).toThrowError(Error, 'Requires a valid JobManager');
+            });
+
+            it('Should fail to start without a node', async () => {
+                const simpleLogViewerInstance = new SimpleLogViewer({
+                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                });
+                await expectAsync(
+                    simpleLogViewerInstance.start({ jobId: TEST_JOB_ID })
+                ).toBeRejectedWithError('Requires a node to start');
+            });
+
+            it('Should fail to start without a jobId', async function () {
+                const simpleLogViewerInstance = new SimpleLogViewer({
+                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                });
+                await expectAsync(
+                    simpleLogViewerInstance.start({ node: this.node })
+                ).toBeRejectedWithError('Requires a job ID to start');
+            });
+
+            it('Should start as expected with inputs, and be stoppable', async function () {
+                const arg = {
+                    node: this.node,
+                    jobId: TEST_JOB_ID,
+                };
+                await this.simpleLogViewerInstance.start(arg);
+                expect(this.node.querySelector('div[data-element="status-line"]')).toBeDefined();
+                this.simpleLogViewerInstance.stop();
+                expect(this.node.innerHTML).toBe('');
+            });
+
+            it('Should send bus messages requesting job status information at startup', async function () {
+                const jobId = TEST_JOB_ID;
+                const arg = {
+                    node: this.node,
+                    jobId,
+                };
+                spyOn(this.bus, 'emit');
+                await this.simpleLogViewerInstance.start(arg);
+
+                expect(this.bus.emit.calls.allArgs()).toEqual([
+                    [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: jobId }],
+                ]);
+                expect(this.simpleLogViewerInstance.lastJobState).toEqual(null);
+            });
+
+            JobsData.allJobsWithBatchParent.forEach((jobState) => {
+                const jobId = jobState.job_id,
+                    { status } = jobState;
+                it(`should use existing job data for job ${jobId}`, async function () {
+                    const arg = {
+                        node: this.node,
+                        jobId,
+                    };
+                    spyOn(this.bus, 'emit');
+                    await this.simpleLogViewerInstance.start(arg);
+                    expect(this.simpleLogViewerInstance.lastJobState).toEqual(
+                        JobsData.jobsById[jobId]
+                    );
+
+                    if (jobState.batch_job) {
+                        expect(this.simpleLogViewerInstance.getLogPanel().textContent).toContain(
+                            this.simpleLogViewerInstance.messages.BATCH_JOB
+                        );
+                        expect(this.bus.emit.calls.allArgs()).toEqual(
+                            jasmine.arrayWithExactContents([
+                                [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: jobId }],
+                            ])
+                        );
+                        checkButtons(this, 'default');
+                        return;
+                    }
+
+                    const mode = this.simpleLogViewerInstance._statusToMode(status);
+                    switch (mode) {
+                        case 'queued':
+                            // queued: LOG_PANEL should contain a message
+                            expectQueuedMessage(this);
+                            expect(this.bus.emit.calls.allArgs()).toEqual(
+                                jasmine.arrayWithExactContents([
+                                    [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: jobId }],
+                                ])
+                            );
+                            checkButtons(this, 'default');
+                            break;
+
+                        case 'running':
+                        case 'terminal':
+                            expect(this.bus.emit.calls.allArgs()).toEqual(
+                                jasmine.arrayWithExactContents([
+                                    [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: jobId }],
+                                    [jcm.MESSAGE_TYPE.LOGS, { [jcm.PARAM.JOB_ID]: jobId }],
+                                ])
+                            );
+                            break;
+
+                        // job not found
+                        default:
+                            expect(
+                                this.simpleLogViewerInstance.getLogPanel().textContent
+                            ).toContain(this.simpleLogViewerInstance.messages.JOB_NOT_FOUND);
+                            expect(this.bus.emit.calls.allArgs()).toEqual(
+                                jasmine.arrayWithExactContents([
+                                    [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: jobId }],
+                                ])
+                            );
+                            checkButtons(this, 'default');
+                            break;
+                    }
+                });
+            });
+            it('should render appropriately without job data in the job manager', async function () {
+                const jobId = TEST_JOB_ID;
+                const arg = {
+                    node: this.node,
+                    jobId,
+                };
+                spyOn(this.bus, 'emit');
+                await this.simpleLogViewerInstance.start(arg);
+                expectAwaitingDataMessage(this);
+                expect(this.bus.emit.calls.allArgs()).toEqual(
+                    jasmine.arrayWithExactContents([
+                        [jcm.MESSAGE_TYPE.STATUS, { [jcm.PARAM.JOB_ID]: jobId }],
+                    ])
+                );
+                checkButtons(this, 'default');
+            });
+        });
+
+        describe('controls', () => {
+            const jobState = jobsByStatus.running[0];
+            const jobId = jobState.job_id;
+            let jlv, container;
+
+            beforeEach(async function () {
+                createLogViewer(this);
+                jlv = this.simpleLogViewerInstance;
+                container = this.node;
+                this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                    TestUtil.sendBusMessage({
+                        bus: this.bus,
+                        message: {
+                            [jobId]: {
+                                [jcm.PARAM.JOB_ID]: jobId,
+                                jobState,
+                            },
+                        },
+                        channelType: jcm.CHANNEL.JOB,
+                        channelId: jobId,
+                        type: jcm.MESSAGE_TYPE.STATUS,
+                    });
+                });
+
+                this.bus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                    expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                    TestUtil.sendBusMessage({
+                        bus: this.bus,
+                        message: {
+                            [jobId]: {
+                                [jcm.PARAM.JOB_ID]: jobId,
+                                [jcm.PARAM.BATCH_ID]: jobState.batch_id,
+                                lines: lotsOfLogLines,
+                                first: 0,
+                                latest: true,
+                                max_lines: lotsOfLogLines.length,
+                            },
+                        },
+                        channelType: jcm.CHANNEL.JOB,
+                        channelId: jobId,
+                        type: jcm.MESSAGE_TYPE.LOGS,
+                    });
+                });
+
+                await this.simpleLogViewerInstance.start({
+                    node: this.node,
+                    jobId,
+                });
+                await TestUtil.waitForElementChange(
+                    this.node.querySelector('[data-element="log-panel"]')
+                );
+                const logPanelTitle = this.node.querySelector(`.${cssBaseClass}__logs_title`);
+                logPanelTitle.click();
+            });
+
+            afterEach(async () => {
+                await jlv.stop();
+                container.remove();
+            });
+
+            it('should have an expand button that toggles the log container class', function () {
+                const standardClass = `.${cssBaseClass}__content`,
+                    expandedClass = `${standardClass}--expanded`,
+                    expandButton = this.node.querySelector(`.${cssBaseClass}__log_button--expand`);
+
+                expect(this.node.querySelectorAll(standardClass).length).toEqual(1);
+                expect(this.node.querySelectorAll(expandedClass).length).toEqual(0);
+
+                expandButton.click();
+                expect(this.node.querySelectorAll(standardClass).length).toEqual(0);
+                expect(this.node.querySelectorAll(expandedClass).length).toEqual(1);
+
+                expandButton.click();
+                expect(this.node.querySelectorAll(standardClass).length).toEqual(1);
+                expect(this.node.querySelectorAll(expandedClass).length).toEqual(0);
+            });
+
+            // the next two tests do not pass consistently when run by the test harness
+            xit('Should have the top button go to the top', async function () {
+                const logContent = this.node.querySelector('.kb-log__content'),
+                    topButton = this.node.querySelector(`.${cssBaseClass}__log_button--top`);
+                // set the scrollTop to the midway point
+                logContent.scrollTop = logContent.clientHeight / 2;
+
+                await TestUtil.waitForElementChange(logContent, () => {
+                    topButton.click();
+                });
+                expect(logContent.scrollTop).toEqual(0);
+            });
+
+            xit('Should have the bottom button go to the end', async function () {
+                const logContent = this.node.querySelector('.kb-log__content'),
+                    bottomButton = this.node.querySelector(`.${cssBaseClass}__log_button--bottom`);
+                // set the scrollTop to the midway point
+                logContent.scrollTop = logContent.clientHeight / 2;
+
+                await TestUtil.waitForElementChange(logContent, () => {
+                    bottomButton.click();
+                });
+                expect(logContent.scrollTop).not.toEqual(0);
+                expect(logContent.scrollTop).toEqual(
+                    logContent.scrollHeight - logContent.clientHeight
+                );
+            });
+
+            xit('should have stop and play buttons to turn logs off and on', () => {});
+        });
+
+        // the log display
+        describe('log viewer', () => {
+            beforeEach(function () {
+                createLogViewer(this, TEST_POLL_INTERVAL);
+            });
+            afterEach(() => {
+                TestUtil.clearRuntime();
+            });
+
+            // start off without a job state for the job ID
+            ['job', 'batch'].forEach((inputType) => {
+                // job not found: logs container is removed
+
+                it(`should not render logs if the job is not found, ${inputType} channel`, async function () {
+                    const jobState = jobsByStatus['does_not_exist'][0];
+                    const jobId = jobState.job_id;
+                    const input = generateInput(jobId);
+                    this.jobManager.model.deleteItem(`exec.jobs.byId.${jobId}`);
+                    this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobState.job_id });
+                        // send the job message
+                        TestUtil.sendBusMessage({
+                            bus: this.bus,
+                            type: jcm.MESSAGE_TYPE.STATUS,
+                            ...input[inputType],
+                        });
+                    });
+
+                    await this.simpleLogViewerInstance.start({
+                        node: this.node,
+                        jobId,
+                    });
+
+                    await TestUtil.waitForElementChange(
+                        this.node.querySelector('[data-element="log-panel"]')
+                    );
+                    // the job log panel should have a message saying that the job does not exist
+                    expectJobNotFound(this);
+                    expectNotAwaitingLog(this);
+                    checkButtons(this, 'default');
+                });
+
+                // queued jobs: message to say that the logs will be available when job runs
+                queueStates.forEach((queueState) => {
+                    it(`should render a queued message for "${queueState}" jobs, ${inputType} channel`, async function () {
+                        const jobState = jobsByStatus[queueState][0];
+                        const jobId = jobState.job_id;
+                        const input = generateInput(jobId);
+                        this.jobManager.model.deleteItem(`exec.jobs.byId.${jobId}`);
+
+                        this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                            expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobState.job_id });
+                            // send the job message
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                type: jcm.MESSAGE_TYPE.STATUS,
+                                ...input[inputType],
+                            });
+                        });
+
+                        await this.simpleLogViewerInstance.start({
+                            node: this.node,
+                            jobId,
+                        });
+
+                        await TestUtil.waitForElementChange(
+                            this.node.querySelector('[data-element="log-panel"]')
+                        );
+                        expectQueuedMessage(this);
+                        expectNotAwaitingLog(this);
+                        checkButtons(this, 'default');
+                    });
+                });
+
+                // running job: job logs are updated as they are received
+                it(`Should render job logs whilst job is running, ${inputType} channel`, async function () {
+                    const jobState = jobsByStatus['running'][0];
+                    const jobId = jobState.job_id;
+                    const input = generateInput(jobId),
+                        { channelType, channelId } = input[inputType];
+
+                    // lines to return each time there is a request for the latest logs
+                    // first request - 0 lines; second: 2 log lines; third: same as second; last: all log lines.
+                    const logMessages = [[], logLines.slice(0, 2), logLines.slice(0, 2), logLines]; //
+                    let acc = 0;
+
+                    spyOn(this.bus, 'emit').and.callFake((...args) => {
+                        if (args[0] === jcm.MESSAGE_TYPE.STATUS) {
+                            expect(args[1]).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                type: jcm.MESSAGE_TYPE.STATUS,
+                                ...input[inputType],
+                            });
+                        } else if (args[0] === jcm.MESSAGE_TYPE.LOGS) {
+                            expectLogRequested(this);
+                            const logUpdate = logMessages[acc];
+                            // set up the mutation observer to watch for UI spinner changes
+                            // the spinner is shown whenever the log viewer is waiting for logs
+                            // and hidden whenever a log update comes in
+                            // there are four job logs messages to check for, so once we have seen
+                            // all four, resolve the promise and finish the test.
+                            const observer = new MutationObserver(() => {
+                                testJobLogs(this, logUpdate);
+                                observer.disconnect();
+                                if (logMessages.length === acc + 1) {
+                                    return;
+                                }
+                            });
+                            observer.observe(this.node.querySelector('[data-element="spinner"]'), {
+                                attributes: true,
+                                childList: true,
+                                subtree: true,
+                            });
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                message: {
+                                    [jobId]: {
+                                        [jcm.PARAM.JOB_ID]: jobId,
+                                        [jcm.PARAM.BATCH_ID]: jobState.batch_id,
+                                        lines: logUpdate,
+                                        first: 0,
+                                        latest: true,
+                                        max_lines: logUpdate.length,
+                                    },
+                                },
+                                channelType,
+                                channelId,
+                                type: jcm.MESSAGE_TYPE.LOGS,
+                            });
+                            acc++;
+                        }
+                    });
+
+                    await this.simpleLogViewerInstance.start({
+                        node: this.node,
+                        jobId,
+                    });
+
+                    await TestUtil.waitForElementState(this.node, () => {
+                        return (
+                            this.node.querySelectorAll('.kb-log__log_line_container li').length ===
+                            logLines.length
+                        );
+                    });
+                    expectNotAwaitingLog(this);
+                    checkButtons(this, 'running_scrolling');
+                });
+
+                // job running, job logs have been deleted
+                it(`should render a message when logs are deleted, state running, ${inputType} channel`, async function () {
+                    const jobState = jobsByStatus['running'][0];
+                    const jobId = jobState.job_id;
+                    const input = generateInput(jobId),
+                        { channelType, channelId } = input[inputType];
+                    this.jobManager.model.deleteItem(`exec.jobs.byId.${jobId}`);
+
+                    this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                        TestUtil.sendBusMessage({
+                            bus: this.bus,
+                            type: jcm.MESSAGE_TYPE.STATUS,
+                            ...input[inputType],
+                        });
+                    });
+
+                    // this is called when the state is 'running'
+                    this.bus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                        expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                        TestUtil.sendBusMessage({
+                            bus: this.bus,
+                            message: {
+                                [jobId]: {
+                                    [jcm.PARAM.JOB_ID]: jobId,
+                                    error: 'summat went wrong',
+                                },
+                            },
+                            channelType,
+                            channelId,
+                            type: jcm.MESSAGE_TYPE.LOGS,
+                        });
+                    });
+
+                    spyOn(console, 'error');
+                    await this.simpleLogViewerInstance.start({
+                        node: this.node,
+                        jobId,
+                    });
+
+                    await TestUtil.waitForElementChange(
+                        this.node.querySelector('[data-element="log-panel"]')
+                    );
+
+                    // await the second change, when the logs message is received
+                    await TestUtil.waitForElementChange(
+                        this.node.querySelector('[data-element="log-panel"]')
+                    );
+
+                    expect(this.node.querySelector('[data-element="log-panel"]').textContent).toBe(
+                        'No log entries to show.'
+                    );
+                    expectNotAwaitingLog(this);
+                    expect(this.simpleLogViewerInstance.state.looping).toBeFalse();
+
+                    const allCalls = console.error.calls.allArgs();
+                    expect(allCalls.length).toEqual(1);
+                    expect(allCalls[0].length).toEqual(1);
+                    expect(allCalls[0][0]).toMatch(
+                        /Error retrieving log for JOB_.*?summat went wrong/
+                    );
+                });
+
+                endStates.forEach((endState) => {
+                    // completed statuses - should be one request for logs
+                    it(`Should render all job logs if the job status is ${endState}, ${inputType} channel`, async function () {
+                        const jobState = jobsByStatus[endState][0];
+                        const jobId = jobState.job_id;
+                        const input = generateInput(jobId),
+                            { channelType, channelId } = input[inputType];
+                        this.jobManager.model.deleteItem(`exec.jobs.byId.${jobId}`);
+
+                        this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                            expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                type: jcm.MESSAGE_TYPE.STATUS,
+                                ...input[inputType],
+                            });
+                        });
+
+                        this.bus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                            expectLogRequested(this);
+                            expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                message: {
+                                    [jobId]: {
+                                        [jcm.PARAM.JOB_ID]: jobId,
+                                        [jcm.PARAM.BATCH_ID]: jobState.batch_id,
+                                        lines: logLines,
+                                        first: 0,
+                                        latest: true,
+                                        max_lines: logLines.length,
+                                    },
+                                },
+                                channelType,
+                                channelId,
+                                type: jcm.MESSAGE_TYPE.LOGS,
+                            });
+                        });
+
+                        await this.simpleLogViewerInstance.start({
+                            node: this.node,
+                            jobId,
+                        });
+
+                        await TestUtil.waitForElementChange(
+                            this.node.querySelector('[data-element="log-panel"]')
+                        );
+                        testJobLogs(this, logLines);
+                        expectNotAwaitingLog(this);
+                        checkButtons(this, 'terminal');
+                    });
+
+                    // logs deleted: 'No log entries to show' message
+                    // create a mutation observer to watch for changes to the log-panel node; when those changes
+                    // occur, `callback` will be run to test that the changes are as expected
+                    it(`should render a message when logs are deleted, state ${endState}, ${inputType} channel`, async function () {
+                        const jobState = jobsByStatus[endState][0];
+                        const jobId = jobState.job_id;
+                        const input = generateInput(jobId),
+                            { channelType, channelId } = input[inputType];
+                        this.jobManager.model.deleteItem(`exec.jobs.byId.${jobId}`);
+
+                        this.bus.on(jcm.MESSAGE_TYPE.STATUS, (msg) => {
+                            expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                type: jcm.MESSAGE_TYPE.STATUS,
+                                ...input[inputType],
+                            });
+                        });
+
+                        this.bus.on(jcm.MESSAGE_TYPE.LOGS, (msg) => {
+                            expectLogRequested(this);
+                            expect(msg).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                message: {
+                                    [jobId]: {
+                                        error: 'DANGER!',
+                                        [jcm.PARAM.JOB_ID]: jobId,
+                                    },
+                                },
+                                channelType,
+                                channelId,
+                                type: jcm.MESSAGE_TYPE.LOGS,
+                            });
+                        });
+                        spyOn(console, 'error');
+                        await this.simpleLogViewerInstance.start({
+                            node: this.node,
+                            jobId,
+                        });
+                        await TestUtil.waitForElementChange(
+                            this.node.querySelector('[data-element="log-panel"]')
+                        );
+
+                        expect(
+                            this.node.querySelector('[data-element="log-panel"]').textContent
+                        ).toBe('No log entries to show.');
+                        expectNotAwaitingLog(this);
+                        expect(this.simpleLogViewerInstance.state.looping).toBeFalse();
+                        const allCalls = console.error.calls.allArgs();
+                        expect(allCalls.length).toEqual(1);
+                        expect(allCalls[0].length).toEqual(1);
+                        expect(allCalls[0][0]).toMatch(/Error retrieving log for JOB_.*?DANGER!/);
+                    });
+                });
+            });
+        });
+
+        describe('fetching logs', () => {
+            beforeEach(function () {
+                createLogViewer(this, TEST_POLL_INTERVAL);
+            });
+            afterEach(() => {
+                TestUtil.clearRuntime();
+            });
+
+            ['job', 'batch'].forEach((inputType) => {
+                it(`can intelligently deal with log updates, ${inputType} mode`, async function () {
+                    const jobId = JobsData.JOB_NAMES.RUNNING,
+                        runningJob = JobsData.jobsByStatus.running[0],
+                        input = generateInput(jobId);
+                    let acc = 0;
+
+                    spyOn(this.simpleLogViewerInstance, 'handleJobStatus').and.callThrough();
+
+                    spyOn(this.bus, 'emit').and.callFake((...args) => {
+                        if (args[0] === jcm.MESSAGE_TYPE.STATUS) {
+                            expect(args[1]).toEqual({ [jcm.PARAM.JOB_ID]: jobId });
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                type: jcm.MESSAGE_TYPE.STATUS,
+                                ...input[inputType],
+                                message: {
+                                    [jobId]: {
+                                        [jcm.PARAM.JOB_ID]: jobId,
+                                        jobState: runningJob,
+                                    },
+                                },
+                            });
+                        } else if (args[0] === jcm.MESSAGE_TYPE.LOGS) {
+                            expectLogRequested(this);
+                            if (acc >= messageSeries.length) {
+                                // finish the test
+                                expect(this.simpleLogViewerInstance.model.getItem('lines')).toEqual(
+                                    logLines
+                                );
+                                return;
+                            }
+                            const messageParams = messageSeries[acc];
+                            expect(args[1]).toEqual({
+                                [jcm.PARAM.JOB_ID]: jobId,
+                                ...messageParams.request,
+                            });
+                            expect(this.simpleLogViewerInstance.model.getItem('lines')).toEqual(
+                                messageParams.model
+                            );
+                            testJobLogs(this, messageParams.model);
+                            TestUtil.sendBusMessage({
+                                bus: this.bus,
+                                type: jcm.MESSAGE_TYPE.LOGS,
+                                ...input[inputType],
+                                message: {
+                                    [jobId]: {
+                                        [jcm.PARAM.JOB_ID]: jobId,
+                                        latest: true,
+                                        batch_id: runningJob.batch_id,
+                                        ...messageParams,
+                                    },
+                                },
+                            });
+                            acc++;
+                        }
+                    });
+
+                    await this.simpleLogViewerInstance.start({
+                        node: this.node,
+                        jobId,
+                    });
+
+                    await TestUtil.waitForElementState(this.node, () => {
+                        return (
+                            this.node.querySelectorAll('.kb-log__log_line_container li').length >=
+                            logLines.length
+                        );
+                    });
+                    expect(this.simpleLogViewerInstance.model.getItem('lines')).toEqual(logLines);
+                    expectNotAwaitingLog(this);
+                });
+            });
+        });
+
+        describe('life cycle tests', () => {
+            beforeEach(function () {
+                createLogViewer(this, TEST_POLL_INTERVAL);
+            });
+            afterEach(() => {
+                TestUtil.clearRuntime();
+            });
+
+            ['job', 'batch'].forEach((inputType) => {
+                it(`has a life cycle when receiving status messages in ${inputType} mode`, async function () {
+                    const jobId = JobsData.JOB_NAMES.CREATED,
+                        input = generateInput(jobId);
+                    let acc = -1;
+
+                    // // set the job manager's status request loop going
+                    this.jobManager.restoreFromSaved();
+
+                    // status updates
+                    const jobStatusSeries = TestUtil.JSONcopy(JobsData.jobProgression);
+
+                    // in batch mode, add a not found message to the end to allow our tests to finish
+                    // this won't work in individual job mode as the listener will be removed
+                    if (inputType === 'batch') {
+                        jobStatusSeries.push({
+                            job_id: JobsData.JOB_NAMES.CREATED,
+                            status: 'does_not_exist',
+                        });
+                    }
+
+                    spyOn(this.bus, 'emit').and.callFake((...args) => {
+                        if (args[0] === jcm.MESSAGE_TYPE.STATUS) {
+                            const jobIdList = args[1][jcm.PARAM.JOB_ID_LIST] || [
+                                args[1][jcm.PARAM.JOB_ID],
+                            ];
+                            acc++;
+
+                            if (acc < jobStatusSeries.length) {
+                                const { status } = jobStatusSeries[acc];
+
+                                // the final request will not contain CREATED as it has already completed
+                                // but we added on the 'does_not_exist' message for fun
+                                if (status === 'does_not_exist') {
+                                    expect(jobIdList).not.toContain(JobsData.JOB_NAMES.CREATED);
+                                } else {
+                                    expect(jobIdList).toContain(JobsData.JOB_NAMES.CREATED);
+                                }
+
+                                TestUtil.sendBusMessage({
+                                    bus: this.bus,
+                                    type: jcm.MESSAGE_TYPE.STATUS,
+                                    ...input[inputType],
+                                    message: {
+                                        ...input[inputType].message,
+                                        [jobId]: {
+                                            [jcm.PARAM.JOB_ID]: jobId,
+                                            jobState: jobStatusSeries[acc],
+                                        },
+                                    },
+                                });
+                            } else {
+                                // otherwise, the test is finished
+                                expect(jobIdList).not.toContain(JobsData.JOB_NAMES.CREATED);
+                                this.node.querySelector('[data-element="log-panel"]').textContent =
+                                    'WORK COMPLETE!';
+                            }
+                        }
+                    });
+
+                    this.simpleLogViewerInstance.jobManager.addEventHandler(
+                        jcm.MESSAGE_TYPE.STATUS,
+                        {
+                            zzz_test_handler: () => {
+                                switch (jobStatusSeries[acc].status) {
+                                    case 'created':
+                                    case 'estimating':
+                                    case 'queued':
+                                        expectQueuedMessage(this);
+                                        expectNotAwaitingLog(this);
+                                        checkButtons(this, 'default');
+                                        break;
+                                    case 'running':
+                                        expectLogRequested(this);
+                                        expect(
+                                            this.simpleLogViewerInstance.state.looping
+                                        ).toBeTrue();
+                                        checkButtons(this, 'running_scrolling');
+                                        break;
+                                    case 'completed':
+                                        expectLogRequested(this);
+                                        expect(
+                                            this.simpleLogViewerInstance.state.looping
+                                        ).toBeFalse();
+                                        checkButtons(this, 'terminal');
+                                        break;
+                                    case 'does_not_exist':
+                                        expectJobNotFound(this);
+                                        expectNotAwaitingLog(this);
+                                        checkButtons(this, 'default');
+                                        break;
+                                }
+                            },
+                        }
+                    );
+
+                    await this.simpleLogViewerInstance.start({
+                        node: this.node,
+                        jobId,
+                    });
+
+                    await TestUtil.waitForElementState(this.node, () => {
+                        return (
+                            this.node.querySelector('[data-element="log-panel"]').textContent ===
+                            'WORK COMPLETE!'
+                        );
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/unit/spec/common/simpleLogViewer-spec.js
+++ b/test/unit/spec/common/simpleLogViewer-spec.js
@@ -308,8 +308,9 @@ define([
             });
 
             it('Should fail to start without a node', async () => {
+                createJobManager(this);
                 const simpleLogViewerInstance = new SimpleLogViewer({
-                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                    jobManager: this.jobManager,
                 });
                 await expectAsync(
                     simpleLogViewerInstance.start({ jobId: TEST_JOB_ID })
@@ -317,8 +318,9 @@ define([
             });
 
             it('Should fail to start without a jobId', async function () {
+                createJobManager(this);
                 const simpleLogViewerInstance = new SimpleLogViewer({
-                    jobManager: { bus: Runtime.make().bus(), model: {} },
+                    jobManager: this.jobManager,
                 });
                 await expectAsync(
                     simpleLogViewerInstance.start({ node: this.node })


### PR DESCRIPTION
# Description of PR purpose/changes

This PR splitting out the job log viewer into a job state viewer and a simplified log viewer, both of which use the job manager. The next PR will switch over the job status table to use these new widgets, so that all the bulk import cell stuff uses the job manager.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-678
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
