### PR TITLE
DATAUP-678: minor tidying

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobActionDropdown.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobActionDropdown.js
@@ -183,7 +183,7 @@ define([
 
         function updateState() {
             const jobCountsByStatus = Jobs.getCurrentJobCounts(
-                jobManager.model.getItem('exec.jobs')
+                jobManager.model.getItem('exec.jobs.byId')
             );
 
             actionArr.forEach((action) => {

--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -913,13 +913,13 @@ define([
     /**
      * group job IDs by job status
      *
-     * @param {object} jobIx
+     * @param {object} jobsIndex jobs indexed by ID
      * @returns {object} jobsByStatus with keys job status and values Set object containing job IDs
      */
-    function _groupJobsByStatus(jobIx) {
+    function _groupJobsByStatus(jobsIndex) {
         // index by status
         const jobsByStatus = {};
-        Object.values(jobIx).forEach((job) => {
+        Object.values(jobsIndex).forEach((job) => {
             const { job_id, status } = job;
             if (!jobsByStatus[status]) {
                 jobsByStatus[status] = new Set();
@@ -938,16 +938,11 @@ define([
      * @returns {object} with keys job status and values number of jobs in that state
      */
     function getCurrentJobCounts(jobsIndex, options = {}) {
-        if (
-            !jobsIndex ||
-            !Object.keys(jobsIndex).length ||
-            !jobsIndex.byId ||
-            !Object.keys(jobsIndex.byId).length
-        ) {
+        if (!jobsIndex || !Object.keys(jobsIndex).length) {
             return {};
         }
         const jobsByRetryParent = {};
-        const currentJobs = getCurrentJobs(Object.values(jobsIndex.byId), jobsByRetryParent);
+        const currentJobs = getCurrentJobs(Object.values(jobsIndex), jobsByRetryParent);
 
         // get job count for each status
         const statuses = _jobCountByStatus(_groupJobsByStatus(currentJobs));
@@ -970,17 +965,12 @@ define([
 
     /**
      * Given an object containing jobs indexed by ID, summarise the status of the jobs
-     * @param {object} jobsIndex the index of job data, e.g. from retrieving `exec.jobs` in a batch cell
+     * @param {object} jobsIndex the index of job data, e.g. from retrieving `exec.jobs.byId` in a batch cell
      * @returns {string} summary string
      */
 
     function createCombinedJobState(jobsIndex) {
-        if (
-            !jobsIndex ||
-            !Object.keys(jobsIndex).length ||
-            !jobsIndex.byId ||
-            !Object.keys(jobsIndex.byId).length
-        ) {
+        if (!jobsIndex || !Object.keys(jobsIndex).length) {
             return '';
         }
 
@@ -1034,17 +1024,12 @@ define([
 
     /**
      * Given an object containing jobs indexed by ID, create a summary for a collapsed cell
-     * @param {object} jobsIndex the index of job data, e.g. from retrieving `exec.jobs` in a batch cell
+     * @param {object} jobsIndex the index of job data, e.g. from retrieving `exec.jobs.byId` in a batch cell
      * @returns {string} summary string
      */
 
     function createCombinedJobStateSummary(jobsIndex) {
-        if (
-            !jobsIndex ||
-            !Object.keys(jobsIndex).length ||
-            !jobsIndex.byId ||
-            !Object.keys(jobsIndex.byId).length
-        ) {
+        if (!jobsIndex || !Object.keys(jobsIndex).length) {
             return '';
         }
         // get job count for each status and retries
@@ -1071,16 +1056,11 @@ define([
     /**
      * Get the FSM state for a bulk cell from the jobs
      *
-     * @param {object} jobsIndex jobs index
+     * @param {object} jobsIndex the index of job data, e.g. from retrieving `exec.jobs.byId` in a batch cell
      * @returns {string} FSM state
      */
     function getFsmStateFromJobs(jobsIndex) {
-        if (
-            !jobsIndex ||
-            !Object.keys(jobsIndex).length ||
-            !jobsIndex.byId ||
-            !Object.keys(jobsIndex.byId).length
-        ) {
+        if (!jobsIndex || !Object.keys(jobsIndex).length) {
             return null;
         }
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseCellToolbarMenu.js
@@ -235,7 +235,10 @@ define([
                         );
                     collapsedCellJobStatus = Jobs.createJobStatusFromFsm(fsmMode, fsmStage);
                 } else if (utils.getCellMeta(_cell, 'kbase.bulkImportCell.exec.jobs')) {
-                    const currentJobs = utils.getCellMeta(_cell, 'kbase.bulkImportCell.exec.jobs');
+                    const currentJobs = utils.getCellMeta(
+                        _cell,
+                        'kbase.bulkImportCell.exec.jobs.byId'
+                    );
                     collapsedCellJobStatus = Jobs.createCombinedJobStateSummary(currentJobs);
                 }
             }

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -676,7 +676,7 @@ define([
                             // Update the execMessage panel with details of the active jobs
                             controlPanel.setExecMessage(
                                 Jobs.createCombinedJobState(
-                                    jobManagerContext.model.getItem('exec.jobs')
+                                    jobManagerContext.model.getItem('exec.jobs.byId')
                                 )
                             );
                         },
@@ -699,7 +699,7 @@ define([
 
                             if (cellCollapsed && jobStatusEl) {
                                 jobStatusEl.innerHTML = Jobs.createCombinedJobStateSummary(
-                                    jobManagerContext.model.getItem('exec.jobs')
+                                    jobManagerContext.model.getItem('exec.jobs.byId')
                                 );
                             }
                         },

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -419,7 +419,7 @@ define([
                 };
             });
         });
-        return { byId: outputJobs };
+        return outputJobs;
     }
 
     describe('createCombinedJobState', () => {
@@ -440,7 +440,7 @@ define([
         const tests = [
             {
                 desc: 'all jobs',
-                jobs: { byId: JobsData.jobsById },
+                jobs: JobsData.jobsById,
                 expected: `${batch} in progress: 3 queued, 1 running, 1 success, 2 failed, 2 cancelled, 1 not found`,
                 fsmState: 'inProgressResultsAvailable',
                 statusBarSummary: summary.running,
@@ -455,7 +455,7 @@ define([
             },
             {
                 desc: 'jobs with retries',
-                jobs: { byId: JobsData.batchJob.jobsById },
+                jobs: JobsData.batchJob.jobsById,
                 expected: `${batch} in progress: 3 queued, 1 running, 1 success (3 jobs retried)`,
                 fsmState: 'inProgressResultsAvailable',
                 statusBarSummary: summary.running,
@@ -464,10 +464,8 @@ define([
             {
                 desc: 'jobs with retries, original jobs only',
                 jobs: {
-                    byId: {
-                        ...JobsData.batchJob.originalJobs,
-                        retryBatchId: JobsData.batchJob.jobsById[retryBatchId],
-                    },
+                    ...JobsData.batchJob.originalJobs,
+                    retryBatchId: JobsData.batchJob.jobsById[retryBatchId],
                 },
                 expected: `${batch} in progress: 2 queued, 1 failed, 2 cancelled`,
                 fsmState: 'inProgress',
@@ -622,22 +620,6 @@ define([
             {
                 desc: 'null',
                 jobs: null,
-                expected: '',
-                fsmState: null,
-                statusBarSummary: '',
-                statuses: {},
-            },
-            {
-                desc: 'byId is empty',
-                jobs: { byId: {} },
-                expected: '',
-                fsmState: null,
-                statusBarSummary: '',
-                statuses: {},
-            },
-            {
-                desc: 'byId is null',
-                jobs: { byId: null },
                 expected: '',
                 fsmState: null,
                 statusBarSummary: '',


### PR DESCRIPTION
# Description of PR purpose/changes

Some minor tidying noticed along the way. I would have integrated it into the previous PRs but don't want to have to rebase them again!

Changes:
- Switch methods using indexed jobs from the model to use `exec.jobs.byId`, rather than `exec.jobs`
- rename JobStateViewer (remove the "Managed" part)
- update tests

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-678
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
