### PR TITLE
DATAUP-719: tab switch fix and new launching tab

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/jobStatus/jobStatusTable.js
@@ -7,8 +7,6 @@ define([
     'common/jobStateViewer',
     'common/simpleLogViewer',
     './jobActionDropdown',
-    'util/jobLogViewer',
-    'util/appCellUtil',
     'util/string',
     'jquery-dataTables',
 ], (
@@ -20,8 +18,6 @@ define([
     JobStateViewerModule,
     SimpleLogViewerModule,
     JobActionDropdown,
-    JobLogViewerModule,
-    Util,
     String
 ) => {
     'use strict';
@@ -302,7 +298,9 @@ define([
             this.jobManager.removeEventHandler('modelUpdate', 'dropdown');
             this.jobManager.removeEventHandler(jcm.MESSAGE_TYPE.INFO, 'jobStatusTable_info');
             this.jobManager.removeEventHandler(jcm.MESSAGE_TYPE.ERROR, 'jobStatusTable_error');
-            this.container.innerHTML = '';
+            if (this.container) {
+                this.container.innerHTML = '';
+            }
             if (this.dropdownWidget) {
                 return this.dropdownWidget.stop();
             }

--- a/nbextensions/bulkImportCell/bulkImportCellStates.js
+++ b/nbextensions/bulkImportCell/bulkImportCellStates.js
@@ -33,7 +33,15 @@ define([], () => {
         const state = {
             tabs: {},
         };
-        ['configure', 'viewConfigure', 'info', 'jobStatus', 'results', 'error'].forEach((tabId) => {
+        [
+            'configure',
+            'viewConfigure',
+            'info',
+            'launching',
+            'jobStatus',
+            'results',
+            'error',
+        ].forEach((tabId) => {
             state.tabs[tabId] = defaultView();
         });
         enabled.forEach((enabledTab) => {
@@ -72,10 +80,10 @@ define([], () => {
         launching: {
             ui: {
                 tab: tabState(
-                    ['viewConfigure', 'info'],
-                    ['viewConfigure', 'info', 'jobStatus', 'results']
+                    ['viewConfigure', 'info', 'launching'],
+                    ['viewConfigure', 'info', 'launching', 'results']
                 ),
-                defaultTab: 'viewConfigure',
+                defaultTab: 'launching',
                 action: {
                     name: 'cancel',
                     disabled: false,

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTab-Spec.js
@@ -32,7 +32,11 @@ define([
 
         it('has expected functions', () => {
             expect(JobStatusTab.make).toBeDefined();
-            expect(JobStatusTab.make).toEqual(jasmine.any(Function));
+            [JobStatusTab.make, JobStatusTab.launchMode.make, JobStatusTab.runMode.make].forEach(
+                (fn) => {
+                    expect(fn).toEqual(jasmine.any(Function));
+                }
+            );
         });
     });
 
@@ -70,7 +74,35 @@ define([
             }, this);
         });
 
-        it('should start the job status tab widget', async function () {
+        it('can be started in launch mode or run mode', function () {
+            // default: run mode
+            expect(this.jobStatusTabInstance.mode()).toEqual('runMode');
+
+            const runModeTab = JobStatusTab.runMode.make();
+            expect(runModeTab.mode()).toEqual('runMode');
+
+            const launchModeTab = JobStatusTab.launchMode.make();
+            expect(launchModeTab.mode()).toEqual('launchMode');
+
+            const specifiedLaunchModeTab = JobStatusTab.make({ launchMode: true });
+            expect(specifiedLaunchModeTab.mode()).toEqual('launchMode');
+        });
+
+        it('should display a message in launch mode', async () => {
+            const launchModeTab = JobStatusTab.launchMode.make();
+            expect(launchModeTab.mode()).toEqual('launchMode');
+            await launchModeTab.start({ node: container });
+
+            expect(container.childNodes.length).toBe(1);
+            const [firstChild] = container.childNodes;
+            expect(firstChild).toHaveClass('kb-job-status-tab__container');
+            expect(firstChild.getAttribute('data-element')).toBeNull();
+            expect(firstChild.textContent).toEqual(
+                'Batch job submitted; waiting for response from job runner.'
+            );
+        });
+
+        it('should start the job status tab widget in run mode', async function () {
             expect(container.classList.length).toBe(0);
             await this.jobStatusTabInstance.start({ node: container });
             expect(container.childNodes.length).toBe(1);

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -444,9 +444,9 @@ define([
                         return !cancelButton.classList.contains('hidden');
                     });
                     checkTabState(cell, {
-                        selectedTab: 'viewConfigure',
-                        enabledTabs: ['viewConfigure', 'info'],
-                        visibleTabs: ['viewConfigure', 'info', 'jobStatus', 'results'],
+                        selectedTab: 'launching',
+                        enabledTabs: ['viewConfigure', 'info', 'launching'],
+                        visibleTabs: ['viewConfigure', 'info', 'launching', 'results'],
                     });
 
                     // wait for the cell to receive the run status message and transition


### PR DESCRIPTION
# Description of PR purpose/changes

Two tab-related tasks:

- Add a new "launching" state to the bulk import cell, with a message saying that the job has been submitted to the job runner and the cell is waiting for a response. I've made this part of the job status tab as it doesn't need its own widget.

- Fix a tab switching error where the BI cell gets confused if no tab is selected/open when it has to change tabs.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-719
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, creating a bulk import cell, and then starting a batch job.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
