### PR TITLE
DATAUP-719: app manager method rename

### DIFF
--- a/kbase-extension/static/kbase/js/common/pythonInterop.js
+++ b/kbase-extension/static/kbase/js/common/pythonInterop.js
@@ -115,7 +115,7 @@ define([], () => {
         return [
             paramSetName + ' = ' + pythonifiedParams,
             'from biokbase.narrative.jobs.appmanager import AppManager',
-            'AppManager().run_app_batch(' + buildNiceArgsList(positionalArgs) + ')',
+            'AppManager().run_legacy_batch_app(' + buildNiceArgsList(positionalArgs) + ')',
         ].join('\n');
     }
 
@@ -131,7 +131,7 @@ define([], () => {
                 run_id: runId,
             }),
             args = positionalArgs.concat(namedArgs),
-            appCall = params instanceof Array ? 'run_app_batch' : 'run_app',
+            appCall = params instanceof Array ? 'run_legacy_batch_app' : 'run_app',
             pythonCode = [
                 'from biokbase.narrative.jobs.appmanager import AppManager',
                 'AppManager().' + appCall + '(' + buildNiceArgsList(args) + ')',
@@ -252,7 +252,7 @@ define([], () => {
     }
 
     /**
-     * Builds the call to run_app_bulk
+     * Builds the call to run_app_batch
      * @param {string} cellId the unique id of the cell, for run metadata
      * @param {string} runId the unique id of the run, for metadata
      * @param {array} appInfo the set of information to send to the function.
@@ -283,7 +283,7 @@ define([], () => {
         ];
         return [
             'from biokbase.narrative.jobs.appmanager import AppManager',
-            `AppManager().run_app_bulk(${buildNiceArgsList(args)})`,
+            `AppManager().run_app_batch(${buildNiceArgsList(args)})`,
         ].join('\n');
     }
 

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -178,7 +178,7 @@ class AppManager(object):
         return self.spec_manager.available_apps(tag)
 
     @_app_error_wrapper
-    def run_app_batch(
+    def run_legacy_batch_app(
         self,
         app_id,
         params,
@@ -408,7 +408,7 @@ class AppManager(object):
             return new_job
 
     @_app_error_wrapper
-    def run_app_bulk(
+    def run_app_batch(
         self,
         app_info: list,
         cell_id: str = None,
@@ -501,7 +501,7 @@ class AppManager(object):
             "username": system_variable("user_id"),
             "wsid": ws_id,
         }
-        kblogging.log_event(self._log, "run_app_bulk", log_info)
+        kblogging.log_event(self._log, "run_app_batch", log_info)
 
         # if we're doing a dry run, stop here and return the setup
         if dry_run:

--- a/src/biokbase/narrative/jobs/batch.py
+++ b/src/biokbase/narrative/jobs/batch.py
@@ -15,7 +15,7 @@ from string import Formatter, Template
 def get_input_scaffold(app, tag="release", use_defaults=False):
     """
     Builds a "scaffold" structure of what app inputs are used, in the structure that's
-    expected by 'run_app_batch' (also the structure expected by 'run_app'). This will
+    expected by 'run_legacy_batch_app' (also the structure expected by 'run_app'). This will
     effectively be a dictionary of keys to None (except for the case of group parameters,
     those will fill out the group with the proper keys, and wrap them in a list if necessary)
 

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -139,7 +139,7 @@ def get_widget_info(job_id):
 @mock.patch(CLIENTS, get_mock_client)
 def get_batch_family_jobs(return_list=False):
     """
-    As invoked in appmanager's run_app_bulk, i.e.,
+    As invoked in appmanager's run_app_batch, i.e.,
     with from_job_id(s)
     """
     child_jobs = Job.from_job_ids(BATCH_CHILDREN, return_list=True)
@@ -242,7 +242,7 @@ class JobTest(unittest.TestCase):
 
     def test_job_init__extra_state(self):
         """
-        test job initialisation as is done by run_app_batch
+        test job initialisation as is done by run_legacy_batch_app
         """
 
         app_id = "kb_BatchApp/run_batch"
@@ -266,7 +266,7 @@ class JobTest(unittest.TestCase):
 
     def test_job_init__batch_family(self):
         """
-        test job initialization, as is done by run_app_bulk
+        test job initialization, as is done by run_app_batch
         """
         batch_jobs = get_batch_family_jobs(return_list=False)
 

--- a/test/unit/spec/common/pythonInterop-Spec.js
+++ b/test/unit/spec/common/pythonInterop-Spec.js
@@ -170,7 +170,7 @@ define(['common/pythonInterop', 'testUtil'], (PythonInterop, TestUtil) => {
                 ],
                 code =
                     'from biokbase.narrative.jobs.appmanager import AppManager\n' +
-                    'AppManager().run_app_batch(\n' +
+                    'AppManager().run_legacy_batch_app(\n' +
                     '    "MyModule/my_app",\n' +
                     '    [{\n' +
                     '        "arg1": 1,\n' +
@@ -222,7 +222,7 @@ define(['common/pythonInterop', 'testUtil'], (PythonInterop, TestUtil) => {
                 ],
                 expectedCode = [
                     'from biokbase.narrative.jobs.appmanager import AppManager',
-                    'AppManager().run_app_bulk(',
+                    'AppManager().run_app_batch(',
                     '    [{',
                     '        "app_id": "some_module/some_app",',
                     '        "tag": "release",',


### PR DESCRIPTION
# Description of PR purpose/changes

Noticed this whilst looking at the backend to see what could be optimised there.

Rename app manager methods to be more correct:
- `run_app_batch` (old batch method) ==> `run_legacy_batch_app`
- `run_app_bulk` (new batch ee2 endpoint) ==> `run_app_batch`
...plus renaming / changing other methods and references accordingly

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-719
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
