### PR TITLE
DATAUP-719: simplify job indexing command

### DIFF
--- a/kbase-extension/static/kbase/js/common/jobStateViewer.js
+++ b/kbase-extension/static/kbase/js/common/jobStateViewer.js
@@ -104,8 +104,6 @@ define([
                 this.bus.emit(jcm.MESSAGE_TYPE.STATUS, {
                     [jcm.PARAM.JOB_ID]: this.jobId,
                 });
-            }).catch((err) => {
-                throw err;
             });
         }
 

--- a/kbase-extension/static/kbase/js/common/jobs.js
+++ b/kbase-extension/static/kbase/js/common/jobs.js
@@ -634,7 +634,7 @@ define([
             throw new Error('More than one batch parent found');
         }
 
-        model.setItem('exec.jobs', jobArrayToIndexedObject(jobArray));
+        model.setItem('exec.jobs.byId', jobArrayToIndexedObject(jobArray));
 
         model.setItem('exec.jobState', Array.from(batchJobs)[0]);
         return model;
@@ -644,19 +644,16 @@ define([
      * Given an array of jobState objects, create an object with jobs indexed by ID
      *
      * @param {array} jobArray array of jobState objects
-     * @returns {object} with indexed job data:
-     *      byId        key: job_id, value: jobState object
+     * @returns {object} comprising indexed job data, with key: job_id, value: jobState object
      */
 
     function jobArrayToIndexedObject(jobArray = []) {
-        const jobIx = {
-            byId: {},
-        };
+        const jobIndex = {};
 
         jobArray.forEach((job) => {
-            jobIx.byId[job.job_id] = job;
+            jobIndex[job.job_id] = job;
         });
-        return jobIx;
+        return jobIndex;
     }
 
     /**

--- a/test/data/testBulkImportObj.js
+++ b/test/data/testBulkImportObj.js
@@ -423,7 +423,9 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
         },
         exec: {
             jobState: batchParentJob,
-            jobs: Jobs.jobArrayToIndexedObject(JobsData.allJobsWithBatchParent),
+            jobs: {
+                byId: Jobs.jobArrayToIndexedObject(JobsData.allJobsWithBatchParent),
+            },
             jobStateUpdated: 1607109635241,
             launchState: {
                 cell_id: '13395335-1f3d-4e0c-80f7-44b634968da0',

--- a/test/unit/spec/common/jobManager-Spec.js
+++ b/test/unit/spec/common/jobManager-Spec.js
@@ -895,7 +895,9 @@ define([
                     this.model = Props.make({
                         data: {
                             exec: {
-                                jobs: Jobs.jobArrayToIndexedObject([this.starterJob]),
+                                jobs: {
+                                    byId: Jobs.jobArrayToIndexedObject([this.starterJob]),
+                                },
                             },
                         },
                     });

--- a/test/unit/spec/common/jobs-Spec.js
+++ b/test/unit/spec/common/jobs-Spec.js
@@ -723,22 +723,18 @@ define([
 
         it('creates a model with jobs indexed by ID', () => {
             const model = Jobs.jobArrayToIndexedObject(JobsData.allJobsWithBatchParent);
-            const idIndex = model.byId;
-            expect(Object.keys(idIndex).sort()).toEqual(
-                JobsData.allJobsWithBatchParent
-                    .map((jobState) => {
-                        return jobState.job_id;
+            expect(Object.keys(model)).toEqual(
+                jasmine.arrayWithExactContents(
+                    JobsData.allJobsWithBatchParent.map((job) => {
+                        return job.job_id;
                     })
-                    .sort()
+                )
             );
         });
 
         it('creates an empty model with an empty jobs array', () => {
             const model = Jobs.jobArrayToIndexedObject([]);
-            expect(model).toEqual({
-                byId: {},
-            });
-            expect(model.byId).toEqual({});
+            expect(model).toEqual({});
         });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

Change `Jobs.jobArrayToIndexedObject` function to return an object comprising job IDs as keys and job states as objects, rather than having it wrapped in an object under a `byId` key. This will prevent creation/updates to the job index from trashing existing job info data.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-719
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
