### PR TITLE
Fix PanGenome viewer error [PTV-1765], & addressing pre-commit linting errors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
 ### Unreleased
 - DATAUP-641 - Adds custom error messages when app cell dropdown menu inputs are incorrect in various different ways.
+- PTV-1765 - Fix Pangenome viewer; wasn't able to get an object ref
 
 ### Version 5.0.2
 - SAM-73 - Extends the ability to use app params as arguments for dynamic dropdown calls to inputs that are part of a struct or sequence.

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
@@ -40,7 +40,8 @@ define([
                 this.objRef = this.options.name;
             } else if ('upas' in this.options && 'name' in this.options.upas) {
                 // See https://github.com/kbase/NarrativeViewers/blob/master/ui/narrative/methods/view_pangenome/spec.json
-                // for the mapping of the upa to the "name" property.
+                // for the mapping of the upa to the "name" property; and widgetmanager.py for how
+                // this is done.
                 this.objRef = this.options.upas.name;
             } else {
                 this.objRef = this.options.ws + '/' + this.options.name;

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbasePanGenome.js
@@ -38,6 +38,10 @@ define([
             this._super(options);
             if (this.options.name.indexOf('/') > -1) {
                 this.objRef = this.options.name;
+            } else if ('upas' in this.options && 'name' in this.options.upas) {
+                // See https://github.com/kbase/NarrativeViewers/blob/master/ui/narrative/methods/view_pangenome/spec.json
+                // for the mapping of the upa to the "name" property.
+                this.objRef = this.options.upas.name;
             } else {
                 this.objRef = this.options.ws + '/' + this.options.name;
             }
@@ -185,7 +189,7 @@ define([
                     const numGenomes = genomeList.length;
                     const numberTable = [];
                     const header = ['<th>Genome</th><th>Legend</th>'];
-                    for (var i = 0; i < numGenomes; i++) {
+                    for (let i = 0; i < numGenomes; i++) {
                         header.push('<th style="text-align:center"><b>G' + (i + 1) + '</b></th>');
                         const singleComp = [];
                         singleComp.push('<b>G' + (i + 1) + '</b> - ' + genomeList[i]);
@@ -205,7 +209,7 @@ define([
                         '<table class="table table-hover table-striped table-bordered">'
                     );
                     $prettyTable.append($('<tr>').append(header.join()));
-                    for (var i = 0; i < numberTable.length; i++) {
+                    for (let i = 0; i < numberTable.length; i++) {
                         $prettyTable.append(self.tableRow(numberTable[i]));
                     }
                     $homologDiv.empty().append($prettyTable);
@@ -407,7 +411,6 @@ define([
             self.dataPromise.then((results) => {
                 results = results[0];
                 getFamilyFunctionNames(fam.orthologs).then((names) => {
-                    console.log(names);
                     $div.empty();
                     new DynamicTable($div, {
                         headers: [


### PR DESCRIPTION
# Description of PR purpose/changes

This change fixes the PanGenome viewer which in production is displays an error, “Bad object.”

The issue is caused by a failure of the viewer to determine a value object reference.

The fix is to observe that if there is a parameter property "this.options.upas.name" to use it. The existing techniques of determining the upa are left in place.

The  parameter property "this.options.upas.name" is set by "widgetmanager.py" based on the spec for the viewer.

This is discussed in more detail in the ticket https://kbase-jira.atlassian.net/browse/PTV-1765.

# PTV-1765

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1765.

- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions

* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, adding a PanGenome object to it, and invoking the viewer 

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
	- existing test does not test any functionality; won't create a new set of tests
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [-] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [-] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
