### PR TITLE
DATAUP-525 fix issue with advanced parameter labels not changing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 - DATAUP-641 - Adds custom error messages when app cell numeric inputs are initialized with non-numeric data.
 - PTV-1765 - Fix Pangenome viewer; wasn't able to get an object ref
 - DATAUP-643 - Adds a warning to the top of a bulk import cell when attempting to use multiple distinct non-file and non-output parameter values. E.g. different assembly types for multiple rows of an assembly uploader spreadsheet.
- 
+- DATAUP-525 - Fix the "show advanced" button in bulk import cells to properly toggle its label when clicked.
+
 ### Version 5.0.2
 - SAM-73 - Extends the ability to use app params as arguments for dynamic dropdown calls to inputs that are part of a struct or sequence.
 - DATAUP-696 - Prevent import specifications from being imported with either unknown data types, or data types not currently registered as using the bulk import cell.

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -19,6 +19,8 @@ define([
     function factory(config) {
         const viewOnly = config.viewOnly || false;
         const { bus, workspaceId, paramIds, initialParams } = config;
+        // key = param id, value = boolean, true if is in error
+        const advancedParamErrors = {};
         const runtime = Runtime.make(),
             model = Props.make(),
             paramResolver = ParamResolver.make(),
@@ -28,7 +30,8 @@ define([
             widgets = [];
         let container,
             ui,
-            places = {};
+            places = {},
+            numAdvanced = 0;
 
         // DATA
         /*
@@ -115,6 +118,8 @@ define([
                 fieldWidget.bus.on('validation', (message) => {
                     // only propagate if invalid. value changes come through
                     // the 'changed' message
+                    const paramId = parameterSpec.id;
+                    advancedParamErrors[paramId] = !message.isValid;
                     if (!message.isValid) {
                         bus.emit('invalid-param-value', {
                             parameter: parameterSpec.id,
@@ -244,44 +249,41 @@ define([
                     areaSelector + ' [data-advanced-parameter]'
                 );
 
-            //remove or add the hidden field class
+            // remove or add the hidden field class
             for (const [, entry] of Object.entries(advancedInputs)) {
                 entry.classList.toggle(`${cssBaseClass}__fields--parameters-hidden`);
             }
 
-            return advancedInputs;
+            // edit the labels
+            let headerLabel = `${numAdvanced} advanced parameter${numAdvanced > 1 ? 's' : ''}`,
+                buttonLabel;
+            if (settings.showAdvanced) {
+                headerLabel += ' showing';
+                buttonLabel = 'hide advanced';
+            } else {
+                headerLabel += ' hidden';
+                buttonLabel = 'show advanced';
+            }
+
+            // set labels
+            const messageElem = ui.getElement('advanced-hidden-message');
+            messageElem.querySelector('span').textContent = `(${headerLabel})`;
+            messageElem.querySelector('button').textContent = buttonLabel;
         }
 
         function renderAdvanced() {
-            //remove or add the hidden field class
-            const areaElement = 'parameters-area',
-                advancedInputs = showHideAdvanced();
+            // remove or add the hidden field class
+            const areaElement = 'parameters-area';
 
-            // Also update the count in the paramters.
+            // Also update the count in the parameters.
             const events = Events.make({ node: container });
 
-            let showAdvancedButton,
-                label,
-                message = String(advancedInputs.length) + ' advanced parameter';
-
-            if (!advancedInputs.length) {
+            if (numAdvanced === 0) {
                 ui.setContent([areaElement, 'advanced-hidden-message'], '');
             } else {
-                if (advancedInputs.length > 1) {
-                    message += 's';
-                }
-
-                if (settings.showAdvanced) {
-                    message += ' showing';
-                    label = 'hide advanced';
-                } else {
-                    label = 'show advanced';
-                    message += ' hidden';
-                }
-
-                showAdvancedButton = ui.buildButton({
+                const showAdvancedButton = ui.buildButton({
                     class: `${cssBaseClass}__toggle--advanced-hidden`,
-                    label,
+                    label: '',
                     type: 'link',
                     name: 'advanced-parameters-toggler',
                     event: {
@@ -292,10 +294,10 @@ define([
 
                 ui.setContent(
                     [areaElement, 'advanced-hidden-message'],
-                    '(' + message + ') ' + showAdvancedButton
+                    span() + showAdvancedButton
                 );
+                showHideAdvanced();
             }
-
             events.attachEvents();
         }
 
@@ -323,8 +325,8 @@ define([
 
             const content = form({ dataElement: 'input-widget-form' }, formContent);
             return {
-                content: content,
-                events: events,
+                content,
+                events,
             };
         }
 
@@ -333,7 +335,7 @@ define([
             container = node;
             ui = UI.make({
                 node: container,
-                bus: bus,
+                bus,
             });
             const layout = renderLayout();
             container.innerHTML = layout.content;
@@ -366,6 +368,12 @@ define([
             });
         }
 
+        /**
+         * Also sets the number of advanced parameters, and initializes the
+         * advancedParamErrors object.
+         * @param {*} params
+         * @returns
+         */
         function makeParamsLayout(params) {
             const view = {},
                 paramMap = {};
@@ -379,6 +387,10 @@ define([
                 .map((parameterId) => {
                     const elementId = html.genId();
                     const advanced = paramMap[parameterId].ui.advanced ? parameterId : false;
+                    if (advanced) {
+                        advancedParamErrors[parameterId] = false; // init these to be no error
+                        numAdvanced++;
+                    }
 
                     view[parameterId] = {
                         id: elementId,
@@ -447,7 +459,7 @@ define([
             const params = model.getItem('parameterSpecs');
             const filteredParams = makeParamsLayout(params);
 
-            //if there aren't any parameters we can just hide the whole area
+            // if there aren't any parameters we can just hide the whole area
             if (!filteredParams.layout.length) {
                 return Promise.resolve(ui.getElement('parameters-area').classList.add('hidden'));
             }
@@ -459,7 +471,7 @@ define([
                     await createParameterWidget(appSpec, filteredParams, parameterId);
                 })
             ).then(() => {
-                renderAdvanced();
+                renderAdvanced(filteredParams.advancedIds);
             });
         }
 
@@ -520,9 +532,7 @@ define([
         return {
             start,
             stop,
-            bus: function () {
-                return bus;
-            },
+            bus: () => bus,
         };
     }
 

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -1146,6 +1146,7 @@ define([
             Object.keys(inputs).forEach((dataType) => {
                 delete inputs[dataType].messages;
             });
+            model.setItem('inputs', inputs);
         }
 
         /**


### PR DESCRIPTION
# Description of PR purpose/changes

There was a flaw in the implementation of the "show advanced" button in the bulk import params widget. This led to that message (and the "X parameters hidden" message) never being toggled to "hide advanced". It also made it really hard to work on DATAUP-642, which involves adding a further error message there, so this got fixed first.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-525
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
