### PR TITLE
DATAUP-728 am.run_app_bulk: merge shared_params into param_sets

### DIFF
--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -924,50 +924,30 @@ class AppManagerTestCase(unittest.TestCase):
             ],
             "other_key": "other_val"
         }
+        expected = {
+            "params": [
+                {
+                    "param_key00": "param_val00",
+                    "param_key01": "param_val01",
+                    "shared_param_key0": "shared_param_val0",
+                    "shared_param_key1": "shared_param_val1"
+                }, {
+                    "param_key10": "param_val10",
+                    "param_key11": "param_val11",
+                    "shared_param_key0": "shared_param_val0",
+                    "shared_param_key1": "shared_param_val1"
+                }
+            ],
+            "other_key": "other_val"
+        }
 
         # Merge shared_params into each params dict
         self.am._reconstitute_shared_params(app_info_el)
-        self.assertEqual(
-            {
-                "params": [
-                    {
-                        "param_key00": "param_val00",
-                        "param_key01": "param_val01",
-                        "shared_param_key0": "shared_param_val0",
-                        "shared_param_key1": "shared_param_val1"
-                    }, {
-                        "param_key10": "param_val10",
-                        "param_key11": "param_val11",
-                        "shared_param_key0": "shared_param_val0",
-                        "shared_param_key1": "shared_param_val1"
-                    }
-                ],
-                "other_key": "other_val"
-            },
-            app_info_el
-        )
+        self.assertEqual(expected, app_info_el)
 
         # No shared_params means no change
         self.am._reconstitute_shared_params(app_info_el)
-        self.assertEqual(
-            {
-                "params": [
-                    {
-                        "param_key00": "param_val00",
-                        "param_key01": "param_val01",
-                        "shared_param_key0": "shared_param_val0",
-                        "shared_param_key1": "shared_param_val1"
-                    }, {
-                        "param_key10": "param_val10",
-                        "param_key11": "param_val11",
-                        "shared_param_key0": "shared_param_val0",
-                        "shared_param_key1": "shared_param_val1"
-                    }
-                ],
-                "other_key": "other_val"
-            },
-            app_info_el
-        )
+        self.assertEqual(expected, app_info_el)
 
     @mock.patch(
         "biokbase.narrative.jobs.appmanager.specmanager.clients.get", get_mock_client


### PR DESCRIPTION
# Description of PR purpose/changes

To reduce the data sent from the FE to BE upon submitting a bulk import job, any shared parameters are condensed into its own field. The BE's responsibility is to, in `am.run_app_bulk`, merge the shared parameters back into the child jobs' parameter sets.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
