### PR TITLE
PTV-1776 Re-Scheme Import Type Names

### DIFF
--- a/docs/adrs/0004-bulk-import-output-cells.md
+++ b/docs/adrs/0004-bulk-import-output-cells.md
@@ -29,7 +29,7 @@ Bulk Import cell importer apps that employ an output cell:
 | Importer | Output cell |
 |---|---|
 | Import GenBank as genome from staging | Genome viewer |
-| Import GFF/FASTA as genome from staging | Genome viewer |
+| Import GFF+FASTA as genome from staging | Genome viewer |
 
 Other importer apps with output cells:
 

--- a/kbase-extension/static/kbase/config/staging_upload.json
+++ b/kbase-extension/static/kbase/config/staging_upload.json
@@ -18,11 +18,11 @@
         },
         {
             "id": "gff_genome",
-            "name": "GFF/FASTA Genome"
+            "name": "GFF+FASTA Genome"
         },
         {
             "id": "gff_metagenome",
-            "name": "GFF/FASTA Metagenome"
+            "name": "GFF+FASTA Metagenome"
         },
         {
             "id": "expression_matrix",
@@ -38,7 +38,7 @@
         },
         {
             "id": "assembly",
-            "name": "Assembly"
+            "name": "FASTA Assembly"
         },
         {
             "id": "phenotype_set",

--- a/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/jobStatusTable-Spec.js
@@ -110,7 +110,7 @@ define([
             },
         },
         assembly: {
-            analysisType: 'Assembly',
+            analysisType: 'FASTA Assembly',
             outputParams: {
                 assembly_name: { value: 'assembly_file.fa', label: 'Assembly object name' },
             },
@@ -201,7 +201,7 @@ define([
                     },
                 ],
             },
-            type: 'Assembly',
+            type: 'FASTA Assembly',
             object: /Assembly object name: assembly_file.fa/,
             displayData: paramDisplayData.assembly,
         },

--- a/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
+++ b/test/unit/spec/narrative_core/upload/stagingAreaViewer-spec.js
@@ -264,12 +264,12 @@ define([
             const menuOptions = [
                 'SRA Reads',
                 'GenBank Genome',
-                'GFF/FASTA Genome',
-                'GFF/FASTA Metagenome',
+                'GFF+FASTA Genome',
+                'GFF+FASTA Metagenome',
                 'Expression Matrix',
                 'Media',
                 'FBA Model',
-                'Assembly',
+                'FASTA Assembly',
                 'Phenotype Set',
                 'Sample Set',
             ];

--- a/test/unit/spec/util/appCellUtil-spec.js
+++ b/test/unit/spec/util/appCellUtil-spec.js
@@ -418,7 +418,7 @@ define([
 
         const uploaders = {
                 dropdown_order: [
-                    { id: 'assembly', name: 'Assembly' },
+                    { id: 'assembly', name: 'FASTA Assembly' },
                     { id: 'fastq_reads_interleaved', name: 'FASTQ Reads Interleaved' },
                     { id: 'fastq_reads_noninterleaved', name: 'FASTQ Reads NonInterleaved' },
                     { id: 'sra_reads', name: 'SRA Reads' },
@@ -431,7 +431,7 @@ define([
                 unknown_type: {},
             },
             expectedFileTypeMapping = {
-                assembly: 'Assembly',
+                assembly: 'FASTA Assembly',
                 fastq_reads_interleaved: 'FASTQ Reads Interleaved',
                 fastq_reads_noninterleaved: 'FASTQ Reads NonInterleaved',
                 sra_reads: 'SRA Reads',
@@ -452,7 +452,7 @@ define([
                 const output = Util.generateFileTypeMappings(ttf);
                 expect(output).toEqual({
                     fileTypesDisplay: {
-                        assembly: { label: 'Assembly' },
+                        assembly: { label: 'FASTA Assembly' },
                         fastq_reads_interleaved: {
                             label: 'FASTQ Reads Interleaved',
                         },


### PR DESCRIPTION
# Description of PR purpose/changes

The original names for the import types for the Bulk Import were confusing for some beginner users because some thought GFF/FASTA meant GFF or FASTA file. This ticket is to make the names more precise and consistent.

Renaming:
* `Assembly` -> `FASTA Assembly`
* `GFF/FASTA Genome` -> `GFF+FASTA Genome`
* `GFF/FASTA Metagenome` -> `GFF+Fasta Metagenome`

All the changes are in the frontend. The frontend tests are not passing, but I don't know if they're in an interim state of not passing anyway. (The backend tests fail as they always do because of those 2 tests that only work in the appdev environment.) Furthermore, I tried to spin up a local narrative, but I tried giving it the token on prompt with the `kbase_session` cookie, then the `narrative_session` cookie, then finally a dev token, but none would let me pass the token prompt. So I could not check to see if it works when spinning up a narrative. So this is done rather blindly for now, unfortunately.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
