### PR TITLE
DATAUP-740 compare in detail ts for jm.list_jobs()

### DIFF
--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -330,16 +330,24 @@ class JobManagerTest(unittest.TestCase):
             jobs_html_0 = self.jm.list_jobs().data
             jobs_html_1 = self.jm.list_jobs().data
 
-            try:
-                self.assertEqual(jobs_html_0, jobs_html_1)
-            except AssertionError:
-                # Sometimes the time is off by a second
-                # This will still fail if on the hour
-                pattern = r"(\d\d:)\d\d:\d\d"
-                sub = r"\1"
-                jobs_html_0 = re.sub(pattern, sub, jobs_html_0)
-                jobs_html_1 = re.sub(pattern, sub, jobs_html_1)
-                self.assertEqual(jobs_html_0, jobs_html_1)
+            def convert_to_s(tstr):
+                arr = tstr.split(":")
+                return int(arr[2]) + int(arr[1]) * 60 + int(arr[0]) * 3600
+
+            time_pattern = r"\d\d:\d\d:\d\d"
+            t0 = convert_to_s(re.search(time_pattern, jobs_html_0)[0])
+            t1 = convert_to_s(re.search(time_pattern, jobs_html_1)[0])
+
+            # if the time wrapped over midnight, increase latter time
+            if t1 < t0:
+                t1 += 24 * 3600
+
+            self.assertTrue(t1 - t0 < 5)  # give it a 5s tol, though usually 1 is enough
+
+            sub = ""
+            jobs_html_0 = re.sub(time_pattern, sub, jobs_html_0)
+            jobs_html_1 = re.sub(time_pattern, sub, jobs_html_1)
+            self.assertEqual(jobs_html_0, jobs_html_1)
 
     def test_cancel_jobs__bad_inputs(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
# Description of PR purpose/changes

`jm.list_jobs` includes a time in the output string. A test was added to make sure it could be run twice because of a previous pass-by-reference bug. This introduced a new intermittent bug when the time between two successive `jm.list_jobs` calls would occasionally be off by 1s. A fix was made so that it would fail less, only if the two calls literally fell on different sides of an hour.

This fix is to make the test of calling `jm.list_jobs` twice deterministically always pass if the testee method works but the time is off by a second.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
