### PR TITLE
DATAUP-747: rough template generation form

### DIFF
--- a/kbase-extension/static/kbase/js/common/ui.js
+++ b/kbase-extension/static/kbase/js/common/ui.js
@@ -430,6 +430,8 @@ define([
             confirmNode = _generateConfirmNode(dialog),
             modalDialogNode = _setUpModalNodes(confirmNode);
 
+        args.modalDialogNode = modalDialogNode;
+
         // this shows the modal
         $(modalDialogNode).modal({ keyboard: false });
 
@@ -458,7 +460,7 @@ define([
                 resolve(resolution);
             });
             if (args.doThisFirst) {
-                args.doThisFirst();
+                args.doThisFirst(modalDialogNode);
             }
         });
     }

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -56,12 +56,12 @@ define([
      */
     function ConfigureWidget(options) {
         const viewOnly = options.viewOnly || false;
-        const { model, specs, fileTypesDisplay, typesToFiles } = options;
+        const { model, specs, fileTypesDisplay, typesToFiles, fileTypeMapping } = options;
         const cellBus = options.bus,
             runtime = Runtime.make(),
             FILE_PATH_TYPE = 'filePaths',
             PARAM_TYPE = 'params',
-            xsvGen = new XsvGenerator({ model, typesToFiles }),
+            xsvGen = new XsvGenerator({ model, typesToFiles, fileTypeMapping }),
             cssBaseClass = 'kb-bulk-import-configure';
         let container = null,
             filePathWidget,

--- a/test/data/kb_uploadmethods.import_fastq_noninterleaved_as_reads_from_staging.spec.json
+++ b/test/data/kb_uploadmethods.import_fastq_noninterleaved_as_reads_from_staging.spec.json
@@ -1,0 +1,347 @@
+{
+    "behavior": {
+      "kb_service_input_mapping": [
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "workspace_name"
+        },
+        {
+          "constant_value": "FASTQ/FASTA",
+          "target_property": "import_type"
+        },
+        {
+          "input_parameter": "fastq_fwd_staging_file_name",
+          "target_property": "fastq_fwd_staging_file_name"
+        },
+        {
+          "input_parameter": "fastq_rev_staging_file_name",
+          "target_property": "fastq_rev_staging_file_name"
+        },
+        {
+          "input_parameter": "sequencing_tech",
+          "target_property": "sequencing_tech"
+        },
+        {
+          "input_parameter": "name",
+          "target_property": "name"
+        },
+        {
+          "input_parameter": "single_genome",
+          "target_property": "single_genome"
+        },
+        {
+          "constant_value": 0,
+          "target_property": "interleaved"
+        },
+        {
+          "input_parameter": "insert_size_mean",
+          "target_property": "insert_size_mean"
+        },
+        {
+          "input_parameter": "insert_size_std_dev",
+          "target_property": "insert_size_std_dev"
+        },
+        {
+          "input_parameter": "read_orientation_outward",
+          "target_property": "read_orientation_outward"
+        }
+      ],
+      "kb_service_method": "import_reads_from_staging",
+      "kb_service_name": "kb_uploadmethods",
+      "kb_service_output_mapping": [
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "wsName"
+        },
+        {
+          "service_method_output_path": [
+            "0",
+            "obj_ref"
+          ],
+          "target_property": "obj_ref",
+          "target_type_transform": "resolved-ref"
+        },
+        {
+          "service_method_output_path": [
+            "0",
+            "report_name"
+          ],
+          "target_property": "report_name"
+        },
+        {
+          "service_method_output_path": [
+            "0",
+            "report_ref"
+          ],
+          "target_property": "report_ref"
+        },
+        {
+          "constant_value": "16",
+          "target_property": "report_window_line_height"
+        }
+      ],
+      "kb_service_url": "",
+      "kb_service_version": "d67ff71a675aed5566d257c267689ea0d2a4a8b0"
+    },
+    "fixed_parameters": [],
+    "full_info": {
+      "app_type": "app",
+      "authors": [
+        "tgu2"
+      ],
+      "categories": [
+        "inactive",
+        "reads",
+        "upload"
+      ],
+      "contact": "http://kbase.us/contact-us/",
+      "description": "<p> Import a NonInterleaved FASTQ file into your Narrative as a Reads data object\nPlease see the <a href=\"https://docs.kbase.us/data/upload-download-guide/\">Data Upload/Download Guide</a> for more information. </p>",
+      "git_commit_hash": "d67ff71a675aed5566d257c267689ea0d2a4a8b0",
+      "icon": {
+        "url": "img?method_id=kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging&image_name=data-pink.png&tag=release"
+      },
+      "id": "kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging",
+      "module_name": "kb_uploadmethods",
+      "name": "Import NonInterleaved FASTQ Files as Reads from Staging Area",
+      "namespace": "kb_uploadmethods",
+      "publications": [],
+      "screenshots": [],
+      "subtitle": "Import a NonInterleaved FASTQ files into your Narrative as a Reads data object",
+      "suggestions": {
+        "next_apps": [],
+        "next_methods": [],
+        "related_apps": [],
+        "related_methods": []
+      },
+      "tag": "release",
+      "technical_description": "none",
+      "tooltip": "Import a NonInterleaved FASTQ files into your Narrative as a Reads data object",
+      "ver": "1.0.55"
+    },
+    "info": {
+      "app_type": "app",
+      "authors": [
+        "tgu2"
+      ],
+      "categories": [
+        "inactive",
+        "reads",
+        "upload"
+      ],
+      "git_commit_hash": "d67ff71a675aed5566d257c267689ea0d2a4a8b0",
+      "icon": {
+        "url": "img?method_id=kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging&image_name=data-pink.png&tag=release"
+      },
+      "id": "kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging",
+      "input_types": [],
+      "module_name": "kb_uploadmethods",
+      "name": "Import NonInterleaved FASTQ Files as Reads from Staging Area",
+      "namespace": "kb_uploadmethods",
+      "output_types": [
+        "KBaseFile.PairedEndLibrary",
+        "KBaseFile.SingleEndLibrary"
+      ],
+      "subtitle": "Import a NonInterleaved FASTQ files into your Narrative as a Reads data object",
+      "tooltip": "Import a NonInterleaved FASTQ files into your Narrative as a Reads data object",
+      "ver": "1.0.55"
+    },
+    "job_id_output_field": "docker",
+    "parameters": [
+      {
+        "advanced": 0,
+        "allow_multiple": 0,
+        "default_values": [
+          ""
+        ],
+        "description": "Valid file extensions for FASTQ: .fastq, .fnq, .fq;",
+        "disabled": 0,
+        "dynamic_dropdown_options": {
+          "data_source": "ftp_staging",
+          "multiselection": 0,
+          "query_on_empty_input": 1,
+          "result_array_index": 0,
+          "service_params": null
+        },
+        "field_type": "dynamic_dropdown",
+        "id": "fastq_fwd_staging_file_name",
+        "optional": 0,
+        "short_hint": "Short read file containing a paired end library in FASTQ format",
+        "ui_class": "parameter",
+        "ui_name": "Forward/left FASTQ file path"
+      },
+      {
+        "advanced": 0,
+        "allow_multiple": 0,
+        "default_values": [
+          ""
+        ],
+        "description": "Valid file extensions for FASTQ: .fastq, .fnq, .fq;",
+        "disabled": 0,
+        "dynamic_dropdown_options": {
+          "data_source": "ftp_staging",
+          "multiselection": 0,
+          "query_on_empty_input": 1,
+          "result_array_index": 0,
+          "service_params": null
+        },
+        "field_type": "dynamic_dropdown",
+        "id": "fastq_rev_staging_file_name",
+        "optional": 1,
+        "short_hint": "Second short read file containing a paired end library in FASTQ format.",
+        "ui_class": "parameter",
+        "ui_name": "Reverse/right FASTQ file path"
+      },
+      {
+        "advanced": 0,
+        "allow_multiple": 0,
+        "default_values": [
+          "Illumina"
+        ],
+        "description": "The name of the sequencing technology used to create the reads file",
+        "disabled": 0,
+        "dropdown_options": {
+          "multiselection": 0,
+          "options": [
+            {
+              "display": "Illumina",
+              "value": "Illumina"
+            },
+            {
+              "display": "PacBio CLR",
+              "value": "PacBio CLR"
+            },
+            {
+              "display": "PacBio CCS",
+              "value": "PacBio CCS"
+            },
+            {
+              "display": "IonTorrent",
+              "value": "IonTorrent"
+            },
+            {
+              "display": "NanoPore",
+              "value": "NanoPore"
+            },
+            {
+              "display": "Unknown",
+              "value": "Unknown"
+            }
+          ]
+        },
+        "field_type": "dropdown",
+        "id": "sequencing_tech",
+        "optional": 0,
+        "short_hint": "The name of the sequencing technology used to create the reads file",
+        "ui_class": "parameter",
+        "ui_name": "Sequencing technology"
+      },
+      {
+        "advanced": 0,
+        "allow_multiple": 0,
+        "default_values": [
+          ""
+        ],
+        "description": "Provide a name for the Reads object that will be created by this importer",
+        "disabled": 0,
+        "field_type": "text",
+        "id": "name",
+        "optional": 0,
+        "short_hint": "Provide a name for the Reads object that will be created by this importer",
+        "text_options": {
+          "is_output_name": 1,
+          "placeholder": "",
+          "regex_constraint": [],
+          "valid_ws_types": [
+            "KBaseFile.SingleEndLibrary",
+            "KBaseFile.PairedEndLibrary"
+          ]
+        },
+        "ui_class": "output",
+        "ui_name": "Reads object name"
+      },
+      {
+        "advanced": 0,
+        "allow_multiple": 0,
+        "checkbox_options": {
+          "checked_value": 1,
+          "unchecked_value": 0
+        },
+        "default_values": [
+          "1"
+        ],
+        "description": "Select if the reads are from a single genome, leave blank if from a metagenome",
+        "disabled": 0,
+        "field_type": "checkbox",
+        "id": "single_genome",
+        "optional": 0,
+        "short_hint": "Select if the reads are from a single genome, leave blank if from a metagenome",
+        "ui_class": "parameter",
+        "ui_name": "Single genome"
+      },
+      {
+        "advanced": 1,
+        "allow_multiple": 0,
+        "checkbox_options": {
+          "checked_value": 1,
+          "unchecked_value": 0
+        },
+        "default_values": [
+          "0"
+        ],
+        "description": "Select if reads in a pair point outward",
+        "disabled": 0,
+        "field_type": "checkbox",
+        "id": "read_orientation_outward",
+        "optional": 1,
+        "short_hint": "Select if reads in a pair point outward",
+        "ui_class": "parameter",
+        "ui_name": "Reads orientation outward"
+      },
+      {
+        "advanced": 1,
+        "allow_multiple": 0,
+        "default_values": [
+          ""
+        ],
+        "description": "The standard deviation of insert lengths",
+        "disabled": 0,
+        "field_type": "text",
+        "id": "insert_size_std_dev",
+        "optional": 1,
+        "short_hint": "The standard deviation of insert lengths",
+        "text_options": {
+          "is_output_name": 0,
+          "placeholder": "",
+          "regex_constraint": [],
+          "validate_as": "float"
+        },
+        "ui_class": "parameter",
+        "ui_name": "St. dev. of insert size"
+      },
+      {
+        "advanced": 1,
+        "allow_multiple": 0,
+        "default_values": [
+          ""
+        ],
+        "description": "The mean (average) insert length",
+        "disabled": 0,
+        "field_type": "text",
+        "id": "insert_size_mean",
+        "optional": 1,
+        "short_hint": "The mean (average) insert length",
+        "text_options": {
+          "is_output_name": 0,
+          "placeholder": "",
+          "regex_constraint": [],
+          "validate_as": "float"
+        },
+        "ui_class": "parameter",
+        "ui_name": "Mean insert size"
+      }
+    ],
+    "widgets": {
+      "input": "null",
+      "output": "no-display"
+    }
+  }

--- a/test/data/kb_uploadmethods.import_sra_as_reads_from_staging.spec.json
+++ b/test/data/kb_uploadmethods.import_sra_as_reads_from_staging.spec.json
@@ -6,12 +6,12 @@
         "target_property": "workspace_name"
       },
       {
-        "constant_value": "FASTQ/FASTA",
+        "constant_value": "SRA",
         "target_property": "import_type"
       },
       {
-        "input_parameter": "fastq_fwd_staging_file_name",
-        "target_property": "fastq_fwd_staging_file_name"
+        "input_parameter": "sra_staging_file_name",
+        "target_property": "sra_staging_file_name"
       },
       {
         "input_parameter": "sequencing_tech",
@@ -91,18 +91,18 @@
       "upload"
     ],
     "contact": "http://kbase.us/contact-us/",
-    "description": "<p> Import a Interleaved FASTQ file from your staging area into your Narrative as an Assembly data object.\nPlease see the <a href=\"https://docs.kbase.us/data/upload-download-guide/\">Data Upload/Download Guide</a> for more information. </p>",
+    "description": "<p> Import a SRA file from your staging area into your Narrative as READS data object.\nPlease see the <a href=\"https://docs.kbase.us/data/upload-download-guide/\">Data Upload/Download Guide</a> for more information. </p>",
     "git_commit_hash": "d67ff71a675aed5566d257c267689ea0d2a4a8b0",
     "icon": {
-      "url": "img?method_id=kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging&image_name=data-pink.png&tag=release"
+      "url": "img?method_id=kb_uploadmethods/import_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
     },
-    "id": "kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging",
+    "id": "kb_uploadmethods/import_sra_as_reads_from_staging",
     "module_name": "kb_uploadmethods",
-    "name": "Import Interleaved FASTQ file as Reads from Staging Area",
+    "name": "Import SRA File as Reads from Staging Area",
     "namespace": "kb_uploadmethods",
     "publications": [],
     "screenshots": [],
-    "subtitle": "Import a interleaved FASTQ file into your Narrative as a Reads data object",
+    "subtitle": "Import a SRA file into your Narrative as a Reads data object",
     "suggestions": {
       "next_apps": [],
       "next_methods": [],
@@ -111,7 +111,7 @@
     },
     "tag": "release",
     "technical_description": "none",
-    "tooltip": "Import a interleaved FASTQ file into your Narrative as a Reads data object",
+    "tooltip": "Import a SRA file into your Narrative as a Reads data object",
     "ver": "1.0.55"
   },
   "info": {
@@ -126,19 +126,19 @@
     ],
     "git_commit_hash": "d67ff71a675aed5566d257c267689ea0d2a4a8b0",
     "icon": {
-      "url": "img?method_id=kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging&image_name=data-pink.png&tag=release"
+      "url": "img?method_id=kb_uploadmethods/import_sra_as_reads_from_staging&image_name=data-pink.png&tag=release"
     },
-    "id": "kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging",
+    "id": "kb_uploadmethods/import_sra_as_reads_from_staging",
     "input_types": [],
     "module_name": "kb_uploadmethods",
-    "name": "Import Interleaved FASTQ file as Reads from Staging Area",
+    "name": "Import SRA File as Reads from Staging Area",
     "namespace": "kb_uploadmethods",
     "output_types": [
       "KBaseFile.PairedEndLibrary",
       "KBaseFile.SingleEndLibrary"
     ],
-    "subtitle": "Import a interleaved FASTQ file into your Narrative as a Reads data object",
-    "tooltip": "Import a interleaved FASTQ file into your Narrative as a Reads data object",
+    "subtitle": "Import a SRA file into your Narrative as a Reads data object",
+    "tooltip": "Import a SRA file into your Narrative as a Reads data object",
     "ver": "1.0.55"
   },
   "job_id_output_field": "docker",
@@ -149,7 +149,7 @@
       "default_values": [
         ""
       ],
-      "description": "Valid file extensions for FASTQ: .fastq, .fnq, .fq;",
+      "description": "SRA staging file path",
       "disabled": 0,
       "dynamic_dropdown_options": {
         "data_source": "ftp_staging",
@@ -159,11 +159,11 @@
         "service_params": null
       },
       "field_type": "dynamic_dropdown",
-      "id": "fastq_fwd_staging_file_name",
+      "id": "sra_staging_file_name",
       "optional": 0,
-      "short_hint": "Short read file containing a paired end library in FASTQ format",
+      "short_hint": "SRA staging file path",
       "ui_class": "parameter",
-      "ui_name": "Forward/left FASTQ file path"
+      "ui_name": "SRA file path"
     },
     {
       "advanced": 0,

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/xsvGenerator-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/xsvGenerator-spec.js
@@ -3,177 +3,19 @@ define([
     '/narrative/nbextensions/bulkImportCell/tabs/xsvGenerator',
     'common/props',
     'common/ui',
-], ($, XSVGenerator, Props, UI) => {
+    'json!/test/data/kb_uploadmethods.import_fastq_interleaved_as_reads_from_staging.spec.json',
+    'json!/test/data/kb_uploadmethods.import_fastq_noninterleaved_as_reads_from_staging.spec.json',
+    'json!/test/data/kb_uploadmethods.import_sra_as_reads_from_staging.spec.json',
+], (
+    $,
+    XSVGenerator,
+    Props,
+    UI,
+    ImportFastqInterleavedSpec,
+    ImportFastqNonInterleavedSpec,
+    ImportSraReadsSpec
+) => {
     'use strict';
-
-    const miniSpec = {
-        'kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging': {
-            parameters: [
-                {
-                    id: 'fastq_fwd_staging_file_name',
-                    ui_name: 'Forward/left FASTQ file path',
-                },
-                {
-                    id: 'name',
-                    ui_name: 'Reads object name',
-                },
-            ],
-        },
-        'kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging': {
-            parameters: [
-                {
-                    id: 'fastq_fwd_staging_file_name',
-                    ui_name: 'Forward/left FASTQ file path',
-                },
-                {
-                    id: 'fastq_rev_staging_file_name',
-                    ui_name: 'Reverse/right FASTQ file path',
-                },
-                {
-                    id: 'name',
-                    ui_name: 'Reads object name',
-                },
-                {
-                    id: 'read_orientation_outward',
-                    ui_name: 'Reads orientation outward',
-                },
-            ],
-        },
-        'kb_uploadmethods/import_sra_as_reads_from_staging': {
-            parameters: [
-                {
-                    id: 'sra_staging_file_name',
-                    ui_name: 'SRA file path',
-                },
-                {
-                    id: 'sequencing_tech',
-                    ui_name: 'Sequencing technology',
-                },
-                {
-                    id: 'name',
-                    ui_name: 'Reads object name',
-                },
-                {
-                    id: 'read_orientation_outward',
-                    ui_name: 'Reads orientation outward',
-                },
-            ],
-        },
-    };
-
-    const params = {
-        fastq_reads_interleaved: {
-            filePaths: [
-                {
-                    fastq_fwd_staging_file_name: 'go.fastq',
-                    name: 'go.fastq_reads',
-                },
-            ],
-            params: {},
-        },
-        fastq_reads_noninterleaved: {
-            filePaths: [
-                {
-                    fastq_fwd_staging_file_name: null,
-                    fastq_rev_staging_file_name: null,
-                    name: null,
-                },
-                {
-                    fastq_fwd_staging_file_name: null,
-                    fastq_rev_staging_file_name: null,
-                    name: null,
-                },
-            ],
-            params: {
-                read_orientation_outward: 0,
-            },
-        },
-        sra_reads: {
-            filePaths: [
-                {
-                    name: 'sample_sra_reads',
-                    sra_staging_file_name: 'sample_sra',
-                },
-            ],
-            params: {
-                read_orientation_outward: 0,
-                sequencing_tech: 'Illumina',
-            },
-        },
-    };
-
-    const expectedOutput = {
-        fastq_reads_interleaved: {
-            order_and_display: [
-                ['fastq_fwd_staging_file_name', 'Forward/left FASTQ file path'],
-                ['name', 'Reads object name'],
-            ],
-            data: [
-                {
-                    fastq_fwd_staging_file_name: 'go.fastq',
-                    name: 'go.fastq_reads',
-                },
-            ],
-        },
-        fastq_reads_noninterleaved: {
-            order_and_display: [
-                ['fastq_fwd_staging_file_name', 'Forward/left FASTQ file path'],
-                ['fastq_rev_staging_file_name', 'Reverse/right FASTQ file path'],
-                ['name', 'Reads object name'],
-                ['read_orientation_outward', 'Reads orientation outward'],
-            ],
-            data: [
-                {
-                    fastq_fwd_staging_file_name: null,
-                    fastq_rev_staging_file_name: null,
-                    name: null,
-                    read_orientation_outward: 0,
-                },
-                {
-                    fastq_fwd_staging_file_name: null,
-                    fastq_rev_staging_file_name: null,
-                    name: null,
-                    read_orientation_outward: 0,
-                },
-            ],
-        },
-        sra_reads: {
-            order_and_display: [
-                ['sra_staging_file_name', 'SRA file path'],
-                ['sequencing_tech', 'Sequencing technology'],
-                ['name', 'Reads object name'],
-                ['read_orientation_outward', 'Reads orientation outward'],
-            ],
-            data: [
-                {
-                    name: 'sample_sra_reads',
-                    sra_staging_file_name: 'sample_sra',
-                    read_orientation_outward: 0,
-                    sequencing_tech: 'Illumina',
-                },
-            ],
-        },
-    };
-
-    const state = {
-        params: {
-            fastq_reads_interleaved: 'complete',
-            fastq_reads_noninterleaved: 'error',
-            sra_reads: 'complete',
-        },
-        selectedAppId: 'kb_uploadmethods/import_sra_as_reads_from_staging',
-        selectedFileType: 'fastq_reads_noninterleaved',
-    };
-
-    const defaultModel = Props.make({
-        data: {
-            state,
-            params,
-            app: {
-                specs: miniSpec,
-            },
-        },
-    });
 
     const typesToFiles = {
         fastq_reads_interleaved: {
@@ -186,24 +28,198 @@ define([
             appId: 'kb_uploadmethods/import_sra_as_reads_from_staging',
         },
     };
-    describe('the xsv generator', () => {
+    const fileTypeMapping = {
+        fastq_reads_interleaved: 'FASTQ something',
+        fastq_reads_noninterleaved: 'FASTQ something else',
+        sra_reads: 'SRA reads',
+    };
+
+    const miniSpec = {
+        'kb_uploadmethods/import_fastq_interleaved_as_reads_from_staging':
+            ImportFastqInterleavedSpec,
+        'kb_uploadmethods/import_fastq_noninterleaved_as_reads_from_staging':
+            ImportFastqNonInterleavedSpec,
+        'kb_uploadmethods/import_sra_as_reads_from_staging': ImportSraReadsSpec,
+    };
+
+    const params = {
+        fastq_reads_interleaved: {
+            filePaths: [
+                {
+                    fastq_fwd_staging_file_name: 'only_forward.fastq',
+                    name: 'only_forward.fastq_reads',
+                },
+            ],
+            params: {
+                insert_size_mean: null,
+                insert_size_std_dev: null,
+                read_orientation_outward: 0,
+                sequencing_tech: 'Illumina',
+                single_genome: 1,
+            },
+        },
+        fastq_reads_noninterleaved: {
+            filePaths: [
+                {
+                    fastq_fwd_staging_file_name: null,
+                    fastq_rev_staging_file_name: null,
+                    name: null,
+                },
+                {
+                    fastq_fwd_staging_file_name: null,
+                    fastq_rev_staging_file_name: null,
+                    name: null,
+                },
+            ],
+            params: {
+                insert_size_mean: null,
+                insert_size_std_dev: null,
+                read_orientation_outward: 0,
+                sequencing_tech: 'Illumina',
+                single_genome: 1,
+            },
+        },
+        sra_reads: {
+            filePaths: [
+                {
+                    name: 'some_sra_file_reads',
+                    sra_staging_file_name: 'some_sra_file',
+                },
+            ],
+            params: {
+                insert_size_mean: null,
+                insert_size_std_dev: null,
+                read_orientation_outward: 0,
+                sequencing_tech: 'Illumina',
+                single_genome: 1,
+            },
+        },
+    };
+
+    const expectedOutput = {
+        fastq_reads_noninterleaved: {
+            order_and_display: [
+                ['fastq_fwd_staging_file_name', 'Forward/left FASTQ file path'],
+                ['fastq_rev_staging_file_name', 'Reverse/right FASTQ file path'],
+                ['sequencing_tech', 'Sequencing technology'],
+                ['name', 'Reads object name'],
+                ['single_genome', 'Single genome'],
+                ['read_orientation_outward', 'Reads orientation outward'],
+                ['insert_size_std_dev', 'St. dev. of insert size'],
+                ['insert_size_mean', 'Mean insert size'],
+            ],
+            data: [
+                {
+                    fastq_fwd_staging_file_name: null,
+                    fastq_rev_staging_file_name: null,
+                    name: null,
+                    insert_size_mean: null,
+                    insert_size_std_dev: null,
+                    read_orientation_outward: 0,
+                    sequencing_tech: 'Illumina',
+                    single_genome: 1,
+                },
+                {
+                    fastq_fwd_staging_file_name: null,
+                    fastq_rev_staging_file_name: null,
+                    name: null,
+                    insert_size_mean: null,
+                    insert_size_std_dev: null,
+                    read_orientation_outward: 0,
+                    sequencing_tech: 'Illumina',
+                    single_genome: 1,
+                },
+            ],
+        },
+        fastq_reads_interleaved: {
+            order_and_display: [
+                ['fastq_fwd_staging_file_name', 'Forward/left FASTQ file path'],
+                ['sequencing_tech', 'Sequencing technology'],
+                ['name', 'Reads object name'],
+                ['single_genome', 'Single genome'],
+                ['read_orientation_outward', 'Reads orientation outward'],
+                ['insert_size_std_dev', 'St. dev. of insert size'],
+                ['insert_size_mean', 'Mean insert size'],
+            ],
+            data: [
+                {
+                    fastq_fwd_staging_file_name: 'only_forward.fastq',
+                    name: 'only_forward.fastq_reads',
+                    insert_size_mean: null,
+                    insert_size_std_dev: null,
+                    read_orientation_outward: 0,
+                    sequencing_tech: 'Illumina',
+                    single_genome: 1,
+                },
+            ],
+        },
+        sra_reads: {
+            order_and_display: [
+                ['sra_staging_file_name', 'SRA file path'],
+                ['sequencing_tech', 'Sequencing technology'],
+                ['name', 'Reads object name'],
+                ['single_genome', 'Single genome'],
+                ['read_orientation_outward', 'Reads orientation outward'],
+                ['insert_size_std_dev', 'St. dev. of insert size'],
+                ['insert_size_mean', 'Mean insert size'],
+            ],
+            data: [
+                {
+                    name: 'some_sra_file_reads',
+                    sra_staging_file_name: 'some_sra_file',
+                    insert_size_mean: null,
+                    insert_size_std_dev: null,
+                    read_orientation_outward: 0,
+                    sequencing_tech: 'Illumina',
+                    single_genome: 1,
+                },
+            ],
+        },
+    };
+
+    const state = {
+        params: {
+            fastq_reads_interleaved: 'complete',
+            fastq_reads_noninterleaved: 'error',
+            sra_reads: 'complete',
+        },
+        selectedAppId: 'kb_uploadmethods/import_sra_as_reads_from_staging',
+        selectedFileType: 'sra_reads',
+    };
+
+    const defaultModel = Props.make({
+        data: {
+            state,
+            params,
+            app: {
+                specs: miniSpec,
+            },
+        },
+    });
+
+    function createXsvGen() {
+        return new XSVGenerator({ model: defaultModel, typesToFiles, fileTypeMapping });
+    }
+
+    describe('the XSV Generator', () => {
         describe('module', () => {
             it('can be instantiated', () => {
-                const xsvGen = new XSVGenerator({ model: {}, typesToFiles });
+                const xsvGen = createXsvGen();
                 expect(xsvGen).toBeDefined();
                 expect(xsvGen.run).toEqual(jasmine.any(Function));
                 expect(xsvGen.cssBaseClass).toEqual(jasmine.any(String));
             });
         });
 
-        const cssBaseClass = new XSVGenerator({ model: {}, typesToFiles }).cssBaseClass;
+        const cssBaseClass = new XSVGenerator({ model: {}, typesToFiles, fileTypeMapping })
+            .cssBaseClass;
         describe('instance', () => {
-            it('requires a model to work', () => {
+            it('requires a model', () => {
                 expect(() => {
                     new XSVGenerator();
                 }).toThrowError(/XSV Generator requires the param "model" for instantiation/);
             });
-            it('requires the typesToFiles mapping to work', () => {
+            it('requires the typesToFiles mapping', () => {
                 expect(() => {
                     new XSVGenerator({ model: {} });
                 }).toThrowError(
@@ -211,12 +227,27 @@ define([
                 );
             });
 
+            it('requires the fileTypeMapping param', () => {
+                expect(() => {
+                    new XSVGenerator({ model: {}, typesToFiles: {} });
+                }).toThrowError(
+                    /XSV Generator requires the param "fileTypeMapping" for instantiation/
+                );
+            });
+
             describe('run', () => {
                 async function checkStartUpDialog(modelData, hasError) {
                     const model = Props.make({
-                        data: modelData,
+                        data: {
+                            state,
+                            params,
+                            app: {
+                                specs: miniSpec,
+                            },
+                            ...modelData,
+                        },
                     });
-                    const xsvGen = new XSVGenerator({ model, typesToFiles });
+                    const xsvGen = new XSVGenerator({ model, typesToFiles, fileTypeMapping });
                     spyOn(UI, 'showConfirmDialog').and.resolveTo(false);
                     await xsvGen.run();
                     expect(UI.showConfirmDialog).toHaveBeenCalledTimes(1);
@@ -263,9 +294,46 @@ define([
                 });
             });
 
+            describe('createForm', () => {
+                beforeEach(function () {
+                    this.xsvGen = createXsvGen();
+                });
+
+                it('creates a form with the appropriate inputs', function () {
+                    const form = document.createElement('div');
+                    form.innerHTML = this.xsvGen.createForm();
+                    const formParams = ['output_directory', 'output_file_type', 'types'];
+                    formParams.forEach((param) => {
+                        const paramElement = form.querySelector(`[name="${param}"]`);
+                        expect(paramElement).toBeDefined();
+                        if (param === 'output_file_type') {
+                            // ensure that all the output file types are present
+                            ['CSV', 'TSV', 'EXCEL'].forEach((type) => {
+                                expect(paramElement.innerHTML).toMatch(`value="${type}"`);
+                            });
+                        } else if (param === 'types') {
+                            // ensure that all the input types are present
+                            Object.keys(params).forEach((type) => {
+                                expect(paramElement.innerHTML).toMatch(`value="${type}"`);
+                            });
+                        }
+                    });
+                });
+            });
+
+            xdescribe('runRequest', () => {
+                // TODO:
+                // retrieving form values
+                // form validation
+            });
+
             describe('generateRequest', () => {
                 beforeEach(function () {
-                    this.xsvGen = new XSVGenerator({ model: defaultModel, typesToFiles });
+                    this.xsvGen = new XSVGenerator({
+                        model: defaultModel,
+                        typesToFiles,
+                        fileTypeMapping,
+                    });
                 });
                 const output_file_type = 'CSV',
                     output_directory = 'new_folder';
@@ -301,7 +369,7 @@ define([
 
             describe('sendRequest', () => {
                 beforeEach(function () {
-                    this.xsvGen = new XSVGenerator({ model: {}, typesToFiles });
+                    this.xsvGen = new XSVGenerator({ model: {}, typesToFiles, fileTypeMapping });
                     this.xsvGen.runtime = {
                         config: () => {
                             return 'http://example.com';
@@ -362,7 +430,7 @@ define([
 
             describe('responses', () => {
                 beforeEach(function () {
-                    this.xsvGen = new XSVGenerator({ model: {}, typesToFiles });
+                    this.xsvGen = new XSVGenerator({ model: {}, typesToFiles, fileTypeMapping });
                     spyOn(UI, 'showInfoDialog').and.callFake((args) => {
                         this.title = args.title;
                         this.container = document.createElement('div');
@@ -389,6 +457,34 @@ define([
                     ).toEqual('your_name_here/new folder/assembly.csv');
                 });
 
+                it('displays a success message, multiple types, single output file', function () {
+                    const result = {
+                        output_file_type: 'EXCEL',
+                        files_created: {
+                            assembly: 'your_name_here/new folder/import_specification.xlsx',
+                            fastq_reads_interleaved:
+                                'your_name_here/new folder/import_specification.xlsx',
+                            fastq_reads_noninterleaved:
+                                'your_name_here/new folder/import_specification.xlsx',
+                            genbank_genome: 'your_name_here/new folder/import_specification.xlsx',
+                            sra_reads: 'your_name_here/new folder/import_specification.xlsx',
+                        },
+                    };
+                    this.xsvGen.displayResult(result);
+                    expect(this.title).toEqual('Template Generation Successful!');
+                    expect(
+                        this.container.querySelector(`.${cssBaseClass}__result_text`).textContent
+                    ).toEqual('The following file has been added to the staging area:');
+                    const fileList = Array.from(
+                        this.container.querySelectorAll(`.${cssBaseClass}__file_list_item`)
+                    );
+                    expect(fileList.length).toEqual(1);
+                    expect(
+                        fileList.map((liElement) => {
+                            return liElement.textContent;
+                        })
+                    ).toEqual(['your_name_here/new folder/import_specification.xlsx']);
+                });
                 it('displays a success message, multiple files', function () {
                     const result = {
                         output_file_type: 'CSV',


### PR DESCRIPTION
# Description of PR purpose/changes

Adding a rough template generation form to the XSV Generator for user testing on Thursday.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-747
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, creating a bulk import cell, click on the XSV generation button, and observing the ugly but functional form.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
