### PR TITLE
Create a new manually-triggered workflow

### DIFF
--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -1,0 +1,23 @@
+name: Build and Tag Latest Image
+
+# Controls when the workflow will run
+on:
+  # Manually triggers the workflow on the develop branch 
+  workflow_dispatch:
+    inputs:
+      branch: 
+        description: 'Branch to build the new image from'     
+        required: true
+        default: 'develop' 
+        type: choice
+        options:
+        - develop
+        - main
+    
+jobs:
+  run_build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+    - 
+      name: say hello
+      run: echo "hello world"


### PR DESCRIPTION
# Description of PR purpose/changes

There is currently an issue where out-of-date builds can be deployed to CI due to the way that GitHub actions are set up. This PR creates a workflow that can be manually triggered to generate a new build for deployment.

Unfortunately, [there is a lot of wobbliness on GitHub's side](https://github.community/t/workflow-dispatch-workflow-not-showing-in-actions-tab/130088/30) around creating manually-triggered workflows; it seems that you have to commit the workflow to the default branch for it to actually show up. Hence this very bare-bones file to check that the new workflow shows up in the Actions tab.

# Jira Ticket / Issue #

N/A
