### PR TITLE
DATAUP-740 Handle testing jm.list_jobs date/delta times

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -1,7 +1,6 @@
 from IPython.display import HTML
 from jinja2 import Template
 from datetime import datetime, timezone, timedelta
-import copy
 from typing import List, Tuple
 import biokbase.narrative.clients as clients
 from .job import (
@@ -771,7 +770,7 @@ class JobManager:
         """
         try:
             all_states = self.get_all_job_states(ignore_refresh_flag=True)
-            state_list = [copy.deepcopy(s["jobState"]) for s in all_states.values()]
+            state_list = [s["jobState"] for s in all_states.values()]
 
             if not state_list:
                 return "No running jobs!"


### PR DESCRIPTION
# Description of PR purpose/changes

Did a brain fart on previous patch for this. If you look at the code being tested, `datetime`s or `deltatime`s are used to produce output time strings. Plus, they can repeat. So, this requires a little more sophistication to handle off-by-1s times.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
