### PR TITLE
DATAUP-639 add paramDisplay metadata

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -174,9 +174,10 @@ define([
                 } else {
                     paramsBus.emit('parameter-changed', {
                         parameter: parameterSpec.id,
-                        newValue: newValue,
+                        newValue,
+                        newDisplayValue: message.newDisplayValue,
                         isError: message.isError,
-                        rowId: rowId,
+                        rowId,
                         rowIndex: dataModel.rowIdToIndex[rowId],
                     });
                 }

--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -20,7 +20,7 @@ define([
 
     function factory(config) {
         const viewOnly = config.viewOnly || false;
-        const { bus, workspaceId, paramIds, initialParams } = config;
+        const { bus, workspaceId, paramIds, initialParams, initialDisplay } = config;
         // key = param id, value = boolean, true if is in error
         const advancedParamErrors = {};
         const runtime = Runtime.make(),
@@ -78,12 +78,20 @@ define([
             be cross-validated for uniqueness (optional)
         */
 
-        function makeFieldWidget(inputWidget, appSpec, parameterSpec, value, closeParameters) {
+        function makeFieldWidget(
+            inputWidget,
+            appSpec,
+            parameterSpec,
+            value,
+            displayValue,
+            closeParameters
+        ) {
             const fieldWidget = FieldWidget.make({
                 inputControlFactory: inputWidget,
                 showHint: true,
                 useRowHighight: true,
                 initialValue: value,
+                initialDisplayValue: displayValue,
                 referenceType: 'name',
                 paramsChannelName: bus.channelName,
                 appSpec,
@@ -100,6 +108,7 @@ define([
                         {
                             parameter: parameterSpec.id,
                             newValue: message.newValue,
+                            newDisplayValue: message.newDisplayValue,
                             isError: message.isError,
                         },
                         {
@@ -113,6 +122,7 @@ define([
                     bus.emit('parameter-changed', {
                         parameter: parameterSpec.id,
                         newValue: message.newValue,
+                        newDisplayValue: message.newDisplayValue,
                         isError: message.isError,
                     });
                 });
@@ -463,7 +473,8 @@ define([
                         inputWidget,
                         appSpec,
                         paramSpec,
-                        initialParams[paramSpec.id]
+                        initialParams[paramSpec.id],
+                        initialDisplay[paramSpec.id]
                     );
 
                     widgets.push(widget);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidget.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidget.js
@@ -55,6 +55,7 @@ define([
             inputControl = inputControlFactory.make({
                 bus: config.bus,
                 initialValue: config.initialValue,
+                initialDisplayValue: config.initialDisplayValue,
                 appSpec: config.appSpec,
                 parameterSpec: config.parameterSpec,
                 workspaceInfo: config.workspaceInfo,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetBare.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetBare.js
@@ -53,6 +53,7 @@ define([
                 paramsChannelName: config.paramsChannelName,
                 channelName: bus.channelName,
                 initialValue: config.initialValue,
+                initialDisplayValue: config.initialDisplayValue,
                 appSpec: config.appSpec,
                 parameterSpec: config.parameterSpec,
                 workspaceInfo: config.workspaceInfo,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetCompact.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetCompact.js
@@ -55,6 +55,7 @@ define([
                 paramsChannelName: config.paramsChannelName,
                 channelName: bus.channelName,
                 initialValue: config.initialValue,
+                initialDisplayValue: config.initialDisplayValue,
                 appSpec: config.appSpec,
                 parameterSpec: config.parameterSpec,
                 workspaceInfo: config.workspaceInfo,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetMicro.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/fieldWidgetMicro.js
@@ -54,6 +54,7 @@ define([
                 paramsChannelName: config.paramsChannelName,
                 channelName: bus.channelName,
                 initialValue: config.initialValue,
+                initialDisplayValue: config.initialDisplayValue,
                 appSpec: config.appSpec,
                 parameterSpec: config.parameterSpec,
                 workspaceInfo: config.workspaceInfo,

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/sequenceInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/sequenceInput.js
@@ -140,8 +140,9 @@ define([
             });
         }
 
-        function doChanged(index, value) {
+        function doChanged(index, value, display) {
             viewModel.setItem(['items', index, 'value'], value);
+            viewModel.setItem(['items', index, 'display'], display);
             return validate(exportModel()).then((result) => {
                 channel.emit('validation', result);
             });
@@ -178,7 +179,7 @@ define([
                     }
                 });
                 fieldWidget.bus.on('changed', (message) => {
-                    doChanged(control.index, message.newValue);
+                    doChanged(control.index, message.newValue, message.newDisplayValue);
                 });
 
                 fieldWidget.bus.on('touched', () => {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
@@ -318,12 +318,8 @@ define([
          */
         function renderSubcontrols() {
             if (viewModel.state.enabled) {
-                const events = Events.make({
-                    node: container,
-                });
-                return makeInputControl(events).then((result) => {
+                return makeInputControl().then((result) => {
                     ui.setContent('input-container.subcontrols', result.content);
-                    events.attachEvents();
                     structFields = {};
                     result.fields.forEach((field) => {
                         structFields[field.fieldName] = field;

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
@@ -225,11 +225,13 @@ define([
             });
         }
 
-        function doChanged(id, newValue) {
+        function doChanged(id, newValue, newDisplayValue) {
             // Absorb and propagate the new value...
             viewModel.data[id] = Util.copy(newValue);
+            viewModel.display[id] = Util.copy(newDisplayValue);
             bus.emit('changed', {
                 newValue: Util.copy(viewModel.data),
+                newDisplayValue: Util.copy(viewModel.display),
             });
 
             // Validate and propagate.
@@ -276,7 +278,7 @@ define([
                     }
                 });
                 fieldWidget.bus.on('changed', (message) => {
-                    doChanged(fieldSpec.id, message.newValue);
+                    doChanged(fieldSpec.id, message.newValue, message.newDisplayValue);
                 });
 
                 fieldWidget.bus.on('touched', () => {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/structInput.js
@@ -67,6 +67,7 @@ define([
             bus = config.bus,
             viewModel = {
                 data: {},
+                displayData: {},
                 state: {
                     enabled: null,
                 },
@@ -84,9 +85,10 @@ define([
             viewModel.state.enabled = false;
         }
 
-        function setModelValue(value) {
+        function setModelValue(value, displayValue) {
             return Promise.try(() => {
                 viewModel.data = value;
+                viewModel.displayData = displayValue || {};
             }).catch((err) => {
                 console.error('Error setting model value', err);
             });
@@ -147,6 +149,7 @@ define([
                 viewModel.state.enabled = true;
                 button.innerHTML = 'Disable';
                 viewModel.data = Util.copy(spec.data.defaultValue);
+                viewModel.displayData = {};
             }
             bus.emit('set-param-state', {
                 state: viewModel.state,
@@ -193,19 +196,20 @@ define([
             );
         }
 
-        function makeInputControl(events, bus) {
+        function makeInputControl() {
             const promiseOfFields = fieldLayout.map((fieldName) => {
                 const fieldSpec = struct.specs[fieldName];
                 const fieldValue = viewModel.data[fieldName];
+                const fieldDisplayValue = viewModel.displayData[fieldName];
 
-                return makeSingleInputControl(fieldValue, fieldSpec, events, bus);
+                return makeSingleInputControl(fieldValue, fieldDisplayValue, fieldSpec);
             });
 
             // TODO: support different layouts, this is a simple stacked
             // one for now.
 
             return Promise.all(promiseOfFields).then((fields) => {
-                const layout = div(
+                const content = div(
                     {
                         class: 'row',
                     },
@@ -219,8 +223,8 @@ define([
                         .join('\n')
                 );
                 return {
-                    content: layout,
-                    fields: fields,
+                    content,
+                    fields,
                 };
             });
         }
@@ -228,15 +232,15 @@ define([
         function doChanged(id, newValue, newDisplayValue) {
             // Absorb and propagate the new value...
             viewModel.data[id] = Util.copy(newValue);
-            viewModel.display[id] = Util.copy(newDisplayValue);
+            viewModel.displayData[id] = Util.copy(newDisplayValue);
             bus.emit('changed', {
                 newValue: Util.copy(viewModel.data),
-                newDisplayValue: Util.copy(viewModel.display),
+                newDisplayValue: Util.copy(viewModel.displayData),
             });
 
             // Validate and propagate.
             // Note: the struct control does not display local error messages. Each
-            // input widget will have an error message if applicable, so not reason
+            // input widget will have an error message if applicable, so no reason
             // (at present) to have yet another one...
 
             validate(viewModel.data).then((result) => {
@@ -248,7 +252,7 @@ define([
          * The single input control wraps a field widget, which provides the
          * wrapper around the input widget itself.
          */
-        function makeSingleInputControl(value, fieldSpec) {
+        function makeSingleInputControl(value, displayValue, fieldSpec) {
             return resolver.loadInputControl(fieldSpec).then((widgetFactory) => {
                 const id = html.genId(),
                     fieldWidget = FieldWidget.make({
@@ -256,6 +260,7 @@ define([
                         showHint: true,
                         useRowHighight: true,
                         initialValue: value,
+                        initialDisplayValue: displayValue,
                         parameterSpec: fieldSpec,
                         referenceType: 'ref',
                         paramsChannelName: config.paramsChannelName,
@@ -264,9 +269,11 @@ define([
                 // set up listeners for the input
                 fieldWidget.bus.on('sync', () => {
                     const value = viewModel.data[fieldSpec.id];
+                    const displayValue = viewModel.displayData[fieldSpec.id];
                     if (value) {
                         fieldWidget.bus.emit('update', {
-                            value: value,
+                            value,
+                            displayValue,
                         });
                     }
                 });
@@ -274,6 +281,7 @@ define([
                     if (message.diagnosis === Constants.DIAGNOSIS.OPTIONAL_EMPTY) {
                         bus.emit('changed', {
                             newValue: Util.copy(viewModel.data),
+                            newDisplayValue: Util.copy(viewModel.displayData),
                         });
                     }
                 });
@@ -297,7 +305,7 @@ define([
                 });
 
                 return {
-                    id: id,
+                    id,
                     fieldName: fieldSpec.id,
                     instance: fieldWidget,
                 };
@@ -396,6 +404,7 @@ define([
                 ui = UI.make({ node: container });
                 events = Events.make({ node: container });
                 viewModel.data = Util.copy(config.initialValue);
+                viewModel.displayData = Util.copy(config.initialDisplayValue || {});
             });
             return init
                 .then(() => {
@@ -418,9 +427,11 @@ define([
                         // FORNOW: just ignore
                         if (viewModel.state.enabled) {
                             viewModel.data = Util.copy(message.value);
+                            viewModel.displayData = Util.copy(message.displayValue);
                             Object.keys(message.value).forEach((id) => {
                                 structFields[id].instance.bus.emit('update', {
                                     value: message.value[id],
+                                    displayValue: message.displayValue[id],
                                 });
                             });
                         }
@@ -429,6 +440,7 @@ define([
                     bus.on('submit', () => {
                         bus.emit('submitted', {
                             value: Util.copy(viewModel.data),
+                            displayValue: Util.copy(viewModel.displayData),
                         });
                     });
 

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/view/sequenceView.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/view/sequenceView.js
@@ -118,6 +118,7 @@ define([
                         showInfo: false,
                         useRowHighight: true,
                         initialValue: control.value,
+                        initialDisplayValue: control.display,
                         parameterSpec: itemSpec,
                         referenceType: 'ref',
                         paramsChannelName: config.paramsChannelName,

--- a/nbextensions/advancedViewCell/widgets/appParamsWidget.js
+++ b/nbextensions/advancedViewCell/widgets/appParamsWidget.js
@@ -81,6 +81,7 @@ define([
                         {
                             parameter: parameterSpec.id,
                             newValue: message.newValue,
+                            newDisplayValue: message.newDisplayValue,
                         },
                         {
                             key: {
@@ -93,6 +94,7 @@ define([
                     paramsBus.emit('parameter-changed', {
                         parameter: parameterSpec.id,
                         newValue: message.newValue,
+                        newDisplayValue: message.newDisplayValue,
                     });
                 });
 

--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -203,6 +203,7 @@ define(
                     widget = AppParamsWidget.make({
                         bus: widgetBus,
                         initialParams: model.getItem('params'),
+                        initialDisplay: model.getItem('paramDisplay') || {},
                     });
 
                 widgetBus.on('sync-params', (message) => {
@@ -281,6 +282,7 @@ define(
                     const isError = Boolean(message.isError);
                     if (state.mode === 'editing') {
                         model.setItem(['params', message.parameter], message.newValue);
+                        model.setItem(['paramDisplay', message.parameter], message.newDisplayValue);
                         evaluateAppState(isError);
                     } else {
                         console.warn(
@@ -392,6 +394,7 @@ define(
                     const { state } = fsm.getCurrentState();
                     if (state.mode === 'editing') {
                         model.setItem(['params', message.parameter], message.newValue);
+                        model.setItem(['paramDisplay', message.parameter], message.newDisplayValue);
                         evaluateAppState();
                     } else {
                         console.warn(

--- a/nbextensions/appCell2/widgets/appParamsWidget.js
+++ b/nbextensions/appCell2/widgets/appParamsWidget.js
@@ -39,6 +39,7 @@ define([
         const runtime = Runtime.make(),
             paramsBus = config.bus,
             initialParams = config.initialParams,
+            initialDisplay = config.initialDisplay,
             bus = runtime.bus().makeChannelBus({ description: 'A app params widget' }),
             model = Props.make(),
             paramResolver = ParamResolver.make(),
@@ -93,13 +94,14 @@ define([
             field, this would be the list of all parameters meant to be output objects, so their names can
             be cross-validated for uniqueness (optional)
         */
-        function makeFieldWidget(appSpec, parameterSpec, value, closeParameters) {
+        function makeFieldWidget(appSpec, parameterSpec, value, display, closeParameters) {
             return paramResolver.loadInputControl(parameterSpec).then((inputWidget) => {
                 const fieldWidget = FieldWidget.make({
                     inputControlFactory: inputWidget,
                     showHint: true,
                     useRowHighight: true,
                     initialValue: value,
+                    initialDisplayValue: display,
                     appSpec,
                     parameterSpec,
                     workspaceId: runtime.workspaceId(),
@@ -114,6 +116,7 @@ define([
                         {
                             parameter: parameterSpec.id,
                             newValue: message.newValue,
+                            newDisplayValue: message.newDisplayValue,
                             isError: message.isError,
                         },
                         {
@@ -127,6 +130,7 @@ define([
                     paramsBus.emit('parameter-changed', {
                         parameter: parameterSpec.id,
                         newValue: message.newValue,
+                        newDisplayValue: message.newDisplayValue,
                         isError: message.isError,
                     });
                 });
@@ -554,7 +558,8 @@ define([
                                         return makeFieldWidget(
                                             appSpec,
                                             spec,
-                                            initialParams[spec.id]
+                                            initialParams[spec.id],
+                                            initialDisplay[spec.id]
                                         ).then((widget) => {
                                             widgets.push(widget);
 
@@ -595,6 +600,7 @@ define([
                                             appSpec,
                                             spec,
                                             initialParams[spec.id],
+                                            initialDisplay[spec.id],
                                             outputParams.layout
                                         ).then((widget) => {
                                             widgets.push(widget);
@@ -633,7 +639,8 @@ define([
                                         return makeFieldWidget(
                                             appSpec,
                                             spec,
-                                            initialParams[spec.id]
+                                            initialParams[spec.id],
+                                            initialDisplay[spec.id]
                                         ).then((widget) => {
                                             widgets.push(widget);
 

--- a/nbextensions/appCell2/widgets/configureTab.js
+++ b/nbextensions/appCell2/widgets/configureTab.js
@@ -63,6 +63,7 @@ define(['bluebird', 'common/runtime'], (Promise, runtime) => {
 
                 bus.on('parameter-changed', (message) => {
                     arg.model.setItem(['params', message.parameter], message.newValue);
+                    arg.model.setItem(['paramDisplay', message.parameter], message.newDisplayValue);
                 });
 
                 return widget.start().then(() => {

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -403,6 +403,7 @@ define([
                 workspaceId: runtime.workspaceId(),
                 paramIds: model.getItem(['app', 'otherParamIds', selectedFileType]),
                 initialParams: model.getItem(['params', selectedFileType, PARAM_TYPE]),
+                initialDisplay: model.getItem(['paramDisplay', selectedFileType, PARAM_TYPE]) || {},
                 viewOnly,
             });
 
@@ -645,6 +646,10 @@ define([
                 ] = message.newValue;
             } else {
                 model.setItem(['params', fileType, paramType, message.parameter], message.newValue);
+                model.setItem(
+                    ['paramDisplay', fileType, paramType, message.parameter],
+                    message.newDisplayValue
+                );
             }
 
             return updateAppConfigState(message.isError);

--- a/nbextensions/editorCell/widgets/editors/readsSet/create.js
+++ b/nbextensions/editorCell/widgets/editors/readsSet/create.js
@@ -87,6 +87,7 @@ define([
                 parentBus.emit('parameter-changed', {
                     parameter: parameterSpec.id(),
                     newValue: message.newValue,
+                    newDisplayValue: message.newDisplayValue,
                 });
             });
 

--- a/nbextensions/editorCell/widgets/editors/readsSet/editor.js
+++ b/nbextensions/editorCell/widgets/editors/readsSet/editor.js
@@ -698,6 +698,10 @@ define(
 
                         bus.on('parameter-changed', (message) => {
                             model.setItem(['params', message.parameter], message.newValue);
+                            model.setItem(
+                                ['paramDisplay', message.parameter],
+                                message.newDisplayValue
+                            );
                             evaluateAppState();
                         });
 

--- a/nbextensions/editorCell/widgets/editors/readsSet/update.js
+++ b/nbextensions/editorCell/widgets/editors/readsSet/update.js
@@ -71,6 +71,7 @@ define([
                     parentBus.emit('parameter-changed', {
                         parameter: parameterSpec.id,
                         newValue: message.newValue,
+                        newDisplayValue: message.newDisplayValue,
                     });
                 });
 

--- a/nbextensions/viewCell/widgets/appParamsViewWidget.js
+++ b/nbextensions/viewCell/widgets/appParamsViewWidget.js
@@ -103,6 +103,7 @@ define([
                         {
                             parameter: parameterSpec.id,
                             newValue: message.newValue,
+                            newDisplayValue: message.newDisplayValue,
                         },
                         {
                             key: {

--- a/nbextensions/viewCell/widgets/appParamsWidget.js
+++ b/nbextensions/viewCell/widgets/appParamsWidget.js
@@ -104,6 +104,7 @@ define([
                         {
                             parameter: parameterSpec.id,
                             newValue: message.newValue,
+                            newDisplayValue: message.newDisplayValue,
                         },
                         {
                             key: {

--- a/test/data/testBulkImportObj.js
+++ b/test/data/testBulkImportObj.js
@@ -487,6 +487,7 @@ define(['./jobsData', 'common/jobs'], (JobsData, Jobs) => {
                     sequencing_tech: 'Illumina',
                     single_genome: 1,
                 },
+                paramDisplay: {},
             },
         },
         'user-settings': {

--- a/test/unit/spec/appWidgets/input/structInputSpec.js
+++ b/test/unit/spec/appWidgets/input/structInputSpec.js
@@ -150,7 +150,7 @@ define([
         });
 
         it('should use a dynamic dropdown and propagate a get-parameters bus message', async () => {
-            const service = 'SomeService';
+            const service = 'SomeDynamicService';
             const method = 'some_method';
             const nsUrl = 'https://kbase.us/service/fakeNSUrl';
 

--- a/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
+++ b/test/unit/spec/common/cellComponents/paramsWidget-Spec.js
@@ -77,11 +77,13 @@ define([
 
             this.workspaceId = 54745;
             this.initialParams = this.model.getItem('params').fastq_reads.params;
+            this.initialDisplay = this.model.getItem('params').fastq_reads.paramDisplay;
 
             this.defaultArgs = {
                 bus: this.bus,
                 workspaceId: this.workspaceId,
                 initialParams: this.initialParams,
+                initialDisplay: this.initialDisplay,
                 paramIds: this.paramIds,
             };
         });

--- a/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeAppPanel-spec.js
@@ -74,7 +74,7 @@ define([
         };
 
     describe('The kbaseNarrativeAppPanel widget', () => {
-        beforeEach(() => {
+        beforeEach(async () => {
             Jupyter.narrative = {
                 getAuthToken: () => FAKE_TOKEN,
                 userId: FAKE_USER,
@@ -108,7 +108,7 @@ define([
 
             $panel = $('<div>');
             appPanel = new AppPanel($panel);
-            return appPanel.refreshFromService();
+            await appPanel.refreshFromService();
         });
 
         afterEach(() => {

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
@@ -9,7 +9,7 @@ define([
 ], (DataList, $, Config, Workspace, Jupyter, Mocks, TestUtil) => {
     'use strict';
 
-    const FAKE_NS_URL = 'https://ci.kbase.us/services/fake_url';
+    const FAKE_NS_URL = 'https://kbase.us/service/fakeNSUrl';
     const FAKE_WS_NAME = 'some_workspace';
 
     function mockNarrativeServiceListObjects(objData) {


### PR DESCRIPTION
# Description of PR purpose/changes

This adds the `paramDisplay` metadata component to the app cell and bulk import cell. Other rarely used app cell variants might not work yet. This enables the dynamic dropdown input to serialize and load its initial display value (instead of getting weird `undefined`s).

This also has some test fixes that stem from mocking dynamic services. The dynamic service client has a somewhat global cache of what services map to what URLs. When making mocks, there are a couple of test specs that use the same fake service name. If they use different urls, then when having the dynamic service url "looked up," the cache will return the other URL. 

Ideally, at the end of a test run, the cache would be invalidated. That doesn't happen, because Jasmine keeps everything in the test browser's state between runs. And the Dynamic Service client doesn't have any external access to that Cache to invalidate it. AND it's a separate installed library from a separate service. It would take time to fix all of these things, so the solution for now is to make sure that each test spec uses a unique fake dynamic service name.

Along with separate test failures in other recent PRs, today has just been fun on a bun.

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-639
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
