### PR TITLE
DATAUP-747: restore lost commits, add dialog for template generation results

### DIFF
--- a/test/unit/spec/common/ui-Spec.js
+++ b/test/unit/spec/common/ui-Spec.js
@@ -657,33 +657,75 @@ define(['common/ui', 'testUtil'], (UI, TestUtil) => {
                 27: false,
             };
             Object.keys(clickLocation).forEach((loc) => {
-                it(`returns ${clickLocation[loc]} when clicking on ${loc}`, async () => {
-                    await UI.showConfirmDialog({
+                it(`returns ${clickLocation[loc]} when clicking on ${loc}, using onConfirm`, async () => {
+                    const res = await UI.showConfirmDialog({
                         title: 'showConfirmDialog',
                         body: 'blah blah blah',
                         doThisFirst: () => {
                             document.querySelector(loc).click();
                         },
-                    }).then((res) => {
-                        expect(res).toBe(clickLocation[loc]);
-                        expect(document.querySelector('.modal-dialog')).toBeNull();
+                        onConfirm: (resolution) => {
+                            // onConfirm should only be triggered when the OK button is clicked
+                            expect(resolution).toEqual(true);
+                            // and then set it to the location clicked
+                            return loc;
+                        },
                     });
+                    if (res) {
+                        expect(res).toEqual(loc);
+                    } else {
+                        expect(res).toEqual(false);
+                    }
+                    expect(document.querySelector('.modal-dialog')).toBeNull();
+                });
+
+                it(`returns ${clickLocation[loc]} when clicking on ${loc}, no onConfirm`, async () => {
+                    const res = await UI.showConfirmDialog({
+                        title: 'showConfirmDialog',
+                        body: 'blah blah blah',
+                        doThisFirst: () => {
+                            document.querySelector(loc).click();
+                        },
+                    });
+                    expect(res).toBe(clickLocation[loc]);
+                    expect(document.querySelector('.modal-dialog')).toBeNull();
                 });
             });
 
             Object.keys(keyCode).forEach((key) => {
-                it(`returns ${keyCode[key]} when hitting key ${key}`, async () => {
-                    await UI.showConfirmDialog({
+                it(`returns ${keyCode[key]} when hitting key ${key}, using onConfirm`, async () => {
+                    const res = await UI.showConfirmDialog({
                         title: 'showConfirmDialog',
                         body: 'blah blah blah',
                         doThisFirst: () => {
                             const e = new KeyboardEvent('keyup', { key: key });
                             document.querySelector('.modal').dispatchEvent(e);
                         },
-                    }).then((res) => {
-                        expect(res).toBe(keyCode[key]);
-                        expect(document.querySelector('.modal-dialog')).toBeNull();
+                        onConfirm: (resolution) => {
+                            expect(resolution).toEqual(true);
+                            return { say: 'ZOMG!' };
+                        },
                     });
+
+                    if (res) {
+                        expect(res).toEqual({ say: 'ZOMG!' });
+                    } else {
+                        expect(res).toBe(keyCode[key]);
+                    }
+                    expect(document.querySelector('.modal-dialog')).toBeNull();
+                });
+
+                it(`returns ${keyCode[key]} when hitting key ${key}, no onConfirm`, async () => {
+                    const res = await UI.showConfirmDialog({
+                        title: 'showConfirmDialog',
+                        body: 'blah blah blah',
+                        doThisFirst: () => {
+                            const e = new KeyboardEvent('keyup', { key: key });
+                            document.querySelector('.modal').dispatchEvent(e);
+                        },
+                    });
+                    expect(res).toBe(keyCode[key]);
+                    expect(document.querySelector('.modal-dialog')).toBeNull();
                 });
             });
         });


### PR DESCRIPTION
# Description of PR purpose/changes

- restore some changes that GitHub helpfully lost
- add an "onConfirm" function to the generic modal to allow for functionality that happens when the user clicks ok
- use aforementioned "onConfirm" function in XSV Generator to add in a dialog that comes up when the template generation is complete

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-747
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to a bulk import cell, clicking on the "generate template" button, and filling your staging area with a load of templates.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
