### PR TITLE
DATAUP-639 add "exact_match_on" support to dynamic dropdown

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
   - selected value wasn't being displayed properly after a page reload or cell refresh
   - selected value wasn't being displayed in view-only version
   - "Loading..." message wasn't displayed while fetching data from a service.
+  - Update the dynamic dropdown to support the `exact_match_on` field in app specs.
 
 Dependency Changes
 - Javascript dependency updates

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/dynamicDropdownInput.js
@@ -138,7 +138,10 @@ define([
                 } else {
                     const dataAdapter = $(control).data('select2').dataAdapter;
                     const newOption = dataAdapter.option(
-                        Object.assign({ id: model.value, value: model.value }, displayValue)
+                        Object.assign(
+                            { id: String(model.value).trim(), value: model.value },
+                            displayValue
+                        )
                     );
                     dataAdapter.addOptions(newOption);
                     $(control).val(value).trigger('change');
@@ -503,9 +506,13 @@ define([
             const data = [];
 
             if (config.isViewOnly) {
+                // For select2, ids should be a string, not "0" or empty string
+                // This sets the value of the <option> element. For view only it doesn't
+                // matter much.
+                // see also: https://select2.org/data-sources/formats#automatic-string-casting
                 let viewData = {
                     selected: true,
-                    id: config.initialValue || undefined,
+                    id: config.initialValue || '1',
                     text: config.initialValue,
                 };
                 if (config.initialDisplayValue) {
@@ -528,7 +535,9 @@ define([
                 let match = null;
                 for (const result of searchResults) {
                     if (
-                        model.value.toLowerCase() === result[ddOptions.exact_match_on].toLowerCase()
+                        result[ddOptions.exact_match_on] &&
+                        String(model.value).trim().toLowerCase() ===
+                            String(result[ddOptions.exact_match_on]).trim().toLowerCase()
                     ) {
                         match = result;
                         break;
@@ -536,7 +545,7 @@ define([
                 }
                 if (match) {
                     data.push(Object.assign(match, { selected: true }));
-                    model.value = match.id;
+                    model.value = String(match.id).trim();
                 } else {
                     model.exactMatchError = true;
                 }
@@ -621,7 +630,6 @@ define([
             container.innerHTML = layout();
 
             if (config.initialValue !== undefined) {
-                // note this might come from a different workspace...
                 model.value = config.initialValue;
             }
             if (config.initialDisplayValue !== undefined) {

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
@@ -721,6 +721,34 @@ define([
         }
 
         /**
+         * Return the correct structure for a result that's always invalid.
+         * For use with widgets that need to trigger validation errors, but the value
+         * might be technically valid. E.g. a dynamic dropdown search result was not
+         * found with an existing value. Technically, the value would pass validation,
+         * but it's not really a valid result.
+         *
+         * The diagnosis is optional, if given, it should be in the Constants.DIAGNOSIS
+         * structure. Otherwise, this will default to Constants.DIAGNOSIS.INVALID.
+         * @param {any} value
+         * @param {string} diagnosis (optional) - should be one of Constants.DIAGNOSIS
+         * @returns an invalid validation structure.
+         */
+        function validateFalse(value, diagnosis) {
+            const defaultDiagnosis = Constants.DIAGNOSIS.INVALID;
+
+            if (!Object.values(Constants.DIAGNOSIS).includes(diagnosis)) {
+                diagnosis = defaultDiagnosis;
+            }
+
+            return {
+                isValid: false,
+                errorMessage: 'error',
+                diagnosis,
+                value,
+            };
+        }
+
+        /**
          * Basically casts undefined -> null, otherwise returns the given string.
          * @param {String} value the value to verify
          * @returns the imported string or null
@@ -811,6 +839,7 @@ define([
             validateStringSet: validateTextSet,
             validateBoolean,
             validateTrue,
+            validateFalse,
             importTextString,
             importIntString,
             importFloatString,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,9 +2288,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001335",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-            "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+            "version": "1.0.30001336",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
+            "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
             "dev": true,
             "funding": [
                 {
@@ -17865,9 +17865,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001335",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-            "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+            "version": "1.0.30001336",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
+            "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/appWidgets/validationSpec.js
+++ b/test/unit/spec/appWidgets/validationSpec.js
@@ -1649,4 +1649,33 @@ define([
             });
         });
     });
+
+    describe('validateFalse', () => {
+        // very simple, but with a few cases to test
+        const value = 'val';
+        const simpleResult = {
+            isValid: false,
+            diagnosis: Constants.DIAGNOSIS.INVALID,
+            errorMessage: 'error',
+            value,
+        };
+
+        [undefined, 1, null, 'foobar'].forEach((badDiag) => {
+            it(`should default to "invalid" for with a given diagnosis of ${badDiag}`, () => {
+                expect(Validation.validateFalse(value, badDiag)).toEqual(simpleResult);
+            });
+        });
+
+        it('should return an "invalid" diagnosis by default', () => {
+            expect(Validation.validateFalse(value)).toEqual(simpleResult);
+        });
+
+        ['ERROR', 'SUSPECT', 'REQUIRED_MISSING'].forEach((diag) => {
+            it(`should show a ${diag} diagnosis`, () => {
+                const expectation = TestUtil.JSONcopy(simpleResult);
+                expectation.diagnosis = Constants.DIAGNOSIS[diag];
+                expect(Validation.validateFalse(value, expectation.diagnosis)).toEqual(expectation);
+            });
+        });
+    });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

When `exact_match_on` is given to an app spec's `dynamic_dropdown_options` map, it's intended to do the following:
1. Automatically do a dynamic search using the `initialValue` as search term
2. The results will be a list of objects. Search out the first one who's `exact_match_on` key exactly matches the value (case insensitive).
3. Use that to populate the field and get the value out of it.

For example, if we're doing the scientific name search (which is the first case this is supposed to work for), and the given initialValue is "Escherichia coli K-12", then when this dropdown initializes, it starts by doing a search with "Escherichia coli K-12" as the input. When it gets a response, it looks for the EXACT match, of the term given by the `exact_match_on` field, case insensitive. In this case, it'll find something like:

```
{
  scientific_name: "Escherichia coli K-12",
  id: "83333",
  ncbi_taxon_id: "83333",
  .... other stuff ....
}
```

Our `exact_match_on` field is `scientific_name`, so match against that. This is the hit, so autoselect the option with that result. it then does the usual bit of validation and processing - the real "value" returned by this field is the taxon id, so 83333 gets returned.

If nothing is found, this becomes invalid and shows an error. A user can fix it by doing a new search, or just clearing the field.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-639
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [x] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
