### PR TITLE
DATAUP-751 add link to docs to upload tour

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
   - selected value wasn't being displayed in view-only version
   - "Loading..." message wasn't displayed while fetching data from a service.
   - Update the dynamic dropdown to support the `exact_match_on` field in app specs.
+- DATAUP-751 - add link to staging area docs in the upload tour
 
 Dependency Changes
 - Javascript dependency updates

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/upload/uploadTour.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/upload/uploadTour.js
@@ -21,7 +21,7 @@ define([
                 placement: 'bottom',
                 orphan: true,
                 content:
-                    'This tour shows how to use the Import panel to upload data files and import them into your Narrative as KBase data objects.',
+                    '<p>This tour shows how to use the Import panel to upload data files and import them into your Narrative as KBase data objects.</p><p>For detailed documentation on uploading data, click <a href="https://docs.kbase.us/data/upload-download-guide/uploads" target="_new">here</a>.</p>',
                 backdrop: true,
             },
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,9 +2288,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001336",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-            "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+            "version": "1.0.30001338",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+            "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
             "dev": true,
             "funding": [
                 {
@@ -17865,9 +17865,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001336",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001336.tgz",
-            "integrity": "sha512-/YxSlBmL7iKXTbIJ48IQTnAOBk7XmWsxhBF1PZLOko5Dt9qc4Pl+84lfqG3Tc4EuavurRn1QLoVJGxY2iSycfw==",
+            "version": "1.0.30001338",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+            "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
             "dev": true
         },
         "chalk": {


### PR DESCRIPTION
# Description of PR purpose/changes

What it says about - adds a blurb of text and a link to docs to the first page of the staging area tour. No real code changes.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-751
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
