### PR TITLE
DATAUP-756 add copying to select dropdowns

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,8 +11,13 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
   - selected value wasn't being displayed in view-only version
   - "Loading..." message wasn't displayed while fetching data from a service.
   - Update the dynamic dropdown to support the `exact_match_on` field in app specs.
+  - Add a copy button to the dynamic dropdown - this will copy the most relevant text from the dropdown to the clipboard.
+    - For dropdowns with an `exact_match_on` field, this will copy the contents of that field (e.g. for those that present taxonomy ids for a species, this copies just the scientific name)
+    - For dropdowns that go against the FTP staging area, this copies the file name and path.
+    - For other dropdowns, this copies the formatted text
 - DATAUP-751 - add link to staging area docs in the upload tour
 - DATAUP-753 - alter the error text for Select input boxes in app cells to be a bit more generalized.
+- DATAUP-756 - add a copy button for other, non-dynamic dropdowns. This copies the displayed text to the clipboard.
 
 Dependency Changes
 - Javascript dependency updates

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/selectInput.js
@@ -4,12 +4,14 @@ define([
     'common/html',
     'common/ui',
     'common/runtime',
+    'common/events',
     '../validation',
+    'widgets/appWidgets2/common',
     '../inputUtils',
     '../validators/constants',
     'select2',
     'bootstrap',
-], ($, Promise, html, UI, Runtime, Validation, inputUtils, Constants) => {
+], ($, Promise, html, UI, Runtime, Events, Validation, WidgetCommon, inputUtils, Constants) => {
     'use strict';
 
     // Constants
@@ -155,7 +157,7 @@ define([
                 {
                     dataElement: 'main-panel',
                 },
-                [div({ dataElement: 'input-container' }, makeInputControl())]
+                [div({ dataElement: 'input-container' })] //, makeInputControl())]
             );
         }
 
@@ -192,6 +194,14 @@ define([
             });
         }
 
+        function getCopyString() {
+            const data = $(ui.getElement('input-container.input')).select2('data')[0];
+            if (!data || !data.text) {
+                return '';
+            }
+            return data.text;
+        }
+
         // LIFECYCLE API
 
         function start(arg) {
@@ -200,6 +210,18 @@ define([
                 container = parent.appendChild(document.createElement('div'));
                 ui = UI.make({ node: container });
                 container.innerHTML = layout();
+                const events = Events.make();
+                const content = WidgetCommon.containerContent(
+                    div,
+                    t('button'),
+                    events,
+                    ui,
+                    ui.getElement('input-container'),
+                    makeInputControl(),
+                    getCopyString
+                );
+                ui.setContent('input-container', content);
+
                 $(ui.getElement('input-container.input'))
                     .select2({
                         allowClear: true,
@@ -214,6 +236,8 @@ define([
                     .on('select2:clear', () => {
                         handleChanged();
                     });
+
+                events.attachEvents(container);
 
                 channel.on('reset-to-defaults', () => {
                     resetModelValue();

--- a/test/unit/spec/appWidgets/input/selectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/selectInputSpec.js
@@ -44,7 +44,7 @@ define([
         };
     }
 
-    describe('Select Input tests', () => {
+    fdescribe('Select Input tests', () => {
         beforeEach(() => {
             runtime = Runtime.make();
             container = document.createElement('div');
@@ -287,6 +287,36 @@ define([
                 for (const child of inputElem.children) {
                     expect(['dirigible', 'elephant', 'frittata'].includes(child.value)).toBeTrue();
                 }
+            });
+        });
+
+        [
+            {
+                initialValue: 'apple',
+                expected: 'Apple',
+            },
+            {
+                initialValue: 'banana',
+                expected: 'Banana',
+            },
+            {
+                initialValue: 'nope',
+                expected: '',
+            },
+            {
+                initialValue: null,
+                expected: '',
+            },
+        ].forEach((testCase) => {
+            it(`Should copy the display text of the currently selected option "${testCase.initialValue}"`, async () => {
+                testConfig.initialValue = testCase.initialValue;
+                const widget = SelectInput.make(testConfig);
+                await widget.start({ node: container });
+
+                const copyBtn = container.querySelector('button.kb-app-row-clip-btn');
+                spyOn(navigator.clipboard, 'writeText');
+                copyBtn.click();
+                expect(navigator.clipboard.writeText).toHaveBeenCalledWith(testCase.expected);
             });
         });
     });


### PR DESCRIPTION
# Description of PR purpose/changes

Dynamic dropdowns and dropdowns for new object inputs have a copy-to-clipboard button next to them. This applies the same thing to regular dropdowns. When clicked, these will copy the displayed text to the clipboard, or an empty string if nothing is selected.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-756
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
