### PR TITLE
Fix appCellWidget not processing status calls

### DIFF
--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -1734,15 +1734,6 @@ define(
                         // this will not change, so we can just render it here.
                         PR.prettyPrint(null, container);
 
-                        const currentFsmState = fsm.getCurrentState().state;
-
-                        // if we start out in 'new' state, we need to promote it to
-                        // one of the 'editing' states
-                        if (currentFsmState.mode === 'new') {
-                            evaluateAppState();
-                            return;
-                        }
-
                         jobManager.addEventHandler('modelUpdate', {
                             execMessage: () => {
                                 // Update the execMessage panel with details of the active job
@@ -1775,6 +1766,15 @@ define(
                                 updateState();
                             },
                         });
+
+                        const currentFsmState = fsm.getCurrentState().state;
+
+                        // if we start out in 'new' state, we need to promote it to
+                        // one of the 'editing' states
+                        if (currentFsmState.mode === 'new') {
+                            evaluateAppState();
+                            return;
+                        }
 
                         /*
                          * Check the job state and init the job manager if appropriate

--- a/test/unit/spec/appWidgets/input/selectInputSpec.js
+++ b/test/unit/spec/appWidgets/input/selectInputSpec.js
@@ -44,7 +44,7 @@ define([
         };
     }
 
-    fdescribe('Select Input tests', () => {
+    describe('Select Input tests', () => {
         beforeEach(() => {
             runtime = Runtime.make();
             container = document.createElement('div');


### PR DESCRIPTION
# Description of PR purpose/changes

There's a nifty new JobManager now that does all the message handling. Sadly, it wasn't being set up correctly when a new app cell is created. A little code reordering fixes that.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
