### PR TITLE
DATAUP-747: get ready for multi select

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validation.js
@@ -749,6 +749,19 @@ define([
         }
 
         /**
+         * Runs importTextString over an array
+         * @param {*} value -- array of values or null
+         * @returns {array} imported values
+         */
+
+        function importTextStringArray(value) {
+            if (value === null || value === undefined) {
+                return [];
+            }
+            return value.map((val) => importTextString(val));
+        }
+
+        /**
          * Basically casts undefined -> null, otherwise returns the given string.
          * @param {String} value the value to verify
          * @returns the imported string or null
@@ -841,6 +854,7 @@ define([
             validateCustomInput,
             validateTrue,
             validateFalse,
+            importTextStringArray,
             importTextString,
             importIntString,
             importFloatString,

--- a/test/unit/spec/appWidgets/validationSpec.js
+++ b/test/unit/spec/appWidgets/validationSpec.js
@@ -425,9 +425,9 @@ define([
                                     options.required = required;
                                     return Validation[method](test.value, options);
                                 }).then((result) => {
-                                    Object.keys(test.result).forEach((key) => {
-                                        expect(result[key]).toEqual(test.result[key]);
-                                    });
+                                    // ensure the result contains everything
+                                    // in test.result
+                                    expect(result).toEqual(jasmine.objectContaining(test.result));
                                 });
                             });
                         });
@@ -436,9 +436,9 @@ define([
                             return Promise.try(() => {
                                 return Validation[method](test.value, test.options);
                             }).then((result) => {
-                                Object.keys(test.result).forEach((key) => {
-                                    expect(result[key]).toEqual(test.result[key]);
-                                });
+                                // ensure the result contains everything
+                                // in test.result
+                                expect(result).toEqual(jasmine.objectContaining(test.result));
                             });
                         });
                     }
@@ -804,7 +804,7 @@ define([
                     diagnosis: Constants.DIAGNOSIS.INVALID,
                     errorMessage: 'value must be a string or number (it is of type "undefined")',
                     value: undefined,
-                    pasedValue: undefined,
+                    parsedValue: undefined,
                 },
             },
             {
@@ -970,7 +970,7 @@ define([
                     diagnosis: Constants.DIAGNOSIS.INVALID,
                     errorMessage: 'value must be a string (it is of type "undefined")',
                     value: undefined,
-                    pasedValue: undefined,
+                    parsedValue: undefined,
                 },
             },
             {
@@ -1604,6 +1604,21 @@ define([
             [undefined, null].forEach((val) => {
                 expect(Validation.importTextString(val)).toBeNull();
             });
+        });
+
+        it('importTextStringArray - plain strings are unchanged', () => {
+            const inputs = ['a', 'bb', 'ccc', '  ', ''];
+            inputs.forEach((str) => {
+                expect(Validation.importTextStringArray([str])).toEqual([str]);
+            });
+            expect(Validation.importTextStringArray(inputs)).toEqual(inputs);
+        });
+
+        it('importTextStringArray - undefined and null are nullified', () => {
+            [undefined, null].forEach((val) => {
+                expect(Validation.importTextStringArray(val)).toEqual([]);
+            });
+            expect(Validation.importTextStringArray([undefined, null])).toEqual([null, null]);
         });
 
         const empties = [undefined, null, '', '  '];


### PR DESCRIPTION
# Description of PR purpose/changes

Some minor changes to ready the world for select elements with multi select capabilities.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-747
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and seeing that nothing has changed. How boring!

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
