### PR TITLE
DATAUP-729: Remove unhelpful "updated" timestamp from jobs

### DIFF
--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import time
 import uuid
 from pprint import pprint
 from typing import List
@@ -27,6 +26,7 @@ JOB_INIT_EXCLUDED_JOB_STATE_FIELDS = [
     "retry_saved_toggle",
     "scheduler_type",
     "scheduler_id",
+    "updated",
 ]
 
 EXCLUDED_JOB_STATE_FIELDS = JOB_INIT_EXCLUDED_JOB_STATE_FIELDS + ["job_input"]
@@ -383,7 +383,6 @@ class Job:
                 "batch_job": bool,
                 "child_jobs": list,
                 "created": epoch ms,
-                "updated": epoch ms,
                 "queued": epoch ms,
                 "running": epoch ms,
                 "finished": epoch ms,
@@ -461,8 +460,6 @@ class Job:
                         "error": "Unable to generate App output viewer!\nThe App appears to have completed successfully,\nbut we cannot construct its output viewer.\nPlease contact https://kbase.us/support for assistance.",
                     },
                 }
-                # update timestamp if there was an error
-                state.update({"updated": int(time.time())})
 
         return {
             "job_id": self.job_id,
@@ -600,7 +597,6 @@ class Job:
             "cell_id": self.cell_id,
             "run_id": self.run_id,
             "created": 0,
-            "updated": 0,
         }
 
     def __repr__(self):

--- a/src/biokbase/narrative/tests/data/response_data.json
+++ b/src/biokbase/narrative/tests/data/response_data.json
@@ -398,7 +398,6 @@
                 "retry_ids": [],
                 "running": 1625755954453,
                 "status": "completed",
-                "updated": 1625756075071,
                 "widget_info": {
                     "name": "no-display",
                     "params": {
@@ -447,8 +446,7 @@
                     "BATCH_RETRY_ERROR"
                 ],
                 "running": 1625755952628,
-                "status": "error",
-                "updated": 1625755962079
+                "status": "error"
             },
             "job_id": "BATCH_ERROR_RETRIED",
             "outputWidgetInfo": null
@@ -471,8 +469,7 @@
                 "job_output": {},
                 "retry_count": 0,
                 "retry_ids": [],
-                "status": "created",
-                "updated": 1625755944607
+                "status": "created"
             },
             "job_id": "BATCH_PARENT",
             "outputWidgetInfo": null
@@ -502,7 +499,6 @@
                 "retry_parent": "BATCH_TERMINATED_RETRIED",
                 "running": 1625756004391,
                 "status": "completed",
-                "updated": 1625756123553,
                 "widget_info": {
                     "name": "no-display",
                     "params": {
@@ -550,8 +546,7 @@
                 "retry_ids": [],
                 "retry_parent": "BATCH_ERROR_RETRIED",
                 "running": 1625757662469,
-                "status": "error",
-                "updated": 1625757676740
+                "status": "error"
             },
             "job_id": "BATCH_RETRY_ERROR",
             "outputWidgetInfo": null
@@ -569,8 +564,7 @@
                 "retry_ids": [],
                 "retry_parent": "BATCH_TERMINATED_RETRIED",
                 "running": 1625757285899,
-                "status": "running",
-                "updated": 1625757405384
+                "status": "running"
             },
             "job_id": "BATCH_RETRY_RUNNING",
             "outputWidgetInfo": null
@@ -589,8 +583,7 @@
                 "retry_ids": [],
                 "running": 1625755952599,
                 "status": "terminated",
-                "terminated_code": 0,
-                "updated": 1625755985250
+                "terminated_code": 0
             },
             "job_id": "BATCH_TERMINATED",
             "outputWidgetInfo": null
@@ -612,8 +605,7 @@
                 ],
                 "running": 1625755952563,
                 "status": "terminated",
-                "terminated_code": 0,
-                "updated": 1625755977130
+                "terminated_code": 0
             },
             "job_id": "BATCH_TERMINATED_RETRIED",
             "outputWidgetInfo": null
@@ -641,7 +633,6 @@
                 "retry_ids": [],
                 "running": 1642431816870,
                 "status": "completed",
-                "updated": 1642431852275,
                 "widget_info": {
                     "name": "no-display",
                     "params": {
@@ -673,8 +664,7 @@
                 "job_output": {},
                 "retry_count": 0,
                 "retry_ids": [],
-                "status": "created",
-                "updated": 1642522062069
+                "status": "created"
             },
             "job_id": "JOB_CREATED",
             "outputWidgetInfo": null
@@ -700,8 +690,7 @@
                 "retry_count": 0,
                 "retry_ids": [],
                 "running": 1642431847689,
-                "status": "error",
-                "updated": 1642431856323
+                "status": "error"
             },
             "job_id": "JOB_ERROR",
             "outputWidgetInfo": null
@@ -718,8 +707,7 @@
                 "retry_count": 0,
                 "retry_ids": [],
                 "running": 1642521775867,
-                "status": "running",
-                "updated": 1642521775870
+                "status": "running"
             },
             "job_id": "JOB_RUNNING",
             "outputWidgetInfo": null
@@ -737,8 +725,7 @@
                 "retry_count": 0,
                 "retry_ids": [],
                 "status": "terminated",
-                "terminated_code": 0,
-                "updated": 1642521729372
+                "terminated_code": 0
             },
             "job_id": "JOB_TERMINATED",
             "outputWidgetInfo": null
@@ -783,7 +770,6 @@
                     "retry_ids": [],
                     "running": 1625755954453,
                     "status": "completed",
-                    "updated": 1625756075071,
                     "widget_info": {
                         "name": "no-display",
                         "params": {
@@ -835,8 +821,7 @@
                         "BATCH_RETRY_ERROR"
                     ],
                     "running": 1625755952628,
-                    "status": "error",
-                    "updated": 1625755962079
+                    "status": "error"
                 },
                 "job_id": "BATCH_ERROR_RETRIED",
                 "outputWidgetInfo": null
@@ -864,8 +849,7 @@
                     "retry_ids": [],
                     "retry_parent": "BATCH_ERROR_RETRIED",
                     "running": 1625757662469,
-                    "status": "error",
-                    "updated": 1625757676740
+                    "status": "error"
                 },
                 "job_id": "BATCH_RETRY_ERROR",
                 "outputWidgetInfo": null
@@ -892,8 +876,7 @@
                     "job_output": {},
                     "retry_count": 0,
                     "retry_ids": [],
-                    "status": "created",
-                    "updated": 1625755944607
+                    "status": "created"
                 },
                 "job_id": "BATCH_PARENT",
                 "outputWidgetInfo": null
@@ -927,7 +910,6 @@
                     "retry_parent": "BATCH_TERMINATED_RETRIED",
                     "running": 1625756004391,
                     "status": "completed",
-                    "updated": 1625756123553,
                     "widget_info": {
                         "name": "no-display",
                         "params": {
@@ -979,8 +961,7 @@
                     "retry_ids": [],
                     "retry_parent": "BATCH_ERROR_RETRIED",
                     "running": 1625757662469,
-                    "status": "error",
-                    "updated": 1625757676740
+                    "status": "error"
                 },
                 "job_id": "BATCH_RETRY_ERROR",
                 "outputWidgetInfo": null
@@ -1002,8 +983,7 @@
                     "retry_ids": [],
                     "retry_parent": "BATCH_TERMINATED_RETRIED",
                     "running": 1625757285899,
-                    "status": "running",
-                    "updated": 1625757405384
+                    "status": "running"
                 },
                 "job_id": "BATCH_RETRY_RUNNING",
                 "outputWidgetInfo": null
@@ -1026,8 +1006,7 @@
                     "retry_ids": [],
                     "running": 1625755952599,
                     "status": "terminated",
-                    "terminated_code": 0,
-                    "updated": 1625755985250
+                    "terminated_code": 0
                 },
                 "job_id": "BATCH_TERMINATED",
                 "outputWidgetInfo": null
@@ -1052,8 +1031,7 @@
                     ],
                     "running": 1625755952563,
                     "status": "terminated",
-                    "terminated_code": 0,
-                    "updated": 1625755977130
+                    "terminated_code": 0
                 },
                 "job_id": "BATCH_TERMINATED_RETRIED",
                 "outputWidgetInfo": null
@@ -1084,7 +1062,6 @@
                     "retry_parent": "BATCH_TERMINATED_RETRIED",
                     "running": 1625756004391,
                     "status": "completed",
-                    "updated": 1625756123553,
                     "widget_info": {
                         "name": "no-display",
                         "params": {
@@ -1137,7 +1114,6 @@
                     "retry_ids": [],
                     "running": 1642431816870,
                     "status": "completed",
-                    "updated": 1642431852275,
                     "widget_info": {
                         "name": "no-display",
                         "params": {
@@ -1173,8 +1149,7 @@
                     "job_output": {},
                     "retry_count": 0,
                     "retry_ids": [],
-                    "status": "created",
-                    "updated": 1642522062069
+                    "status": "created"
                 },
                 "job_id": "JOB_CREATED",
                 "outputWidgetInfo": null
@@ -1204,8 +1179,7 @@
                     "retry_count": 0,
                     "retry_ids": [],
                     "running": 1642431847689,
-                    "status": "error",
-                    "updated": 1642431856323
+                    "status": "error"
                 },
                 "job_id": "JOB_ERROR",
                 "outputWidgetInfo": null
@@ -1226,8 +1200,7 @@
                     "retry_count": 0,
                     "retry_ids": [],
                     "running": 1642521775867,
-                    "status": "running",
-                    "updated": 1642521775870
+                    "status": "running"
                 },
                 "job_id": "JOB_RUNNING",
                 "outputWidgetInfo": null
@@ -1249,8 +1222,7 @@
                     "retry_count": 0,
                     "retry_ids": [],
                     "status": "terminated",
-                    "terminated_code": 0,
-                    "updated": 1642521729372
+                    "terminated_code": 0
                 },
                 "job_id": "JOB_TERMINATED",
                 "outputWidgetInfo": null

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -371,7 +371,6 @@ class JobTest(unittest.TestCase):
             "cell_id": job.cell_id,
             "run_id": job.run_id,
             "created": 0,
-            "updated": 0,
         }
 
         with mock.patch.object(Job, "state", mock_state):

--- a/src/biokbase/narrative/tests/util.py
+++ b/src/biokbase/narrative/tests/util.py
@@ -1,6 +1,3 @@
-"""
-Test utility functions
-"""
 import logging
 import pickle
 import struct
@@ -17,7 +14,7 @@ from biokbase.narrative.common import util
 from biokbase.workspace.client import Workspace
 from biokbase.narrative.common.narrative_ref import NarrativeRef
 
-__author__ = "Dan Gunter <dkgunter@lbl.gov>, Bill Riehl <wjriehl@lbl.gov>"
+
 _log = logging.getLogger("kbtest")
 _hnd = logging.StreamHandler()
 _hnd.setFormatter(
@@ -37,7 +34,11 @@ def test_logger(name):
     return logging.getLogger("kbtest." + name)
 
 
-class ConfigTests(object):
+class ConfigTests:
+    """
+    Test utility functions
+    """
+
     def __init__(self):
         self._path_prefix = os.path.join(
             os.environ["NARRATIVE_DIR"], "src", "biokbase", "narrative", "tests"
@@ -204,26 +205,26 @@ def read_json_file(path):
 
 class MyTestCase(unittest.TestCase):
     def test_kvparse(self):
-        for input, text, kvp in (
+        for user_input, text, kvp in (
             ("foo", "foo", {}),
             ("name=val", "", {"name": "val"}),
             ("a name=val boy", "a boy", {"name": "val"}),
         ):
             rkvp = {}
-            rtext = util.parse_kvp(input, rkvp)
+            rtext = util.parse_kvp(user_input, rkvp)
             self.assertEqual(
                 text,
                 rtext,
                 "Text '{}' does not match "
                 "result '{}' "
-                "from input '{}'".format(text, rtext, input),
+                "from input '{}'".format(text, rtext, user_input),
             )
             self.assertEqual(
                 text,
                 rtext,
                 "Dict '{}' does not match "
                 "result '{}' "
-                "from input '{}'".format(kvp, rkvp, input),
+                "from input '{}'".format(kvp, rkvp, user_input),
             )
 
 
@@ -252,10 +253,8 @@ def recvall(socket, n, timeout=0):
         if b:
             buf += b
             m += len(b)
-            # print("@@ recv {}".format(len(b)))
         else:
             time.sleep(0.1)
-            # print("@@ recv 0/{}".format(n - m))
     return buf
 
 
@@ -270,11 +269,9 @@ class LogProxyMessageBufferer(socketserver.BaseRequestHandler):
             if not hdr:
                 return
             size = struct.unpack(">L", hdr)[0]
-            #  print("@@ body {}".format(size))
             if size < 65536:
                 chunk = recvall(self.request, size, timeout=1)
                 record = pickle.loads(chunk)
-                # print("@@ message <{}>".format(record['msg']))
                 self.server.buf += record["msg"]
 
 
@@ -334,7 +331,6 @@ def validate_job_state(job_state: dict) -> None:
             "job_id": str,
             "status": str,
             "created": int,
-            "updated": int,
         },
         "optional": {
             "batch_id": (NoneType, str),


### PR DESCRIPTION
# Description of PR purpose/changes

Removing the 'updated' timestamp from jobs, which isn't used in the FE or BE.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-729
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
