### PR TITLE
DATAUP-747: Add in special option for resolving multiselections

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/resolver.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/validators/resolver.js
@@ -8,6 +8,7 @@ define(['require', 'bluebird', 'widgets/appWidgets2/validation'], (require, Prom
         custom: 'validateCustomInput',
         customSubdata: 'validateCustomInput',
         subdata: 'validateCustomInput',
+        multiselection: 'validateTextSet',
     };
 
     const typeToValidatorModule = {
@@ -19,7 +20,18 @@ define(['require', 'bluebird', 'widgets/appWidgets2/validation'], (require, Prom
 
     function validate(fieldValue, fieldSpec, options) {
         return new Promise((resolve, reject) => {
-            const fieldType = fieldSpec.data.type;
+            let fieldType = fieldSpec.data.type;
+            // is this a select element with multiple selection enabled?
+            try {
+                if (
+                    fieldSpec.data.constraints.options.length > 0 &&
+                    fieldSpec.data.constraints.multiselection
+                ) {
+                    fieldType = 'multiselection';
+                }
+            } catch (err) {
+                // no op
+            }
             if (!(fieldType in typeToValidatorModule) && !(fieldType in typeToValidator)) {
                 reject(new Error(`No validator for type: ${fieldType}`));
             } else if (fieldType in typeToValidator) {

--- a/test/unit/spec/appWidgets/validators/resolver-spec.js
+++ b/test/unit/spec/appWidgets/validators/resolver-spec.js
@@ -56,6 +56,27 @@ define([
                         expect(Validation[validationFn].calls.allArgs()).toEqual([[null, {}, {}]]);
                     });
                 }
+                it(`sends multiselects to the ${ValidationResolver.typeToValidator.multiselection} module`, async () => {
+                    const validationFn = ValidationResolver.typeToValidator.multiselection;
+                    spyOn(Validation, validationFn);
+                    await ValidationResolver.validate(
+                        null,
+                        {
+                            data: {
+                                type: 'string',
+                                constraints: { options: [{ a: 1 }, { b: 2 }], multiselection: 1 },
+                            },
+                        },
+                        { this: 'that' }
+                    );
+                    expect(Validation[validationFn].calls.allArgs()).toEqual([
+                        [
+                            null,
+                            { options: [{ a: 1 }, { b: 2 }], multiselection: 1 },
+                            { this: 'that' },
+                        ],
+                    ]);
+                });
             });
 
             describe('resolving to an individual module', () => {


### PR DESCRIPTION
# Description of PR purpose/changes

When running `spec.validateModel()`, the validation resolver needs a bit of help in directing multi selection inputs to the correct validator.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
