### PR TITLE
DATAUP-729: no more magic job attributes

### DIFF
--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -194,16 +194,7 @@ class Job:
             .get("narrative_cell_info", {})
             .get("cell_id", JOB_ATTR_DEFAULTS["cell_id"]),
             "child_jobs": lambda: copy.deepcopy(
-                # TODO
-                # Only batch container jobs have a child_jobs field
-                # and need the state refresh.
-                # But KBParallel/KB Batch App jobs may not have the
-                # batch_job field
-                self.state(force_refresh=True).get(
-                    "child_jobs", JOB_ATTR_DEFAULTS["child_jobs"]
-                )
-                if self.batch_job
-                else self._acc_state.get("child_jobs", JOB_ATTR_DEFAULTS["child_jobs"])
+                self._acc_state.get("child_jobs", JOB_ATTR_DEFAULTS["child_jobs"])
             ),
             "job_id": lambda: self._acc_state.get("job_id"),
             "params": lambda: copy.deepcopy(
@@ -212,13 +203,7 @@ class Job:
                 )
             ),
             "retry_ids": lambda: copy.deepcopy(
-                # Batch container and retry jobs don't have a
-                # retry_ids field so skip the state refresh
                 self._acc_state.get("retry_ids", JOB_ATTR_DEFAULTS["retry_ids"])
-                if self.batch_job or self.retry_parent
-                else self.state(force_refresh=True).get(
-                    "retry_ids", JOB_ATTR_DEFAULTS["retry_ids"]
-                )
             ),
             "retry_parent": lambda: self._acc_state.get(
                 "retry_parent", JOB_ATTR_DEFAULTS["retry_parent"]
@@ -226,7 +211,7 @@ class Job:
             "run_id": lambda: self._acc_state.get("job_input", {})
             .get("narrative_cell_info", {})
             .get("run_id", JOB_ATTR_DEFAULTS["run_id"]),
-            # TODO: add the status attribute!
+            "status": lambda: self._acc_state.get("status", ""),
             "tag": lambda: self._acc_state.get("job_input", {})
             .get("narrative_cell_info", {})
             .get("tag", JOB_ATTR_DEFAULTS["tag"]),
@@ -560,7 +545,7 @@ class Job:
             )
 
         inst_child_ids = [job.job_id for job in children]
-        if sorted(inst_child_ids) != sorted(self._acc_state.get("child_jobs")):
+        if sorted(inst_child_ids) != sorted(self.child_jobs):
             raise ValueError("Child job id mismatch")
 
     def update_children(self, children: List["Job"]) -> None:

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -742,6 +742,8 @@ class JobManager:
         if not batch_job.batch_job:
             raise JobRequestException(JOB_NOT_BATCH_ERR, batch_id)
 
+        # update the batch job
+        batch_job.state()
         child_ids = batch_job.child_jobs
 
         reg_child_jobs = []

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -776,14 +776,11 @@ class JobManagerTest(unittest.TestCase):
         reg_child_jobs = [
             self.jm.get_job(job_id) for job_id in batch_job._acc_state["child_jobs"]
         ]
-
         self.assertCountEqual(batch_job.children, reg_child_jobs)
-        self.assertCountEqual(batch_job._acc_state["child_jobs"], new_child_ids)
 
-        with mock.patch.object(
-            MockClients, "check_job", side_effect=mock_check_job
-        ) as m:
+        with assert_obj_method_called(MockClients, "check_job", call_status=False):
             self.assertCountEqual(batch_job.child_jobs, new_child_ids)
+            self.assertCountEqual(batch_job.child_jobs, batch_job._acc_state["child_jobs"])
 
     def test_modify_job_refresh(self):
         for job_id, refreshing in REFRESH_STATE.items():


### PR DESCRIPTION

# Description of PR purpose/changes

Removing the 'magic' from retry_ids and child_jobs so that they now return their current state instead of triggering a job look up.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-729
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
