### PR TITLE
DATAUP-759: fix the checkbox input

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
@@ -217,7 +217,8 @@ define([
 
                 // initialize based on config.initialValue. If it's not 0 or 1, then
                 // note that we have an initial value error, and set to the default.
-                const initValue = config.initialValue || spec.data.defaultValue;
+                const initValue =
+                    'initialValue' in config ? config.initialValue : spec.data.defaultValue;
                 if (initValue !== 0 && initValue !== 1) {
                     model.hasInitialValueError = true;
                 }

--- a/test/unit/spec/appWidgets/input/checkboxInputSpec.js
+++ b/test/unit/spec/appWidgets/input/checkboxInputSpec.js
@@ -6,7 +6,7 @@ define([
 ], (CheckboxInput, Runtime, TestUtil, Constants) => {
     'use strict';
 
-    describe('Test checkbox data input widget', () => {
+    describe('The checkbox input widget', () => {
         let testConfig = {},
             runtime,
             bus,
@@ -82,6 +82,18 @@ define([
             const input = container.querySelector('input[type="checkbox"]');
             expect(input).toBeDefined();
             expect(input.checked).toBeTrue();
+            await widget.stop();
+            expect(container.childElementCount).toBe(0);
+        });
+
+        it('should start and stop properly with initial value', async () => {
+            testConfig.initialValue = 0;
+            const widget = CheckboxInput.make(testConfig);
+            await widget.start({ node: container });
+            expect(container.childElementCount).toBeGreaterThan(0);
+            const input = container.querySelector('input[type="checkbox"]');
+            expect(input).toBeDefined();
+            expect(input.checked).toBeFalse();
             await widget.stop();
             expect(container.childElementCount).toBe(0);
         });


### PR DESCRIPTION
# Description of PR purpose/changes

Fixing the checkbox input so that it starts up in the correct state if the initial value is 0

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-759
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, heading to a bulk import cell, switching the checkboxes off, and then clicking between tabs.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
