### PR TITLE
DATAUP-718 add loading spinner to configure tab

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/paramsWidget.js
@@ -513,11 +513,10 @@ define([
 
             places.parameterFields.innerHTML = filteredParams.content;
 
-            return Promise.all(
-                filteredParams.layout.map(async (parameterId) => {
-                    await createParameterWidget(appSpec, filteredParams, parameterId);
-                })
-            ).then(() => {
+            const parameterPromises = filteredParams.layout.map((parameterId) =>
+                createParameterWidget(appSpec, filteredParams, parameterId)
+            );
+            return Promise.all(parameterPromises).then(() => {
                 renderAdvanced();
             });
         }
@@ -559,7 +558,6 @@ define([
 
             return renderParameters()
                 .then(() => {
-                    // do something after success
                     attachEvents();
                 })
                 .catch((error) => {
@@ -568,7 +566,7 @@ define([
         }
 
         function stop() {
-            return Promise.try(() => {
+            return Promise.all(widgets.map((widget) => widget.stop())).then(() => {
                 if (container) {
                     container.innerHTML = '';
                 }

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/fileInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/fileInput.js
@@ -336,7 +336,7 @@ define([
         function render() {
             Promise.try(() => {
                 const events = Events.make(),
-                    inputControl = makeInputControl(model.value, events);
+                    inputControl = makeInputControl(events);
 
                 ui.setContent('input-container', inputControl);
                 events.attachEvents(container);

--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/floatInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/floatInput.js
@@ -227,23 +227,21 @@ define([
         // LIFECYCLE API
 
         function start(arg) {
-            return Promise.try(() => {
-                parent = arg.node;
-                container = parent.appendChild(document.createElement('div'));
-                ui = UI.make({ node: container });
+            parent = arg.node;
+            container = parent.appendChild(document.createElement('div'));
+            ui = UI.make({ node: container });
 
-                container.innerHTML = layout();
+            container.innerHTML = layout();
 
-                channel.on('reset-to-defaults', () => {
-                    resetModelValue();
-                });
-                channel.on('update', (message) => {
-                    model.setItem('value', message.value);
-                });
+            channel.on('reset-to-defaults', () => {
+                resetModelValue();
+            });
+            channel.on('update', (message) => {
+                model.setItem('value', message.value);
+            });
 
-                return render().then(() => {
-                    return autoValidate();
-                });
+            return render().then(() => {
+                return autoValidate();
             });
         }
 

--- a/nbextensions/bulkImportCell/tabs/configure.js
+++ b/nbextensions/bulkImportCell/tabs/configure.js
@@ -86,6 +86,16 @@ define([
                     allFiles.add(file);
                 }
             });
+            container = args.node;
+            const spinnerNode = document.createElement('div');
+            spinnerNode.classList.add('kb-loading-spinner');
+            spinnerNode.innerHTML = UI.loading({ size: '2x' });
+            container.appendChild(spinnerNode);
+
+            const configNode = document.createElement('div');
+            configNode.classList.add('hidden');
+            container.appendChild(configNode);
+
             return Util.getMissingFiles(Array.from(allFiles))
                 .catch((error) => {
                     // if the missing files call fails, just continue and let the cell render.
@@ -99,11 +109,10 @@ define([
                     return Util.evaluateConfigReadyState(model, specs, unavailableFiles);
                 })
                 .then((readyState) => {
-                    container = args.node;
                     ui = UI.make({ node: container });
 
                     const layout = renderLayout(events);
-                    container.innerHTML = layout;
+                    configNode.innerHTML = layout;
                     events.attachEvents(container);
 
                     const fileTypeNode = ui.getElement('filetype-panel');
@@ -113,6 +122,10 @@ define([
                     ];
                     running = true;
                     return Promise.all(initPromises);
+                })
+                .finally(() => {
+                    spinnerNode.remove();
+                    configNode.classList.remove('hidden');
                 });
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,9 +2288,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001344",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-            "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+            "version": "1.0.30001346",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
+            "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
             "dev": true,
             "funding": [
                 {
@@ -17865,9 +17865,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001344",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-            "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+            "version": "1.0.30001346",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
+            "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -101,12 +101,11 @@ define([
         afterEach(() => {
             jasmine.Ajax.uninstall();
             container.remove();
-            runtime.destroy();
-            TestUtil.clearRuntime();
         });
 
         afterAll(() => {
             Jupyter.narrative = null;
+            TestUtil.clearRuntime();
         });
 
         [
@@ -167,6 +166,40 @@ define([
             });
         });
 
+        it('starts with a disappearing loading spinner', () => {
+            const model = Props.make({
+                data: Object.assign({}, TestBulkImportObject, { state: initialState }),
+                onUpdate: () => {
+                    /* intentionally left blank */
+                },
+            });
+            spyOn(UI, 'loading').and.callThrough();
+            const configure = ConfigureTab.make({
+                bus,
+                model,
+                specs,
+                typesToFiles,
+                fileTypesDisplay,
+                fileTypeMapping,
+            });
+
+            return configure
+                .start({
+                    node: container,
+                })
+                .then(() => {
+                    // it's hard to trap when this appears / disappears when run in tests.
+                    // just make sure it's been called, and the .kb-loading-spinner node
+                    // no longer exists.
+                    expect(UI.loading).toHaveBeenCalled();
+                    expect(container.querySelector('.kb-loading-spinner')).toBeNull();
+                    return configure.stop();
+                })
+                .then(() => {
+                    expect(container.innerHTML).toEqual('');
+                });
+        });
+
         it('should stop itself and empty the node it was in', () => {
             const model = Props.make({
                 data: Object.assign({}, TestBulkImportObject, { state: initialState }),
@@ -188,7 +221,7 @@ define([
                     node: container,
                 })
                 .then(() => {
-                    // just make sure it renders the "File Paths" and "Parameters" headers
+                    // just make sure it renders the "Parameters" header
                     expect(container.innerHTML).toContain('Parameters');
                     return configure.stop();
                 })


### PR DESCRIPTION
# Description of PR purpose/changes

As part of the performance work on the configure tab, we decided it would be helpful to have a loading spinner while the configure tab loads. This puts that in place! It also fixes some test wackiness that was resulting in false-positive errors and fails in the Configure tab tests.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-718
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
Open a configure tab in a bulk import cell!
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
