### PR TITLE
bump version to 5.1.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
-### Unreleased
+### Version 5.1.0
 - PTV-1783 - fixed issue where the previous object revert option was unavailable
 - DATAUP-639 - fix problems with dynamic dropdown app cell input
   - selected value wasn't being displayed properly after a page reload or cell refresh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "kbase-narrative-core",
-    "version": "5.0.3",
+    "version": "5.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "kbase-narrative-core",
-            "version": "5.0.3",
+            "version": "5.1.0",
             "dependencies": {
                 "bluebird": "3.7.2",
                 "bootstrap": "3.3.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kbase-narrative-core",
     "description": "Core components for the KBase Narrative Interface",
-    "version": "5.0.3",
+    "version": "5.1.0",
     "private": true,
     "repository": "github.com/kbase/narrative",
     "devDependencies": {

--- a/src/biokbase/narrative/__init__.py
+++ b/src/biokbase/narrative/__init__.py
@@ -2,7 +2,7 @@ __all__ = ["magics", "common", "handlers", "contents", "services", "widgetmanage
 
 from semantic_version import Version
 
-__version__ = Version("5.0.3")
+__version__ = Version("5.1.0")
 
 
 def version():

--- a/src/config.json
+++ b/src/config.json
@@ -391,5 +391,5 @@
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,
-    "version": "5.0.3"
+    "version": "5.1.0"
 }

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -391,5 +391,5 @@
         "globus_upload_url": "https://app.globus.org/file-manager?destination_id=c3c0a65f-5827-4834-b6c9-388b0b19953a"
     },
     "use_local_widgets": true,
-    "version": "5.0.3"
+    "version": "5.1.0"
 }


### PR DESCRIPTION
As it says above, just bumping the version to 5.1.0 for the pending release. No code changes.
