### PR TITLE
PUBLIC-2083 fix issue with viewConfigure tab not loading for older apps

### DIFF
--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -330,7 +330,7 @@ define(
                     widget = AppParamsViewWidget.make({
                         bus: widgetBus,
                         initialParams: model.getItem('params'),
-                        initialDisplay: model.getItem('paramDisplay'),
+                        initialDisplay: model.getItem('paramDisplay') || {},
                     });
 
                 widgetBus.on('sync-params', (message) => {

--- a/nbextensions/appCell2/widgets/appParamsWidget.js
+++ b/nbextensions/appCell2/widgets/appParamsWidget.js
@@ -39,7 +39,7 @@ define([
         const runtime = Runtime.make(),
             paramsBus = config.bus,
             initialParams = config.initialParams,
-            initialDisplay = config.initialDisplay,
+            initialDisplay = config.initialDisplay || {},
             bus = runtime.bus().makeChannelBus({ description: 'A app params widget' }),
             model = Props.make(),
             paramResolver = ParamResolver.make(),

--- a/test/unit/spec/nbextensions/appCell2/widgets/appParamsViewWidget-spec.js
+++ b/test/unit/spec/nbextensions/appCell2/widgets/appParamsViewWidget-spec.js
@@ -1,0 +1,164 @@
+define([
+    '/narrative/nbextensions/appCell2/widgets/appParamsViewWidget',
+    'common/runtime',
+    'common/spec',
+    'testUtil',
+], (AppParamsViewWidget, Runtime, Spec, TestUtil) => {
+    'use strict';
+
+    describe('app params view widget tests', () => {
+        const appSpec = {
+            id: 'NarrativeTest/app_succeed',
+            gitCommitHash: '8d1f8480aee9852e9354cf723f0808fae53b2fcc',
+            version: '0.0.2',
+            tag: 'dev',
+            spec: {
+                info: {
+                    id: 'NarrativeTest/app_succeed',
+                    module_name: 'NarrativeTest',
+                    git_commit_hash: '8d1f8480aee9852e9354cf723f0808fae53b2fcc',
+                    name: 'App Succeed',
+                    ver: '0.0.2',
+                    subtitle: 'A simple test app that always succeeds.',
+                    tooltip: 'A simple test app that always succeeds.',
+                    categories: ['active'],
+                    authors: ['wjriehl'],
+                    input_types: [],
+                    output_types: [],
+                    app_type: 'app',
+                    namespace: 'NarrativeTest',
+                },
+                widgets: {
+                    input: 'null',
+                    output: 'no-display',
+                },
+                parameters: [
+                    {
+                        id: 'some_param',
+                        ui_name: 'A String',
+                        short_hint: 'A string.',
+                        description: '',
+                        field_type: 'text',
+                        allow_multiple: 0,
+                        optional: 0,
+                        advanced: 0,
+                        disabled: 0,
+                        ui_class: 'parameter',
+                        default_values: [''],
+                        text_options: {
+                            is_output_name: 0,
+                            placeholder: '',
+                            regex_constraint: [],
+                        },
+                    },
+                ],
+                fixed_parameters: [],
+                behavior: {
+                    kb_service_url: '',
+                    kb_service_name: 'NarrativeTest',
+                    kb_service_version: '8d1f8480aee9852e9354cf723f0808fae53b2fcc',
+                    kb_service_method: 'app_succeed',
+                    kb_service_input_mapping: [
+                        {
+                            input_parameter: 'some_param',
+                            target_argument_position: 0,
+                        },
+                    ],
+                    kb_service_output_mapping: [],
+                },
+                job_id_output_field: 'docker',
+            },
+        };
+        const compiledSpec = Spec.make({ appSpec: appSpec.spec });
+        const paramId = 'some_param';
+        const initialParams = {
+            [paramId]: 'foo',
+        };
+        const initialDisplay = {
+            [paramId]: null,
+        };
+
+        afterEach(() => {
+            TestUtil.clearRuntime();
+        });
+
+        it('should have a factory', () => {
+            expect(AppParamsViewWidget.make).toEqual(jasmine.any(Function));
+            const bus = Runtime.make().bus();
+            const widget = AppParamsViewWidget.make({
+                bus,
+                initialParams,
+                initialDisplay,
+            });
+            ['start', 'stop', 'bus'].forEach((fn) => {
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
+        });
+
+        describe('starting and stopping with simple value', () => {
+            let bus, node;
+
+            async function runSimpleTest(widget) {
+                await widget.start({
+                    node,
+                    appSpec: appSpec.spec,
+                    parameters: compiledSpec.getSpec().parameters,
+                });
+                checkRendering();
+                await widget.stop();
+                expect(node.innerHTML).toBe('');
+            }
+
+            function checkRendering() {
+                // get the (single) input element, ensure it has the startup value
+                const inputElem = node.querySelector('input[data-element="input"]');
+                expect(inputElem).not.toBeNull();
+                expect(inputElem.value).toEqual(initialParams[paramId]);
+            }
+
+            beforeEach(() => {
+                bus = Runtime.make().bus();
+                bus.respond({
+                    key: {
+                        type: 'get-batch-mode',
+                    },
+                    handle: () => {
+                        return false;
+                    },
+                });
+                node = document.createElement('div');
+                document.body.appendChild(node);
+            });
+
+            afterEach(() => {
+                node.remove();
+            });
+
+            it('should start and stop as expected, and have an accessible bus', async () => {
+                const widget = AppParamsViewWidget.make({
+                    bus,
+                    initialParams,
+                    initialDisplay,
+                });
+                await runSimpleTest(widget);
+            });
+
+            it('should start with missing display values', async () => {
+                const widget = AppParamsViewWidget.make({
+                    bus,
+                    initialParams,
+                });
+                await runSimpleTest(widget);
+            });
+
+            it('should start with specific missing display value', async () => {
+                const widget = AppParamsViewWidget.make({
+                    bus,
+                    initialParams,
+                    initialDisplay: {},
+                });
+                await runSimpleTest(widget);
+            });
+        });
+    });
+});


### PR DESCRIPTION
# Description of PR purpose/changes

There's a new `initialDisplay` field used when loading up sets of app cell inputs. That gets stored and loaded from the app cell metadata. However, there are plenty of older app cells that do not have that field - in that case, an empty object should be used for loading.

This does that and adds some basic tests to the appParamsViewWidget showing that it works.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PUBLIC-2083
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
