### PR TITLE
DATAUP-729: non job ts changes

### DIFF
--- a/docs/testing/HeadlessTesting.md
+++ b/docs/testing/HeadlessTesting.md
@@ -161,9 +161,9 @@ job = AppManager().run_app(
 import time
 import pprint
 import json
-while job.state()['job_state'] not in ['completed', 'suspend']:
+while job.refresh_state()['job_state'] not in ['completed', 'suspend']:
     time.sleep(5)
-job_result = job.state()
+job_result = job.refresh_state()
 if job_result['job_state'] != 'completed':
     print "Failed - job did not complete: " + ",".join(job_result['status'][0:3])
 else:

--- a/src/biokbase/narrative/jobs/job.py
+++ b/src/biokbase/narrative/jobs/job.py
@@ -103,7 +103,7 @@ class Job:
         if ee2_state.get("job_id") is None:
             raise ValueError("Cannot create a job without a job ID!")
 
-        self._update_state(ee2_state)
+        self.update_state(ee2_state)
         self.extra_data = extra_data
 
         # verify parent-children relationship
@@ -129,9 +129,9 @@ class Job:
             return jobs
 
     @staticmethod
-    def _trim_ee2_state(state: dict, exclude: list) -> None:
-        if exclude:
-            for field in exclude:
+    def _trim_ee2_state(state: dict, exclude_fields: list) -> None:
+        if exclude_fields:
+            for field in exclude_fields:
                 if field in state:
                     del state[field]
 
@@ -199,7 +199,7 @@ class Job:
                 # and need the state refresh.
                 # But KBParallel/KB Batch App jobs may not have the
                 # batch_job field
-                self.state(force_refresh=True).get(
+                self.refresh_state(force_refresh=True).get(
                     "child_jobs", JOB_ATTR_DEFAULTS["child_jobs"]
                 )
                 if self.batch_job
@@ -216,7 +216,7 @@ class Job:
                 # retry_ids field so skip the state refresh
                 self._acc_state.get("retry_ids", JOB_ATTR_DEFAULTS["retry_ids"])
                 if self.batch_job or self.retry_parent
-                else self.state(force_refresh=True).get(
+                else self.refresh_state(force_refresh=True).get(
                     "retry_ids", JOB_ATTR_DEFAULTS["retry_ids"]
                 )
             ),
@@ -240,16 +240,7 @@ class Job:
 
     def __setattr__(self, name, value):
         if name in STATE_ATTRS:
-            self._acc_state[name] = value
-        elif name in JOB_INPUT_ATTRS:
-            self._acc_state["job_input"] = self._acc_state.get("job_input", {})
-            self._acc_state["job_input"][name] = value
-        elif name in NARR_CELL_INFO_ATTRS:
-            self._acc_state["job_input"] = self._acc_state.get("job_input", {})
-            self._acc_state["job_input"]["narrative_cell_info"] = self._acc_state[
-                "job_input"
-            ].get("narrative_cell_info", {})
-            self._acc_state["job_input"]["narrative_cell_info"][name] = value
+            self.update_state({name: value})
         else:
             object.__setattr__(self, name, value)
 
@@ -272,14 +263,6 @@ class Job:
 
         else:
             return self._acc_state.get("status") in TERMINAL_STATUSES
-
-    def is_terminal(self):
-        self.state()
-        if self._acc_state.get("batch_job"):
-            for child_job in self.children:
-                if child_job._acc_state.get("status") != COMPLETED_STATUS:
-                    child_job.state(force_refresh=True)
-        return self.was_terminal()
 
     def in_cells(self, cell_ids: List[str]) -> bool:
         """
@@ -324,9 +307,10 @@ class Job:
                     f"Unable to fetch parameters for job {self.job_id} - {e}"
                 )
 
-    def _update_state(self, state: dict) -> None:
+    def update_state(self, state: dict) -> None:
         """
-        given a state data structure (as emitted by ee2), update the stored state in the job object
+        Given a state data structure (as emitted by ee2), update the stored state in the job object.
+        All updates to the job state should go through this function.
         """
         if not isinstance(state, dict):
             raise TypeError("state must be a dict")
@@ -335,7 +319,7 @@ class Job:
         if self._acc_state:
             if "job_id" in state and state["job_id"] != self.job_id:
                 raise ValueError(
-                    f"Job ID mismatch in _update_state: job ID: {self.job_id}; state ID: {state['job_id']}"
+                    f"Job ID mismatch in update_state: job ID: {self.job_id}; state ID: {state['job_id']}"
                 )
 
         # Check if there would be no change in updating
@@ -348,30 +332,30 @@ class Job:
         if self._acc_state is None:
             self._acc_state = state
         else:
-            self._acc_state.update(state)
+            self._acc_state = {**self._acc_state, **state}
 
-    def state(self, force_refresh=False, exclude=JOB_INIT_EXCLUDED_JOB_STATE_FIELDS):
+    def refresh_state(self, force_refresh=False, exclude_fields=JOB_INIT_EXCLUDED_JOB_STATE_FIELDS):
         """
         Queries the job service to see the state of the current job.
         """
 
         if force_refresh or not self.was_terminal():
             state = self.query_ee2_state(self.job_id, init=False)
-            self._update_state(state)
+            self.update_state(state)
 
-        return self._internal_state(exclude)
+        return self.cached_state(exclude_fields)
 
-    def _internal_state(self, exclude=None):
+    def cached_state(self, exclude_fields=None):
         """Wrapper for self._acc_state"""
         state = copy.deepcopy(self._acc_state)
-        self._trim_ee2_state(state, exclude)
+        self._trim_ee2_state(state, exclude_fields)
         return state
 
     def output_state(self, state=None, no_refresh=False) -> dict:
         """
         :param state:   Supplied when the state is queried beforehand from EE2 in bulk,
                         or when it is retrieved from a cache. If not supplied, must be
-                        queried with self.state() or self._internal_state()
+                        queried with self.refresh_state() or self.cached_state()
         :return:        dict, with structure
 
         {
@@ -424,10 +408,10 @@ class Job:
         :rtype: dict
         """
         if not state:
-            state = self._internal_state() if no_refresh else self.state()
+            state = self.cached_state() if no_refresh else self.refresh_state()
         else:
-            self._update_state(state)
-            state = self._internal_state()
+            self.update_state(state)
+            state = self.cached_state()
 
         if state is None:
             return self._create_error_state(
@@ -475,10 +459,10 @@ class Job:
         from biokbase.narrative.widgetmanager import WidgetManager
 
         if not state:
-            state = self.state()
+            state = self.refresh_state()
         else:
-            self._update_state(state)
-            state = self._internal_state()
+            self.update_state(state)
+            state = self.cached_state()
 
         if state["status"] == COMPLETED_STATUS and "job_output" in state:
             (output_widget, widget_params) = self._get_output_info(state)
@@ -541,7 +525,7 @@ class Job:
             return (num_available_lines, [])
         return (
             num_available_lines,
-            self._job_logs[first_line : first_line + num_lines],
+            self._job_logs[first_line: first_line + num_lines],
         )
 
     def _update_log(self):
@@ -611,7 +595,7 @@ class Job:
         print(f"Version: {spec['info']['ver']}")
 
         try:
-            state = self.state()
+            state = self.refresh_state()
             print(f"Status: {state['status']}")
             print("Inputs:\n------")
             pprint(self.params)
@@ -631,7 +615,7 @@ class Job:
         """
         output_widget_info = None
         try:
-            state = self.state()
+            state = self.refresh_state()
             spec = self.app_spec()
             if state.get("status", "") == COMPLETED_STATUS:
                 (output_widget, widget_params) = self._get_output_info(state)

--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -116,7 +116,11 @@ class JobRequest:
 
     @property
     def ts(self):
-        """This param is completely optional"""
+        """
+        Optional field sent with STATUS requests indicating to filter out
+        job states in the STATUS response that have not been updated since
+        this epoch time (in ns)
+        """
         return self.rq_data.get(PARAM["TS"])
 
 
@@ -199,10 +203,7 @@ class JobComm:
         if req.has_batch_id():
             return self._jm.update_batch_job(req.batch_id)
 
-        try:
-            return req.job_id_list
-        except Exception as ex:
-            raise JobRequestException(ONE_INPUT_TYPE_ONLY_ERR) from ex
+        return req.job_id_list
 
     def start_job_status_loop(
         self,

--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -29,13 +29,13 @@ __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 __version__ = "0.0.1"
 
 JOB_NOT_REG_ERR = "Job ID is not registered"
+JOB_NOT_REG_2_ERR = "Cannot find job with ID %s"  # TODO unify these
 JOB_NOT_BATCH_ERR = "Job ID is not for a batch job"
 
 JOBS_TYPE_ERR = "List expected for job_id_list"
 JOBS_MISSING_ERR = "No valid job IDs provided"
 
 CELLS_NOT_PROVIDED_ERR = "cell_id_list not provided"
-DOES_NOT_EXIST = "does_not_exist"
 
 
 class JobManager:
@@ -321,8 +321,7 @@ class JobManager:
 
     def get_job_states(self, job_ids: List[str], ts: int = None) -> dict:
         """
-        Retrieves the job states for the supplied job_ids, with the option to
-        replace any jobs that have not been updated since ts with a short stub
+        Retrieves the job states for the supplied job_ids.
 
         Jobs that cannot be found in the `_running_jobs` index will return
         {
@@ -719,7 +718,7 @@ class JobManager:
         for error_id in error_ids:
             results[error_id] = {
                 "job_id": error_id,
-                "error": f"Cannot find job with ID {error_id}",
+                "error": JOB_NOT_REG_2_ERR % error_id,
             }
         return results
 

--- a/src/biokbase/narrative/tests/test_job.py
+++ b/src/biokbase/narrative/tests/test_job.py
@@ -74,7 +74,7 @@ def create_job_from_ee2(job_id, extra_data=None, children=None):
 
 def create_state_from_ee2(job_id, exclude_fields=JOB_INIT_EXCLUDED_JOB_STATE_FIELDS):
     """
-    create the output of job.state() from raw job data
+    create the output of job.refresh_state() from raw job data
     """
     state = get_test_job(job_id)
 
@@ -178,7 +178,7 @@ class JobTest(unittest.TestCase):
         self.assertEqual(jobl._acc_state, jobr._acc_state)
 
         with mock.patch(CLIENTS, get_mock_client):
-            self.assertEqual(jobl.state(), jobr.state())
+            self.assertEqual(jobl.refresh_state(), jobr.refresh_state())
 
         for attr in JOB_ATTRS:
             self.assertEqual(getattr(jobl, attr), getattr(jobr, attr))
@@ -201,7 +201,7 @@ class JobTest(unittest.TestCase):
         if not exp_attrs and not skip_state:
             state = create_state_from_ee2(job_id)
             with mock.patch(CLIENTS, get_mock_client):
-                self.assertEqual(state, job.state())
+                self.assertEqual(state, job.refresh_state())
 
         attrs = create_attrs_from_ee2(job_id)
         attrs.update(exp_attrs)
@@ -322,7 +322,7 @@ class JobTest(unittest.TestCase):
         # ee2_state is fully populated (includes job_input, no job_output)
         job = create_job_from_ee2(JOB_CREATED)
         self.assertFalse(job.was_terminal())
-        state = job.state()
+        state = job.refresh_state()
         self.assertFalse(job.was_terminal())
         self.assertEqual(state["status"], "created")
 
@@ -338,7 +338,7 @@ class JobTest(unittest.TestCase):
         expected = create_state_from_ee2(JOB_COMPLETED)
 
         with assert_obj_method_called(MockClients, "check_job", call_status=False):
-            state = job.state()
+            state = job.refresh_state()
             self.assertEqual(state["status"], "completed")
             self.assertEqual(state, expected)
 
@@ -350,7 +350,7 @@ class JobTest(unittest.TestCase):
         job = create_job_from_ee2(JOB_CREATED)
         self.assertFalse(job.was_terminal())
         with self.assertRaisesRegex(ServerError, "check_job failed"):
-            job.state()
+            job.refresh_state()
 
     def test_state__returns_none(self):
         def mock_state(self, state=None):
@@ -373,7 +373,7 @@ class JobTest(unittest.TestCase):
             "created": 0,
         }
 
-        with mock.patch.object(Job, "state", mock_state):
+        with mock.patch.object(Job, "refresh_state", mock_state):
             state = job.output_state()
         self.assertEqual(expected, state)
 
@@ -387,10 +387,10 @@ class JobTest(unittest.TestCase):
 
         # should fail with error 'state must be a dict'
         with self.assertRaisesRegex(TypeError, "state must be a dict"):
-            job._update_state(None)
+            job.update_state(None)
         self.assertFalse(job.was_terminal())
 
-        job._update_state({})
+        job.update_state({})
         self.assertFalse(job.was_terminal())
 
     @mock.patch(CLIENTS, get_mock_client)
@@ -400,11 +400,11 @@ class JobTest(unittest.TestCase):
         """
         job = create_job_from_ee2(JOB_RUNNING)
         expected = create_state_from_ee2(JOB_RUNNING)
-        self.assertEqual(job.state(), expected)
+        self.assertEqual(job.refresh_state(), expected)
 
         # try to update it with the job state from a different job
-        with self.assertRaisesRegex(ValueError, "Job ID mismatch in _update_state"):
-            job._update_state(get_test_job(JOB_COMPLETED))
+        with self.assertRaisesRegex(ValueError, "Job ID mismatch in update_state"):
+            job.update_state(get_test_job(JOB_COMPLETED))
 
     @mock.patch(CLIENTS, get_mock_client)
     def test_job_info(self):
@@ -559,7 +559,7 @@ class JobTest(unittest.TestCase):
             mock.Mock(return_value={"status": COMPLETED_STATUS}),
         ):
             for child_job in child_jobs:
-                child_job.state(force_refresh=True)
+                child_job.refresh_state(force_refresh=True)
 
         self.assertTrue(parent_job.was_terminal())
 
@@ -726,7 +726,7 @@ class JobTest(unittest.TestCase):
 
         with mock.patch.object(MockClients, "check_job", mock_check_job):
             for job in child_jobs:
-                job.state(force_refresh=True)
+                job.refresh_state(force_refresh=True)
 
         self.assertTrue(batch_job.was_terminal())
 
@@ -757,7 +757,7 @@ class JobTest(unittest.TestCase):
         batch_job, child_jobs = batch_fam[0], batch_fam[1:]
 
         for job in child_jobs:
-            job.cell_id = "hello"
+            job._acc_state["job_input"]["narrative_cell_info"]["cell_id"] = "hello"
 
         self.assertTrue(batch_job.in_cells(["hi", "hello"]))
 
@@ -769,7 +769,7 @@ class JobTest(unittest.TestCase):
 
         children_cell_ids = ["hi", "hello", "greetings"]
         for job, cell_id in zip(child_jobs, itertools.cycle(children_cell_ids)):
-            job.cell_id = cell_id
+            job._acc_state["job_input"]["narrative_cell_info"]["cell_id"] = cell_id
 
         for cell_id in children_cell_ids:
             self.assertTrue(batch_job.in_cells([cell_id]))

--- a/src/biokbase/narrative/tests/test_jobmanager.py
+++ b/src/biokbase/narrative/tests/test_jobmanager.py
@@ -736,7 +736,7 @@ class JobManagerTest(unittest.TestCase):
         new_child_ids = BATCH_CHILDREN[1:] + [JOB_CREATED, JOB_NOT_FOUND]
 
         def mock_check_job(params):
-            """Called from job.state()"""
+            """Called from job.refresh_state()"""
             job_id = params["job_id"]
             if job_id == BATCH_PARENT:
                 return {"child_jobs": new_child_ids}


### PR DESCRIPTION
# Description of PR purpose/changes

This extracts the parts of the stalled DATAUP-729 PR that have already been OK'd into a separate PR so they can be used in a fix for DATAUP-765.

The first commit is @n1mus 's work, the second is a few bits and bobs that I added in.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-729
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
