### PR TITLE
PTV-1798: datalist not loading

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Unreleased
+- PTV-1798 - fixed issue where invalid component ID was causing data list not to load properly
+
 ### Version 5.1.0
 - PTV-1783 - fixed issue where the previous object revert option was unavailable
 - DATAUP-639 - fix problems with dynamic dropdown app cell input

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -12,7 +12,6 @@ define([
     'util/string',
     'util/display',
     'util/timeFormat',
-    'util/icon',
     'kbase-client-api',
     'kb_service/client/workspace',
     'kb_common/jsonRpc/genericClient',
@@ -39,7 +38,6 @@ define([
     StringUtil,
     DisplayUtil,
     TimeFormat,
-    Icon,
     kbase_client_api,
     Workspace,
     GenericClient,
@@ -80,7 +78,6 @@ define([
         maxWsObjId: null,
         n_objs_rendered: 0,
         real_name_lookup: {},
-        $searchInput: null,
         $filterTypeSelect: null,
         availableTypes: {},
         $searchDiv: null,
@@ -479,10 +476,6 @@ define([
                 .then(() => {
                     this.showLoading('Rendering data...');
                     const numObj = Object.keys(this.dataObjects).length;
-                    if (numObj > this.options.maxObjsToPreventFilterAsYouTypeInSearch) {
-                        this.$searchInput.off('input');
-                    }
-
                     if (numObj <= this.options.max_objs_to_prevent_initial_sort) {
                         this.viewOrder.sort((a, b) => {
                             const idA = a.objId,
@@ -2009,7 +2002,7 @@ define([
         },
 
         pluralize(word, count) {
-            if (count > 0) {
+            if (count !== 1) {
                 return `${word}s`;
             }
             return word;


### PR DESCRIPTION
# Description of PR purpose/changes

Some old code referring to an element that no longer exists was being triggered by a narrative with a large number of data items. Removed the offending stanzas and reality was restored.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1798
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
