### PR TITLE
DATAUP-763 Bulk Import datatypes always showing error in certain states

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 - DATAUP-751 - add link to staging area docs in the upload tour
 - DATAUP-753 - alter the error text for Select input boxes in app cells to be a bit more generalized.
 - DATAUP-756 - add a copy button for other, non-dynamic dropdowns. This copies the displayed text to the clipboard.
+- DATAUP-763 - fixed an issue where data type icons in the bulk import cell during a run would always show an error, saying that the cell is not ready to run, when it is clearly running.
 
 Dependency Changes
 - Javascript dependency updates

--- a/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/filePathWidget.js
@@ -328,11 +328,13 @@ define([
         }
 
         function syncDataModel() {
-            // map structure of data into an array of parameter objects
-            const dataValues = dataModel.rowOrder.map((rowId) => dataModel.rows[rowId].values);
-            paramsBus.emit('sync-data-model', {
-                values: dataValues,
-            });
+            if (!viewOnly) {
+                // map structure of data into an array of parameter objects
+                const dataValues = dataModel.rowOrder.map((rowId) => dataModel.rows[rowId].values);
+                paramsBus.emit('sync-data-model', {
+                    values: dataValues,
+                });
+            }
         }
 
         /**

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -739,19 +739,33 @@ define([
                             expectedFiles.add(f);
                         }
                     });
-                    return BulkImportUtil.getMissingFiles(Array.from(expectedFiles)).catch(
-                        (error) => {
-                            // if the missing files call fails, just continue.
-                            console.error(
-                                'Unable to fetch missing files from the Staging Service',
-                                error
-                            );
-                        }
-                    );
+                    return expectedFiles;
                 })
-                .then((missingFiles = []) =>
-                    BulkImportUtil.evaluateConfigReadyState(model, specs, new Set(missingFiles))
-                )
+                .then((expectedFiles) => {
+                    if (
+                        ['editingIncomplete', 'editingComplete'].includes(
+                            model.getItem('state.state')
+                        )
+                    ) {
+                        return BulkImportUtil.getMissingFiles(Array.from(expectedFiles))
+                            .catch((error) => {
+                                // if the missing files call fails, just continue.
+                                console.error(
+                                    'Unable to fetch missing files from the Staging Service',
+                                    error
+                                );
+                            })
+                            .then((missingFiles = []) =>
+                                BulkImportUtil.evaluateConfigReadyState(
+                                    model,
+                                    specs,
+                                    new Set(missingFiles)
+                                )
+                            );
+                    } else {
+                        return Promise.resolve(model.getItem('state.params'));
+                    }
+                })
                 .then((readyState) => {
                     jobManager.runHandler('modelUpdate');
 

--- a/nbextensions/bulkImportCell/bulkImportCell.js
+++ b/nbextensions/bulkImportCell/bulkImportCell.js
@@ -777,10 +777,11 @@ define([
                     if (updatedReadyState) {
                         model.setItem(['state', 'params'], readyState);
                     }
-                    if (curState.state === 'launching') {
+                    if (curState.state === 'launching' && !developerMode) {
                         // TODO: if the cell has got stuck in 'launching' mode,
                         // we should get jobs by cell_id
                         // for now, reset the cell to 'editingComplete'
+                        // if we're in devMode, leave it as is for debugging.
                         newState = 'editingComplete';
                     }
 

--- a/nbextensions/bulkImportCell/tabs/fileTypePanel.js
+++ b/nbextensions/bulkImportCell/tabs/fileTypePanel.js
@@ -43,7 +43,8 @@ define(['bluebird', 'common/ui', 'common/html', 'common/events'], (Promise, UI, 
         const bus = options.bus,
             fileTypes = options.fileTypes,
             header = options.header,
-            toggleFileType = options.toggleAction;
+            toggleFileType = options.toggleAction,
+            viewOnly = options.viewOnly;
         let container = null,
             ui = null,
             /*
@@ -167,17 +168,19 @@ define(['bluebird', 'common/ui', 'common/html', 'common/events'], (Promise, UI, 
                     ui.getElement(key).classList.remove(selected);
                 }
                 ui.getElement(`${key}.icon`).classList.remove(...completeIcon, ...incompleteIcon);
-                const icon = state.completed[key] ? completeIcon : incompleteIcon;
-                ui.getElement(`${key}.icon`).classList.add(...icon);
-                // if there's a warning, and the fileType doesn't already have a warning icon,
-                // make one and insert it.
-                const warningIconElem = ui.getElement(`${key}.warning-icon`);
-                if (state.warnings.has(key) && !warningIconElem) {
-                    addWarningIcon(key);
-                }
-                // if the state has changed so that the warning icon shouldn't be there, remove it.
-                else if (!state.warnings.has(key) && warningIconElem) {
-                    warningIconElem.remove();
+                if (!viewOnly) {
+                    const icon = state.completed[key] ? completeIcon : incompleteIcon;
+                    ui.getElement(`${key}.icon`).classList.add(...icon);
+                    // if there's a warning, and the fileType doesn't already have a warning icon,
+                    // make one and insert it.
+                    const warningIconElem = ui.getElement(`${key}.warning-icon`);
+                    if (state.warnings.has(key) && !warningIconElem) {
+                        addWarningIcon(key);
+                    }
+                    // if the state has changed so that the warning icon shouldn't be there, remove it.
+                    else if (!state.warnings.has(key) && warningIconElem) {
+                        warningIconElem.remove();
+                    }
                 }
             });
             // if the "selected" file type is real, select it

--- a/nbextensions/bulkImportCell/tabs/multiAppInfo.js
+++ b/nbextensions/bulkImportCell/tabs/multiAppInfo.js
@@ -44,11 +44,16 @@ define([
             for (const [fileType, status] of Object.entries(readyState)) {
                 fileTypeCompleted[fileType] = status === 'complete';
             }
-
+            const viewOnlyFileType = !['editingComplete', 'editingIncomplete'].includes(
+                model.getItem('state.state')
+            );
             const layout = renderLayout();
             container.innerHTML = layout;
             const fileTypeNode = ui.getElement('filetype-panel');
-            const initPromises = [buildFileTypePanel(fileTypeNode), startInfoTab()];
+            const initPromises = [
+                buildFileTypePanel(fileTypeNode, viewOnlyFileType),
+                startInfoTab(),
+            ];
             return Promise.all(initPromises);
         }
 
@@ -90,8 +95,10 @@ define([
          * Builds the file type panel (the left column); the right column will be app info
          *
          * @param {DOMElement} node - the node that should be used for the left column
+         * @param {boolean} viewOnly - if true, should start the left column in view only mode, with
+         *  no ready state icons.
          */
-        function buildFileTypePanel(node) {
+        function buildFileTypePanel(node, viewOnly) {
             fileTypePanel = FileTypePanel.make({
                 bus,
                 header: {
@@ -100,6 +107,7 @@ define([
                 },
                 fileTypes: fileTypesDisplay,
                 toggleAction: toggleFileType,
+                viewOnly,
             });
 
             return fileTypePanel.start({

--- a/package-lock.json
+++ b/package-lock.json
@@ -2586,9 +2586,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001346",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-            "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
+            "version": "1.0.30001359",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001359.tgz",
+            "integrity": "sha512-Xln/BAsPzEuiVLgJ2/45IaqD9jShtk3Y33anKb4+yLwQzws3+v6odKfpgES/cDEaZMLzSChpIGdbOYtH9MyuHw==",
             "dev": true,
             "funding": [
                 {
@@ -18568,9 +18568,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001346",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-            "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
+            "version": "1.0.30001359",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001359.tgz",
+            "integrity": "sha512-Xln/BAsPzEuiVLgJ2/45IaqD9jShtk3Y33anKb4+yLwQzws3+v6odKfpgES/cDEaZMLzSChpIGdbOYtH9MyuHw==",
             "dev": true
         },
         "chalk": {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -138,7 +138,7 @@ define([
         });
     }
 
-    fdescribe('The bulk import cell module', () => {
+    describe('The bulk import cell module', () => {
         let runtime;
         beforeAll(() => {
             Jupyter.narrative = {
@@ -860,7 +860,7 @@ define([
         for (const [state, expectEval] of Object.entries(iconTestCases)) {
             it(`Should ${
                 iconTestCases[state] ? '' : 'not '
-            }evaluate params when starting in ${state} state`, async () => {
+            } evaluate params when starting in ${state} state`, async () => {
                 // if the cell is starting in a state where we don't expect params to
                 // be evaluated, then the call to initCell will set up these spies.
                 if (!expectEval) {

--- a/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/bulkImportCell-spec.js
@@ -860,7 +860,7 @@ define([
         for (const [state, expectEval] of Object.entries(iconTestCases)) {
             it(`Should ${
                 iconTestCases[state] ? '' : 'not '
-            } evaluate params when starting in ${state} state`, async () => {
+            }evaluate params when starting in ${state} state`, async () => {
                 // if the cell is starting in a state where we don't expect params to
                 // be evaluated, then the call to initCell will set up these spies.
                 if (!expectEval) {

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -5,10 +5,22 @@ define([
     'common/props',
     'common/spec',
     'common/ui',
+    'util/appCellUtil',
     'testUtil',
     'narrativeMocks',
     '/test/data/testBulkImportObj',
-], (ConfigureTab, Jupyter, Runtime, Props, Spec, UI, TestUtil, Mocks, TestBulkImportObject) => {
+], (
+    ConfigureTab,
+    Jupyter,
+    Runtime,
+    Props,
+    Spec,
+    UI,
+    AppCellUtil,
+    TestUtil,
+    Mocks,
+    TestBulkImportObject
+) => {
     'use strict';
 
     describe('test the bulk import cell configure tab', () => {
@@ -125,44 +137,74 @@ define([
                 label: 'view',
             },
         ].forEach((testCase) => {
-            it(`should start in ${testCase.label} mode`, () => {
-                const model = Props.make({
-                    data: Object.assign({}, TestBulkImportObject, { state: initialState }),
-                    onUpdate: () => {
-                        /* intentionally left blank */
-                    },
-                });
-                const configure = testCase.widget.make({
-                    bus,
-                    model,
-                    specs,
-                    typesToFiles,
-                    fileTypesDisplay,
-                    fileTypeMapping,
+            describe(`${testCase.label} mode`, () => {
+                let configureWidget;
+                beforeEach(() => {
+                    const model = Props.make({
+                        data: Object.assign({}, TestBulkImportObject, { state: initialState }),
+                        onUpdate: () => {
+                            /* intentionally left blank */
+                        },
+                    });
+                    configureWidget = testCase.widget.make({
+                        bus,
+                        model,
+                        specs,
+                        typesToFiles,
+                        fileTypesDisplay,
+                        fileTypeMapping,
+                    });
                 });
 
-                return configure
-                    .start({
-                        node: container,
-                    })
-                    .then(() => {
-                        // just make sure it renders the "File Paths" and "Parameters" headers
-                        expect(container.innerHTML).toContain('Parameters');
-                        expect(container.innerHTML).toContain('File Paths');
-                        const inputForm = container.querySelector(
-                            '[data-parameter="import_type"] select[data-element="input"]'
-                        );
-                        expect(inputForm.hasAttribute('readonly')).toBe(testCase.viewOnly);
-                        spyOn(UI, 'showConfirmDialog').and.resolveTo(false);
-                        const xsvButton = container.querySelector(
-                            '.kb-bulk-import-configure__button--generate-template'
-                        );
-                        // click on the button to check it functions correctly
-                        xsvButton.click();
-                        expect(xsvButton.textContent).toContain('Create Import Template');
-                        expect(UI.showConfirmDialog).toHaveBeenCalled();
-                        return configure.stop();
-                    });
+                it(`should start in ${testCase.label} mode`, async () => {
+                    await configureWidget.start({ node: container });
+                    // just make sure it renders the "File Paths" and "Parameters" headers
+                    expect(container.innerHTML).toContain('Parameters');
+                    expect(container.innerHTML).toContain('File Paths');
+                    const inputForm = container.querySelector(
+                        '[data-parameter="import_type"] select[data-element="input"]'
+                    );
+                    expect(inputForm.hasAttribute('readonly')).toBe(testCase.viewOnly);
+                    spyOn(UI, 'showConfirmDialog').and.resolveTo(false);
+                    const xsvButton = container.querySelector(
+                        '.kb-bulk-import-configure__button--generate-template'
+                    );
+                    // click on the button to check it functions correctly
+                    xsvButton.click();
+                    expect(xsvButton.textContent).toContain('Create Import Template');
+                    expect(UI.showConfirmDialog).toHaveBeenCalled();
+                    await configureWidget.stop();
+                });
+
+                it(`should ${testCase.viewOnly ? 'not ' : ''}show file type icons`, async () => {
+                    await configureWidget.start({ node: container });
+                    const filePanelButtons = container.querySelectorAll(
+                        '.kb-bulk-import-configure__panel--filetype button'
+                    );
+                    for (const fpButton of filePanelButtons) {
+                        const icon = fpButton.querySelector('.kb-filetype-panel__filetype_icon');
+                        const hasCheck = icon.classList.contains('fa-check');
+                        const hasExclamation = icon.classList.contains('fa-exclamation');
+                        // if withIcon, should have one of fa-exclamation, fa-check
+                        // otherwise, should have neither
+                        expect(hasCheck || hasExclamation).toBe(!testCase.viewOnly);
+                    }
+                });
+
+                it(`should ${
+                    testCase.viewOnly ? 'not ' : ''
+                }validate parameters on startup`, async () => {
+                    // set up spy. we hope.
+                    spyOn(AppCellUtil, 'evaluateConfigReadyState').and.returnValue(
+                        Promise.resolve({})
+                    );
+                    await configureWidget.start({ node: container });
+                    if (testCase.viewOnly) {
+                        expect(AppCellUtil.evaluateConfigReadyState).not.toHaveBeenCalled();
+                    } else {
+                        expect(AppCellUtil.evaluateConfigReadyState).toHaveBeenCalled();
+                    }
+                });
             });
         });
 

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/configure-spec.js
@@ -195,9 +195,7 @@ define([
                     testCase.viewOnly ? 'not ' : ''
                 }validate parameters on startup`, async () => {
                     // set up spy. we hope.
-                    spyOn(AppCellUtil, 'evaluateConfigReadyState').and.returnValue(
-                        Promise.resolve({})
-                    );
+                    spyOn(AppCellUtil, 'evaluateConfigReadyState').and.resolveTo({});
                     await configureWidget.start({ node: container });
                     if (testCase.viewOnly) {
                         expect(AppCellUtil.evaluateConfigReadyState).not.toHaveBeenCalled();

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/fileTypePanel-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/fileTypePanel-spec.js
@@ -162,46 +162,34 @@ define([
                 });
         });
 
-        it('should show icons when not in view only mode', async () => {
-            const panel = FileTypePanel.make({
-                bus: Runtime.make().bus(),
-                fileTypes,
-                header,
-                toggleAction: () => {},
-                viewOnly: false,
-            });
-            await panel.start({
-                node: container,
-                state: {},
-            });
-            for (const fpButton of container.querySelectorAll(
-                '.kb-filetype-panel__filetype_button'
-            )) {
-                const icon = fpButton.querySelector('.kb-filetype-panel__filetype_icon');
-                expect(icon.classList.contains('fa-exclamation')).toBeTrue();
-            }
-        });
-
-        it('should not show icons while in view only mode', async () => {
-            const panel = FileTypePanel.make({
-                bus: Runtime.make().bus(),
-                fileTypes,
-                header,
-                toggleAction: () => {},
-                viewOnly: true,
-            });
-            await panel.start({
-                node: container,
-                state: {},
-            });
-            for (const fpButton of container.querySelectorAll(
-                '.kb-filetype-panel__filetype_button'
-            )) {
-                const icon = fpButton.querySelector('.kb-filetype-panel__filetype_icon');
-                ['exclamation', 'check'].forEach((iconType) => {
-                    expect(icon.classList.contains(`fa-${iconType}`)).toBeFalse();
+        [true, false].forEach((viewOnly) => {
+            it(`should${viewOnly ? ' not' : ''} show icons when${
+                viewOnly ? '' : ' not'
+            } in view only mode`, async () => {
+                const panel = FileTypePanel.make({
+                    bus: Runtime.make().bus(),
+                    fileTypes,
+                    header,
+                    toggleAction: () => {},
+                    viewOnly,
                 });
-            }
+                await panel.start({
+                    node: container,
+                    state: {},
+                });
+                for (const fpButton of container.querySelectorAll(
+                    '.kb-filetype-panel__filetype_button'
+                )) {
+                    const icon = fpButton.querySelector('.kb-filetype-panel__filetype_icon');
+                    if (viewOnly) {
+                        ['exclamation', 'check'].forEach((iconType) => {
+                            expect(icon.classList.contains(`fa-${iconType}`)).toBeFalse();
+                        });
+                    } else {
+                        expect(icon.classList.contains('fa-exclamation')).toBeTrue();
+                    }
+                }
+            });
         });
     });
 });

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/fileTypePanel-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/fileTypePanel-spec.js
@@ -161,5 +161,47 @@ define([
                     // so it doesn't dangle.
                 });
         });
+
+        it('should show icons when not in view only mode', async () => {
+            const panel = FileTypePanel.make({
+                bus: Runtime.make().bus(),
+                fileTypes,
+                header,
+                toggleAction: () => {},
+                viewOnly: false,
+            });
+            await panel.start({
+                node: container,
+                state: {},
+            });
+            for (const fpButton of container.querySelectorAll(
+                '.kb-filetype-panel__filetype_button'
+            )) {
+                const icon = fpButton.querySelector('.kb-filetype-panel__filetype_icon');
+                expect(icon.classList.contains('fa-exclamation')).toBeTrue();
+            }
+        });
+
+        it('should not show icons while in view only mode', async () => {
+            const panel = FileTypePanel.make({
+                bus: Runtime.make().bus(),
+                fileTypes,
+                header,
+                toggleAction: () => {},
+                viewOnly: true,
+            });
+            await panel.start({
+                node: container,
+                state: {},
+            });
+            for (const fpButton of container.querySelectorAll(
+                '.kb-filetype-panel__filetype_button'
+            )) {
+                const icon = fpButton.querySelector('.kb-filetype-panel__filetype_icon');
+                ['exclamation', 'check'].forEach((iconType) => {
+                    expect(icon.classList.contains(`fa-${iconType}`)).toBeFalse();
+                });
+            }
+        });
     });
 });

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/multiAppInfo-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/multiAppInfo-spec.js
@@ -5,7 +5,7 @@ define(['/narrative/nbextensions/bulkImportCell/tabs/multiAppInfo', 'common/prop
 ) => {
     'use strict';
 
-    describe('The multi-app info tab', () => {
+    fdescribe('The multi-app info tab', () => {
         describe('module', () => {
             it('exposes a constructor', () => {
                 expect(MultiAppInfoWidget.make).toEqual(jasmine.any(Function));
@@ -147,6 +147,94 @@ define(['/narrative/nbextensions/bulkImportCell/tabs/multiAppInfo', 'common/prop
                     ['toggled-active-filetype', { fileType: 'FILE_TYPE_TWO' }],
                     ['toggled-active-filetype', { fileType: 'FILE_TYPE_THREE' }],
                 ]);
+            });
+        });
+
+        describe('Mode icon display', () => {
+            function buildOptions(cellState) {
+                const bus = {
+                    emit: () => {
+                        /* do nowt */
+                    },
+                };
+                const fileTypesDisplay = {
+                    FILE_TYPE_ONE: { label: 'file type one' },
+                };
+
+                const model = Props.make({
+                    data: {
+                        state: {
+                            selectedFileType: 'FILE_TYPE_ONE',
+                            params: {
+                                FILE_TYPE_ONE: 'complete',
+                            },
+                            state: cellState,
+                        },
+                        inputs: {
+                            FILE_TYPE_ONE: {
+                                appId: 'APP_ONE_ID',
+                            },
+                        },
+                        app: {
+                            specs: {
+                                APP_ONE_ID: {
+                                    full_info: {},
+                                    parameters: [],
+                                },
+                            },
+                        },
+                    },
+                });
+
+                return {
+                    bus,
+                    fileTypesDisplay,
+                    model,
+                };
+            }
+
+            // const iconCases = ['editingComplete', 'editingIncomplete'];
+            // const noIconCases = ['launching', 'inProgress', 'inProgressResultsAvailable', 'jobsFinishedResultsAvailable', 'jobsFinished', 'error'];
+            const iconTestCases = {
+                editingComplete: true,
+                editingIncomplete: true,
+                launching: false,
+                inProgress: false,
+                inProgressResultsAvailable: false,
+                jobsFinishedResultsAvailable: false,
+                jobsFinished: false,
+                error: false,
+            };
+
+            let container;
+
+            beforeEach(() => {
+                container = document.createElement('div');
+            });
+
+            afterEach(() => {
+                container.remove();
+            });
+
+            Object.keys(iconTestCases).forEach((testCase) => {
+                const withIcon = iconTestCases[testCase];
+                it(`${withIcon ? 'shows' : 'does not show'} a file type icon when ${
+                    !withIcon ? 'not' : ''
+                } in editing states`, async () => {
+                    const widgetInstance = MultiAppInfoWidget.make(buildOptions(testCase));
+                    await widgetInstance.start({ node: container });
+                    const filePanelButtons = container.querySelectorAll(
+                        '.kb-bulk-import-info__panel--filetype button'
+                    );
+                    for (const fpButton of filePanelButtons) {
+                        const icon = fpButton.querySelector('.kb-filetype-panel__filetype_icon');
+                        const hasCheck = icon.classList.contains('fa-check');
+                        const hasExclamation = icon.classList.contains('fa-exclamation');
+                        // if withIcon, should have one of fa-exclamation, fa-check
+                        // otherwise, should have neither
+                        expect(hasCheck || hasExclamation).toBe(withIcon);
+                    }
+                });
             });
         });
     });

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/multiAppInfo-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/multiAppInfo-spec.js
@@ -5,7 +5,7 @@ define(['/narrative/nbextensions/bulkImportCell/tabs/multiAppInfo', 'common/prop
 ) => {
     'use strict';
 
-    fdescribe('The multi-app info tab', () => {
+    describe('The multi-app info tab', () => {
         describe('module', () => {
             it('exposes a constructor', () => {
                 expect(MultiAppInfoWidget.make).toEqual(jasmine.any(Function));

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/multiAppInfo-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/multiAppInfo-spec.js
@@ -193,8 +193,6 @@ define(['/narrative/nbextensions/bulkImportCell/tabs/multiAppInfo', 'common/prop
                 };
             }
 
-            // const iconCases = ['editingComplete', 'editingIncomplete'];
-            // const noIconCases = ['launching', 'inProgress', 'inProgressResultsAvailable', 'jobsFinishedResultsAvailable', 'jobsFinished', 'error'];
             const iconTestCases = {
                 editingComplete: true,
                 editingIncomplete: true,


### PR DESCRIPTION
# Description of PR purpose/changes

This addresses an error where, when either reloading a bulk import cell or loading a bulk import cell that's been shared / copied, it would always show that each tab's configuration was in error - each icon for each file type button on the left selector would have a red exclamation mark.

This happened for a couple of reasons:
1. Staging area files would have gone missing for some reason - either they weren't available, or were from another user's workspace (in the case of a copy).
2. There were objects with the same name and different data types present.

This all got triggered because when the Configure and View Configure tabs start up, they trigger an evaluation of the parameter state for the whole cell, regardless of who owns it, or what state the cell is in. The solution here was two-fold.

1. Limit the parameter evaluation step to only happen when the cell is in an editing state.
2. Don't show any icons (either checkmarks or exclamation points) when in a running state. They're meant to show whether the cell is ready to run, and are not useful when the cell is running.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-763
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
* Load up a Narrative with a running / complete / errored cell, and go to the view configure tab.
  * It should show the various file types as options, but no icons.
  * It should also, theoretically, load a bit more efficiently.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
