### PR TITLE
DATAUP-778: Fix bug where lack of a paramDisplay value was causing widget to stall

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.0.2 (more notes will follow).
 
+### Unreleased
+- DATAUP-778 - fixed bug where xsvGenerator would not run if the paramDisplay value was not present
+
 ### Version 5.1.1
 - PTV-1798 - fixed issue where invalid component ID was causing data list not to load properly
 - DATAUP-762 - fixed bug where previously run cells were showing errors in the View Configure tab

--- a/nbextensions/bulkImportCell/tabs/xsvGenerator.js
+++ b/nbextensions/bulkImportCell/tabs/xsvGenerator.js
@@ -387,7 +387,7 @@ define([
                                     }
                                 }
                             }
-                        } else if (paramDisplay[fileType]) {
+                        } else if (paramDisplay && paramDisplay[fileType]) {
                             // special display value from a dynamic dropdown
                             try {
                                 const displayParam =

--- a/test/unit/spec/nbextensions/bulkImportCell/tabs/xsvGenerator-spec.js
+++ b/test/unit/spec/nbextensions/bulkImportCell/tabs/xsvGenerator-spec.js
@@ -277,6 +277,8 @@ define([
         },
     });
 
+    const OUTPUT_FOLDER = 'your_name_here/new folder';
+
     function createXsvGen() {
         return new XSVGenerator({ model: defaultModel, typesToFiles, fileTypeMapping });
     }
@@ -334,6 +336,7 @@ define([
                             ...modelData,
                         },
                     });
+
                     const xsvGen = new XSVGenerator({ model, typesToFiles, fileTypeMapping });
                     const container = document.createElement('div');
                     container.innerHTML = xsvGen.renderLayout();
@@ -425,6 +428,35 @@ define([
                     output_directory = 'new_folder';
 
                 it('generates params with a single input', function () {
+                    const output = this.xsvGen.generateRequest({
+                        output_file_type,
+                        output_directory,
+                        types: ['sra_reads'],
+                    });
+                    expect(output).toEqual({
+                        output_file_type,
+                        output_directory,
+                        types: {
+                            sra_reads: expectedOutput.sra_reads,
+                        },
+                    });
+                });
+
+                it('generates params with a single input, no paramDisplay data', function () {
+                    const modelWithoutParamDisplay = Props.make({
+                        data: {
+                            state,
+                            params,
+                            app: {
+                                specs: miniSpec,
+                            },
+                        },
+                    });
+                    this.xsvGen = new XSVGenerator({
+                        model: modelWithoutParamDisplay,
+                        typesToFiles,
+                        fileTypeMapping,
+                    });
                     const output = this.xsvGen.generateRequest({
                         output_file_type,
                         output_directory,
@@ -589,7 +621,7 @@ define([
                     const result = {
                         output_file_type: 'CSV',
                         files_created: {
-                            assembly: 'your_name_here/new folder/assembly.csv',
+                            assembly: `${OUTPUT_FOLDER}/assembly.csv`,
                         },
                     };
                     this.xsvGen.displayResult(result);
@@ -602,20 +634,18 @@ define([
                     ).toEqual(Object.keys(result.files_created).length);
                     expect(
                         this.container.querySelector(`.${cssBaseClass}__file_list_item`).textContent
-                    ).toEqual('your_name_here/new folder/assembly.csv');
+                    ).toEqual(`${OUTPUT_FOLDER}/assembly.csv`);
                 });
 
                 it('displays a success message, multiple types, single output file', function () {
                     const result = {
                         output_file_type: 'EXCEL',
                         files_created: {
-                            assembly: 'your_name_here/new folder/import_specification.xlsx',
-                            fastq_reads_interleaved:
-                                'your_name_here/new folder/import_specification.xlsx',
-                            fastq_reads_noninterleaved:
-                                'your_name_here/new folder/import_specification.xlsx',
-                            genbank_genome: 'your_name_here/new folder/import_specification.xlsx',
-                            sra_reads: 'your_name_here/new folder/import_specification.xlsx',
+                            assembly: `${OUTPUT_FOLDER}/import_specification.xlsx`,
+                            fastq_reads_interleaved: `${OUTPUT_FOLDER}/import_specification.xlsx`,
+                            fastq_reads_noninterleaved: `${OUTPUT_FOLDER}/import_specification.xlsx`,
+                            genbank_genome: `${OUTPUT_FOLDER}/import_specification.xlsx`,
+                            sra_reads: `${OUTPUT_FOLDER}/import_specification.xlsx`,
                         },
                     };
                     this.xsvGen.displayResult(result);
@@ -631,19 +661,17 @@ define([
                         fileList.map((liElement) => {
                             return liElement.textContent;
                         })
-                    ).toEqual(['your_name_here/new folder/import_specification.xlsx']);
+                    ).toEqual([`${OUTPUT_FOLDER}/import_specification.xlsx`]);
                 });
                 it('displays a success message, multiple files', function () {
                     const result = {
                         output_file_type: 'CSV',
                         files_created: {
-                            assembly: 'your_name_here/new folder/assembly.csv',
-                            fastq_reads_interleaved:
-                                'your_name_here/new folder/fastq_reads_interleaved.csv',
-                            fastq_reads_noninterleaved:
-                                'your_name_here/new folder/fastq_reads_noninterleaved.csv',
-                            genbank_genome: 'your_name_here/new folder/genbank_genome.csv',
-                            sra_reads: 'your_name_here/new folder/sra_reads.csv',
+                            assembly: `${OUTPUT_FOLDER}/assembly.csv`,
+                            fastq_reads_interleaved: `${OUTPUT_FOLDER}/fastq_reads_interleaved.csv`,
+                            fastq_reads_noninterleaved: `${OUTPUT_FOLDER}/fastq_reads_noninterleaved.csv`,
+                            genbank_genome: `${OUTPUT_FOLDER}/genbank_genome.csv`,
+                            sra_reads: `${OUTPUT_FOLDER}/sra_reads.csv`,
                         },
                     };
                     this.xsvGen.displayResult(result);


### PR DESCRIPTION
# Description of PR purpose/changes

Fixes a bug where the xsvGenerator expects a paramDisplay value to be present and stalls if it is not.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-778
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative, importing some files that don't populate paramDisplay (e.g. FASTA assemblies), and then attempting to generate a template from it.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
