### PR TITLE
PTV-1514 clean HTML from input text fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ This is built on the Jupyter Notebook v6.4.12 and IPython 8.5.0 (more notes will
 ## Unreleased
 
 - PTV-1620 - fix problem with Expression Pairwise Correlation creating or displaying large heatmaps and freezing or crashing browser
+- PTV-1514 - sanitized HTML being used for app input tooltips
 
 Dependency Changes
 - Python dependency updates

--- a/kbase-extension/static/kbase/js/common/html.js
+++ b/kbase-extension/static/kbase/js/common/html.js
@@ -1,4 +1,4 @@
-define(['uuid'], (Uuid) => {
+define(['uuid', 'util/string'], (Uuid, StringUtil) => {
     'use strict';
 
     const TAGS = {};
@@ -102,10 +102,7 @@ define(['uuid'], (Uuid) => {
                 })();
                 switch (typeof attribValue) {
                     case 'string': {
-                        const escapedValue = attribValue.replace(
-                            new RegExp('\\' + quoteChar, 'g'),
-                            '\\' + quoteChar
-                        );
+                        const escapedValue = StringUtil.escape(attribValue);
                         return `${attribName}=${quoteChar}${escapedValue}${quoteChar}`;
                     }
                     case 'boolean':

--- a/test/unit/spec/common/html-Spec.js
+++ b/test/unit/spec/common/html-Spec.js
@@ -166,6 +166,17 @@ define(['common/html', 'testUtil'], (html, TestUtil) => {
             );
         });
 
+        it('Creates a tag with properly escaped attribute values', () => {
+            const div = html.tag('div');
+            const value =
+                '"This is a very "strange" value with <lots> of <tag> thingies <=> <= => in it';
+            const escapedValue =
+                '&quot;This is a very &quot;strange&quot; value with &lt;lots&gt; of &lt;tag&gt; thingies &lt;=&gt; &lt;= =&gt; in it';
+            expect(div({ attribute: value }, 'hello')).toEqual(
+                `<div attribute="${escapedValue}">hello</div>`
+            );
+        });
+
         it('Creates a tag with empty attributes', () => {
             const div = html.tag('div');
             expect(div({}, 'hello')).toEqual('<div>hello</div>');


### PR DESCRIPTION
# Description of PR purpose/changes

This sanitizes text used for display in app inputs to remove HTML. This has had the potential for damage for a long time, and now, with a recent security update to the Bootstrap framework that drives the tooltips, has started to cause problems.

This turns what would be otherwise HTML into just the plain text via the `escape` function.

ETA:
It turns out that there's 39 apps in production that'll be affected by this. The effects are minor yet annoying. For example, in the "Cluster Expression Data - K-means" text changes from "Number of Clusters (_k_)" to "Number of Clusters(<i>k</i>)". I'm of the opinion that having huge swaths of unsafe HTML injected in input text fields is not a good thing, but some basic highlighting and italicizing is probably very useful.

So version one of this PR was an overkill no-go.

However, that wasn't the issue anyway. The issue was that text that wound up in the `title` attribute of those input fields (which makes tooltips) wasn't being escaped properly. Adding the `escape` function to the code that generates DOM element attributes fixed the problem and should continue to be safe going forward.

__TODO__: 
- [x] add tests
- [x] check which apps will be affected, list below, discuss on Slack

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1514
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [n/a] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
