### PR TITLE
PTV-1620 fix usage of $('<tag>') in PR #3116

### DIFF
--- a/docs/developer/local-docker.md
+++ b/docs/developer/local-docker.md
@@ -131,3 +131,29 @@ make start build-image=f env=next local-narrative=t
 ## Done
 
 You should now be able to navigate to https://ci.kbase.us, log in, and pull a Narrative from the Dashboard.
+
+## Testing with a local container
+
+Testing instructions assume that all JS and Python dependencies are installed locally, and that Narrative is built on the host for local usage.
+
+This, however, is not necessary with the container, although it is necessary for now to install JS dependencies because tooling relies up it. Of course,
+it would be possible to run any node-based tool via a simple node container, but that is for another day.
+
+- Get the narrative running in one terminal window:
+  - `make dev-image`
+  - `ENV=ci make run-dev-image`
+- In another terminal window:
+  - `NARRATIVE_SERVER_URL=http://localhost:8888 npm run test_local`
+
+Please note the volume mounts in `scripts/local-def-run.sh`. Not all directories in kbase-extension/static local narrative repo are mounted, due to
+the fact that ext_components is installed.
+
+To explain the `ext_` directories briefly.
+
+- `ext_modules` is where all node modules should be placed; that is what it was originally designed for and a very few npm dependencies are placed there;
+   it does not exist until the narrative is built.
+- `ext_components` is where `node_modules` is copied to, for those bower components which were migrated to npm modules; it also does not exist until the
+   narrative is built.
+- `ext_packages` is where old dependencies which cannot be brought into the codebase as normal npm dependencies reside; it essentially never changes as
+   it freezes certain dependencies that could not be brought in as bower dependencies when the narrative was converted from manually installed
+   dependencies to bower.

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionPairwiseCorrelation.js
@@ -1,3 +1,4 @@
+/* eslint-disable strict */
 /**
  * Pairwise correlation of gene expression profiles.
  *
@@ -7,15 +8,13 @@
 define([
     'kbwidget',
     'jquery',
-    'uuid',
+    'widgets/common/jQueryUtils',
     'kbaseExpressionGenesetBaseWidget',
     'kbaseHeatmap',
 
     /* for effect */
     'bootstrap',
-], (KBWidget, $, Uuid, kbaseExpressionGenesetBaseWidget, kbaseHeatmap) => {
-    'use strict';
-
+], (KBWidget, $, { $el }, kbaseExpressionGenesetBaseWidget, kbaseHeatmap) => {
     // The "MAX_GENES_*" constants are utilized to control performance of using a
     // matrix, which has N² character, generally.
 
@@ -39,20 +38,20 @@ define([
     const HEATMAP_X_PADDING = 150;
 
     function $renderWarningAlert(warningContent) {
-        const $warningElement = $('<div>')
+        const $warningElement = $el('div')
             .addClass('alert alert-warning')
             .css('display', 'flex')
             .css('flex-direction', 'row')
             .css('align-items', 'center');
 
         $warningElement.append(
-            $('<span>')
+            $el('span')
                 .addClass('fa fa-exclamation-triangle')
                 .css('margin-right', '0.5em')
                 .css('font-size', '130%')
         );
         if (typeof warningContent === 'string') {
-            $warningElement.append($('<span>').text(warningContent));
+            $warningElement.append($el('span').text(warningContent));
         } else {
             $warningElement.append(warningContent);
         }
@@ -125,7 +124,7 @@ define([
             };
 
             if (controlType === 'button') {
-                return $.jqElem('button')
+                return $el('button')
                     .attr('data-testid', 'download-button')
                     .append('Download the SVG image file for this pairwise correlation')
                     .addClass('btn btn-primary')
@@ -133,7 +132,7 @@ define([
                         downloadHeatmap();
                     });
             }
-            return $('<a>')
+            return $el('a')
                 .attr('href', '#')
                 .click((event) => {
                     event.preventDefault();
@@ -172,7 +171,7 @@ define([
                 data,
             };
 
-            const $container = $('<div>').css('margin-top', '5px');
+            const $container = $el('div').css('margin-top', '5px');
             $hostDiv.html($container);
 
             if (rowIds.length > MAX_GENES_FOR_HEATMAP) {
@@ -205,7 +204,7 @@ define([
                 return [width, height];
             })();
 
-            const $heatmapContainer = $('<div>')
+            const $heatmapContainer = $el('div')
                 .css('width', `${heatmapWidth}px`)
                 .css('height', `${heatmapHeight}px`)
                 .attr('data-testid', 'heatmap');
@@ -219,11 +218,11 @@ define([
             });
 
             if (rowIds.length > MAX_GENES_FOR_INLINE_HEATMAP) {
-                const $message = $('<span>')
-                    .append($('<span>').text(`The selected cluster has ${rowIds.length} genes.`))
+                const $message = $el('span')
+                    .append($el('span').text(`The selected cluster has ${rowIds.length} genes.`))
                     .append(' ')
                     .append(
-                        $('<span>').text(
+                        $el('span').text(
                             [
                                 `Heatmaps for clusters with more than ${MAX_GENES_FOR_INLINE_HEATMAP} genes are not `,
                                 'displayed inline, for performance reasons.',
@@ -232,7 +231,7 @@ define([
                     )
                     .append(' ')
                     .append(
-                        $('<p>')
+                        $el('p')
                             .append('However you may')
                             .append(' ')
                             .append(
@@ -249,7 +248,7 @@ define([
                 $container.append($renderWarningAlert($message));
 
                 $container.append(
-                    $.jqElem('p').append(
+                    $el('p').append(
                         this.$renderDownloadControl($heatmapContainer, 'download', 'button')
                     )
                 );

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -1,7 +1,7 @@
 module.exports = function (config) {
     'use strict';
 
-    const narrativeServer = 'http://localhost:32323';
+    const narrativeServer = process.env.NARRATIVE_SERVER_URL || 'http://localhost:32323';
 
     const alwaysExclude = [
         'kbase-extension/static/buildTools/*.js',


### PR DESCRIPTION
# Description of PR purpose/changes

This is a quick amendment to the prior PR # 3116.
I had used a form of creating jQuery wrapped elements $('<tag>') which omits the closing tag and doesn't use the self-closing form. It does work and is shorter, which is why I used it, but had bookmarked reading the documentation for this. When I did, I found that jQuery says to use a closing tag for any element which requires it. Now, it doesn't seem to make a difference, but another issue is that using $('<tag></tag>') is also much less efficient than $(document.createElement('tag')), as jQuery has to parse and interpret that string. jQuery uses the input to $() for multiple purposes, of course. Fortunately there was already a more concise wrapper for this in jqueryUtils, $el('tag'), so this change essentially adds that dependency and converts usages of $('<tag>') to $el('tag').

I had made this fix, but PR #3116 had already been merged, so this is just a quick PR to make that correction.

Also included is a minor test config tweak, an optional NARRATIVE_SERVER_URL environment variable, and bit of explanatory documentation to support container-based narrative workflows.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions

This change is covered by the existing test for kbaseExpressionPairwiseCorrelation.js

- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [-] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [-] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

No additional release note required, as covered by PR #3116.

- [-] [Version has been bumped](https://semver.org/) for each release
- [-] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
