### PR TITLE
PTV-1859: Add search to fetchWorkspaceData to fix.

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -602,10 +602,10 @@ define([
                         if (obj.set_items) {
                             updateSetInfo(obj);
                         }
-                        const term = this.bsSearch.val();
-                        const type = this.$filterTypeSelect.find('option:selected').val();
-                        this.search(term, type);
                     });
+                    const term = this.bsSearch.val();
+                    const type = this.$filterTypeSelect.find('option:selected').val();
+                    this.search(term, type);
                 })
                 .catch((error) => {
                     this.showBlockingError(

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDataList.js
@@ -602,6 +602,9 @@ define([
                         if (obj.set_items) {
                             updateSetInfo(obj);
                         }
+                        const term = this.bsSearch.val();
+                        const type = this.$filterTypeSelect.find('option:selected').val();
+                        this.search(term, type);
                     });
                 })
                 .catch((error) => {


### PR DESCRIPTION
# Description of PR purpose/changes

* PTV-1859 outlines a bug where a filtered data panel does not remain filtered after renaming or deleting a data object.
* No dependency changes.

Related Jira ticket: [PTV-1859](https://kbase-jira.atlassian.net/browse/PTV-1859)
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to a narrative with multiple data objects, filtering the data panel so that not all are listed, renaming and/or deleting an item in the list should result in a list filtered by the existing query.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)


[PTV-1859]: https://kbase-jira.atlassian.net/browse/PTV-1859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ