### PR TITLE
UIP-19 fix build image issues

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -65,8 +65,6 @@ jobs:
           NARRATIVE_VERSION=${{ env.NARRATIVE_VERSION }}
           VCS_REF=${{ github.sha }}
           TAG='${{ github.ref }}'
-        labels: |
-          us.kbase.vcs-pull-req=pr-${{ env.PR }}
     -
       name: Build version image
       uses: docker/build-push-action@v3
@@ -83,5 +81,3 @@ jobs:
           NARRATIVE_GIT_HASH=${{ env.NARRATIVE_GIT_HASH }}
           VCS_REF=${{ github.sha }}
           TAG='${{ github.ref }}'
-        labels: |
-          us.kbase.vcs-pull-req=pr-${{ env.PR }}

--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -37,11 +37,7 @@ jobs:
         echo "PR=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
         echo "VCS_REF=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c -7)" >> $GITHUB_ENV
     -
-      name: Log environment
-      run: |
-        echo "$GITHUB.CONTEXT"
-        echo '${{ toJSON(github) }}'
-    - name: Get current date
+      name: Get current date
       id: date
       run: echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
     -

--- a/.github/workflows/build_test_pr.yaml
+++ b/.github/workflows/build_test_pr.yaml
@@ -16,6 +16,11 @@ jobs:
       GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
 
+  trivy-scans:
+    if: (github.base_ref == 'develop' || github.base_ref == 'main' || github.base_ref == 'master' ) && github.event.pull_request.merged == false
+    uses: kbase/.github/.github/workflows/reusable_trivy-scans.yml@main
+    secrets: inherit
+
   run_unit_tests:
     uses: ./.github/workflows/unit_test.yml
     needs: run_build_and_push

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -30,7 +30,7 @@ jobs:
         if [ ${{ github.base_ref }} == 'main' ]; then
             branch=''
         else
-            branch=`"-""${{ github.base_ref }}" | awk '{print tolower($0)}'`
+            branch=`echo "-""${{ github.base_ref }}" | awk '{print tolower($0)}'`
         fi
         narrative_version=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
         narrative_git_hash=`grep '\"git_commit_hash\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g' | sed 's/,//'`

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,16 +1,17 @@
 ---
 name: Pull Request Build, Tag, & Push
 on:
-  pull_request:
-    branches:
-      - develop
-      - main
-      - master
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_dispatch:
+  # pull_request:
+  #   branches:
+  #     - develop
+  #     - main
+  #     - master
+  #   types:
+  #     - opened
+  #     - reopened
+  #     - synchronize
+  #     - closed
 jobs:
   build-develop-open:
     if: github.base_ref == 'develop' && github.event.pull_request.merged == false

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -28,7 +28,7 @@ jobs:
         if [ ${{ github.base_ref }} == 'main' ]; then
             branch=''
         else
-            branch=`"-""${{ github.base_ref }}" | awk '{print tolower($0)}'`
+            branch=`echo "-""${{ github.base_ref }}" | awk '{print tolower($0)}'`
         fi
         narrative_version=`grep '\"version\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g'`
         narrative_git_hash=`grep '\"git_commit_hash\":' src/config.json.templ | awk '{print $2}' | sed 's/"//g' | sed 's/,//'`


### PR DESCRIPTION
# Description of PR purpose/changes

A couple issues that show up downstream of the previous PR.
1. We still need some additional Docker build args for the Narrative containers, so we can't use the KBase-provided build actions. These were modified here.
2. There was some leftover debugging script that's now causing an issue.
3. The parallel PR-build script (which uses the reusable docker build actions) was made manual, but the non-manual bit was left commented out for possible further use.
4. Also fixes a bug in how image names are referenced - `narrative` vs `narrative-develop`, for example. Tests were using `narrative` while the previous PR fixed the issue and created `narrative-develop` properly. But that was masked by already having a `narrative` image for that PR while it was in progress. Tricksy!

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-19
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

Rest of the usual stuff isn't relevant, and was removed.
