### PR TITLE
PTV-1810 Update select2 inputs to store ref.

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/select2ObjectInput.js
@@ -41,7 +41,7 @@ define([
 
     function factory(config) {
         const spec = config.parameterSpec,
-            objectRefType = config.referenceType || 'name',
+            objectRefType = 'ref',
             runtime = Runtime.make(),
             bus = runtime.bus().connect(),
             channel = bus.channel(config.channelName),
@@ -355,7 +355,8 @@ define([
                             if (!object.id) {
                                 return object.text;
                             }
-                            return model.availableValues[object.id].name;
+                            const objectInfo = model.availableValues[object.id];
+                            return `${objectInfo.name} (v${objectInfo.version})`;
                         },
                     })
                     .on('change', () => {


### PR DESCRIPTION
This commit updates the select2 input widget to use refs for the selection values instead of names. This solves a problem where renamed objects disappear from selection.

Related Jira ticket: [PTV-1810](https://kbase-jira.atlassian.net/browse/PTV-1810)
- [x] Added the Jira Ticket to the title of the PR.

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [x] Testing:
   1. Create a narrative with a data object and an app cell with a select2 widget.
   2. Use the select2 widget to select the data object.
   3. Save the narrative, reload.
   4. Rename the data object to a new name.
   5. (optional) Reload
   6. Observe that the select2 widget reflects the updated name and displays the object version number.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

[PTV-1810]: https://kbase-jira.atlassian.net/browse/PTV-1810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ