### PR TITLE
PTV-1810 - spruce up select2objectview, add tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,9 +4,12 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.4.12 and IPython 8.5.0 (more notes will follow).
 
+## Unreleased
+- PTV-1810 - address object name display issues in the View Configure tab of app cells.
+
 ## Version 5.1.4
 - PTV-1234 - add padding to the bottom of the data list so that the bottom-most row can slide up above the add data button and show its ellipsis icon.
-- PTV-1793 - fix problem where users could sometimes not enter spaces in bulk import cells
+- PTV-1793 - fix problem where users could sometimes not enter spaces in bulk import cells.
 
 Dependency Changes
 - Github Actions

--- a/test/unit/spec/appWidgets/view/select2ObjectViewSpec.js
+++ b/test/unit/spec/appWidgets/view/select2ObjectViewSpec.js
@@ -1,0 +1,262 @@
+define([
+    'jquery',
+    'testUtil',
+    'common/runtime',
+    'widgets/appWidgets2/view/select2ObjectView',
+    'widgets/appWidgets2/validators/constants',
+    'base/js/namespace',
+    'narrativeMocks',
+    'narrativeConfig',
+], ($, TestUtil, Runtime, Select2ObjectView, Constants, Jupyter, Mocks, Config) => {
+    'use strict';
+
+    const AUTH_TOKEN = 'fakeAuthToken';
+    // this is a bit of a cheat, as it relies on this specific version of Select2.
+    // but Select2 does some annoying things where the rendered text doesn't get stored
+    // anywhere else (like in a data accessor), so we have to use this to check
+    // for expected object version text.
+    const RENDERED_ELEM_SELECTOR = 'span.select2-selection__rendered';
+
+    const PARAM_SPEC = {
+        data: {
+            defaultValue: 'default_value',
+            nullValue: '',
+            constraints: {
+                required: false,
+                defaultValue: 'default_value',
+                types: ['KBaseFile.SingleEndLibrary'],
+            },
+        },
+    };
+
+    const refLookupItem = [
+            22,
+            'SomeObject',
+            'KBaseObject.Object-1.1',
+            '2023-04-21T12:45:00+0000',
+            33,
+            'someuser',
+            11,
+            'someuser:narrative12345',
+            '1231231234',
+            100,
+            {},
+        ],
+        defaultRef = '11/22/33';
+
+    function objectify(infoArr) {
+        const splitType = infoArr[2].split('-');
+        const moduleAndType = splitType[0].split('.');
+        return {
+            id: infoArr[0],
+            name: infoArr[1],
+            ref: [infoArr[6], infoArr[0], infoArr[4]].join('/'),
+            metadata: infoArr[10],
+            type: infoArr[2],
+            obj_id: 'ws.' + infoArr[6] + '.obj.' + infoArr[0],
+            save_date: infoArr[3],
+            version: infoArr[4],
+            wsid: infoArr[6],
+            saveDate: new Date(infoArr[3]),
+            typeModule: moduleAndType[0],
+            typeName: moduleAndType[1],
+        };
+    }
+
+    describe('Select 2 Object View tests', () => {
+        let bus, container, runtime, runtimeBus;
+
+        function updateData(data, objectInfo) {
+            runtime.bus().set(
+                {
+                    data,
+                    timestamp: new Date().getTime(),
+                    objectInfo,
+                },
+                {
+                    channel: 'data',
+                    key: {
+                        type: 'workspace-data-updated',
+                    },
+                }
+            );
+        }
+
+        beforeEach(() => {
+            container = document.createElement('div');
+            runtime = Runtime.make();
+            runtimeBus = runtime.bus();
+            Mocks.setAuthToken(AUTH_TOKEN);
+            Jupyter.narrative = {
+                getAuthToken: () => AUTH_TOKEN,
+                userId: 'test_user',
+            };
+            bus = runtimeBus.makeChannelBus({
+                description: 'select input testing',
+            });
+
+            jasmine.Ajax.install();
+
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('workspace'),
+                body: /11\/22\/33/,
+                response: [refLookupItem],
+            });
+            updateData([], []);
+        });
+
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+            bus.stop();
+            runtime.destroy();
+            TestUtil.clearRuntime();
+            Jupyter.narrative = null;
+            container.remove();
+        });
+
+        it('Should be instantiable, basic test', () => {
+            const initialValue = 'SomeInputObject';
+            const widget = Select2ObjectView.make({
+                parameterSpec: PARAM_SPEC,
+                bus,
+                initialValue,
+                channelName: bus.channelName,
+            });
+            expect(widget).toEqual(jasmine.any(Object));
+            ['start', 'stop'].forEach((fn) => {
+                expect(widget[fn]).toBeDefined();
+                expect(widget[fn]).toEqual(jasmine.any(Function));
+            });
+        });
+
+        async function startWidgetTest(initialValue, initialExpected) {
+            const widget = Select2ObjectView.make({
+                parameterSpec: PARAM_SPEC,
+                bus,
+                initialValue,
+                channelName: bus.channelName,
+            });
+            await widget.start({ node: container });
+            expect(container.childElementCount).toBeGreaterThan(0);
+            const input = container.querySelector('select[data-element="input"]');
+            expect(input).toBeDefined();
+            expect(container.querySelector(RENDERED_ELEM_SELECTOR).textContent).toBe(
+                initialExpected
+            );
+            return widget;
+        }
+
+        it('Should start and stop with some default text value', async () => {
+            const initialValue = 'SomeInputObject';
+            const widget = await startWidgetTest(initialValue, initialValue);
+            await widget.stop();
+            expect(container.childElementCount).toBe(0);
+        });
+
+        it('Should render an UPA as its object name + version', async () => {
+            const initialValue = defaultRef;
+            const initialExpected = `${refLookupItem[1]} (v${refLookupItem[4]})`;
+            const widget = await startWidgetTest(initialValue, initialExpected);
+            await widget.stop();
+            expect(container.childElementCount).toBe(0);
+        });
+
+        it('Should respond to messages over the data channel with a new object version by not changing the view', async () => {
+            const initialValue = defaultRef;
+            const initialExpected = `${refLookupItem[1]} (v${refLookupItem[4]})`;
+            const widget = await startWidgetTest(initialValue, initialExpected);
+            // send an update over the data channel - code lifted from the kbaseNarrativeDataList module.
+            const newObjInfo = Array.from(refLookupItem);
+            newObjInfo[4] = '123';
+            updateData([newObjInfo], [objectify(newObjInfo)]);
+            // gonna cheat here and say that nothing happens after 500ms
+            await TestUtil.wait(500);
+            expect(container.querySelector(RENDERED_ELEM_SELECTOR).textContent).toBe(
+                initialExpected
+            );
+            await widget.stop();
+        });
+
+        it('Should respond to messages over the data channel with a new object name by updating', async () => {
+            const initialValue = defaultRef;
+            const initialExpected = `${refLookupItem[1]} (v${refLookupItem[4]})`;
+            const newName = 'New Object Name';
+            const widget = await startWidgetTest(initialValue, initialExpected);
+            // send an update over the data channel - code lifted from the kbaseNarrativeDataList module.
+            const newObjInfo = Array.from(refLookupItem);
+            newObjInfo[1] = newName;
+
+            await TestUtil.waitForElementChange(
+                container.querySelector(RENDERED_ELEM_SELECTOR),
+                () => {
+                    updateData([newObjInfo], [objectify(newObjInfo)]);
+                }
+            );
+            const newExpectation = `${newObjInfo[1]} (v${refLookupItem[4]})`;
+            expect(container.querySelector(RENDERED_ELEM_SELECTOR).textContent).toBe(
+                newExpectation
+            );
+            await widget.stop();
+        });
+
+        it('Should ignore data channel messages if the given value is not a UPA/objectInfo', async () => {
+            const initialValue = 'SomeInputObject';
+            const widget = await startWidgetTest(initialValue, initialValue);
+            updateData([refLookupItem], [objectify(refLookupItem)]);
+            // gonna cheat here and say that nothing happens after 500ms
+            await TestUtil.wait(500);
+            expect(container.querySelector(RENDERED_ELEM_SELECTOR).textContent).toBe(initialValue);
+            await widget.stop();
+        });
+
+        it('Should respond to the "update" bus message', async () => {
+            const initialValue = 'SomeInputObject';
+            const widget = await startWidgetTest(initialValue, initialValue);
+            await TestUtil.waitForElementChange(
+                container.querySelector(RENDERED_ELEM_SELECTOR),
+                () => {
+                    bus.emit('update', { value: defaultRef });
+                }
+            );
+            const newExpectation = `${refLookupItem[1]} (v${refLookupItem[4]})`;
+            expect(container.querySelector(RENDERED_ELEM_SELECTOR).textContent).toBe(
+                newExpectation
+            );
+            await widget.stop();
+        });
+
+        it('Should respond to the "reset-to-defaults" bus message', async () => {
+            const initialValue = 'SomeInputObject';
+            const widget = await startWidgetTest(initialValue, initialValue);
+            await TestUtil.waitForElementChange(
+                container.querySelector(RENDERED_ELEM_SELECTOR),
+                () => {
+                    bus.emit('reset-to-defaults');
+                }
+            );
+            expect(container.querySelector(RENDERED_ELEM_SELECTOR).textContent).toBe(
+                PARAM_SPEC.data.defaultValue
+            );
+            await widget.stop();
+        });
+
+        [null, undefined, ''].forEach((initValue) => {
+            it(`Should show an empty name if "${initValue}" is provided`, async () => {
+                const widget = await startWidgetTest(initValue, '');
+                await widget.stop();
+            });
+        });
+
+        it('Should show an error if the UPA cannot be resolved to a name', async () => {
+            const initValue = 'xx/yy/zz';
+            Mocks.mockJsonRpc1Call({
+                url: Config.url('workspace'),
+                body: new RegExp(initValue),
+                statusCode: 500,
+                isError: true,
+            });
+            const widget = await startWidgetTest(initValue, `Error resolving ${initValue}`);
+            await widget.stop();
+        });
+    });
+});


### PR DESCRIPTION
# Description of PR purpose/changes

The short version of the PTV-1810 ticket is that when object names change or when their version gets bumped, they get lost in existing apps. The overall fix is not to store the object name in the metadata, but to store the ref. However, this means refactoring both Select2ObjectView and Select2ObjectInput to handle loading/storing refs and some other things.

This PR updates the View form of the widget that appears in the "View Configure" tab of app cells. We do a few things here:
1. accept either strings (i.e. object names) or UPAs as inputs
2. if the input is an UPA (or a workspace_name/object_name ref), look up the relevant object info and display the name from it.
3. if not, just show the given string.

It also fixes a few other small things.
1. This uses code that had a side effect of setting up a data panel listener that wasn't always reaped.
2. This had the Select2 code for interactive usage, when the dropdown is non-interactive.
3. Removes a number of other code pieces to support interactivity that isn't applicable.

The next PR will address a couple issues with the Select2ObjectInput widget.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1810
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
1. Open an existing narrative with an app cell and go to the View Configure tab - it should work as it used to.
2. Run an app cell (on CI only), this should store the UPA right now, and the View Configure tab should display the name properly (with object version number)
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [n/a] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
