### PR TITLE
PTV-1877 - wrong url for data upload/download guide in bulk import cell's "info" tab

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,17 @@
-### OVERVIEW
+# OVERVIEW
 
 The Narrative Interface allows users to craft KBase Narratives using a combination of GUI-based commands, Python and R scripts, and graphical output elements.
 
 This is built on the Jupyter Notebook v6.4.12 and IPython 8.5.0 (more notes will follow).
 
 ## Unreleased
-
+- PTV-1878 - fix some failing front end unit tests
 - PTV-1877 - "fix" app descriptions to replace the documentation link for the upload / download guid
 
 Dependency Changes
 
 - Javascript dependency updates
-  - dompurify none -> 2.3.8 
+  - dompurify none -> 2.3.8
 
 ## Version 5.1.4
 - PTV-1234 - add padding to the bottom of the data list so that the bottom-most row can slide up above the add data button and show its ellipsis icon.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,15 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 
 This is built on the Jupyter Notebook v6.4.12 and IPython 8.5.0 (more notes will follow).
 
+## Unreleased
+
+- PTV-1877 - "fix" app descriptions to replace the documentation link for the upload / download guid
+
+Dependency Changes
+
+- Javascript dependency updates
+  - dompurify none -> 2.3.8 
+
 ## Version 5.1.4
 - PTV-1234 - add padding to the bottom of the data list so that the bottom-most row can slide up above the add data button and show its ellipsis icon.
 - PTV-1793 - fix problem where users could sometimes not enter spaces in bulk import cells

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,10 +5,11 @@ The Narrative Interface allows users to craft KBase Narratives using a combinati
 This is built on the Jupyter Notebook v6.4.12 and IPython 8.5.0 (more notes will follow).
 
 ## Unreleased
-- PTV-1878 - fix some failing front end unit tests
-- PTV-1877 - "fix" app descriptions to replace the documentation link for the upload / download guid
 
-Dependency Changes
+- PTV-1878 - fix some failing front end unit tests
+- PTV-1877 - "fix" app descriptions to replace the documentation link for the upload / download guide
+
+### Dependency Changes
 
 - Javascript dependency updates
   - dompurify none -> 2.3.8

--- a/docs/developer/local-docker.md
+++ b/docs/developer/local-docker.md
@@ -144,6 +144,9 @@ it would be possible to run any node-based tool via a simple node container, but
 - Get the narrative running in one terminal window:
   - `make dev-image`
   - `ENV=ci make run-dev-image`
+
+- Ensure node testing dependencies are installed:
+  - `npm install`
   
 - In another terminal window:
   - `NARRATIVE_SERVER_URL=http://localhost:8888 npm run test_local` if running w/o kbase-ui

--- a/docs/developer/local-docker.md
+++ b/docs/developer/local-docker.md
@@ -134,26 +134,28 @@ You should now be able to navigate to https://ci.kbase.us, log in, and pull a Na
 
 ## Testing with a local container
 
-Testing instructions assume that all JS and Python dependencies are installed locally, and that Narrative is built on the host for local usage.
+Testing instructions assume that JS and Python dependencies are installed locally, and that the Narrative is built on the host for local usage.
 
-This, however, is not necessary with the container, although it is necessary for now to install JS dependencies because tooling relies up it. Of course,
+> Recent changes introduce running the Narrative via a Docker container
+
+This, however, is not necessary with the container, although it is still necessary (for now) to install JS dependencies because tooling relies up it. Of course,
 it would be possible to run any node-based tool via a simple node container, but that is for another day.
 
 - Get the narrative running in one terminal window:
   - `make dev-image`
   - `ENV=ci make run-dev-image`
+  
 - In another terminal window:
-  - `NARRATIVE_SERVER_URL=http://localhost:8888 npm run test_local`
+  - `NARRATIVE_SERVER_URL=http://localhost:8888 npm run test_local` if running w/o kbase-ui
+  - `NARRATIVE_SERVER_URL=https://ci.kbase.us/narrative npm run test_local`, optionally if running with kbase-ui proxying ci.
 
-Please note the volume mounts in `scripts/local-def-run.sh`. Not all directories in kbase-extension/static local narrative repo are mounted, due to
+Please note the volume mounts in `scripts/local-dev-run.sh`. Not all directories in kbase-extension/static local narrative repo are mounted, due to
 the fact that ext_components is installed.
 
 To explain the `ext_` directories briefly.
 
-- `ext_modules` is where all node modules should be placed; that is what it was originally designed for and a very few npm dependencies are placed there;
-   it does not exist until the narrative is built.
-- `ext_components` is where `node_modules` is copied to, for those bower components which were migrated to npm modules; it also does not exist until the
-   narrative is built.
+- `ext_modules` is where all node modules should be placed; that is what it was originally designed for and a very few npm dependencies are placed there; it does not exist until the narrative is built.
+- `ext_components` is where `node_modules` is copied to, for those bower components which were migrated to npm modules; it also does not exist until the narrative is built.
 - `ext_packages` is where old dependencies which cannot be brought into the codebase as normal npm dependencies reside; it essentially never changes as
    it freezes certain dependencies that could not be brought in as bower dependencies when the narrative was converted from manually installed
    dependencies to bower.

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
@@ -158,9 +158,7 @@ define(['domPurify', 'common/format', 'common/html', 'util/string'], (
                             if (
                                 node
                                     .getAttribute('href')
-                                    .match(
-                                        new RegExp('https?://kbase.us/data-upload-download-guide')
-                                    )
+                                    .match(/http[:]\/\/kbase.us\/data-upload-download-guide/)
                             ) {
                                 node.setAttribute(
                                     'href',
@@ -168,9 +166,7 @@ define(['domPurify', 'common/format', 'common/html', 'util/string'], (
                                 );
                             }
                             // Ensure all docs links open into a new window (or tab).
-                            if (
-                                node.getAttribute('href').match(new RegExp('https://docs.kbase.us'))
-                            ) {
+                            if (node.getAttribute('href').match(/https:\/\/docs.kbase.us/)) {
                                 node.setAttribute('target', '_blank');
                             }
                         }

--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
@@ -1,5 +1,13 @@
-define(['common/format', 'common/html', 'util/string'], (format, html, string) => {
+define(['domPurify', 'common/format', 'common/html', 'util/string'], (
+    DOMPurify,
+    format,
+    html,
+    string
+) => {
     'use strict';
+
+    // Note - would destructure in the arguments, but that would require a change to eslint rules.
+    const { sanitize } = DOMPurify;
 
     const cssBaseClass = 'kb-info-tab',
         div = html.tag('div'),
@@ -105,9 +113,9 @@ define(['common/format', 'common/html', 'util/string'], (format, html, string) =
 
             // run count and average runtime
             const execStats = model.getItem('executionStats');
-            let avgRuntime, runtimeInfo;
+            let runtimeInfo;
             if (execStats && execStats.total_exec_time && execStats.number_of_calls > 0) {
-                avgRuntime = format.niceDuration(
+                const avgRuntime = format.niceDuration(
                     1000 * (execStats.total_exec_time / execStats.number_of_calls)
                 );
                 runtimeInfo = div(
@@ -119,7 +127,79 @@ define(['common/format', 'common/html', 'util/string'], (format, html, string) =
                 );
             }
 
-            const infoContainer = div(
+            /**
+             * A self-executing function which, given a string which purports to be an app description, is
+             * sanitized and repaired, if necessary.
+             *
+             * @param {string} descriptionText The description value for an app.
+             *
+             * @returns {string} The sanitized and possibly fixed description
+             */
+            const description = ((descriptionText) => {
+                if (!descriptionText) {
+                    return 'No description specified';
+                }
+
+                /**
+                 * "Fixes" the given node by recursively visiting it and all its children and applying fixes.
+                 *
+                 * At present, the fixes include:
+                 * - for the app info description:
+                 *  - replace the old data upload/download guide link with the current one
+                 *  - ensure that all KBase doc links open in a new window/tab
+                 *
+                 * @param {Node} node A DOM node
+                 * @returns {string} the input node, with fixes applied.
+                 */
+                const fix = (node) => {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        if (node.tagName === 'A') {
+                            // Fix the broken link for the Upload/Download Guide
+                            if (
+                                node
+                                    .getAttribute('href')
+                                    .match(
+                                        new RegExp('https?://kbase.us/data-upload-download-guide')
+                                    )
+                            ) {
+                                node.setAttribute(
+                                    'href',
+                                    'https://docs.kbase.us/data/upload-download-guide'
+                                );
+                            }
+                            // Ensure all docs links open into a new window (or tab).
+                            if (
+                                node.getAttribute('href').match(new RegExp('https://docs.kbase.us'))
+                            ) {
+                                node.setAttribute('target', '_blank');
+                            }
+                        }
+                    }
+
+                    if (node.hasChildNodes()) {
+                        for (const child of node.childNodes) {
+                            fix(child);
+                        }
+                    }
+                    return node;
+                };
+
+                try {
+                    const node = document.createElement('div');
+                    node.innerHTML = sanitize(descriptionText);
+                    // After sanitization and fixing, we want the raw html string back.
+                    return fix(node).innerHTML;
+                } catch (ex) {
+                    console.error(
+                        'Error in app description - probably invalid HTML',
+                        ex.message,
+                        ex
+                    );
+                    return '<div class="alert alert-danger">Error in app description</div>';
+                }
+            })(fullInfo.description);
+
+            containerNode.innerHTML = div(
                 {
                     class: `${cssBaseClass}__container`,
                 },
@@ -163,9 +243,7 @@ define(['common/format', 'common/html', 'util/string'], (format, html, string) =
                         {
                             class: `${cssBaseClass}__description`,
                         },
-                        fullInfo.description && fullInfo.description.length
-                            ? fullInfo.description
-                            : 'No description specified'
+                        description
                     ),
                     div(
                         {
@@ -189,7 +267,6 @@ define(['common/format', 'common/html', 'util/string'], (format, html, string) =
                     runtimeInfo,
                 ]
             );
-            containerNode.innerHTML = infoContainer;
             return Promise.resolve(containerNode);
         }
 

--- a/kbase-extension/static/narrative_paths.js
+++ b/kbase-extension/static/narrative_paths.js
@@ -23,6 +23,7 @@ require.config({
         d3: 'ext_components/d3/d3.min',
         md5: 'ext_components/spark-md5/spark-md5',
         domReady: 'ext_components/requirejs-domready/domReady',
+        domPurify: 'ext_components/dompurify/dist/purify.min',
         dropzone: 'ext_components/dropzone/dist/dropzone-amd-module',
         handlebars: 'ext_components/handlebars/dist/handlebars.amd.min',
         json: 'ext_components/requirejs-plugins/src/json',
@@ -388,9 +389,8 @@ require.config({
     map: {
         '*': {
             css: 'ext_components/require-css/css',
-            'jquery-dataTables': 'datatables.net-bs'
+            'jquery-dataTables': 'datatables.net-bs',
         },
-
     },
 
     shim: {
@@ -411,10 +411,10 @@ require.config({
             deps: ['jquery'],
         },
         'datatables.net-bs': {
-            deps: ['jquery', 'datatables.net', 'bootstrap']
+            deps: ['jquery', 'datatables.net', 'bootstrap'],
         },
         'datatables.net': {
-            deps: ['jquery']
+            deps: ['jquery'],
         },
         kbaseNarrativeMethodCell: {
             deps: ['kbaseNarrativeMethodInput', 'kbaseNarrativeCellMenu'],
@@ -511,7 +511,7 @@ require.config({
             deps: ['jquery', 'jqueryui'],
         },
         'bootstrap-slider': {
-            deps: ['jquery', 'css!bootstrap-slider-css']
-        }
+            deps: ['jquery', 'css!bootstrap-slider-css'],
+        },
     },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,12 +49,12 @@
             "devDependencies": {
                 "@lodder/grunt-postcss": "^3.0.1",
                 "@types/puppeteer": "5.4.4",
-                "@wdio/browserstack-service": "8.3.9",
-                "@wdio/cli": "8.3.9",
-                "@wdio/local-runner": "8.3.9",
-                "@wdio/mocha-framework": "8.3.0",
-                "@wdio/selenium-standalone-service": "8.3.2",
-                "@wdio/spec-reporter": "8.6.8",
+                "@wdio/browserstack-service": "8.10.2",
+                "@wdio/cli": "8.10.2",
+                "@wdio/local-runner": "8.10.2",
+                "@wdio/mocha-framework": "8.10.2",
+                "@wdio/selenium-standalone-service": "8.10.2",
+                "@wdio/spec-reporter": "8.10.2",
                 "autoprefixer": "^10.4.5",
                 "bootstrap-sass": "^3.4.1",
                 "chrome-launcher": "0.15.1",
@@ -115,7 +115,7 @@
                 "stylelint-config-standard": "^22.0.0",
                 "terser": "5.15.0",
                 "wdio-chromedriver-service": "8.1.1",
-                "webdriverio": "8.3.9"
+                "webdriverio": "8.10.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -561,6 +561,79 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+            "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -840,6 +913,16 @@
             "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
             "dev": true
         },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@puppeteer/browsers": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.3.1.tgz",
@@ -940,6 +1023,15 @@
             "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.3.tgz",
             "integrity": "sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==",
             "dev": true
+        },
+        "node_modules/@tootallnate/once": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10"
+            }
         },
         "node_modules/@trysound/sax": {
             "version": "0.2.0",
@@ -1084,9 +1176,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.15.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-            "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+            "version": "20.1.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.7.tgz",
+            "integrity": "sha512-WCuw/o4GSwDGMoonES8rcvwsig77dGCMbZDrZr2x4ZZiNW4P/gcoZXe/0twgtobcTkmg9TuKflxYL/DuwDyJzg==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -1190,22 +1282,22 @@
             }
         },
         "node_modules/@wdio/browserstack-service": {
-            "version": "8.3.9",
-            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-8.3.9.tgz",
-            "integrity": "sha512-YHuA15/wjGl16EkpAi86k7EfjJwudJ4GDoWxAHKjGCXSfkIg6de5hmNvskj0c2KH+5n4J1P/OJT8Vt0wSQCJfg==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/browserstack-service/-/browserstack-service-8.10.2.tgz",
+            "integrity": "sha512-8iBpRDjzw2nTR3suhm7GKImjYk0pdkIQA8AH+CJqObfoIOfopZkw4SjKzaGAtf1wAXmT789p6b4zvak89zZ1Og==",
             "dev": true,
             "dependencies": {
                 "@types/gitconfiglocal": "^2.0.1",
-                "@wdio/logger": "8.1.0",
-                "@wdio/reporter": "8.3.0",
-                "@wdio/types": "8.3.0",
+                "@wdio/logger": "8.6.6",
+                "@wdio/reporter": "8.10.2",
+                "@wdio/types": "8.10.2",
                 "browserstack-local": "^1.5.1",
                 "form-data": "^4.0.0",
                 "git-repo-info": "^2.1.1",
                 "gitconfiglocal": "^2.1.0",
                 "got": "^12.1.0",
                 "uuid": "^8.3.2",
-                "webdriverio": "8.3.9"
+                "webdriverio": "8.10.2"
             },
             "engines": {
                 "node": "^16.13 || >=18"
@@ -1215,34 +1307,33 @@
             }
         },
         "node_modules/@wdio/cli": {
-            "version": "8.3.9",
-            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-8.3.9.tgz",
-            "integrity": "sha512-Lt0Yo/oIMRR23mVRVRmGi6k0OvmmMS3LAL3xWpYrhiwXna3LS+7bdFcLixC9cwiI1NlacgLvbvXTr5gJb1XvJQ==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-8.10.2.tgz",
+            "integrity": "sha512-cfSAbJISQ9T7q716r/Qm6q1dZoXpEuiyoJgWXgi4IQa+bbzYxt4jCTT0+6K+g9TPmAJlqr4Qokb6TTyzVvr4MQ==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/config": "8.3.2",
-                "@wdio/globals": "8.3.9",
-                "@wdio/logger": "8.1.0",
-                "@wdio/protocols": "8.3.5",
-                "@wdio/types": "8.3.0",
-                "@wdio/utils": "8.3.0",
+                "@types/node": "^20.1.1",
+                "@wdio/config": "8.10.2",
+                "@wdio/globals": "8.10.2",
+                "@wdio/logger": "8.6.6",
+                "@wdio/protocols": "8.10.2",
+                "@wdio/types": "8.10.2",
+                "@wdio/utils": "8.10.2",
                 "async-exit-hook": "^2.0.1",
-                "chalk": "^5.0.1",
+                "chalk": "^5.2.0",
                 "chokidar": "^3.5.3",
-                "cli-spinners": "^2.6.1",
-                "ejs": "^3.1.8",
-                "execa": "^7.0.0",
-                "import-meta-resolve": "^2.1.0",
-                "inquirer": "9.1.2",
+                "cli-spinners": "^2.9.0",
+                "ejs": "^3.1.9",
+                "execa": "^7.1.1",
+                "import-meta-resolve": "^3.0.0",
+                "inquirer": "9.2.2",
                 "lodash.flattendeep": "^4.4.0",
                 "lodash.pickby": "^4.6.0",
                 "lodash.union": "^4.6.0",
-                "mkdirp": "^2.0.0",
                 "read-pkg-up": "9.1.0",
-                "recursive-readdir": "^2.2.2",
-                "webdriverio": "8.3.9",
-                "yargs": "^17.5.1",
+                "recursive-readdir": "^2.2.3",
+                "webdriverio": "8.10.2",
+                "yargs": "^17.7.2",
                 "yarn-install": "^1.0.0"
             },
             "bin": {
@@ -1252,19 +1343,75 @@
                 "node": "^16.13 || >=18"
             }
         },
-        "node_modules/@wdio/config": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.3.2.tgz",
-            "integrity": "sha512-lLZh53MorYRxAr08x2o6B1npRgc5ZmGEGdzH2neILnVcs/x3fQV9uFKpC9sKtMmU8B0G0oMUSoIaj8GfqygcNQ==",
+        "node_modules/@wdio/cli/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/@wdio/cli/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@wdio/cli/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "dependencies": {
-                "@wdio/logger": "8.1.0",
-                "@wdio/types": "8.3.0",
-                "@wdio/utils": "8.3.0",
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@wdio/cli/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@wdio/cli/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@wdio/config": {
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.10.2.tgz",
+            "integrity": "sha512-CBPyxay3vVlAnwF+Dv2zsM4QMOVg8rOiD1HAdm9BilwbID2RnLF5i0IYNIFsAblhSZQhXkn5BXAcFSEIVHwOgA==",
+            "dev": true,
+            "dependencies": {
+                "@wdio/logger": "8.6.6",
+                "@wdio/types": "8.10.2",
+                "@wdio/utils": "8.10.2",
                 "decamelize": "^6.0.0",
-                "deepmerge-ts": "^4.2.2",
-                "glob": "^8.0.3",
-                "import-meta-resolve": "^2.1.0",
+                "deepmerge-ts": "^5.0.0",
+                "glob": "^10.2.2",
+                "import-meta-resolve": "^3.0.0",
                 "read-pkg-up": "^9.1.0"
             },
             "engines": {
@@ -1281,47 +1428,53 @@
             }
         },
         "node_modules/@wdio/config/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "version": "10.2.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.4.tgz",
+            "integrity": "sha512-fDboBse/sl1oXSLhIp0FcCJgzW9KmhC/q8ULTKC82zc+DL3TL7FNb8qlt5qqXN53MsKEUSIcb+7DLmEygOE5Yw==",
             "dev": true,
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.0.3",
+                "minimatch": "^9.0.0",
+                "minipass": "^5.0.0 || ^6.0.0",
+                "path-scurry": "^1.7.0"
+            },
+            "bin": {
+                "glob": "dist/cjs/src/bin.js"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@wdio/config/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+            "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@wdio/globals": {
-            "version": "8.3.9",
-            "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.3.9.tgz",
-            "integrity": "sha512-Y4cB2l92NO2WqgkRQE/oLwrvCAT/pPSvmFXKvk0avsHbTPHnukaf0gfB0ku0EKbsyaC9glwPE/PEVrXSC8Hsiw==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.10.2.tgz",
+            "integrity": "sha512-AA9FIdZy60wptCf5SaPRLOZVCEvujnd7iOxZCdzquceaMCxBGlWgr0brsJxjRe35Cd9hPuGddpuyYyFGzUgKDQ==",
             "dev": true,
             "engines": {
                 "node": "^16.13 || >=18"
             },
             "optionalDependencies": {
                 "expect-webdriverio": "^4.0.1",
-                "webdriverio": "8.3.9"
+                "webdriverio": "8.10.2"
             }
         },
         "node_modules/@wdio/globals/node_modules/@jest/types": {
@@ -1433,21 +1586,21 @@
             }
         },
         "node_modules/@wdio/globals/node_modules/expect-webdriverio": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.1.2.tgz",
-            "integrity": "sha512-punU19F1Nq0m9H7f5+A/OtT/LljA+d04sVB9nHIFDYbumdDBOy3I23EFzCsSZMvMdda5r3stKmKalTX4SG2yhA==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.2.3.tgz",
+            "integrity": "sha512-B5y5NYVUWHQGbMiBzH8UBHcGTHhwu13o4/uUZEpc1wmJk2JxWP7fNpmpkUyiW5yygb2Sp0/02ds4b/xw6sBR/A==",
             "dev": true,
             "optional": true,
             "dependencies": {
-                "expect": "^29.4.0",
-                "jest-matcher-utils": "^29.4.0"
+                "expect": "^29.5.0",
+                "jest-matcher-utils": "^29.5.0"
             },
             "engines": {
                 "node": ">=16 || >=18 || >=20"
             },
             "optionalDependencies": {
-                "@wdio/globals": "^8.2.4",
-                "webdriverio": "^8.2.4"
+                "@wdio/globals": "^8.8.8",
+                "webdriverio": "^8.8.8"
             }
         },
         "node_modules/@wdio/globals/node_modules/has-flag": {
@@ -1559,16 +1712,16 @@
             }
         },
         "node_modules/@wdio/local-runner": {
-            "version": "8.3.9",
-            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-8.3.9.tgz",
-            "integrity": "sha512-h4q1ehhscg5fbCGqiOE6jhoEVMpI2rl6+Ga/PRMXCxxNpBXwxZu7EhrgbD4e1pk69i3rgFX3DwjTC/yrawcK3w==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-8.10.2.tgz",
+            "integrity": "sha512-f9XkFe09KqhtabuvbJIMs95138Jo8eCp+MbG3/zy789kD4Y2yndkmcmtthI75H2VuT+zwmiwtBp9pSnGQkBrOw==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/logger": "8.1.0",
-                "@wdio/repl": "8.1.0",
-                "@wdio/runner": "8.3.9",
-                "@wdio/types": "8.3.0",
+                "@types/node": "^20.1.0",
+                "@wdio/logger": "8.6.6",
+                "@wdio/repl": "8.10.1",
+                "@wdio/runner": "8.10.2",
+                "@wdio/types": "8.10.2",
                 "async-exit-hook": "^2.0.1",
                 "split2": "^4.1.0",
                 "stream-buffers": "^3.0.2"
@@ -1578,9 +1731,9 @@
             }
         },
         "node_modules/@wdio/logger": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.1.0.tgz",
-            "integrity": "sha512-QRC5b7FF4JIYUCqggnVA0sZ80TwIUFN9JyBSbuGuMxaSLSLujSo7WfuSrnQXVvsRbnJ16wWwJWYigfLkxOW86Q==",
+            "version": "8.6.6",
+            "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.6.6.tgz",
+            "integrity": "sha512-MS+Y5yqFGx2zVXMOfuBQAVdFsP4DuYz+/hM552xwiDWjGg6EZHoccqUYgH3J5zpu3JFpYV3R/a5jExFiGGck6g==",
             "dev": true,
             "dependencies": {
                 "chalk": "^5.1.2",
@@ -1593,16 +1746,16 @@
             }
         },
         "node_modules/@wdio/mocha-framework": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-8.3.0.tgz",
-            "integrity": "sha512-19BVsTe0DBlArNy12HTYAEFAepUXvU67JceKUOpNcYIr8lpk6ZqPVZ8tm4GiBTDvt7FSt8u5Iw2BsnsrcbQGuA==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-8.10.2.tgz",
+            "integrity": "sha512-qD8wGJWCXDXMiH917aAzZaOfWavgI2H9SjrNjSHbE8BEZSd9cX43zTo5ZBsqY0JEWD0Ihz32iOyTCvRNynUImA==",
             "dev": true,
             "dependencies": {
                 "@types/mocha": "^10.0.0",
-                "@types/node": "^18.0.0",
-                "@wdio/logger": "8.1.0",
-                "@wdio/types": "8.3.0",
-                "@wdio/utils": "8.3.0",
+                "@types/node": "^20.1.0",
+                "@wdio/logger": "8.6.6",
+                "@wdio/types": "8.10.2",
+                "@wdio/utils": "8.10.2",
                 "mocha": "^10.0.0"
             },
             "engines": {
@@ -1610,32 +1763,32 @@
             }
         },
         "node_modules/@wdio/protocols": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.3.5.tgz",
-            "integrity": "sha512-/zWz+ok6gIB1/L/VEOCoD8nCB8inNF+rsVOYps3FgNbrliQ782YLfA1uAVJTw3U6CaO+7zZ8aJw82EswpoxWjg==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.10.2.tgz",
+            "integrity": "sha512-Iv7Nqq6YsMQR9qvOM2mswUcKwx7bdx3cWVSmbMc8hwGJuNCBI+BP1fzmD9OidUftd1CQNvfugsG8Vq8vQWRyGg==",
             "dev": true
         },
         "node_modules/@wdio/repl": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.1.0.tgz",
-            "integrity": "sha512-96G4TzbYnRf95+GURo15FYt6iTYq85nbWU6YQedLRAV15RfSp4foKTbAnq++bKKMALNL6gdzTc+HGhQr3Q0sQg==",
+            "version": "8.10.1",
+            "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.10.1.tgz",
+            "integrity": "sha512-VZ1WFHTNKjR8Ga97TtV2SZM6fvRjWbYI2i/f4pJB4PtusorKvONAMJf2LQcUBIyzbVobqr7KSrcjmSwRolI+yw==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0"
+                "@types/node": "^20.1.0"
             },
             "engines": {
                 "node": "^16.13 || >=18"
             }
         },
         "node_modules/@wdio/reporter": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-8.3.0.tgz",
-            "integrity": "sha512-SCI6YXMDOs+rIDXUqaQYncv3SAcMPU9nQKGCLWjtZXsYHYlLZMT/PaFy7lWyebsObiRAKJYayXOqG7ymS6hDzA==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-8.10.2.tgz",
+            "integrity": "sha512-Ve1I6l5vZu9yBgDaCmBxXRK0Dq9qV9bZ/w1r9YeqvghVExtyk64VH217q9iEvfbdUMmGQOuXjMr20sSNYjInoQ==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/logger": "8.1.0",
-                "@wdio/types": "8.3.0",
+                "@types/node": "^20.1.0",
+                "@wdio/logger": "8.6.6",
+                "@wdio/types": "8.10.2",
                 "diff": "^5.0.0",
                 "object-inspect": "^1.12.0",
                 "supports-color": "9.3.1"
@@ -1645,22 +1798,22 @@
             }
         },
         "node_modules/@wdio/runner": {
-            "version": "8.3.9",
-            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.3.9.tgz",
-            "integrity": "sha512-26BD9VdNpG/pGBTEeQsXwArDE6C89cG9dzJnfh4k+/HgABbroSir2ugHvieF0pRhoOrUGLdevjkFk0DYjrrRnw==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.10.2.tgz",
+            "integrity": "sha512-xPDiTjPLS49dPYiHSrHe94sLIaivdGGIsaeuflzV3Ow7RUudUEiaj1XUc0/znJHmNJJF1MHyZgV+9NJRtQJK8Q==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/config": "8.3.2",
-                "@wdio/globals": "8.3.9",
-                "@wdio/logger": "8.1.0",
-                "@wdio/types": "8.3.0",
-                "@wdio/utils": "8.3.0",
-                "deepmerge-ts": "^4.2.2",
+                "@types/node": "^20.1.0",
+                "@wdio/config": "8.10.2",
+                "@wdio/globals": "8.10.2",
+                "@wdio/logger": "8.6.6",
+                "@wdio/types": "8.10.2",
+                "@wdio/utils": "8.10.2",
+                "deepmerge-ts": "^5.0.0",
                 "expect-webdriverio": "^4.0.1",
                 "gaze": "^1.1.2",
-                "webdriver": "8.3.8",
-                "webdriverio": "8.3.9"
+                "webdriver": "8.10.2",
+                "webdriverio": "8.10.2"
             },
             "engines": {
                 "node": "^16.13 || >=18"
@@ -1767,20 +1920,20 @@
             }
         },
         "node_modules/@wdio/runner/node_modules/expect-webdriverio": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.1.2.tgz",
-            "integrity": "sha512-punU19F1Nq0m9H7f5+A/OtT/LljA+d04sVB9nHIFDYbumdDBOy3I23EFzCsSZMvMdda5r3stKmKalTX4SG2yhA==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.2.3.tgz",
+            "integrity": "sha512-B5y5NYVUWHQGbMiBzH8UBHcGTHhwu13o4/uUZEpc1wmJk2JxWP7fNpmpkUyiW5yygb2Sp0/02ds4b/xw6sBR/A==",
             "dev": true,
             "dependencies": {
-                "expect": "^29.4.0",
-                "jest-matcher-utils": "^29.4.0"
+                "expect": "^29.5.0",
+                "jest-matcher-utils": "^29.5.0"
             },
             "engines": {
                 "node": ">=16 || >=18 || >=20"
             },
             "optionalDependencies": {
-                "@wdio/globals": "^8.2.4",
-                "webdriverio": "^8.2.4"
+                "@wdio/globals": "^8.8.8",
+                "webdriverio": "^8.8.8"
             }
         },
         "node_modules/@wdio/runner/node_modules/has-flag": {
@@ -1884,15 +2037,15 @@
             }
         },
         "node_modules/@wdio/selenium-standalone-service": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/@wdio/selenium-standalone-service/-/selenium-standalone-service-8.3.2.tgz",
-            "integrity": "sha512-X0QiPyeE0e7TN76UDeod4O5blGdhcG7i2gEClw5feIK+s3Wg622GFLTejeSLtWxRJMD8be5uO0QHSMVroTGIKg==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/selenium-standalone-service/-/selenium-standalone-service-8.10.2.tgz",
+            "integrity": "sha512-165JuNg1cfDroYTjETy8gedWvyUM94H++PR8fAi4gYeDE9zkvcc1GxUFe+TyjC5T3QbayalLPMs3ZeUXKacxxg==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/config": "8.3.2",
-                "@wdio/logger": "8.1.0",
-                "@wdio/types": "8.3.0",
+                "@types/node": "^20.1.0",
+                "@wdio/config": "8.10.2",
+                "@wdio/logger": "8.6.6",
+                "@wdio/types": "8.10.2",
                 "selenium-standalone": "^8.2.1"
             },
             "engines": {
@@ -1900,13 +2053,13 @@
             }
         },
         "node_modules/@wdio/spec-reporter": {
-            "version": "8.6.8",
-            "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-8.6.8.tgz",
-            "integrity": "sha512-AWwvg123SgQaYxqVe6q/YsjD4HbjpAu1a8QO32z4uke+6k+BcGgzl0JsXHP21rit4dmqBe8W4zKVGNlKL1RdbQ==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-8.10.2.tgz",
+            "integrity": "sha512-gcbbp/UCZXHwbLrRHwBSvwMxwopOKH147dLzpRJgPo+JbLOiVkLh1pEzq9/vr3+705HpThDZMxFfTGySPFn42g==",
             "dev": true,
             "dependencies": {
-                "@wdio/reporter": "8.6.8",
-                "@wdio/types": "8.6.8",
+                "@wdio/reporter": "8.10.2",
+                "@wdio/types": "8.10.2",
                 "chalk": "^5.1.2",
                 "easy-table": "^1.2.0",
                 "pretty-ms": "^7.0.0"
@@ -1915,71 +2068,27 @@
                 "node": "^16.13 || >=18"
             }
         },
-        "node_modules/@wdio/spec-reporter/node_modules/@wdio/logger": {
-            "version": "8.6.6",
-            "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.6.6.tgz",
-            "integrity": "sha512-MS+Y5yqFGx2zVXMOfuBQAVdFsP4DuYz+/hM552xwiDWjGg6EZHoccqUYgH3J5zpu3JFpYV3R/a5jExFiGGck6g==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^5.1.2",
-                "loglevel": "^1.6.0",
-                "loglevel-plugin-prefix": "^0.8.4",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": "^16.13 || >=18"
-            }
-        },
-        "node_modules/@wdio/spec-reporter/node_modules/@wdio/reporter": {
-            "version": "8.6.8",
-            "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-8.6.8.tgz",
-            "integrity": "sha512-9x5YD759puJM1rhvbOq9nGA1ztVbKfm3niR4bqqmddyHI5onH+TpIowUJXt8WULdwZoxeWnz/P/E8mKMKNFwXw==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/logger": "8.6.6",
-                "@wdio/types": "8.6.8",
-                "diff": "^5.0.0",
-                "object-inspect": "^1.12.0",
-                "supports-color": "9.3.1"
-            },
-            "engines": {
-                "node": "^16.13 || >=18"
-            }
-        },
-        "node_modules/@wdio/spec-reporter/node_modules/@wdio/types": {
-            "version": "8.6.8",
-            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.6.8.tgz",
-            "integrity": "sha512-hwlkQ6E8DNIFL/l8vHve3Zpl1t6Hqle7vtatEkAlrmbnExc7qI6Yw6SI5T/KiBSAi0ez1OypbGhdrbXFfywxng==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "^18.0.0"
-            },
-            "engines": {
-                "node": "^16.13 || >=18"
-            }
-        },
         "node_modules/@wdio/types": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.3.0.tgz",
-            "integrity": "sha512-TTs3ETVOJtooTIY/u2+feeBnMBx2Hb4SEItN31r0pFncn37rnIZXE/buywLNf5wvZW9ukxoCup5hCnohOR27eQ==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.10.2.tgz",
+            "integrity": "sha512-d0oWX82CVE4Z7ipD2GpPhaeFKh7JDaDNzgiQpPYkS74TBSqQV+yrqvqRlrmHD4nmRgFwnjtD8AFOo7ackeURhg==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0"
+                "@types/node": "^20.1.0"
             },
             "engines": {
                 "node": "^16.13 || >=18"
             }
         },
         "node_modules/@wdio/utils": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.3.0.tgz",
-            "integrity": "sha512-BbgzxAu4AN99l9hwaRUvkvBJLeIxON7F6ts+vq4LASRiGVRErrwYGeO9H3ffYgpCAaYSvXnw2GtOf2SQGaPoLA==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.10.2.tgz",
+            "integrity": "sha512-lMIqztb4Mmi2arsM089SDfubx9v0/a/7Ul+vMOt7P19ZEogiWnbELmIs/CaVOxjEcgaNjXM2s56ORKnAObJfgg==",
             "dev": true,
             "dependencies": {
-                "@wdio/logger": "8.1.0",
-                "@wdio/types": "8.3.0",
-                "import-meta-resolve": "^2.2.0",
+                "@wdio/logger": "8.6.6",
+                "@wdio/types": "8.10.2",
+                "import-meta-resolve": "^3.0.0",
                 "p-iteration": "^1.1.8"
             },
             "engines": {
@@ -2134,25 +2243,23 @@
             }
         },
         "node_modules/ansi-escapes": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-            "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
-            "dev": true,
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
             "dependencies": {
-                "type-fest": "^1.0.2"
+                "type-fest": "^0.21.3"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true,
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "engines": {
                 "node": ">=10"
             },
@@ -2489,14 +2596,38 @@
             }
         },
         "node_modules/bl": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-            "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "dev": true,
             "dependencies": {
-                "buffer": "^6.0.3",
+                "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/bl/node_modules/readable-stream": {
@@ -3355,24 +3486,20 @@
             }
         },
         "node_modules/cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-            "dev": true,
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
             "dependencies": {
-                "restore-cursor": "^4.0.0"
+                "restore-cursor": "^3.1.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/cli-spinners": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.8.0.tgz",
-            "integrity": "sha512-/eG5sJcvEIwxcdYM86k5tPwn0MUzkX5YY3eImTGpJOZgVe4SdTMY14vQpcxgBzJ0wXwAYrS8E+c3uHeK4JNyzQ==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+            "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -4365,12 +4492,12 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
         },
         "node_modules/deepmerge-ts": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.3.0.tgz",
-            "integrity": "sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
+            "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
             "dev": true,
             "engines": {
-                "node": ">=12.4.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/defaults": {
@@ -4469,21 +4596,21 @@
             }
         },
         "node_modules/devtools": {
-            "version": "8.3.8",
-            "resolved": "https://registry.npmjs.org/devtools/-/devtools-8.3.8.tgz",
-            "integrity": "sha512-zMulliftMVMUiMRp/YYoCFA3DebzdFij7gkIHlj1yq+gHqwsPSd6pNO+CyZVa0CJhH5uHOs3FAsbIpXeR/woew==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/devtools/-/devtools-8.10.2.tgz",
+            "integrity": "sha512-pvnTf0GtY1ILgBBxjGpQmwmiIklPQFQNirW4deluoLnhKLt6ekdKjYRLoK7goNN0rYPx7R/KK6Aqe5mgWKxBaA==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/config": "8.3.2",
-                "@wdio/logger": "8.1.0",
-                "@wdio/protocols": "8.3.5",
-                "@wdio/types": "8.3.0",
-                "@wdio/utils": "8.3.0",
+                "@types/node": "^20.1.0",
+                "@wdio/config": "8.10.2",
+                "@wdio/logger": "8.6.6",
+                "@wdio/protocols": "8.10.2",
+                "@wdio/types": "8.10.2",
+                "@wdio/utils": "8.10.2",
                 "chrome-launcher": "^0.15.0",
                 "edge-paths": "^3.0.5",
-                "import-meta-resolve": "^2.1.0",
-                "puppeteer-core": "19.6.3",
+                "import-meta-resolve": "^3.0.0",
+                "puppeteer-core": "20.1.1",
                 "query-selector-shadow-dom": "^1.0.0",
                 "ua-parser-js": "^1.0.1",
                 "uuid": "^9.0.0",
@@ -4494,9 +4621,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1082910",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
-            "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww==",
+            "version": "0.0.1138159",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1138159.tgz",
+            "integrity": "sha512-IVXe1ZEQJWkMkeg10hRoZu3luP054z8USOpBIyorCTTABKVg0gBGt4rmwjGmThMEKaTb4nEmjVJkZ3/YxU0whA==",
             "dev": true
         },
         "node_modules/devtools/node_modules/ua-parser-js": {
@@ -4528,9 +4655,9 @@
             }
         },
         "node_modules/devtools/node_modules/which": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
-            "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+            "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
             "dev": true,
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -4774,9 +4901,9 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.1.tgz",
-            "integrity": "sha512-JFYQurD/nbsA5BSPmbaOSLa3tSVj8L6o4srSwXXY3NqE+gGUNmmPTbhn8tjzcCtSqhFgIeqef81ngny8JM25hw==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
+            "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
             "dev": true,
             "dependencies": {
                 "@types/cookie": "^0.4.1",
@@ -6022,6 +6149,34 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/form-data": {
@@ -7426,6 +7581,20 @@
                 "node": ">=8.0.0"
             }
         },
+        "node_modules/http-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/http2-wrapper": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
@@ -7558,9 +7727,9 @@
             }
         },
         "node_modules/import-meta-resolve": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
-            "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-3.0.0.tgz",
+            "integrity": "sha512-4IwhLhNNA8yy445rPjD/lWh++7hMDOml2eHtd58eG7h+qK3EryMuuRbsHGPikCoAgIkkDnckKfWSk2iDla/ejg==",
             "dev": true,
             "funding": {
                 "type": "github",
@@ -7610,41 +7779,79 @@
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "node_modules/inquirer": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.1.2.tgz",
-            "integrity": "sha512-Hj2Ml1WpxKJU2npP2Rj0OURGkHV+GtNW2CwFdHDiXlqUBAUrWTcZHxCkFywX/XHzOS7wrG/kExgJFbUkVgyHzg==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.2.tgz",
+            "integrity": "sha512-VV2ZOZe4ilLlOgEo7drIdzbi+EYJcNty0leF2vJq49zOW8+IoK1miJ+V5FjZY/X21Io29j66T/AiqHvS4tPIrw==",
             "dev": true,
             "dependencies": {
-                "ansi-escapes": "^5.0.0",
-                "chalk": "^5.0.1",
-                "cli-cursor": "^4.0.0",
+                "ansi-escapes": "^4.3.2",
+                "chalk": "^5.2.0",
+                "cli-cursor": "^3.1.0",
                 "cli-width": "^4.0.0",
                 "external-editor": "^3.0.3",
                 "figures": "^5.0.0",
                 "lodash": "^4.17.21",
-                "mute-stream": "0.0.8",
-                "ora": "^6.1.2",
+                "mute-stream": "1.0.0",
+                "ora": "^5.4.1",
                 "run-async": "^2.4.0",
-                "rxjs": "^7.5.6",
-                "string-width": "^5.1.2",
+                "rxjs": "^7.8.1",
+                "string-width": "^4.2.3",
                 "strip-ansi": "^7.0.1",
                 "through": "^2.3.6",
-                "wrap-ansi": "^8.0.1"
+                "wrap-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.18.0"
             }
         },
-        "node_modules/inquirer/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+        "node_modules/inquirer/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
+            }
+        },
+        "node_modules/inquirer/node_modules/mute-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+            "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+            "dev": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/inquirer/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/inquirer/node_modules/strip-ansi": {
@@ -7660,6 +7867,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/inquirer/node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/internal-slot": {
@@ -7950,15 +8169,12 @@
             }
         },
         "node_modules/is-interactive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
             "dev": true,
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/is-map": {
@@ -8428,6 +8644,24 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.0.tgz",
+            "integrity": "sha512-r5XBrqIJfwRIjRt/Xr5fv9Wh09qyhHfKnYddDlpM+ibRR20qrYActpCAgU6U+d53EOEjzkvxPMVHSlgR7leXrQ==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/jake": {
@@ -9533,31 +9767,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/kbase-ui-plugin-catalog/node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/kbase-ui-plugin-catalog/node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/kbase-ui-plugin-catalog/node_modules/ansi-regex": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -9593,17 +9802,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/kbase-ui-plugin-catalog/node_modules/cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dependencies": {
-                "restore-cursor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/kbase-ui-plugin-catalog/node_modules/cli-width": {
@@ -9863,40 +10061,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/kbase-ui-plugin-catalog/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/kbase-ui-plugin-catalog/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/kbase-ui-plugin-catalog/node_modules/restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/kbase-ui-plugin-catalog/node_modules/rimraf": {
@@ -10748,21 +10912,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/log-update/node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/log-update/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -10787,18 +10936,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/log-update/node_modules/cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dev": true,
-            "dependencies": {
-                "restore-cursor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/log-update/node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -10817,54 +10954,11 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "node_modules/log-update/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
-        },
         "node_modules/log-update/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/log-update/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/log-update/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dev": true,
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
             "engines": {
                 "node": ">=8"
             }
@@ -10884,46 +10978,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
-        "node_modules/log-update/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/log-update/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-update/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/log4js": {
@@ -11431,6 +11485,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/minipass": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.1.tgz",
+            "integrity": "sha512-Tenl5QPpgozlOGBiveNYHg2f6y+VpxsXRoIHFUVJuSmTonXRAE6q9b8Mp/O46762/2AlW4ye4Nkyvx0fgWDKbw==",
+            "dev": true,
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/mitt": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
@@ -11813,33 +11876,6 @@
                 "url": "https://opencollective.com/mswjs"
             }
         },
-        "node_modules/msw/node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/msw/node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/msw/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -11853,41 +11889,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/msw/node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/msw/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
             }
         },
         "node_modules/msw/node_modules/chalk": {
@@ -11904,18 +11905,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/msw/node_modules/cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dev": true,
-            "dependencies": {
-                "restore-cursor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/msw/node_modules/cli-width": {
@@ -12015,117 +12004,6 @@
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/msw/node_modules/is-interactive": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/msw/node_modules/is-unicode-supported": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/msw/node_modules/log-symbols": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^4.1.0",
-                "is-unicode-supported": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/msw/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/msw/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/msw/node_modules/ora": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-            "dev": true,
-            "dependencies": {
-                "bl": "^4.1.0",
-                "chalk": "^4.1.0",
-                "cli-cursor": "^3.1.0",
-                "cli-spinners": "^2.5.0",
-                "is-interactive": "^1.0.0",
-                "is-unicode-supported": "^0.1.0",
-                "log-symbols": "^4.1.0",
-                "strip-ansi": "^6.0.0",
-                "wcwidth": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/msw/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/msw/node_modules/restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dev": true,
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
             "engines": {
                 "node": ">=8"
             }
@@ -12657,69 +12535,124 @@
             }
         },
         "node_modules/ora": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
-            "integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
             "dev": true,
             "dependencies": {
-                "chalk": "^5.0.0",
-                "cli-cursor": "^4.0.0",
-                "cli-spinners": "^2.6.1",
-                "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^1.1.0",
-                "log-symbols": "^5.1.0",
-                "stdin-discarder": "^0.1.0",
-                "strip-ansi": "^7.0.1",
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
                 "wcwidth": "^1.0.1"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ora/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+        "node_modules/ora/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
             },
             "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/ora/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/ora/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/ora/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ora/node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ora/node_modules/log-symbols": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-            "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
             "dependencies": {
-                "chalk": "^5.0.0",
-                "is-unicode-supported": "^1.1.0"
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ora/node_modules/strip-ansi": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-            "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+        "node_modules/ora/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/os-homedir": {
@@ -13139,6 +13072,31 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-scurry": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.1.tgz",
+            "integrity": "sha512-UgmoiySyjFxP6tscZDgWGEAgsW5ok8W3F5CJDnnH2pozwSTGE6eH7vwTotMwATWA2r5xqdkKdxYPkwlJjAI/3g==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^9.1.1",
+                "minipass": "^5.0.0 || ^6.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
+            "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+            "dev": true,
+            "engines": {
+                "node": "14 || >=16.14"
             }
         },
         "node_modules/path-type": {
@@ -13629,9 +13587,9 @@
             }
         },
         "node_modules/postcss-load-config/node_modules/yaml": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
-            "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+            "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
             "dev": true,
             "engines": {
                 "node": ">= 14"
@@ -14494,24 +14452,103 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "19.6.3",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.3.tgz",
-            "integrity": "sha512-8MbhioSlkDaHkmolpQf9Z7ui7jplFfOFTnN8d5kPsCazRRTNIH6/bVxPskn0v5Gh9oqOBlknw0eHH0/OBQAxpQ==",
+            "version": "20.1.1",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.1.tgz",
+            "integrity": "sha512-iB9F2Om8J+nU4qi30oYw0hMWOw6eQN7kFkLLI/u3UvxONOCx5o0KmM6+byaK2/QGIuQu2ly1mPaJnC1DyoW07Q==",
             "dev": true,
             "dependencies": {
+                "@puppeteer/browsers": "1.0.1",
+                "chromium-bidi": "0.4.7",
                 "cross-fetch": "3.1.5",
                 "debug": "4.3.4",
-                "devtools-protocol": "0.0.1082910",
+                "devtools-protocol": "0.0.1120988",
                 "extract-zip": "2.0.1",
                 "https-proxy-agent": "5.0.1",
                 "proxy-from-env": "1.1.0",
-                "rimraf": "3.0.2",
                 "tar-fs": "2.1.1",
                 "unbzip2-stream": "1.4.3",
-                "ws": "8.11.0"
+                "ws": "8.13.0"
             },
             "engines": {
-                "node": ">=14.1.0"
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.7.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.0.1.tgz",
+            "integrity": "sha512-9wkYhON9zBgtjYRE3FcokGCfjG25zjzNAYmsHpiWitRZ/4DeT3v125/fCUU66SaPJ4nUsxGNPgpS1TOcQ+8StA==",
+            "dev": true,
+            "dependencies": {
+                "debug": "4.3.4",
+                "extract-zip": "2.0.1",
+                "http-proxy-agent": "5.0.0",
+                "https-proxy-agent": "5.0.1",
+                "progress": "2.0.3",
+                "proxy-from-env": "1.1.0",
+                "tar-fs": "2.1.1",
+                "unbzip2-stream": "1.4.3",
+                "yargs": "17.7.1"
+            },
+            "bin": {
+                "browsers": "lib/cjs/main-cli.js"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "typescript": ">= 4.7.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/chromium-bidi": {
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
+            "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
+            "dev": true,
+            "dependencies": {
+                "mitt": "3.0.0"
+            },
+            "peerDependencies": {
+                "devtools-protocol": "*"
+            }
+        },
+        "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+            "version": "0.0.1120988",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
+            "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q==",
+            "dev": true
+        },
+        "node_modules/puppeteer-core/node_modules/ws": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/puppeteer/node_modules/devtools-protocol": {
@@ -15273,26 +15310,21 @@
             "dev": true
         },
         "node_modules/restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-            "dev": true,
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
             "dependencies": {
                 "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/restore-cursor/node_modules/mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -15301,7 +15333,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -15378,9 +15409,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+            "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
             "dev": true,
             "dependencies": {
                 "tslib": "^2.1.0"
@@ -16051,31 +16082,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/standard/node_modules/ansi-escapes": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-            "dependencies": {
-                "type-fest": "^0.21.3"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/standard/node_modules/ansi-escapes/node_modules/type-fest": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/standard/node_modules/ansi-regex": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -16106,17 +16112,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/standard/node_modules/cli-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-            "dependencies": {
-                "restore-cursor": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/standard/node_modules/cli-width": {
@@ -16586,14 +16581,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/standard/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/standard/node_modules/mkdirp": {
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -16609,20 +16596,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        },
-        "node_modules/standard/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/standard/node_modules/optionator": {
             "version": "0.8.3",
@@ -16755,18 +16728,6 @@
             "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
             "engines": {
                 "node": ">=6.5.0"
-            }
-        },
-        "node_modules/standard/node_modules/restore-cursor": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/standard/node_modules/rimraf": {
@@ -16950,21 +16911,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/stdin-discarder": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-            "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
-            "dev": true,
-            "dependencies": {
-                "bl": "^5.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/stop-iteration-iterator": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
@@ -17101,6 +17047,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/string-width/node_modules/ansi-regex": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -17194,6 +17170,19 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -18321,41 +18310,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tar-stream/node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/tar-stream/node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
-        },
         "node_modules/tar-stream/node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -19165,19 +19119,19 @@
             }
         },
         "node_modules/webdriver": {
-            "version": "8.3.8",
-            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.3.8.tgz",
-            "integrity": "sha512-85ga5IMX8btQbLTQhJrt6HoXNDK0msEV2Ff1E2UYnfgmK8IGvqtZWxz8LM3fKrnjS8NNgxpYB4y81ixfnzRRFA==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.10.2.tgz",
+            "integrity": "sha512-xwoY+JtmEwN9hFx00V08PBlLLbuOHnPcO78ImPn6IzlhDW960f/6C8fzP0oiJkDyjQ7U81gHU6Mjkp/tBNpKEQ==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
+                "@types/node": "^20.1.0",
                 "@types/ws": "^8.5.3",
-                "@wdio/config": "8.3.2",
-                "@wdio/logger": "8.1.0",
-                "@wdio/protocols": "8.3.5",
-                "@wdio/types": "8.3.0",
-                "@wdio/utils": "8.3.0",
-                "deepmerge-ts": "^4.2.2",
+                "@wdio/config": "8.10.2",
+                "@wdio/logger": "8.6.6",
+                "@wdio/protocols": "8.10.2",
+                "@wdio/types": "8.10.2",
+                "@wdio/utils": "8.10.2",
+                "deepmerge-ts": "^5.0.0",
                 "got": "^12.1.0",
                 "ky": "^0.33.0",
                 "ws": "^8.8.0"
@@ -19187,36 +19141,36 @@
             }
         },
         "node_modules/webdriverio": {
-            "version": "8.3.9",
-            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.3.9.tgz",
-            "integrity": "sha512-r1fkBs06zqt9UGAlGVK/bGY+mfF/4SBDGTzKQSh+osqSDAtu/heWE2Xwn9CTbbzLlK1HhBVftDhQYEFOmfSvDg==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.10.2.tgz",
+            "integrity": "sha512-VrA9oFI17sBhPDvMwywve4CwODHi5FEzjn9gyInN7Nv+6tVaDC+PVGsKV7ZQQSj5C0bzPCn3IgXSoM1Qqn3XeQ==",
             "dev": true,
             "dependencies": {
-                "@types/node": "^18.0.0",
-                "@wdio/config": "8.3.2",
-                "@wdio/logger": "8.1.0",
-                "@wdio/protocols": "8.3.5",
-                "@wdio/repl": "8.1.0",
-                "@wdio/types": "8.3.0",
-                "@wdio/utils": "8.3.0",
+                "@types/node": "^20.1.0",
+                "@wdio/config": "8.10.2",
+                "@wdio/logger": "8.6.6",
+                "@wdio/protocols": "8.10.2",
+                "@wdio/repl": "8.10.1",
+                "@wdio/types": "8.10.2",
+                "@wdio/utils": "8.10.2",
                 "archiver": "^5.0.0",
                 "aria-query": "^5.0.0",
                 "css-shorthand-properties": "^1.1.1",
                 "css-value": "^0.0.1",
-                "devtools": "8.3.8",
-                "devtools-protocol": "^0.0.1103684",
+                "devtools": "8.10.2",
+                "devtools-protocol": "^0.0.1138159",
                 "grapheme-splitter": "^1.0.2",
-                "import-meta-resolve": "^2.1.0",
+                "import-meta-resolve": "^3.0.0",
                 "is-plain-obj": "^4.1.0",
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.zip": "^4.2.0",
-                "minimatch": "^6.1.4",
-                "puppeteer-core": "19.6.3",
+                "minimatch": "^9.0.0",
+                "puppeteer-core": "20.1.1",
                 "query-selector-shadow-dom": "^1.0.0",
                 "resq": "^1.9.1",
                 "rgb2hex": "0.2.5",
                 "serialize-error": "^8.0.0",
-                "webdriver": "8.3.8"
+                "webdriver": "8.10.2"
             },
             "engines": {
                 "node": "^16.13 || >=18"
@@ -19231,12 +19185,6 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/webdriverio/node_modules/devtools-protocol": {
-            "version": "0.0.1103684",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1103684.tgz",
-            "integrity": "sha512-44Qr4zFQkzW8r4WdDOSuQoxIzPDczY/K1RDfyxzEsiG2nSzbTojDW3becX5+HrDw3gENG8jY6ffbHZ2/Ix5LSA==",
-            "dev": true
-        },
         "node_modules/webdriverio/node_modules/is-plain-obj": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -19250,15 +19198,15 @@
             }
         },
         "node_modules/webdriverio/node_modules/minimatch": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-            "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+            "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -19423,59 +19371,159 @@
             "dev": true
         },
         "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
             "dev": true,
             "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
-            "engines": {
-                "node": ">=12"
+            "dependencies": {
+                "color-convert": "^2.0.1"
             },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "dev": true,
             "engines": {
-                "node": ">=12"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-            "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+        "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "color-name": "~1.1.4"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             },
             "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "datatables.net": "^1.12.1",
                 "datatables.net-bs": "^1.12.1",
                 "datatables.net-buttons-bs": "2.2.3",
+                "dompurify": "2.3.8",
                 "dropzone": "5.7.0",
                 "file-saver": "1.3.4",
                 "font-awesome": "4.7.0",
@@ -4645,6 +4646,11 @@
             "dependencies": {
                 "domelementtype": "1"
             }
+        },
+        "node_modules/dompurify": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+            "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
         },
         "node_modules/domutils": {
             "version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
                 "autoprefixer": "^10.4.5",
                 "bootstrap-sass": "^3.4.1",
                 "chrome-launcher": "0.15.1",
-                "chromedriver": "^110.0.0",
+                "chromedriver": "^112.0.0",
                 "commander": "10.0.0",
                 "cssnano": "6.0.0",
                 "ejs": "^3.1.7",
@@ -3163,9 +3163,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001474",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
-            "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==",
+            "version": "1.0.30001487",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+            "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
             "dev": true,
             "funding": [
                 {
@@ -3280,9 +3280,9 @@
             }
         },
         "node_modules/chromedriver": {
-            "version": "110.0.0",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-110.0.0.tgz",
-            "integrity": "sha512-Le6q8xrA/3fAt+g8qiN0YjsYxINIhQMC6wj9X3W5L77uN4NspEzklDrqYNwBcEVn7PcAEJ73nLlS7mTyZRspHA==",
+            "version": "112.0.1",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-112.0.1.tgz",
+            "integrity": "sha512-ieQzvellbtPY4MUrFzzayC1bZa/HoBsGXejUQJhAPWcYALxtkjUZNUYWbojMjIzf8iIhVda9VvdXiRKqdlN7ow==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -3298,7 +3298,7 @@
                 "chromedriver": "bin/chromedriver"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
         },
         "node_modules/chromium-bidi": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "datatables.net": "^1.12.1",
         "datatables.net-bs": "^1.12.1",
         "datatables.net-buttons-bs": "2.2.3",
+        "dompurify": "2.3.8",
         "dropzone": "5.7.0",
         "file-saver": "1.3.4",
         "font-awesome": "4.7.0",
@@ -151,8 +152,8 @@
     },
     "lint-staged": {
         "*.js": [
-            "eslint --fix",
-            "prettier --ignore-unknown --write"
+            "npx eslint --fix",
+            "npx prettier --ignore-unknown --write"
         ],
         "*.py": [
             "npm run black_files",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "autoprefixer": "^10.4.5",
         "bootstrap-sass": "^3.4.1",
         "chrome-launcher": "0.15.1",
-        "chromedriver": "^110.0.0",
+        "chromedriver": "^112.0.0",
         "commander": "10.0.0",
         "cssnano": "6.0.0",
         "ejs": "^3.1.7",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "devDependencies": {
         "@lodder/grunt-postcss": "^3.0.1",
         "@types/puppeteer": "5.4.4",
-        "@wdio/browserstack-service": "8.3.9",
-        "@wdio/cli": "8.3.9",
-        "@wdio/local-runner": "8.3.9",
-        "@wdio/mocha-framework": "8.3.0",
-        "@wdio/selenium-standalone-service": "8.3.2",
-        "@wdio/spec-reporter": "8.6.8",
+        "@wdio/browserstack-service": "8.10.2",
+        "@wdio/cli": "8.10.2",
+        "@wdio/local-runner": "8.10.2",
+        "@wdio/mocha-framework": "8.10.2",
+        "@wdio/selenium-standalone-service": "8.10.2",
+        "@wdio/spec-reporter": "8.10.2",
         "autoprefixer": "^10.4.5",
         "bootstrap-sass": "^3.4.1",
         "chrome-launcher": "0.15.1",
@@ -73,7 +73,7 @@
         "stylelint-config-standard": "^22.0.0",
         "terser": "5.15.0",
         "wdio-chromedriver-service": "8.1.1",
-        "webdriverio": "8.3.9"
+        "webdriverio": "8.10.2"
     },
     "dependencies": {
         "bluebird": "3.7.2",

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -139,7 +139,8 @@ module.exports = function (config) {
         // enable the following setting to prevent source code log entries from cluttering up
         // test output.
         // browserConsoleLogOptions: {
-        //     level: 'disable'
+        //     level: 'error',
+        //     terminal: false
         // },
         browserNoActivityTimeout: 30000,
         singleRun: true,

--- a/test/unit/karma.conf.js
+++ b/test/unit/karma.conf.js
@@ -143,6 +143,9 @@ module.exports = function (config) {
         // },
         browserNoActivityTimeout: 30000,
         singleRun: true,
+        // enable the following setting when using a local Narrative container
+        // behind an https proxy
+        // proxyValidateSSL: false,
         proxies: {
             '/kbase_templates/': '/base/kbase-extension/kbase_templates/',
             '/narrative/nbextensions': '/base/nbextensions',

--- a/test/unit/karma.local.conf.js
+++ b/test/unit/karma.local.conf.js
@@ -9,28 +9,25 @@ module.exports = function (config) {
     });
     config.preprocessors = {};
     config.reporters = ['kjhtml', 'brief'];
-    config.exclude = config.exclude
-        .filter((file) => {
-            return file.indexOf('test/unit/spec/') === -1;
-        })
-        .concat([
-            // To isolate groups of tests, uncomment ALL of the
-            // exclude filters below, and comment the group you
-            // want to test.
-            //
-            // 'test/unit/spec/*.js',
-            // 'test/unit/spec/api/**/*',
-            // 'test/unit/spec/appWidgets/**/*',
-            // 'test/unit/spec/common/**/*',
-            // 'test/unit/spec/function_output/*.js',
-            // 'test/unit/spec/function_output/kbaseSampleSet/**/*',
-            // 'test/unit/spec/function_output/modeling/**/*',
-            // 'test/unit/spec/function_output/rna-seq/**/*',
-            // 'test/unit/spec/jsonrpc/**/*',
-            // 'test/unit/spec/narrative_core/**/*',
-            // 'test/unit/spec/nbextensions/**/*',
-            // 'test/unit/spec/util/**/*',
-            // 'test/unit/spec/vis/**/*',
-            // 'test/unit/spec/widgets/**/*'
-        ]);
+    config.exclude = config.exclude.concat([
+        // To isolate groups of tests, uncomment ALL of the
+        // exclude filters below, and comment the group you
+        // want to test.
+        //
+        // 'test/unit/spec/*.js',
+        // 'test/unit/spec/api/**/*',
+        // 'test/unit/spec/appWidgets/**/*',
+        // 'test/unit/spec/common/**/*',
+        // 'test/unit/spec/function_output/*.js',
+        // 'test/unit/spec/function_output/kbaseExpressionPairwiseCorrelation/**/*',
+        // 'test/unit/spec/function_output/kbaseSampleSet/**/*',
+        // 'test/unit/spec/function_output/modeling/**/*',
+        // 'test/unit/spec/function_output/rna-seq/**/*',
+        // 'test/unit/spec/jsonrpc/**/*',
+        // 'test/unit/spec/narrative_core/**/*',
+        // 'test/unit/spec/nbextensions/**/*',
+        // 'test/unit/spec/util/*',
+        // 'test/unit/spec/vis/**/*',
+        // 'test/unit/spec/widgets/**/*',
+    ]);
 };

--- a/test/unit/spec/appWidgets/view/dynamicDropdownViewSpec.js
+++ b/test/unit/spec/appWidgets/view/dynamicDropdownViewSpec.js
@@ -87,14 +87,18 @@ define(['jquery', 'widgets/appWidgets2/view/dynamicDropdownView', 'common/runtim
             });
 
             await widget.start({ node: this.node });
-            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toBe(displayValue);
+            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toContain(
+                displayValue
+            );
             await TestUtil.waitForElementChange(
                 this.node.querySelector('.select2-container'),
                 () => {
                     this.bus.emit('reset-to-defaults');
                 }
             );
-            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toBe(DEFAULT_VALUE);
+            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toContain(
+                DEFAULT_VALUE
+            );
             await widget.stop();
         });
 
@@ -108,7 +112,9 @@ define(['jquery', 'widgets/appWidgets2/view/dynamicDropdownView', 'common/runtim
 
             const updatedValue = 'apple';
             await widget.start({ node: this.node });
-            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toBe(DEFAULT_VALUE);
+            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toContain(
+                DEFAULT_VALUE
+            );
             await TestUtil.waitForElementChange(
                 this.node.querySelector('.select2-container'),
                 () => {
@@ -117,9 +123,9 @@ define(['jquery', 'widgets/appWidgets2/view/dynamicDropdownView', 'common/runtim
                     });
                 }
             );
-            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toBe(updatedValue);
-
-            // expect($(selectElem).select2('data')[0].text).toBe(updatedValue);
+            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toContain(
+                updatedValue
+            );
             await widget.stop();
         });
 
@@ -153,7 +159,7 @@ define(['jquery', 'widgets/appWidgets2/view/dynamicDropdownView', 'common/runtim
                 const selectElem = this.node.querySelector(SELECTOR);
                 expect(selectElem).not.toBeNull();
                 expect(selectElem.children.length).toBe(2); // blank is an option
-                expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toBe(
+                expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toContain(
                     testCase.expected
                 );
 
@@ -172,7 +178,9 @@ define(['jquery', 'widgets/appWidgets2/view/dynamicDropdownView', 'common/runtim
             const updateValue = 'apple';
             const updateDisplayValue = { someKey: 'some display value' };
             await widget.start({ node: this.node });
-            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toBe(DEFAULT_VALUE);
+            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toContain(
+                DEFAULT_VALUE
+            );
             await TestUtil.waitForElementChange(
                 this.node.querySelector('.select2-container'),
                 () => {
@@ -183,7 +191,7 @@ define(['jquery', 'widgets/appWidgets2/view/dynamicDropdownView', 'common/runtim
                 }
             );
 
-            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toBe(
+            expect(this.node.querySelector(SELECT2_OPTION_SELECTOR).innerText).toContain(
                 `value: ${updateDisplayValue.someKey}`
             );
             await widget.stop();

--- a/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
@@ -131,7 +131,10 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
             app: {
                 spec: {
                     full_info: {
-                        // triggers error in domPurity.sanitize
+                        // triggers error in domPurity's sanitize, as a "toString" is expected to
+                        // be a method (returning a string) if the provided "string" is an object.
+                        // If there is no toString property, it is converted to a string, which would
+                        // fail the test for different reasons.
                         description: { toString: 123 },
                         name: APP.THREE.NAME,
                         authors: [],
@@ -389,7 +392,6 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
                         'https://docs.kbase.us/data/upload-download-guide'
                     );
                     expect(description).toContain('target="_blank"');
-                    // toBe(appData[APP.TWO.ID].app.spec.full_info.description);
                 });
             }
 

--- a/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
@@ -42,6 +42,12 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
                     TAG: 'blah',
                     VERSION: 'halb',
                 },
+                FOUR: {
+                    ID: 'fourapp',
+                    NAME: 'The Fourth App',
+                    TAG: 'dev',
+                    VERSION: '5.0.0',
+                },
             },
             DOCSTRING = 'View full documentation',
             FONT_TAG_CONTENTS = 'Some text in a font tag';
@@ -108,6 +114,25 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
             app: {
                 spec: {
                     full_info: {
+                        description:
+                            'Contains <i>safe</i> and <script>unsafe</script>, and <a href="http://kbase.us/data-upload-download-guide/">docs</a>',
+                        name: APP.THREE.NAME,
+                        authors: [],
+                        id: APP.THREE.ID,
+                        ver: APP.THREE.VERSION,
+                        tag: APP.THREE.TAG,
+                    },
+                    parameters: [],
+                },
+            },
+        };
+
+        appData[APP.FOUR.ID] = {
+            app: {
+                spec: {
+                    full_info: {
+                        // triggers error in domPurity.sanitize
+                        description: { toString: 123 },
                         name: APP.THREE.NAME,
                         authors: [],
                         id: APP.THREE.ID,
@@ -125,7 +150,7 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
             },
         };
 
-        ['ONE', 'TWO', 'THREE'].forEach((number) => {
+        ['ONE', 'TWO', 'THREE', 'FOUR'].forEach((number) => {
             appData.multi.app.specs[APP[number].ID] = appData[APP[number].ID].app.spec;
         });
 
@@ -354,6 +379,27 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
                         `/#appcatalog/app/${APP.THREE.ID}/${APP.THREE.TAG}`
                     );
                 });
+                it('displays the description', () => {
+                    const description = container.querySelector(
+                        `.${cssBaseClass}__description`
+                    ).innerHTML;
+                    expect(description).toContain('safe');
+                    expect(description).not.toContain('unsafe');
+                    expect(description).toContain(
+                        'https://docs.kbase.us/data/upload-download-guide'
+                    );
+                    expect(description).toContain('target="_blank"');
+                    // toBe(appData[APP.TWO.ID].app.spec.full_info.description);
+                });
+            }
+
+            function appFourTests() {
+                it('displays the description error message', () => {
+                    const description = container.querySelector(
+                        `.${cssBaseClass}__description`
+                    ).innerHTML;
+                    expect(description).toContain('Error in app description');
+                });
             }
 
             afterEach(() => {
@@ -382,6 +428,14 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
                     container = this.container;
                 });
                 appThreeTests();
+            });
+
+            describe('app four info, single app mode', () => {
+                beforeEach(async function () {
+                    await createInfoTab(this, { model: appModels[APP.FOUR.ID] });
+                    container = this.container;
+                });
+                appFourTests();
             });
 
             describe('app one info, multi-app mode', () => {

--- a/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDataList-spec.js
@@ -230,7 +230,10 @@ define([
             expect($addDataButton).toBeDefined();
             expect($addDataButton.length).toEqual(1);
             expect($addDataButton.is('button')).toBeTruthy();
-            expect($addDataButton.css('display')).toEqual('block');
+            // What we are testing is that the button has been displayed - it is controlled
+            // with jquery hide()/show(), which sets display to "none" to hide,
+            // and leaves alone or restores the display value to show.
+            expect($addDataButton.css('display')).not.toEqual('none');
         });
 
         it('Should render with data, conduct a search, and show a resulting data card', async () => {


### PR DESCRIPTION
# Description of PR purpose/changes

This fixes an issue reported by a user in https://kbase-jira.atlassian.net/browse/PUBLIC-2378, reported as a broken link. The link in question should be to the Data Upload and Download Guide. The url for this guide changed when the single kbase.us public information site was reimplemented as separate documentation and marketing sites. It seems that most import apps invoked by the Import panel, and subsequently managed by the bulk import cell, include hardcoded links to this documentation.

Now, the wisdom of that aside, at least some apps still, after over a year, have now-obsolete links to that documentation. Although the response in the public ticket is that the app has not been updated, there is indeed a fix in this PR that will repair such obsolete links. The fix is to simply replace such links with the (currently) correct one before the link is rendered. These links appear in the "description" field for an app, so that is the field which has the fix applied.

In addition to this fix, another issue is that some of these links are not set up to open in a new browser window. This is a bad experience for users, as it causes the Narrative to be unloaded and replaced with the documentation. If a narrative is actively being edited, as will be the case for a user who just inserted the import cell and is attempting to read the documentation, the browse will also pop up an alert warning the user that they are about to leave the current page. This warning is issued because the Narrative contains unsaved changes. So another "fix" is to add 'target="_blank"' to such links.

Finally, since the description field is expected to contain html, it is subjected to DOM Purify sanitize. While the source of the content is the description field from the app spec, it is still wise to sanitize this content since it does originate outside the codebase and the narrative runtime. Although apps are curated, it is quite possible for a reviewer to be unfamiliar with unsafe html and for something to slip through. And, in any case, it is easy to accomplish.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1877

- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [-] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
  - there don't seem to be specific coding guidelines at this url
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [-] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [-] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [-] [Version has been bumped](https://semver.org/) for each release
- [-] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
