### PR TITLE
UIP-28 update google analytics id tags

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ This is built on the Jupyter Notebook v6.4.12 and IPython 8.5.0 (more notes will
 
 ## Unreleased
 
+- UIP-28 - update Google Analytics tags to GA4 properties
 - PTV-1878 - fix some failing front end unit tests
 - PTV-1877 - "fix" app descriptions to replace the documentation link for the upload / download guide
 

--- a/src/config.json
+++ b/src/config.json
@@ -48,7 +48,7 @@
         "version_check": "/narrative_version",
         "workspace": "https://appdev.kbase.us/services/ws",
         "ws_browser": "https://appdev.kbase.us/#ws",
-        "google_analytics_id": "UA-74533556-1"
+        "google_analytics_id": "G-00WLPPN9SM"
     },
     "auth_cookie": "kbase_session",
     "auth_sleep_recheck_ms": 60000,
@@ -100,7 +100,7 @@
         "version_check": "/narrative_version",
         "workspace": "https://ci.kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-137652528-1",
+        "google_analytics_id": "G-GSSGYX2WB8",
         "google_ad_id": "AW-753507180",
         "google_ad_conversion": "kR9OCLas4JgBEOy2pucC"
     },
@@ -165,7 +165,7 @@
         "version_check": "/narrative_version",
         "workspace": "https://ci.kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-74532036-1"
+        "google_analytics_id": "G-GW0WBP8HJS"
     },
     "dev_mode": true,
     "git_commit_hash": "3f9ee0617",
@@ -221,7 +221,7 @@
         "version_check": "/narrative_version",
         "workspace": "https://next.kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-74530365-1"
+        "google_analytics_id": "G-0XX39Q67P9"
     },
     "prod": {
         "auth": "https://kbase.us/services/auth",
@@ -272,7 +272,7 @@
         "version_check": "/narrative_version",
         "workspace": "https://kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-137652528-1",
+        "google_analytics_id": "G-KXZCE6YQFZ",
         "google_ad_id": "AW-753507180",
         "google_ad_conversion": "kR9OCLas4JgBEOy2pucC"
     },
@@ -326,7 +326,7 @@
         "version_check": "/narrative_version",
         "workspace": "https://narrative-dev.kbase.us/services/ws",
         "ws_browser": "https://narrative-dev.kbase.us/#ws",
-        "google_analytics_id": "UA-131054609-1"
+        "google_analytics_id": "G-GW0WBP8HJS"
     },
     "narrative-refactor": {
         "auth": "https://narrative-refactor.kbase.us/services/auth",
@@ -377,7 +377,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://narrative-refactor.kbase.us/services/ws",
         "ws_browser": "https://narrative-refactor.kbase.us/#ws",
-        "google_analytics_id": "UA-131054609-1"
+        "google_analytics_id": "G-GSSGYX2WB8"
     },
     "release_notes": "https://github.com/kbase/narrative/blob/main/RELEASE_NOTES.md",
     "tooltip": {

--- a/src/config.json.templ
+++ b/src/config.json.templ
@@ -48,7 +48,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://appdev.kbase.us/services/ws",
         "ws_browser": "https://appdev.kbase.us/#ws",
-        "google_analytics_id": "UA-74533556-1"
+        "google_analytics_id": "G-00WLPPN9SM"
     },
     "auth_cookie": "kbase_session",
     "auth_sleep_recheck_ms": 60000,
@@ -100,7 +100,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://ci.kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-137652528-1",
+        "google_analytics_id": "G-GSSGYX2WB8",
         "google_ad_id": "AW-753507180",
         "google_ad_conversion": "kR9OCLas4JgBEOy2pucC"
     },
@@ -165,7 +165,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://ci.kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-74532036-1"
+        "google_analytics_id": "G-GW0WBP8HJS"
     },
     "dev_mode": {{ if ne .Env.CONFIG_ENV "prod" }}true{{- else }}false{{- end }},
     "git_commit_hash": "27fda32ec",
@@ -221,7 +221,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://next.kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-74530365-1"
+        "google_analytics_id": "G-0XX39Q67P9"
     },
     "prod": {
         "auth": "https://kbase.us/services/auth",
@@ -272,7 +272,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://kbase.us/services/ws",
         "ws_browser": "https://narrative.kbase.us/#ws",
-        "google_analytics_id": "UA-137652528-1",
+        "google_analytics_id": "G-KXZCE6YQFZ",
         "google_ad_id": "AW-753507180",
         "google_ad_conversion": "kR9OCLas4JgBEOy2pucC"
     },
@@ -326,7 +326,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://narrative-dev.kbase.us/services/ws",
         "ws_browser": "https://narrative-dev.kbase.us/#ws",
-        "google_analytics_id": "UA-131054609-1"
+        "google_analytics_id": "G-GW0WBP8HJS"
     },
     "narrative-refactor": {
         "auth": "https://narrative-refactor.kbase.us/services/auth",
@@ -377,7 +377,7 @@
         "version_check": "{{ .Env.VERSION_CHECK }}",
         "workspace": "https://narrative-refactor.kbase.us/services/ws",
         "ws_browser": "https://narrative-refactor.kbase.us/#ws",
-        "google_analytics_id": "UA-131054609-1"
+        "google_analytics_id": "G-GSSGYX2WB8"
     },
     "release_notes": "https://github.com/kbase/narrative/blob/main/RELEASE_NOTES.md",
     "tooltip": {


### PR DESCRIPTION
# Description of PR purpose/changes

This updates the various Google Analytics tags to use GA4 tags. In theory, no other changes are necessary.  
Next steps include updating Auth to generate an anonymous user id, and propagating that through to GA.  
For now, however, no code changes.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-28
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
Hard to test - but fire up the narrative locally and ensure that a number of local google cookies get created with the proper tag.
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [n/a] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [n/a] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] New and existing unit tests pass locally with my changes
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [n/a] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [n/a] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
