### PR TITLE
PTV-1810 fix obj input 2

### DIFF
--- a/src/biokbase/narrative/tests/test_app_util.py
+++ b/src/biokbase/narrative/tests/test_app_util.py
@@ -2,7 +2,7 @@
 Tests for the app_util module
 """
 import os
-import unittest
+import pytest
 from unittest import mock
 
 from biokbase.narrative.app_util import (
@@ -10,174 +10,231 @@ from biokbase.narrative.app_util import (
     get_result_sub_path,
     map_inputs_from_job,
     map_outputs_from_state,
+    transform_param_value
 )
 
 from . import util
+from .narrative_mock.mockclients import get_mock_client
 
-__author__ = "Bill Riehl <wjriehl@lbl.gov>"
+user_token = "SOME_TOKEN"
+config = util.ConfigTests()
+user_id = config.get("users", "test_user")
+user_token = util.read_token_file(config.get_path("token_files", "test_user", from_root=True))
 
+good_tag = "release"
+bad_tag = "not_a_tag"
+# inject phony variables into the environment
+bad_fake_token = "NotAGoodTokenLOL"
+workspace = "valid_workspace"
+bad_variable = "not a variable"
 
-class DummyWorkspace:
-    def get_workspace_info(*args, **kwargs):
-        return [12345]
+def test_check_tag_good():
+    assert check_tag(good_tag) is True
 
+def test_check_tag_bad():
+    assert check_tag(bad_tag) is False
 
-class AppUtilTestCase(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        config = util.ConfigTests()
-        cls.user_id = config.get("users", "test_user")
-        cls.user_token = util.read_token_file(
-            config.get_path("token_files", "test_user", from_root=True)
-        )
+def test_check_tag_bad_except():
+    with pytest.raises(ValueError):
+        check_tag(bad_tag, raise_exception=True)
 
-        cls.good_tag = "release"
-        cls.bad_tag = "notATag"
-        # inject phony variables into the environment
-        cls.bad_fake_token = "NotAGoodTokenLOL"
-        cls.workspace = "valid_workspace"
+@pytest.fixture(scope="module")
+def workspace_name():
+    os.environ["KB_WORKSPACE_ID"] = workspace
+    yield
+    del os.environ["KB_WORKSPACE_ID"]
 
-    def test_check_tag_good(self):
-        self.assertTrue(check_tag(self.good_tag))
+get_result_sub_path_cases = [
+    (
+        [{"report": "this_is_a_report", "report_ref": "123/456/7"}],
+        [0, "report_ref"],
+        "123/456/7"
+    ),
+    (
+        ["foo", "bar", "baz"],
+        [2],
+        "baz"
+    ),
+    (
+        ["foo", {"bar": "baz"}, "foobar"],
+        [1, "bar"],
+        "baz"
+    ),
+    (
+        ["foo", 0, {"bar": {"baz": [10, 11, 12, 13]}}],
+        [2, "bar", "baz", 3],
+        13
+    ),
+    (
+        ["foo"],
+        [2],
+        None
+    ),
+    (
+        {"foo": "bar"},
+        ["baz"],
+        None
+    )
+]
+@pytest.mark.parametrize("result,path,expected", get_result_sub_path_cases)
+def test_get_result_sub_path(result, path, expected):
+    assert get_result_sub_path(result, path) == expected
 
-    def test_check_tag_bad(self):
-        self.assertFalse(check_tag(self.bad_tag))
-
-    def test_check_tag_bad_except(self):
-        with self.assertRaises(ValueError):
-            check_tag(self.bad_tag, raise_exception=True)
-
-    def test_get_result_sub_path(self):
-        result = [{"report": "this_is_a_report", "report_ref": "123/456/7"}]
-        path = [0, "report_ref"]
-        self.assertEqual(get_result_sub_path(result, path), "123/456/7")
-
-    def test_get_result_sub_path_deep_list(self):
-        result = ["foo", "bar", "baz"]
-        path = [2]
-        self.assertEqual(get_result_sub_path(result, path), "baz")
-
-    def test_get_result_sub_path_deep_obj(self):
-        result = ["foo", {"bar": "baz"}, "foobar"]
-        path = [1, "bar"]
-        self.assertEqual(get_result_sub_path(result, path), "baz")
-
-    def test_get_result_obj_path(self):
-        result = ["foo", 0, {"bar": {"baz": [10, 11, 12, 13]}}]
-        path = [2, "bar", "baz", 3]
-        self.assertEqual(get_result_sub_path(result, path), 13)
-
-    def test_get_result_sub_path_list_fail(self):
-        result = ["foo"]
-        path = [2]
-        self.assertIsNone(get_result_sub_path(result, path))
-
-    def test_get_result_sub_path_key_fail(self):
-        result = {"foo": "bar"}
-        path = ["baz"]
-        self.assertIsNone(get_result_sub_path(result, path))
-
-    def test_map_inputs_from_job(self):
-        inputs = [
-            "input1",
-            {"ws": "my_workspace", "foo": "bar"},
-            "some_ref/obj_id",
-            ["ref/num_1", "ref/num_2", "num_3"],
-            123,
-        ]
-        app_spec = {
-            "behavior": {
-                "kb_service_input_mapping": [
-                    {"target_position": 0, "input_parameter": "an_input"},
-                    {
-                        "target_position": 1,
-                        "target_property": "ws",
-                        "input_parameter": "workspace",
-                    },
-                    {
-                        "target_position": 1,
-                        "target_property": "foo",
-                        "input_parameter": "baz",
-                    },
-                    {
-                        "target_position": 2,
-                        "input_parameter": "ref_input",
-                        "target_type_transform": "ref",
-                    },
-                    {
-                        "target_position": 3,
-                        "input_parameter": "a_list",
-                        "target_type_transform": "list<ref>",
-                    },
-                    {
-                        "target_position": 4,
-                        "input_parameter": "a_num",
-                        "target_type_transform": "int",
-                    },
-                ],
-            }
+def test_map_inputs_from_job():
+    inputs = [
+        "input1",
+        {"ws": "my_workspace", "foo": "bar"},
+        "some_ref/obj_id",
+        ["ref/num_1", "ref/num_2", "num_3"],
+        123,
+    ]
+    app_spec = {
+        "behavior": {
+            "kb_service_input_mapping": [
+                {"target_position": 0, "input_parameter": "an_input"},
+                {
+                    "target_position": 1,
+                    "target_property": "ws",
+                    "input_parameter": "workspace",
+                },
+                {
+                    "target_position": 1,
+                    "target_property": "foo",
+                    "input_parameter": "baz",
+                },
+                {
+                    "target_position": 2,
+                    "input_parameter": "ref_input",
+                    "target_type_transform": "ref",
+                },
+                {
+                    "target_position": 3,
+                    "input_parameter": "a_list",
+                    "target_type_transform": "list<ref>",
+                },
+                {
+                    "target_position": 4,
+                    "input_parameter": "a_num",
+                    "target_type_transform": "int",
+                },
+            ],
         }
-        expected = {
-            "an_input": "input1",
-            "workspace": "my_workspace",
-            "baz": "bar",
-            "ref_input": "obj_id",
-            "a_list": ["num_1", "num_2", "num_3"],
-            "a_num": 123,
-        }
-        self.assertDictEqual(map_inputs_from_job(inputs, app_spec), expected)
-
-    def test_map_outputs_from_state_simple(self):
-        os.environ["KB_WORKSPACE_ID"] = self.workspace
-        app_spec = {
-            "parameters": [],
-            "behavior": {
-                "output_mapping": [{"narrative_system_variable": "workspace"}]
-            },
-        }
-        self.assertTupleEqual(
-            map_outputs_from_state(None, None, app_spec),
-            ("kbaseDefaultNarrativeOutput", self.workspace),
-        )
-
-    def test_map_outputs_from_state(self):
-        os.environ["KB_WORKSPACE_ID"] = self.workspace
-        app_spec = {
-            "widgets": {"input": None, "output": "testOutputWidget"},
-            "parameters": [],
-            "behavior": {
-                "kb_service_output_mapping": [
-                    {"narrative_system_variable": "workspace", "target_property": "ws"},
-                    {"constant_value": 5, "target_property": "a_constant"},
-                    {
-                        "service_method_output_path": [1],
-                        "target_property": "a_path_ref",
-                    },
-                    {"input_parameter": "an_input", "target_property": "an_input"},
-                ]
-            },
-        }
-        params = {"an_input": "input_val"}
-        state = {"job_output": {"result": ["foo", "bar"]}}
-        expected = (
-            "testOutputWidget",
-            {
-                "ws": self.workspace,
-                "a_constant": 5,
-                "a_path_ref": "bar",
-                "an_input": "input_val",
-            },
-        )
-        self.assertTupleEqual(map_outputs_from_state(state, params, app_spec), expected)
-
-    def test_map_outputs_from_state_bad_spec(self):
-        os.environ["KB_WORKSPACE_ID"] = self.workspace
-        app_spec = {"not": "really"}
-        params = {"an_input": "input_val"}
-        state = {}
-        with self.assertRaises(ValueError):
-            map_outputs_from_state(state, params, app_spec)
+    }
+    expected = {
+        "an_input": "input1",
+        "workspace": "my_workspace",
+        "baz": "bar",
+        "ref_input": "obj_id",
+        "a_list": ["num_1", "num_2", "num_3"],
+        "a_num": 123,
+    }
+    assert map_inputs_from_job(inputs, app_spec) == expected
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_map_outputs_from_state_simple(workspace_name):
+    app_spec = {
+        "parameters": [],
+        "behavior": {
+            "output_mapping": [{"narrative_system_variable": "workspace"}]
+        },
+    }
+    expected = ("kbaseDefaultNarrativeOutput", workspace)
+    assert map_outputs_from_state(None, None, app_spec) == expected
+
+def test_map_outputs_from_state(workspace_name):
+    app_spec = {
+        "widgets": {"input": None, "output": "testOutputWidget"},
+        "parameters": [],
+        "behavior": {
+            "kb_service_output_mapping": [
+                {"narrative_system_variable": "workspace", "target_property": "ws"},
+                {"constant_value": 5, "target_property": "a_constant"},
+                {
+                    "service_method_output_path": [1],
+                    "target_property": "a_path_ref",
+                },
+                {"input_parameter": "an_input", "target_property": "an_input"},
+            ]
+        },
+    }
+    params = {"an_input": "input_val"}
+    state = {"job_output": {"result": ["foo", "bar"]}}
+    expected = (
+        "testOutputWidget",
+        {
+            "ws": workspace,
+            "a_constant": 5,
+            "a_path_ref": "bar",
+            "an_input": "input_val",
+        },
+    )
+    assert map_outputs_from_state(state, params, app_spec) == expected
+
+def test_map_outputs_from_state_bad_spec(workspace_name):
+    app_spec = {"not": "really"}
+    params = {"an_input": "input_val"}
+    state = {}
+    with pytest.raises(ValueError):
+        map_outputs_from_state(state, params, app_spec)
+
+
+transform_param_value_simple_cases = [
+    ( "string", None, None, None ),
+    ( "string", "foo", None, "foo" ),
+    ( "string", 123, None, "123" ),
+    ( "string", ["a", "b", "c"], None, "a,b,c"),
+    ( "string", {"a": "b", "c": "d"}, None, "a=b,c=d"),
+    ( "string", [], None, "" ),
+    ( "string", {}, None, "" ),
+    ( "int", "1", None, 1 ),
+    ( "int", None, None, None ),
+    ( "int", "", None, None ),
+    ( "list<string>", [1, 2, 3], None, ["1", "2", "3"] ),
+    ( "list<int>", ["1", "2", "3"], None, [1, 2, 3] ),
+    ( "list<string>", "asdf", None, ["asdf"] ),
+    ( "list<int>", "1", None, [1] )
+]
+@pytest.mark.parametrize("transform_type,value,spec_param,expected", transform_param_value_simple_cases)
+def test_transform_param_value_simple(transform_type, value, spec_param, expected):
+    assert transform_param_value(transform_type, value, spec_param) == expected
+
+def test_transform_param_value_fail():
+    ttype = "foobar"
+    with pytest.raises(ValueError, match=f"Unsupported Transformation type: {ttype}"):
+        transform_param_value(ttype, "foo", None)
+
+textsubdata_cases = [
+    (None, None),
+    ("asdf", "asdf"),
+    (123, "123"),
+    (["1", "2", "3"], "1,2,3"),
+    ({"a":"b", "c": "d"}, "a=b,c=d")
+]
+@pytest.mark.parametrize("value,expected", textsubdata_cases)
+def test_transform_param_value_textsubdata(value, expected):
+    spec = {
+        "type": "textsubdata"
+    }
+    assert transform_param_value(None, value, spec) == expected
+
+ref_cases = [
+    (None, None),
+    ("foo/bar", "foo/bar"),
+    ("1/2/3", "1/2/3"),
+    ("name", workspace + "/name")
+]
+@pytest.mark.parametrize("value,expected", ref_cases)
+def test_transform_param_value_simple_ref(value, expected, workspace_name):
+    for tf_type in ["ref", "unresolved-ref"]:
+        assert transform_param_value(tf_type, value, None) == expected
+
+mock_upa = "18836/5/1"
+upa_cases = [
+    ("some_name", mock_upa),
+    (["multiple", "names"], [mock_upa, mock_upa]),
+    ("already/ref", mock_upa)
+]
+@mock.patch("biokbase.narrative.app_util.clients.get", get_mock_client)
+@pytest.mark.parametrize("value,expected", upa_cases)
+def test_transform_param_value_resolved_ref(value, expected, workspace_name):
+    assert transform_param_value("resolved-ref", value, None) == expected

--- a/src/biokbase/narrative/tests/test_app_util.py
+++ b/src/biokbase/narrative/tests/test_app_util.py
@@ -46,7 +46,6 @@ def workspace_name():
         os.environ["KB_WORKSPACE_ID"] = ws_name
     yield set_ws_name
     del os.environ["KB_WORKSPACE_ID"]
-    print(f'workspace id: {os.environ.get("KB_WORKSPACE_ID", "key missing")}')
 
 get_result_sub_path_cases = [
     (
@@ -183,6 +182,8 @@ def test_map_outputs_from_state_bad_spec(workspace_name):
     state = {}
     with pytest.raises(ValueError):
         map_outputs_from_state(state, params, app_spec)
+
+
 
 # app_param tests
 base_app_param = {

--- a/src/biokbase/narrative/tests/test_app_util.py
+++ b/src/biokbase/narrative/tests/test_app_util.py
@@ -40,11 +40,13 @@ def test_check_tag_bad_except():
     with pytest.raises(ValueError):
         check_tag(bad_tag, raise_exception=True)
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def workspace_name():
-    os.environ["KB_WORKSPACE_ID"] = workspace
-    yield
+    def set_ws_name(ws_name):
+        os.environ["KB_WORKSPACE_ID"] = ws_name
+    yield set_ws_name
     del os.environ["KB_WORKSPACE_ID"]
+    print(f'workspace id: {os.environ.get("KB_WORKSPACE_ID", "key missing")}')
 
 get_result_sub_path_cases = [
     (
@@ -134,6 +136,7 @@ def test_map_inputs_from_job():
 
 
 def test_map_outputs_from_state_simple(workspace_name):
+    workspace_name(workspace)
     app_spec = {
         "parameters": [],
         "behavior": {
@@ -144,6 +147,7 @@ def test_map_outputs_from_state_simple(workspace_name):
     assert map_outputs_from_state(None, None, app_spec) == expected
 
 def test_map_outputs_from_state(workspace_name):
+    workspace_name(workspace)
     app_spec = {
         "widgets": {"input": None, "output": "testOutputWidget"},
         "parameters": [],
@@ -173,6 +177,7 @@ def test_map_outputs_from_state(workspace_name):
     assert map_outputs_from_state(state, params, app_spec) == expected
 
 def test_map_outputs_from_state_bad_spec(workspace_name):
+    workspace_name(workspace)
     app_spec = {"not": "really"}
     params = {"an_input": "input_val"}
     state = {}
@@ -390,6 +395,7 @@ ref_cases = [
 ]
 @pytest.mark.parametrize("value,expected", ref_cases)
 def test_transform_param_value_simple_ref(value, expected, workspace_name):
+    workspace_name(workspace)
     for tf_type in ["ref", "unresolved-ref"]:
         assert transform_param_value(tf_type, value, None) == expected
 
@@ -402,4 +408,5 @@ upa_cases = [
 @mock.patch("biokbase.narrative.app_util.clients.get", get_mock_client)
 @pytest.mark.parametrize("value,expected", upa_cases)
 def test_transform_param_value_resolved_ref(value, expected, workspace_name):
+    workspace_name(workspace)
     assert transform_param_value("resolved-ref", value, None) == expected


### PR DESCRIPTION
# Description of PR purpose/changes

See #3320 for details

This PR creates regression tests for `app_util.transform_param_value`, which will get modified and
updated in the next PR.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1810
- [X] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [X] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [X] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [X] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
