### PR TITLE
UIP-36 use the anonymous user id in Google Analytics calls

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ This is built on the Jupyter Notebook v6.4.12 and IPython 8.5.0 (more notes will
 -   PTV-1810 - address object name display issues in the View Configure tab of app cells.
 -   PTV-1877 - fix app descriptions to replace the documentation link for the upload / download guide
 -   PTV-1878 - fix some failing front end unit tests
+-   UIP-36 - add support for anonymous user ids sent to Google Analytics
 
 ### Dependency Changes
 

--- a/kbase-extension/kbase_templates/page.html
+++ b/kbase-extension/kbase_templates/page.html
@@ -44,12 +44,12 @@
       function gtag() { dataLayer.push(arguments); }
       gtag('js', new Date());
       gtag('config', '{{google_analytics_id}}', {
-        'username': '{{userName}}',
+        'username': '{{anon_user_id}}',
         'Page_location': document.location,
         'page_path': document.location.pathname,
         'page_title': document.location.pathname
       });
-      gtag('set', {'user_id': '{{userName}}'});
+      gtag('set', {'user_id': '{{anon_user_id}}'});
       {% if google_ad_id %}
         gtag('config', '{{google_ad_id}}');
         gtag('event', 'conversion', {'send_to': '{{google_ad_id}}'+'{{google_ad_conversion}}'});

--- a/src/biokbase/auth.py
+++ b/src/biokbase/auth.py
@@ -132,7 +132,7 @@ def get_token_info(token: str) -> TokenInfo:
     return auth_info
 
 
-def init_session_env(auth_info: TokenInfo, ip: str) -> None:
+def init_session_env(auth_info: TokenInfo, user_info: UserInfo, ip: str) -> None:
     """
     Initializes the internal session environment.
     Parameters:
@@ -142,6 +142,7 @@ def init_session_env(auth_info: TokenInfo, ip: str) -> None:
     set_environ_token(auth_info.token)
     kbase_env.session = auth_info.token_id
     kbase_env.user = auth_info.user
+    kbase_env.anon_user_id = user_info.anon_id
     kbase_env.client_ip = ip
 
 

--- a/src/biokbase/narrative/common/util.py
+++ b/src/biokbase/narrative/common/util.py
@@ -32,6 +32,7 @@ class _KBaseEnv:
     env_workspace = "KB_WORKSPACE_ID"
     env_user = "KB_USER_ID"
     env_env = "KB_ENVIRONMENT"
+    env_anon_user_id = "KB_ANON_USER_ID"
 
     _defaults = {
         "auth_token": "none",
@@ -41,6 +42,7 @@ class _KBaseEnv:
         "user": "anonymous",
         "workspace": "none",
         "env": "none",
+        "anon_user_id": "none",
     }
 
     def __getattr__(self, name):

--- a/src/biokbase/narrative/handlers/authhandlers.py
+++ b/src/biokbase/narrative/handlers/authhandlers.py
@@ -7,7 +7,12 @@ from notebook.auth.login import LoginHandler
 from notebook.auth.logout import LogoutHandler
 from traitlets.config import Application
 
-from biokbase.auth import get_token_info, init_session_env, set_environ_token
+from biokbase.auth import (
+    get_token_info,
+    get_user_info,
+    init_session_env,
+    set_environ_token,
+)
 from biokbase.narrative.common.kblogging import get_logger, log_event
 from biokbase.narrative.common.util import kbase_env
 
@@ -53,6 +58,7 @@ class KBaseLoginHandler(LoginHandler):
             token = urllib.parse.unquote(auth_cookie.value)
             try:
                 auth_info = get_token_info(token)
+                user_info = get_user_info(token)
             except Exception:
                 app_log.error(
                     "Unable to get user information from authentication token!"
@@ -65,7 +71,7 @@ class KBaseLoginHandler(LoginHandler):
             #     app_log.debug("KBaseLoginHandler.get: user_id={uid} token={tok}"
             #                   .format(uid=auth_info.get('user', 'none'),
             #                           tok=token))
-            init_session_env(auth_info, client_ip)
+            init_session_env(auth_info, user_info, client_ip)
             self.current_user = kbase_env.user
             log_event(
                 g_log, "session_start", {"user": kbase_env.user, "user_agent": ua}
@@ -99,7 +105,10 @@ class KBaseLoginHandler(LoginHandler):
 
     @classmethod
     def login_available(cls, settings):
-        """Whether this LoginHandler is needed - and therefore whether the login page should be displayed."""
+        """
+        Whether this LoginHandler is needed - and therefore whether the login page should be
+        displayed.
+        """
         return True
 
 

--- a/src/biokbase/narrative/handlers/narrativehandler.py
+++ b/src/biokbase/narrative/handlers/narrativehandler.py
@@ -6,7 +6,7 @@ from notebook.utils import url_escape, url_path_join
 from tornado import web
 from traitlets.config import Application
 
-from biokbase.auth import get_token_info, init_session_env
+from biokbase.auth import get_token_info, get_user_info, init_session_env
 from biokbase.narrative.common.kblogging import get_logger, log_event
 from biokbase.narrative.common.url_config import URLS
 from biokbase.narrative.common.util import kbase_env
@@ -35,7 +35,7 @@ def _init_session(request, cookies):
             reason="Authorization required for Narrative access",
         )
     if token != kbase_env.auth_token:
-        init_session_env(get_token_info(token), client_ip)
+        init_session_env(get_token_info(token), get_user_info(token), client_ip)
         log_event(g_log, "session_start", {"user": kbase_env.user, "user_agent": ua})
 
 
@@ -83,7 +83,7 @@ class NarrativeMainHandler(IPythonHandler):
                 kill_kernel=False,
                 mathjax_url=self.mathjax_url,
                 google_analytics_id=URLS.google_analytics_id,
-                userName=kbase_env.user,
+                anon_user_id=kbase_env.anon_user_id,
                 google_ad_id=URLS.google_ad_id,
                 google_ad_conversion=URLS.google_ad_conversion,
             )

--- a/src/biokbase/narrative/tests/test_auth.py
+++ b/src/biokbase/narrative/tests/test_auth.py
@@ -6,6 +6,7 @@ from requests import HTTPError
 
 from biokbase.auth import (
     TokenInfo,
+    UserInfo,
     get_agent_token,
     get_auth_token,
     get_display_names,
@@ -144,14 +145,17 @@ def test_init_session_env():
     ip = "127.0.0.1"
     token_id = "some-token-id"
     user = "kbase_user"
+    anonymous_id = "some_anon_id"
 
     token_info = TokenInfo({"id": token_id, "user": user}, token=token)
-    init_session_env(token_info, ip)
+    user_info = UserInfo({"user": user, "anonid": anonymous_id})
+    init_session_env(token_info, user_info, ip)
     assert get_auth_token() == token
     assert kbase_env.session == token_info.token_id
     assert kbase_env.user == token_info.user
     assert kbase_env.client_ip == ip
-    init_session_env(TokenInfo({}), None)
+    assert kbase_env.anon_user_id == anonymous_id
+    init_session_env(TokenInfo({}), UserInfo({}), None)
 
 
 def test_get_agent_token_ok(mock_token_endpoint):


### PR DESCRIPTION
# Description of PR purpose/changes

This uses the previously introduced `get_user_info` call to set up the anonymous user id and send it off to Google Analytics. There's a few other minor tweaks here, too - the anon id gets added to the user's environment on session startup, and some bits of linting cleanup.

TODO:
- [ ] full integration test

List any dependencies that are required for this change.
* Depends on #3342 and #3343 
* Depends on Auth version 0.6.0. This will work without it, but will send a blank username instead.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-36
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [n/a] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
