### PR TITLE
PTV-1900: Add putative-ref to transform types; convert app_util tests over to u…

### DIFF
--- a/src/biokbase/narrative/clients.py
+++ b/src/biokbase/narrative/clients.py
@@ -7,34 +7,28 @@ from biokbase.workspace.client import Workspace
 
 
 def get(client_name, token=None):
+    """Retrieve the client for a KBase service."""
     return __init_client(client_name, token=token)
-
-
-def reset():
-    # this is never used
-    pass
 
 
 def __init_client(client_name, token=None):
     if client_name == "workspace":
-        c = Workspace(URLS.workspace, token=token)
-    elif client_name == "execution_engine2":
-        c = execution_engine2(URLS.execution_engine2, token=token)
-    elif client_name == "narrative_method_store":
-        c = NarrativeMethodStore(URLS.narrative_method_store, token=token)
-    elif client_name == "service":
-        c = ServiceClient(URLS.service_wizard, use_url_lookup=True, token=token)
-    elif client_name == "catalog":
-        c = Catalog(URLS.catalog, token=token)
-    else:
-        raise ValueError(
-            'Unknown client name "%s"\n' % client_name
-            + "The following client names are recognised:\n"
-            + 'Catalog: "catalog"\n'
-            + 'Execution Engine 2: "execution_engine2"\n'
-            + 'NMS: "narrative_method_store"\n'
-            + 'Service Wizard: "service"\n'
-            + 'Workspace: "workspace"'
-        )
+        return Workspace(URLS.workspace, token=token)
+    if client_name == "execution_engine2":
+        return execution_engine2(URLS.execution_engine2, token=token)
+    if client_name == "narrative_method_store":
+        return NarrativeMethodStore(URLS.narrative_method_store, token=token)
+    if client_name == "service":
+        return ServiceClient(URLS.service_wizard, use_url_lookup=True, token=token)
+    if client_name == "catalog":
+        return Catalog(URLS.catalog, token=token)
 
-    return c
+    raise ValueError(
+        'Unknown client name "%s"\n' % client_name
+        + "The following client names are recognised:\n"
+        + 'Catalog: "catalog"\n'
+        + 'Execution Engine 2: "execution_engine2"\n'
+        + 'NMS: "narrative_method_store"\n'
+        + 'Service Wizard: "service"\n'
+        + 'Workspace: "workspace"'
+    )

--- a/src/biokbase/narrative/jobs/appmanager.py
+++ b/src/biokbase/narrative/jobs/appmanager.py
@@ -6,10 +6,10 @@ import functools
 import random
 import re
 import traceback
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional
 
-import biokbase.auth as auth
-import biokbase.narrative.clients as clients
+from biokbase import auth
+from biokbase.narrative import clients
 from biokbase.narrative.app_util import (
     extract_ws_refs,
     map_outputs_from_state,
@@ -23,12 +23,13 @@ from biokbase.narrative.system import (
     strict_system_variable,
     system_variable
 )
+
 from biokbase.narrative.widgetmanager import WidgetManager
 
-from . import specmanager
-from .job import Job
-from .jobcomm import MESSAGE_TYPE, JobComm
-from .jobmanager import JobManager
+from biokbase.narrative.jobs import specmanager
+from biokbase.narrative.jobs.job import Job
+from biokbase.narrative.jobs.jobcomm import MESSAGE_TYPE, JobComm
+from biokbase.narrative.jobs.jobmanager import JobManager
 
 """
 A module for managing apps, specs, requirements, and for starting jobs.
@@ -645,10 +646,10 @@ class AppManager:
         spec: dict,
         tag: str,
         param_set: dict,
-        version: str = None,
-        cell_id: str = None,
-        run_id: str = None,
-        ws_id: int = None,
+        version: Optional[str] = None,
+        cell_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        ws_id: Optional[int] = None,
     ) -> dict:
         """
         Builds the set of inputs for EE2.run_job and EE2.run_job_batch (RunJobParams) given a spec

--- a/src/biokbase/narrative/tests/conftest.py
+++ b/src/biokbase/narrative/tests/conftest.py
@@ -1,0 +1,15 @@
+"""General configurations and fixtures for the narrative tests."""
+
+import vcr
+
+# Set up a local instance of VCR that stores its recordings in
+# "src/biokbase/narrative/tests/data/cassettes/" and omits the
+# authorization header.
+#
+# If the files in the cassette_library_dir are deleted, they will
+# be rerecorded during the next test run.
+narrative_vcr = vcr.VCR(
+    cassette_library_dir="src/biokbase/narrative/tests/data/cassettes/",
+    record_mode="once",
+    filter_headers=["authorization"],
+)

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-name_resolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-name_resolved-ref.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/some_defective_name"}]}], "version":
+      "1.1", "id": "019036565533659622"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: '{"version":"1.1","error":{"name":"JSONRPCError","code":-32500,"message":"No
+        object with name some_defective_name exists in workspace 69356 (name test_narrative:narrative_1695311690413)","error":"us.kbase.workspace.database.exceptions.NoSuchObjectException:
+        No object with name some_defective_name exists in workspace 69356 (name test_narrative:narrative_1695311690413)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.queryObjects(MongoWorkspaceDB.java:3069)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveObjectIDs(MongoWorkspaceDB.java:3013)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.getObjectInformation(MongoWorkspaceDB.java:2966)\n\tat
+        us.kbase.workspace.database.Workspace.getObjectInformation(Workspace.java:1367)\n\tat
+        us.kbase.workspace.kbase.WorkspaceServerMethods.getObjectInformation(WorkspaceServerMethods.java:416)\n\tat
+        us.kbase.workspace.WorkspaceServer.getObjectInfo3(WorkspaceServer.java:1155)\n\tat
+        sun.reflect.GeneratedMethodAccessor100.invoke(Unknown Source)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+        java.lang.reflect.Method.invoke(Method.java:498)\n\tat us.kbase.common.service.JsonServerServlet.processRpcCall(JsonServerServlet.java:681)\n\tat
+        us.kbase.common.service.JsonServerServlet.doPost(JsonServerServlet.java:553)\n\tat
+        javax.servlet.http.HttpServlet.service(HttpServlet.java:660)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:741)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:200)\n\tat
+        org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)\n\tat
+        org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:543)\n\tat
+        org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)\n\tat
+        org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)\n\tat
+        org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)\n\tat
+        org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)\n\tat
+        org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)\n\tat
+        org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:609)\n\tat
+        org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)\n\tat
+        org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:810)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1630)\n\tat
+        org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n\tat
+        org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1082)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:566)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:544)\n\tat
+        sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:126)\n\tat sun.nio.ch.Invoker$2.run(Invoker.java:218)\n\tat
+        sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)\n\tat
+        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat
+        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat
+        java.lang.Thread.run(Thread.java:748)\n"},"id":"019036565533659622"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57c5e8b02700-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-name_upa.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-name_upa.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/some_defective_name"}]}], "version":
+      "1.1", "id": "8890448093950898"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: '{"version":"1.1","error":{"name":"JSONRPCError","code":-32500,"message":"No
+        object with name some_defective_name exists in workspace 69356 (name test_narrative:narrative_1695311690413)","error":"us.kbase.workspace.database.exceptions.NoSuchObjectException:
+        No object with name some_defective_name exists in workspace 69356 (name test_narrative:narrative_1695311690413)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.queryObjects(MongoWorkspaceDB.java:3069)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveObjectIDs(MongoWorkspaceDB.java:3013)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.getObjectInformation(MongoWorkspaceDB.java:2966)\n\tat
+        us.kbase.workspace.database.Workspace.getObjectInformation(Workspace.java:1367)\n\tat
+        us.kbase.workspace.kbase.WorkspaceServerMethods.getObjectInformation(WorkspaceServerMethods.java:416)\n\tat
+        us.kbase.workspace.WorkspaceServer.getObjectInfo3(WorkspaceServer.java:1155)\n\tat
+        sun.reflect.GeneratedMethodAccessor100.invoke(Unknown Source)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+        java.lang.reflect.Method.invoke(Method.java:498)\n\tat us.kbase.common.service.JsonServerServlet.processRpcCall(JsonServerServlet.java:681)\n\tat
+        us.kbase.common.service.JsonServerServlet.doPost(JsonServerServlet.java:553)\n\tat
+        javax.servlet.http.HttpServlet.service(HttpServlet.java:660)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:741)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:200)\n\tat
+        org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)\n\tat
+        org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:543)\n\tat
+        org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)\n\tat
+        org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)\n\tat
+        org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)\n\tat
+        org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)\n\tat
+        org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)\n\tat
+        org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:609)\n\tat
+        org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)\n\tat
+        org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:810)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1630)\n\tat
+        org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n\tat
+        org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1082)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:566)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:544)\n\tat
+        sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:126)\n\tat sun.nio.ch.Invoker$2.run(Invoker.java:218)\n\tat
+        sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)\n\tat
+        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat
+        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat
+        java.lang.Thread.run(Thread.java:748)\n"},"id":"8890448093950898"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57c4f842cebd-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-upa_ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-upa_ref.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "666/666/666"}]}], "version": "1.1", "id": "7898995914794643"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '135'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: '{"version":"1.1","error":{"name":"JSONRPCError","code":-32500,"message":"Object
+        666 cannot be accessed: Workspace 666 is deleted","error":"us.kbase.workspace.database.exceptions.InaccessibleObjectException:
+        Object 666 cannot be accessed: Workspace 666 is deleted\n\tat us.kbase.workspace.database.PermissionsCheckerFactory$ObjectPermissionsChecker.check(PermissionsCheckerFactory.java:312)\n\tat
+        us.kbase.workspace.database.ObjectResolver.resolve(ObjectResolver.java:202)\n\tat
+        us.kbase.workspace.database.ObjectResolver.<init>(ObjectResolver.java:79)\n\tat
+        us.kbase.workspace.database.ObjectResolver.<init>(ObjectResolver.java:37)\n\tat
+        us.kbase.workspace.database.ObjectResolver$Builder.resolve(ObjectResolver.java:592)\n\tat
+        us.kbase.workspace.database.Workspace.getObjectInformation(Workspace.java:1365)\n\tat
+        us.kbase.workspace.kbase.WorkspaceServerMethods.getObjectInformation(WorkspaceServerMethods.java:416)\n\tat
+        us.kbase.workspace.WorkspaceServer.getObjectInfo3(WorkspaceServer.java:1155)\n\tat
+        sun.reflect.GeneratedMethodAccessor100.invoke(Unknown Source)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+        java.lang.reflect.Method.invoke(Method.java:498)\n\tat us.kbase.common.service.JsonServerServlet.processRpcCall(JsonServerServlet.java:681)\n\tat
+        us.kbase.common.service.JsonServerServlet.doPost(JsonServerServlet.java:553)\n\tat
+        javax.servlet.http.HttpServlet.service(HttpServlet.java:660)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:741)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:200)\n\tat
+        org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)\n\tat
+        org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:543)\n\tat
+        org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)\n\tat
+        org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)\n\tat
+        org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)\n\tat
+        org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)\n\tat
+        org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)\n\tat
+        org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:609)\n\tat
+        org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)\n\tat
+        org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:810)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1630)\n\tat
+        org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n\tat
+        org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1082)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:566)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:544)\n\tat
+        sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:126)\n\tat sun.nio.ch.Invoker$2.run(Invoker.java:218)\n\tat
+        sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)\n\tat
+        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat
+        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat
+        java.lang.Thread.run(Thread.java:748)\nCaused by: us.kbase.workspace.database.exceptions.NoSuchWorkspaceException:
+        Workspace 666 is deleted\n\tat us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveWorkspaces(MongoWorkspaceDB.java:1217)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveWorkspaces(MongoWorkspaceDB.java:1191)\n\tat
+        us.kbase.workspace.database.PermissionsCheckerFactory$ObjectPermissionsChecker.check(PermissionsCheckerFactory.java:309)\n\t...
+        41 more\n"},"id":"7898995914794643"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57c6cd4c943e-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-upa_unresolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-fail-upa_unresolved-ref.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "666/666/666"}]}], "version": "1.1", "id": "5647908433060499"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '135'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: '{"version":"1.1","error":{"name":"JSONRPCError","code":-32500,"message":"Object
+        666 cannot be accessed: Workspace 666 is deleted","error":"us.kbase.workspace.database.exceptions.InaccessibleObjectException:
+        Object 666 cannot be accessed: Workspace 666 is deleted\n\tat us.kbase.workspace.database.PermissionsCheckerFactory$ObjectPermissionsChecker.check(PermissionsCheckerFactory.java:312)\n\tat
+        us.kbase.workspace.database.ObjectResolver.resolve(ObjectResolver.java:202)\n\tat
+        us.kbase.workspace.database.ObjectResolver.<init>(ObjectResolver.java:79)\n\tat
+        us.kbase.workspace.database.ObjectResolver.<init>(ObjectResolver.java:37)\n\tat
+        us.kbase.workspace.database.ObjectResolver$Builder.resolve(ObjectResolver.java:592)\n\tat
+        us.kbase.workspace.database.Workspace.getObjectInformation(Workspace.java:1365)\n\tat
+        us.kbase.workspace.kbase.WorkspaceServerMethods.getObjectInformation(WorkspaceServerMethods.java:416)\n\tat
+        us.kbase.workspace.WorkspaceServer.getObjectInfo3(WorkspaceServer.java:1155)\n\tat
+        sun.reflect.GeneratedMethodAccessor100.invoke(Unknown Source)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+        java.lang.reflect.Method.invoke(Method.java:498)\n\tat us.kbase.common.service.JsonServerServlet.processRpcCall(JsonServerServlet.java:681)\n\tat
+        us.kbase.common.service.JsonServerServlet.doPost(JsonServerServlet.java:553)\n\tat
+        javax.servlet.http.HttpServlet.service(HttpServlet.java:660)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:741)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:200)\n\tat
+        org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)\n\tat
+        org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:543)\n\tat
+        org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)\n\tat
+        org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)\n\tat
+        org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)\n\tat
+        org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)\n\tat
+        org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)\n\tat
+        org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:609)\n\tat
+        org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)\n\tat
+        org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:810)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1630)\n\tat
+        org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n\tat
+        org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1082)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:566)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:544)\n\tat
+        sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:126)\n\tat sun.nio.ch.Invoker$2.run(Invoker.java:218)\n\tat
+        sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)\n\tat
+        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat
+        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat
+        java.lang.Thread.run(Thread.java:748)\nCaused by: us.kbase.workspace.database.exceptions.NoSuchWorkspaceException:
+        Workspace 666 is deleted\n\tat us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveWorkspaces(MongoWorkspaceDB.java:1217)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveWorkspaces(MongoWorkspaceDB.java:1191)\n\tat
+        us.kbase.workspace.database.PermissionsCheckerFactory$ObjectPermissionsChecker.check(PermissionsCheckerFactory.java:309)\n\t...
+        41 more\n"},"id":"5647908433060499"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57c79a74fa1e-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-invalid-name_putative-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-invalid-name_putative-ref.yaml
@@ -1,0 +1,84 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/some_defective_name"}]}], "version":
+      "1.1", "id": "6639633925777726"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: '{"version":"1.1","error":{"name":"JSONRPCError","code":-32500,"message":"No
+        object with name some_defective_name exists in workspace 69356 (name test_narrative:narrative_1695311690413)","error":"us.kbase.workspace.database.exceptions.NoSuchObjectException:
+        No object with name some_defective_name exists in workspace 69356 (name test_narrative:narrative_1695311690413)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.queryObjects(MongoWorkspaceDB.java:3069)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveObjectIDs(MongoWorkspaceDB.java:3013)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.getObjectInformation(MongoWorkspaceDB.java:2966)\n\tat
+        us.kbase.workspace.database.Workspace.getObjectInformation(Workspace.java:1367)\n\tat
+        us.kbase.workspace.kbase.WorkspaceServerMethods.getObjectInformation(WorkspaceServerMethods.java:416)\n\tat
+        us.kbase.workspace.WorkspaceServer.getObjectInfo3(WorkspaceServer.java:1155)\n\tat
+        sun.reflect.GeneratedMethodAccessor100.invoke(Unknown Source)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+        java.lang.reflect.Method.invoke(Method.java:498)\n\tat us.kbase.common.service.JsonServerServlet.processRpcCall(JsonServerServlet.java:681)\n\tat
+        us.kbase.common.service.JsonServerServlet.doPost(JsonServerServlet.java:553)\n\tat
+        javax.servlet.http.HttpServlet.service(HttpServlet.java:660)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:741)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:200)\n\tat
+        org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)\n\tat
+        org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:543)\n\tat
+        org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)\n\tat
+        org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)\n\tat
+        org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)\n\tat
+        org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)\n\tat
+        org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)\n\tat
+        org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:609)\n\tat
+        org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)\n\tat
+        org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:810)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1630)\n\tat
+        org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n\tat
+        org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1082)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:566)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:544)\n\tat
+        sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:126)\n\tat sun.nio.ch.Invoker$2.run(Invoker.java:218)\n\tat
+        sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)\n\tat
+        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat
+        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat
+        java.lang.Thread.run(Thread.java:748)\n"},"id":"6639633925777726"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57c1feb6cfbc-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:04 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-invalid-upa_putative-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-invalid-upa_putative-ref.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/666/666"}]}], "version": "1.1", "id": "9585510138637938"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: '{"version":"1.1","error":{"name":"JSONRPCError","code":-32500,"message":"No
+        object with id 666 exists in workspace 69356 (name test_narrative:narrative_1695311690413)","error":"us.kbase.workspace.database.exceptions.NoSuchObjectException:
+        No object with id 666 exists in workspace 69356 (name test_narrative:narrative_1695311690413)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.queryObjects(MongoWorkspaceDB.java:3069)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.resolveObjectIDs(MongoWorkspaceDB.java:3013)\n\tat
+        us.kbase.workspace.database.mongo.MongoWorkspaceDB.getObjectInformation(MongoWorkspaceDB.java:2966)\n\tat
+        us.kbase.workspace.database.Workspace.getObjectInformation(Workspace.java:1367)\n\tat
+        us.kbase.workspace.kbase.WorkspaceServerMethods.getObjectInformation(WorkspaceServerMethods.java:416)\n\tat
+        us.kbase.workspace.WorkspaceServer.getObjectInfo3(WorkspaceServer.java:1155)\n\tat
+        sun.reflect.GeneratedMethodAccessor100.invoke(Unknown Source)\n\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\n\tat
+        java.lang.reflect.Method.invoke(Method.java:498)\n\tat us.kbase.common.service.JsonServerServlet.processRpcCall(JsonServerServlet.java:681)\n\tat
+        us.kbase.common.service.JsonServerServlet.doPost(JsonServerServlet.java:553)\n\tat
+        javax.servlet.http.HttpServlet.service(HttpServlet.java:660)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:741)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193)\n\tat
+        org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166)\n\tat
+        org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:200)\n\tat
+        org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96)\n\tat
+        org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:543)\n\tat
+        org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139)\n\tat
+        org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:81)\n\tat
+        org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:678)\n\tat
+        org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:87)\n\tat
+        org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343)\n\tat
+        org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:609)\n\tat
+        org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65)\n\tat
+        org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:810)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1630)\n\tat
+        org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)\n\tat
+        org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1082)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:566)\n\tat
+        org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:544)\n\tat
+        sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:126)\n\tat sun.nio.ch.Invoker$2.run(Invoker.java:218)\n\tat
+        sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)\n\tat
+        java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat
+        java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat
+        java.lang.Thread.run(Thread.java:748)\n"},"id":"9585510138637938"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce5d39fae917de-SJC
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:47:48 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<putative-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<putative-ref>.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "2675810953611064"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57926c9c9809-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<ref>.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "08620245236939905"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce578cfd3f2578-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<resolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<resolved-ref>.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "5823912802644593"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce578ec8f3168e-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<unresolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<unresolved-ref>.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "4832195988988377"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57909e7c174a-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<upa>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-list<upa>.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "5558044856819974"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57945db3fa92-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-putative-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-putative-ref.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "24128225686497762"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce5791797acf6d-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-ref.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "11376069078642037"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce578c0c752566-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-resolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-resolved-ref.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "05417880718114476"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce578dea13fa56-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-unresolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-unresolved-ref.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "6961252451568651"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce578fbd26f9d8-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-upa.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name-upa.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "9043335670185586"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57935a939e68-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<putative-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<putative-ref>.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "6868213857949637"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b0cd272517-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "7700089701663704"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b1aece5c17-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<ref>.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "664861539836858"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '194'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a5f92cf973-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "3948364729644893"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a6ce2a964b-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<resolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<resolved-ref>.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "4898863047254767"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a97a62238d-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "37370576671838607"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '185'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57aa4abe15b8-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<unresolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<unresolved-ref>.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "6278059118850368"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57ad0bde228b-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "9159416400867487"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57ae0d5315c6-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<upa>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-list<upa>.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "3735436678276921"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b41f78fa2a-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "7512476739868984"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b50ee61749-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-putative-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-putative-ref.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "8502678198114875"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57aee90bfb28-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "43936831327729686"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '185'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57afdb4b9815-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-ref.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "9451668389803797"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a449ca942c-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "7832016713154895"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a50c60229f-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-resolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-resolved-ref.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "3368167130501666"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a7ae529831-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "8919349194609231"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a87dcb15d0-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-unresolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-unresolved-ref.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "9570711717195924"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57ab1a5017e6-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "4486022654893512"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57ac0b541686-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-upa.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-name_arr-upa.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "41322998182097803"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b27ce717c4-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "02633622972070504"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '185'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b34871176b-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-list<putative-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-list<putative-ref>.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "5304643676109494"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce578aea336459-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-list<ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-list<ref>.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "1245321089195931"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57871e69cf9b-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:55 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-list<unresolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-list<unresolved-ref>.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "2907492457617694"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce5788fc74ce3c-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:55 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-putative-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-putative-ref.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "7461661505703197"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce5789ee6097b5-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:55 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-ref.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "742492376935645"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '132'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce578638bc24f3-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:55 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-unresolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa-unresolved-ref.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "9857562567102288"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57881daacedd-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:55 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-list<putative-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-list<putative-ref>.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "3861931057573338"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a28ba66435-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/4/1"}]}], "version": "1.1", "id": "9347741959488903"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a3696d9661-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-list<ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-list<ref>.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "9327938860025781"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579b2c9bcfd5-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:58 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/4/1"}]}], "version": "1.1", "id": "5688214959027291"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579c187d1694-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:58 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-list<unresolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-list<unresolved-ref>.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "6262155235582874"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579eea88967c-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/4/1"}]}], "version": "1.1", "id": "14637615011757632"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579fba6315e1-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-putative-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-putative-ref.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "20685464572847923"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a0be442344-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/4/1"}]}], "version": "1.1", "id": "4903715051984069"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57a19e61cfc0-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-ref.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "7073959133216069"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579969b71698-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:58 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/4/1"}]}], "version": "1.1", "id": "6361266837575867"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579a2a59fa8a-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:58 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-unresolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-upa_arr-unresolved-ref.yaml
@@ -1,0 +1,104 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/5/2"}]}], "version": "1.1", "id": "6066925784412737"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579d1d786434-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:58 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "69356/4/1"}]}], "version": "1.1", "id": "9531875622757315"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579de985168e-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-list<resolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-list<resolved-ref>.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "05165896942101034"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57963e26238d-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-list<upa>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-list<upa>.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "5560369092337673"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57983ec915f1-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:58 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-resolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-resolved-ref.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "8515781596298805"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57954af097ff-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-upa.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name-upa.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "7438437511579054"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce579748c4fa6a-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:43:58 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-list<resolved-ref>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-list<resolved-ref>.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "21745469274221219"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b7ad6d9694-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:03 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "8177522783452752"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b88dd9643a-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:03 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-list<upa>.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-list<upa>.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "6706158966156789"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57be2c93cf8f-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:04 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "6396614289266421"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57c119cf968e-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:04 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-resolved-ref.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-resolved-ref.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "3773347988668643"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b5f843cfd5-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "8181691184404177"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b6cc94944a-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:03 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-upa.yaml
+++ b/src/biokbase/narrative/tests/data/cassettes/test_app_util/transform_param_value-ws_name_arr-upa.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/Abiotrophia_defectiva_ATCC_49176"}]}],
+      "version": "1.1", "id": "5767791806583695"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '195'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PPWsDMQz9L1rru1j+rG9LM3Tomi2Yw73qiOFqB9vJEvLfa1LoUCGkh97TE7rD
+        jUqNOcEEOCIwKFSvW4PpdIeY1lw7OmkG+8+YW8mXcwzzF620tHgL8/54OMzKoTV98+MtVHqnlL+p
+        jr99QDvyTgku5MDdIMwR5dRT2RfeA5hg0Ki2OYVSQvckYMZJbf6Ppz80o3FaYq9coezm2iCSEtbR
+        aqUjaQSq5RW7ZtEq2ADM8s46ZOm6bd4zuIR2fj4Gz1s7vRPg/cM/fgAIZRLWDwEAAA==
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57b98cd9176a-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:03 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"method": "Workspace.get_object_info3", "params": [{"objects": [{"ref":
+      "test_narrative:narrative_1695311690413/_Nostoc_azollae__0708"}]}], "version":
+      "1.1", "id": "7298096164421983"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '184'
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ci.kbase.us/services/ws
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA11PTWvDMAz9L7rOSSV/JfFxlx4GO+1WjHETlwY8u8RuDyv97/M62GHiIT2kx3vo
+        DrewlTUnMEA9AYMtlGusYA53WNMpl8YOkoF7z6Xm2fmvHKMPzuGAY5O/vfoS9iHlz1D639nR0GM7
+        ceSiw6nj9EHaEBkpXrAVMGJQQ6ku+W3zdb0FYHoSSv9fmz/mSE9KUOsoSfyYe94w+2XhIw6LJk3z
+        wvF4WpTEYTq2EE04KqlYusZoLYOLr+fnO/AM28kdgbUP+/gGGyZNNwUBAAA=
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 80ce57babd0e9434-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 26 Sep 2023 20:44:03 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/biokbase/narrative/tests/test.cfg
+++ b/src/biokbase/narrative/tests/test.cfg
@@ -1,9 +1,9 @@
 [users]
-test_user=wjriehl
+test_user=test_narrative
 private_user=narrativetest
 
 [token_files]
-test_user=test/wjriehl.tok
+test_user=test/test.tok
 private_user=test/narrativetest.tok
 
 [narratives]

--- a/src/biokbase/narrative/tests/test_clients.py
+++ b/src/biokbase/narrative/tests/test_clients.py
@@ -1,6 +1,6 @@
-import unittest
+import pytest
 
-import biokbase.narrative.clients as clients
+from biokbase.narrative import clients
 from biokbase.catalog.Client import Catalog as Catalog_Client
 from biokbase.execution_engine2.execution_engine2Client import (
     execution_engine2 as EE2_Client,
@@ -10,23 +10,22 @@ from biokbase.service.Client import Client as Service_Client
 from biokbase.workspace.client import Workspace as WS_Client
 
 
-class ClientsTestCase(unittest.TestCase):
-    def test_valid_clients(self):
-        name_to_type = {
-            "workspace": WS_Client,
-            "execution_engine2": EE2_Client,
-            "narrative_method_store": NMS_Client,
-            "service": Service_Client,
-            "catalog": Catalog_Client,
-        }
+name_to_type_tests = [
+    ("workspace", WS_Client),
+    ("execution_engine2", EE2_Client),
+    ("narrative_method_store", NMS_Client),
+    ("service", Service_Client),
+    ("catalog", Catalog_Client),
+]
 
-        for client_name, client_type in name_to_type.items():
-            client = clients.get(client_name)
-            self.assertIsInstance(client, client_type)
 
-    def test_invalid_clients(self):
-        invalid_names = ["service_wizard", "ee2", "ws"]
+@pytest.mark.parametrize("client_name,client_type", name_to_type_tests)
+def test_valid_clients(client_name, client_type):
+    client = clients.get(client_name)
+    assert isinstance(client, client_type)
 
-        for name in invalid_names:
-            with self.assertRaisesRegex(ValueError, "Unknown client name"):
-                clients.get(name)
+
+@pytest.mark.parametrize("client_name", ["service_wizard", "ee2", "ws"])
+def test_invalid_clients(client_name):
+    with pytest.raises(ValueError, match="Unknown client name"):
+        clients.get(client_name)

--- a/src/biokbase/narrative/tests/test_system.py
+++ b/src/biokbase/narrative/tests/test_system.py
@@ -13,7 +13,9 @@ from .narrative_mock.mockclients import get_mock_client
 user_token = "SOME_TOKEN"
 config = util.ConfigTests()
 user_id = config.get("users", "test_user")
-user_token = util.read_token_file(config.get_path("token_files", "test_user", from_root=True))
+user_token = util.read_token_file(
+    config.get_path("token_files", "test_user", from_root=True)
+)
 
 # inject phony variables into the environment
 bad_fake_token = "NotAGoodTokenLOL"
@@ -23,43 +25,52 @@ bad_variable = "not a variable"
 
 # test standard system_variable function
 
+
 def test_sys_var_user():
     if user_token:
         biokbase.auth.set_environ_token(user_token)
         assert system_variable("user_id") == user_id
+
 
 def test_sys_var_no_ws():
     if "KB_WORKSPACE_ID" in os.environ:
         del os.environ["KB_WORKSPACE_ID"]
     assert system_variable("workspace") is None
 
+
 def test_sys_var_workspace():
     os.environ["KB_WORKSPACE_ID"] = workspace
     assert system_variable("workspace") == workspace
+
 
 def test_sys_var_no_ws_id():
     if "KB_WORKSPACE_ID" in os.environ:
         del os.environ["KB_WORKSPACE_ID"]
     assert system_variable("workspace_id") is None
 
+
 @mock.patch("biokbase.narrative.app_util.clients.get", get_mock_client)
 def test_sys_var_workspace_id():
     os.environ["KB_WORKSPACE_ID"] = workspace
     assert system_variable("workspace_id") == 12345
+
 
 @mock.patch("biokbase.narrative.app_util.clients.get", get_mock_client)
 def test_sys_var_workspace_id_except():
     os.environ["KB_WORKSPACE_ID"] = "invalid_workspace"
     assert system_variable("workspace_id") is None
 
+
 def test_sys_var_user_bad():
     biokbase.auth.set_environ_token(bad_fake_token)
     assert system_variable("user_id") is None
+
 
 def test_sys_var_user_none():
     if "KB_AUTH_TOKEN" in os.environ:
         del os.environ["KB_AUTH_TOKEN"]
     assert system_variable("user_id") is None
+
 
 def test_sys_var_time_ms():
     cur_t = int(time.time() * 1000)
@@ -67,11 +78,13 @@ def test_sys_var_time_ms():
     assert cur_t <= ts
     assert ts - cur_t < 1000
 
+
 def test_sys_var_time_sec():
     cur_t = int(time.time())
     ts = system_variable("timestamp_epoch_sec")
     assert cur_t <= ts
     assert ts - cur_t < 1
+
 
 def test_sys_var_bad():
     assert system_variable(bad_variable) is None
@@ -84,9 +97,12 @@ def test_strict_sys_var_user_ok():
         assert strict_system_variable("user_id") == user_id
         biokbase.auth.set_environ_token(None)
 
+
 def test_strict_sys_var_user_bad():
     biokbase.auth.set_environ_token(bad_fake_token)
-    with pytest.raises(ValueError, match='Unable to retrieve system variable: "user_id"') as e:
+    with pytest.raises(
+        ValueError, match='Unable to retrieve system variable: "user_id"'
+    ) as e:
         strict_system_variable("user_id")
         assert e
     biokbase.auth.set_environ_token(None)

--- a/src/biokbase/narrative/upa.py
+++ b/src/biokbase/narrative/upa.py
@@ -97,7 +97,7 @@ def deserialize(serial_upa: str) -> str:
     if not isinstance(serial_upa, str):
         raise ValueError("Can only deserialize UPAs from strings.")
     if serial_upa.startswith(external_tag):
-        deserial = serial_upa[len(external_tag):]
+        deserial = serial_upa[len(external_tag) :]
     else:
         ws_id = system_variable("workspace_id")
         if ws_id is None:

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -52,7 +52,7 @@ class WidgetManager:
     This will fetch and render a widget and its required environment from the configured external CDN.
     """
 
-    widget_info = dict()
+    widget_info = {}
     _version_tags = ["release", "beta", "dev"]
     _cell_id_prefix = "kb-vis-"
     _default_input_widget = "kbaseNarrativeDefaultInput"
@@ -67,7 +67,7 @@ class WidgetManager:
             )
             self.widget_param_map = json.loads(widget_param_file.read())
         except BaseException:
-            self.widget_param_map = dict()
+            self.widget_param_map = {}
         self.reload_info()
 
     def reload_info(self):
@@ -81,7 +81,7 @@ class WidgetManager:
         Loads all widget info and stores it in this object.
         It does this by calling load_widget_info on all available tags.
         """
-        info = dict()
+        info = {}
         for tag in self._version_tags:
             info[tag] = self.load_widget_info(tag)
         return info
@@ -108,7 +108,7 @@ class WidgetManager:
         check_tag(tag, raise_exception=True)
 
         methods = list(self._sm.app_specs[tag].values())
-        all_widgets = dict()
+        all_widgets = {}
         """
         keys = widget names / namespaced require path / etc.
          Individual widget values should be:
@@ -322,7 +322,7 @@ class WidgetManager:
             raise ValueError("Widget %s not found!" % widget_name)
 
         params = self.widget_info[tag][widget_name]["params"]
-        constants = dict()
+        constants = {}
         for p in params:
             if params[p]["is_constant"]:
                 if "param_value" in params[p]:
@@ -370,7 +370,7 @@ class WidgetManager:
             with WidgetManager.print_widget_inputs()
         """
 
-        input_data = dict()
+        input_data = {}
 
         if check_widget:
             check_tag(tag, raise_exception=True)
@@ -455,10 +455,10 @@ class WidgetManager:
 
         """
         param_to_context = self.widget_param_map.get(widget_name, {})
-        obj_names = list()  # list of tuples - first = param id, second = object name
-        obj_refs = list()  # list of tuples - first = param id, second = UPA
-        obj_name_list = list()  # list of tuples, but the second is a list of names
-        obj_ref_list = list()  # list of tuples, but second is a list of upas
+        obj_names = []  # list of tuples - first = param id, second = object name
+        obj_refs = []  # list of tuples - first = param id, second = UPA
+        obj_name_list = []  # list of tuples, but the second is a list of names
+        obj_ref_list = []  # list of tuples, but second is a list of upas
         ws = None
         for param in params.keys():
             if param in param_to_context and params.get(param) is not None:
@@ -481,13 +481,13 @@ class WidgetManager:
         #   param3: [upa1, upa2],
         #   ... etc
         # }
-        upas = dict()
+        upas = {}
 
         # First, test obj_refs, and obj_refs_list
         # These might be references of the form ws_name/obj_name, which are not proper UPAs and
         # need to be resolved. Gotta test 'em all.
-        lookup_params = list()
-        info_params = list()
+        lookup_params = []
+        info_params = []
 
         for param, ref in obj_refs:
             if is_upa(str(ref)):
@@ -520,8 +520,8 @@ class WidgetManager:
                 upas[lookup_params[idx]] = ";".join(path)
 
         # obj_refs and obj_names are done. Do the list versions now.
-        lookup_params = list()
-        info_params = list()
+        lookup_params = []
+        info_params = []
         for param, ref_list in obj_ref_list:
             # error fast if any member of a list isn't actually a ref.
             # this might be me being lazy, but I suspect there's a problem if the inputs aren't
@@ -535,7 +535,7 @@ class WidgetManager:
             info_params.append([{"ref": ref} for ref in ref_list])
 
         for param, name_list in obj_name_list:
-            info_param = list()
+            info_param = []
             for name in name_list:
                 if is_ref(str(name)):
                     info_param.append({"ref": name})
@@ -584,7 +584,7 @@ class WidgetManager:
             with WidgetManager.print_widget_inputs()
         """
 
-        input_data = dict()
+        input_data = {}
 
         if check_widget:
             check_tag(tag, raise_exception=True)
@@ -653,8 +653,8 @@ class WidgetManager:
             release state (should be one of release, beta, or dev)
         """
         widget_name = "widgets/function_output/kbaseDefaultObjectView"  # set as default, overridden below
-        widget_data = dict()
-        upas = dict()
+        widget_data = {}
+        upas = {}
         info_tuple = clients.get("workspace").get_object_info_new(
             {"objects": [{"ref": upa}], "includeMetadata": 1}
         )[0]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -24,3 +24,4 @@ requests==2.31.0
 requests-mock==1.11.0
 rsa==4.9
 terminado==0.17.1
+vcrpy==5.1.0


### PR DESCRIPTION
Add putative-ref to transform types
Convert app_util tests over to using vcrpy to capture live resp/reqs from the WS

# Description of PR purpose/changes

* Please include a summary of the change and which issue is fixed.
* Please also include relevant motivation and context.
* List any dependencies that are required for this change.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1900
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [-] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
