### PR TITLE
DATAUP-765: add user and wsid to job output

### DIFF
--- a/src/biokbase/narrative/jobs/jobmanager.py
+++ b/src/biokbase/narrative/jobs/jobmanager.py
@@ -1,17 +1,16 @@
 import copy
 from datetime import datetime, timedelta, timezone
-from typing import List, Tuple
+from typing import Any
 
-from IPython.display import HTML
-from jinja2 import Template
-
-import biokbase.narrative.clients as clients
-from biokbase.narrative.system import system_variable
+from biokbase.narrative import clients
 from biokbase.narrative.common import kblogging
 from biokbase.narrative.exception_util import (
     JobRequestException,
     transform_job_exception,
 )
+from biokbase.narrative.system import system_variable
+from IPython.display import HTML
+from jinja2 import Template
 
 from .job import JOB_INIT_EXCLUDED_JOB_STATE_FIELDS, Job
 
@@ -54,7 +53,7 @@ class JobManager:
 
     _log = kblogging.get_logger(__name__)
 
-    def __new__(cls):
+    def __new__(cls) -> "JobManager":
         if JobManager.__instance is None:
             JobManager.__instance = object.__new__(cls)
         return JobManager.__instance
@@ -70,14 +69,14 @@ class JobManager:
         return {job_id: states[job_id] for job_id in ordering}
 
     def _check_job_list(
-        self, input_ids: List[str] = None
-    ) -> Tuple[List[str], List[str]]:
+        self: "JobManager", input_ids: list[str] | None = None
+    ) -> tuple[list[str], list[str]]:
         """
         Deduplicates the input job list, maintaining insertion order.
         Any jobs not present in self._running_jobs are added to an error list
 
         :param input_ids: list of putative job IDs, defaults to []
-        :type input_ids: List[str], optional
+        :type input_ids: list[str], optional
 
         :raises JobRequestException: if the input_ids parameter is not a list or
         or if there are no valid job IDs supplied
@@ -85,7 +84,7 @@ class JobManager:
         :return: tuple with items
             job_ids - valid job IDs
             error_ids - jobs that the narrative backend does not know about
-        :rtype: Tuple[List[str], List[str]]
+        :rtype: tuple[list[str], list[str]]
         """
         if not input_ids:
             raise JobRequestException(JOBS_MISSING_ERR, input_ids)
@@ -107,7 +106,9 @@ class JobManager:
 
         return job_ids, error_ids
 
-    def register_new_job(self, job: Job, refresh: bool = None) -> None:
+    def register_new_job(
+        self: "JobManager", job: Job, refresh: bool | None = None
+    ) -> None:
         """
         Registers a new Job with the manager and stores the job locally.
         This should only be invoked when a new Job gets started.
@@ -120,19 +121,19 @@ class JobManager:
         kblogging.log_event(self._log, "register_new_job", {"job_id": job.job_id})
 
         if refresh is None:
-            refresh = not job.was_terminal()
+            refresh = not job.in_terminal_state()
         self._running_jobs[job.job_id] = {"job": job, "refresh": refresh}
 
         # add the new job to the _jobs_by_cell_id mapping if there is a cell_id present
         if job.cell_id:
-            if job.cell_id not in self._jobs_by_cell_id.keys():
+            if job.cell_id not in self._jobs_by_cell_id:
                 self._jobs_by_cell_id[job.cell_id] = set()
 
             self._jobs_by_cell_id[job.cell_id].add(job.job_id)
             if job.batch_id:
                 self._jobs_by_cell_id[job.cell_id].add(job.batch_id)
 
-    def initialize_jobs(self, cell_ids: List[str] = None) -> None:
+    def initialize_jobs(self: "JobManager", cell_ids: list[str] | None = None) -> None:
         """
         Initializes this JobManager.
         This is expected to be run by a running Narrative, and naturally linked to a workspace.
@@ -143,7 +144,7 @@ class JobManager:
         4. start the status lookup loop.
 
         :param cell_ids: list of cell IDs to filter the existing jobs for, defaults to None
-        :type cell_ids: List[str], optional
+        :type cell_ids: list[str], optional
 
         :raises NarrativeException: if the call to ee2 fails
         """
@@ -161,10 +162,10 @@ class JobManager:
         except Exception as e:
             kblogging.log_event(self._log, "init_error", {"err": str(e)})
             new_e = transform_job_exception(e, "Unable to initialize jobs")
-            raise new_e
+            raise new_e from e
 
         self._running_jobs = {}
-        job_states = self._reorder_parents_children(job_states)
+        job_states: dict[str, Any] = self._reorder_parents_children(job_states)
         for job_state in job_states.values():
             child_jobs = None
             if job_state.get("batch_job"):
@@ -178,19 +179,19 @@ class JobManager:
             # Set to refresh when job is not in terminal state
             # and when job is present in cells (if given)
             # and when it is not part of a batch
-            refresh = not job.was_terminal() and not job.batch_id
+            refresh = not job.in_terminal_state() and not job.batch_id
             if cell_ids is not None:
                 refresh = refresh and job.in_cells(cell_ids)
 
             self.register_new_job(job, refresh)
 
-    def _create_jobs(self, job_ids: List[str]) -> dict:
+    def _create_jobs(self: "JobManager", job_ids: list[str]) -> dict:
         """
         Given a list of job IDs, creates job objects for them and populates the _running_jobs dictionary.
         TODO: error handling
 
         :param job_ids: job IDs to create job objects for
-        :type job_ids: List[str]
+        :type job_ids: list[str]
 
         :return: dictionary of job states indexed by job ID
         :rtype: dict
@@ -207,7 +208,7 @@ class JobManager:
 
         return job_states
 
-    def get_job(self, job_id: str) -> Job:
+    def get_job(self: "JobManager", job_id: str) -> Job:
         """
         Retrieve a job from the Job Manager's _running_jobs index.
 
@@ -224,8 +225,8 @@ class JobManager:
         return self._running_jobs[job_id]["job"]
 
     def _construct_job_output_state_set(
-        self, job_ids: List[str], states: dict = None
-    ) -> dict:
+        self: "JobManager", job_ids: list[str], states: dict[str, Any] | None = None
+    ) -> dict[str, dict[str, Any]]:
         """
         Builds a set of job states for the list of job ids.
 
@@ -263,7 +264,7 @@ class JobManager:
         }
 
         :param job_ids: list of job IDs
-        :type job_ids: List[str]
+        :type job_ids: list[str]
         :param states: dict of job state data from EE2, indexed by job ID, defaults to None
         :type states: dict, optional
 
@@ -278,6 +279,9 @@ class JobManager:
         if not job_ids:
             return {}
 
+        # ensure states is initialised
+        if not states:
+            states = {}
         output_states = {}
         jobs_to_lookup = []
 
@@ -285,17 +289,19 @@ class JobManager:
         # These are already post-processed and ready to return.
         for job_id in job_ids:
             job = self.get_job(job_id)
-            if job.was_terminal():
+            if job.in_terminal_state():
+                # job is already finished, will not change
                 output_states[job_id] = job.output_state()
-            elif states and job_id in states:
-                state = states[job_id]
-                output_states[job_id] = job.output_state(state)
+            elif job_id in states:
+                job.update_state(states[job_id])
+                output_states[job_id] = job.output_state()
             else:
                 jobs_to_lookup.append(job_id)
 
         fetched_states = {}
         # Get the rest of states direct from EE2.
         if jobs_to_lookup:
+            error_message = ""
             try:
                 fetched_states = Job.query_ee2_states(jobs_to_lookup, init=False)
             except Exception as e:
@@ -312,16 +318,19 @@ class JobManager:
             for job_id in jobs_to_lookup:
                 job = self.get_job(job_id)
                 if job_id in fetched_states:
-                    output_states[job_id] = job.output_state(fetched_states[job_id])
+                    job.update_state(fetched_states[job_id])
+                    output_states[job_id] = job.output_state()
                 else:
                     # fetch the current state without updating it
-                    output_states[job_id] = job.output_state({})
+                    output_states[job_id] = job.output_state()
                     # add an error field with the error message from the failed look up
                     output_states[job_id]["error"] = error_message
 
         return output_states
 
-    def get_job_states(self, job_ids: List[str], ts: int = None) -> dict:
+    def get_job_states(
+        self: "JobManager", job_ids: list[str], ts: int | None = None
+    ) -> dict:
         """
         Retrieves the job states for the supplied job_ids.
 
@@ -332,7 +341,7 @@ class JobManager:
         }
 
         :param job_ids: job IDs to retrieve job state data for
-        :type job_ids: List[str]
+        :type job_ids: list[str]
         :param ts: timestamp (as generated by time.time_ns()) to filter the jobs, defaults to None
         :type ts: int, optional
 
@@ -343,7 +352,9 @@ class JobManager:
         output_states = self._construct_job_output_state_set(job_ids)
         return self.add_errors_to_results(output_states, error_ids)
 
-    def get_all_job_states(self, ignore_refresh_flag=False) -> dict:
+    def get_all_job_states(
+        self: "JobManager", ignore_refresh_flag: bool = False
+    ) -> dict:
         """
         Fetches states for all running jobs.
         If ignore_refresh_flag is True, then returns states for all jobs this
@@ -356,23 +367,26 @@ class JobManager:
         :return: dictionary of job states, indexed by job ID
         :rtype: dict
         """
-        jobs_to_lookup = []
-
         # grab the list of running job ids, so we don't run into update-while-iterating problems.
-        for job_id in self._running_jobs:
-            if self._running_jobs[job_id]["refresh"] or ignore_refresh_flag:
-                jobs_to_lookup.append(job_id)
-        if len(jobs_to_lookup) > 0:
+        jobs_to_lookup = [
+            job_id
+            for job_id in self._running_jobs
+            if self._running_jobs[job_id]["refresh"] or ignore_refresh_flag
+        ]
+
+        if jobs_to_lookup:
             return self._construct_job_output_state_set(jobs_to_lookup)
         return {}
 
-    def _get_job_ids_by_cell_id(self, cell_id_list: List[str] = None) -> tuple:
+    def _get_job_ids_by_cell_id(
+        self: "JobManager", cell_id_list: list[str] | None = None
+    ) -> tuple:
         """
         Finds jobs with a cell_id in cell_id_list.
         Mappings of job ID to cell ID are added when new jobs are registered.
 
         :param cell_id_list: cell IDs to retrieve job state data for
-        :type cell_id_list: List[str]
+        :type cell_id_list: list[str]
 
         :return: tuple with two components:
             job_id_list: list of job IDs associated with the cell IDs supplied
@@ -392,12 +406,14 @@ class JobManager:
         job_id_list = set().union(*cell_to_job_mapping.values())
         return (job_id_list, cell_to_job_mapping)
 
-    def get_job_states_by_cell_id(self, cell_id_list: List[str] = None) -> dict:
+    def get_job_states_by_cell_id(
+        self: "JobManager", cell_id_list: list[str] | None = None
+    ) -> dict:
         """
         Retrieves the job states for jobs associated with the cell_id_list supplied.
 
         :param cell_id_list: cell IDs to retrieve job state data for
-        :type cell_id_list: List[str]
+        :type cell_id_list: list[str]
 
         :return: dictionary with two keys:
             'jobs': job states, indexed by job ID
@@ -413,7 +429,7 @@ class JobManager:
 
         return {"jobs": job_states, "mapping": cell_to_job_mapping}
 
-    def get_job_info(self, job_ids: List[str]) -> dict:
+    def get_job_info(self: "JobManager", job_ids: list[str]) -> dict:
         """
         Gets job information for a list of job IDs.
 
@@ -433,7 +449,7 @@ class JobManager:
         }
 
         :param job_ids: job IDs to retrieve job info for
-        :type job_ids: List[str]
+        :type job_ids: list[str]
         :return: job info for each job, indexed by job ID
         :rtype: dict
         """
@@ -452,10 +468,10 @@ class JobManager:
         return self.add_errors_to_results(infos, error_ids)
 
     def get_job_logs(
-        self,
+        self: "JobManager",
         job_id: str,
         first_line: int = 0,
-        num_lines: int = None,
+        num_lines: int | None = None,
         latest: bool = False,
     ) -> dict:
         """
@@ -518,7 +534,13 @@ class JobManager:
                     logs = logs[first_line:]
             else:
                 (max_lines, logs) = job.log(first_line=first_line, num_lines=num_lines)
-
+        except Exception as e:
+            return {
+                "job_id": job.job_id,
+                "batch_id": job.batch_id,
+                "error": e.message,
+            }
+        else:
             return {
                 "job_id": job.job_id,
                 "batch_id": job.batch_id,
@@ -527,18 +549,12 @@ class JobManager:
                 "max_lines": max_lines,
                 "lines": logs,
             }
-        except Exception as e:
-            return {
-                "job_id": job.job_id,
-                "batch_id": job.batch_id,
-                "error": e.message,
-            }
 
     def get_job_logs_for_list(
-        self,
-        job_id_list: List[str],
+        self: "JobManager",
+        job_id_list: list[str],
         first_line: int = 0,
-        num_lines: int = None,
+        num_lines: int | None = None,
         latest: bool = False,
     ) -> dict:
         """
@@ -551,7 +567,7 @@ class JobManager:
         }
 
         :param job_id_list: list of jobs to fetch logs for
-        :type job_id_list: List[str]
+        :type job_id_list: list[str]
         :param first_line: the first line to be returned, defaults to 0
         :type first_line: int, optional
         :param num_lines: number of lines to be returned, defaults to None
@@ -570,7 +586,7 @@ class JobManager:
 
         return self.add_errors_to_results(output, error_ids)
 
-    def cancel_jobs(self, job_id_list: List[str]) -> dict:
+    def cancel_jobs(self: "JobManager", job_id_list: list[str]) -> dict:
         """
         Cancel a list of jobs and return their new state. After sending the cancellation
         request, the job states are refreshed and their new output states returned.
@@ -588,7 +604,7 @@ class JobManager:
         }
 
         :param job_id_list: job IDs to cancel
-        :type job_id_list: List[str]
+        :type job_id_list: list[str]
 
         :return: job output states, indexed by job ID
         :rtype: dict
@@ -596,7 +612,7 @@ class JobManager:
         job_ids, error_ids = self._check_job_list(job_id_list)
         error_states = {}
         for job_id in job_ids:
-            if not self.get_job(job_id).was_terminal():
+            if not self.get_job(job_id).in_terminal_state():
                 error = self._cancel_job(job_id)
                 if error:
                     error_states[job_id] = error.message
@@ -608,7 +624,7 @@ class JobManager:
 
         return self.add_errors_to_results(job_states, error_ids)
 
-    def _cancel_job(self, job_id: str) -> None:
+    def _cancel_job(self: "JobManager", job_id: str) -> Exception | None:
         """
         Cancel a single job. If an error occurs during cancellation, that error is converted
         into a NarrativeException and returned to the caller.
@@ -633,7 +649,7 @@ class JobManager:
         del self._running_jobs[job_id]["canceling"]
         return error
 
-    def retry_jobs(self, job_id_list: List[str]) -> dict:
+    def retry_jobs(self: "JobManager", job_id_list: list[str]) -> dict:
         """
         Retry a list of job IDs, returning job output states for the jobs to be retried
         and the new jobs created by the retry command.
@@ -667,7 +683,7 @@ class JobManager:
         }
 
         :param job_id_list: list of job IDs
-        :type job_id_list: List[str]
+        :type job_id_list: list[str]
 
         :raises NarrativeException: if EE2 returns an error from the retry request
 
@@ -676,9 +692,9 @@ class JobManager:
         """
         job_ids, error_ids = self._check_job_list(job_id_list)
         try:
-            retry_results = clients.get("execution_engine2").retry_jobs(
-                {"job_ids": job_ids}
-            )
+            retry_results: list[dict[str, Any]] = clients.get(
+                "execution_engine2"
+            ).retry_jobs({"job_ids": job_ids})
         except Exception as e:
             raise transform_job_exception(e, "Unable to retry job(s)") from e
 
@@ -706,14 +722,16 @@ class JobManager:
                 results_by_job_id[job_id]["error"] = result["error"]
         return self.add_errors_to_results(results_by_job_id, error_ids)
 
-    def add_errors_to_results(self, results: dict, error_ids: List[str]) -> dict:
+    def add_errors_to_results(
+        self: "JobManager", results: dict, error_ids: list[str]
+    ) -> dict:
         """
         Add the generic "not found" error for each job_id in error_ids.
 
         :param results: dictionary of job data (output state, info, retry, etc.) indexed by job ID
         :type results: dict
         :param error_ids: list of IDs that could not be found
-        :type error_ids: List[str]
+        :type error_ids: list[str]
 
         :return: input results dictionary augmented by a dictionary containing job ID and a short
         not found error message for every ID in the error_ids list
@@ -726,7 +744,9 @@ class JobManager:
             }
         return results
 
-    def modify_job_refresh(self, job_ids: List[str], update_refresh: bool) -> None:
+    def modify_job_refresh(
+        self: "JobManager", job_ids: list[str], update_refresh: bool
+    ) -> None:
         """
         Modifies how many things want to get the job updated.
         If this sets the current "refresh" key to be less than 0, it gets reset to 0.
@@ -737,7 +757,7 @@ class JobManager:
         for job_id in job_ids:
             self._running_jobs[job_id]["refresh"] = update_refresh
 
-    def update_batch_job(self, batch_id: str) -> List[str]:
+    def update_batch_job(self: "JobManager", batch_id: str) -> list[str]:
         """
         Update a batch job and create child jobs if necessary
         """
@@ -755,13 +775,13 @@ class JobManager:
             else:
                 unreg_child_ids.append(job_id)
 
-        unreg_child_jobs = []
+        unreg_child_jobs: list[Job] = []
         if unreg_child_ids:
             unreg_child_jobs = Job.from_job_ids(unreg_child_ids)
             for job in unreg_child_jobs:
                 self.register_new_job(
                     job=job,
-                    refresh=not job.was_terminal(),
+                    refresh=not job.in_terminal_state(),
                 )
 
         batch_job.update_children(reg_child_jobs + unreg_child_jobs)

--- a/src/biokbase/narrative/tests/data/response_data.json
+++ b/src/biokbase/narrative/tests/data/response_data.json
@@ -408,7 +408,8 @@
                         "wsName": "wjriehl:1475006266615"
                     },
                     "tag": "release"
-                }
+                },
+                "wsid": 10538
             },
             "job_id": "BATCH_COMPLETED",
             "outputWidgetInfo": {
@@ -446,7 +447,8 @@
                     "BATCH_RETRY_ERROR"
                 ],
                 "running": 1625755952628,
-                "status": "error"
+                "status": "error",
+                "wsid": 10538
             },
             "job_id": "BATCH_ERROR_RETRIED",
             "outputWidgetInfo": null
@@ -469,7 +471,8 @@
                 "job_output": {},
                 "retry_count": 0,
                 "retry_ids": [],
-                "status": "created"
+                "status": "created",
+                "wsid": 10538
             },
             "job_id": "BATCH_PARENT",
             "outputWidgetInfo": null
@@ -509,7 +512,8 @@
                         "wsName": "wjriehl:1475006266615"
                     },
                     "tag": "release"
-                }
+                },
+                "wsid": 10538
             },
             "job_id": "BATCH_RETRY_COMPLETED",
             "outputWidgetInfo": {
@@ -546,7 +550,8 @@
                 "retry_ids": [],
                 "retry_parent": "BATCH_ERROR_RETRIED",
                 "running": 1625757662469,
-                "status": "error"
+                "status": "error",
+                "wsid": 10538
             },
             "job_id": "BATCH_RETRY_ERROR",
             "outputWidgetInfo": null
@@ -564,7 +569,8 @@
                 "retry_ids": [],
                 "retry_parent": "BATCH_TERMINATED_RETRIED",
                 "running": 1625757285899,
-                "status": "running"
+                "status": "running",
+                "wsid": 10538
             },
             "job_id": "BATCH_RETRY_RUNNING",
             "outputWidgetInfo": null
@@ -583,7 +589,8 @@
                 "retry_ids": [],
                 "running": 1625755952599,
                 "status": "terminated",
-                "terminated_code": 0
+                "terminated_code": 0,
+                "wsid": 10538
             },
             "job_id": "BATCH_TERMINATED",
             "outputWidgetInfo": null
@@ -605,7 +612,8 @@
                 ],
                 "running": 1625755952563,
                 "status": "terminated",
-                "terminated_code": 0
+                "terminated_code": 0,
+                "wsid": 10538
             },
             "job_id": "BATCH_TERMINATED_RETRIED",
             "outputWidgetInfo": null
@@ -641,7 +649,8 @@
                         "report_window_line_height": "16"
                     },
                     "tag": "dev"
-                }
+                },
+                "wsid": 54321
             },
             "job_id": "JOB_COMPLETED",
             "outputWidgetInfo": {
@@ -664,7 +673,8 @@
                 "job_output": {},
                 "retry_count": 0,
                 "retry_ids": [],
-                "status": "created"
+                "status": "created",
+                "wsid": 55555
             },
             "job_id": "JOB_CREATED",
             "outputWidgetInfo": null
@@ -690,7 +700,8 @@
                 "retry_count": 0,
                 "retry_ids": [],
                 "running": 1642431847689,
-                "status": "error"
+                "status": "error",
+                "wsid": 65854
             },
             "job_id": "JOB_ERROR",
             "outputWidgetInfo": null
@@ -707,7 +718,8 @@
                 "retry_count": 0,
                 "retry_ids": [],
                 "running": 1642521775867,
-                "status": "running"
+                "status": "running",
+                "wsid": 54321
             },
             "job_id": "JOB_RUNNING",
             "outputWidgetInfo": null
@@ -725,7 +737,8 @@
                 "retry_count": 0,
                 "retry_ids": [],
                 "status": "terminated",
-                "terminated_code": 0
+                "terminated_code": 0,
+                "wsid": 54321
             },
             "job_id": "JOB_TERMINATED",
             "outputWidgetInfo": null
@@ -780,7 +793,8 @@
                             "wsName": "wjriehl:1475006266615"
                         },
                         "tag": "release"
-                    }
+                    },
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_COMPLETED",
                 "outputWidgetInfo": {
@@ -821,7 +835,8 @@
                         "BATCH_RETRY_ERROR"
                     ],
                     "running": 1625755952628,
-                    "status": "error"
+                    "status": "error",
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_ERROR_RETRIED",
                 "outputWidgetInfo": null
@@ -849,7 +864,8 @@
                     "retry_ids": [],
                     "retry_parent": "BATCH_ERROR_RETRIED",
                     "running": 1625757662469,
-                    "status": "error"
+                    "status": "error",
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_RETRY_ERROR",
                 "outputWidgetInfo": null
@@ -876,7 +892,8 @@
                     "job_output": {},
                     "retry_count": 0,
                     "retry_ids": [],
-                    "status": "created"
+                    "status": "created",
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_PARENT",
                 "outputWidgetInfo": null
@@ -920,7 +937,8 @@
                             "wsName": "wjriehl:1475006266615"
                         },
                         "tag": "release"
-                    }
+                    },
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_RETRY_COMPLETED",
                 "outputWidgetInfo": {
@@ -961,7 +979,8 @@
                     "retry_ids": [],
                     "retry_parent": "BATCH_ERROR_RETRIED",
                     "running": 1625757662469,
-                    "status": "error"
+                    "status": "error",
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_RETRY_ERROR",
                 "outputWidgetInfo": null
@@ -983,7 +1002,8 @@
                     "retry_ids": [],
                     "retry_parent": "BATCH_TERMINATED_RETRIED",
                     "running": 1625757285899,
-                    "status": "running"
+                    "status": "running",
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_RETRY_RUNNING",
                 "outputWidgetInfo": null
@@ -1006,7 +1026,8 @@
                     "retry_ids": [],
                     "running": 1625755952599,
                     "status": "terminated",
-                    "terminated_code": 0
+                    "terminated_code": 0,
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_TERMINATED",
                 "outputWidgetInfo": null
@@ -1031,7 +1052,8 @@
                     ],
                     "running": 1625755952563,
                     "status": "terminated",
-                    "terminated_code": 0
+                    "terminated_code": 0,
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_TERMINATED_RETRIED",
                 "outputWidgetInfo": null
@@ -1072,7 +1094,8 @@
                             "wsName": "wjriehl:1475006266615"
                         },
                         "tag": "release"
-                    }
+                    },
+                    "wsid": 10538
                 },
                 "job_id": "BATCH_RETRY_COMPLETED",
                 "outputWidgetInfo": {
@@ -1122,7 +1145,8 @@
                             "report_window_line_height": "16"
                         },
                         "tag": "dev"
-                    }
+                    },
+                    "wsid": 54321
                 },
                 "job_id": "JOB_COMPLETED",
                 "outputWidgetInfo": {
@@ -1149,7 +1173,8 @@
                     "job_output": {},
                     "retry_count": 0,
                     "retry_ids": [],
-                    "status": "created"
+                    "status": "created",
+                    "wsid": 55555
                 },
                 "job_id": "JOB_CREATED",
                 "outputWidgetInfo": null
@@ -1179,7 +1204,8 @@
                     "retry_count": 0,
                     "retry_ids": [],
                     "running": 1642431847689,
-                    "status": "error"
+                    "status": "error",
+                    "wsid": 65854
                 },
                 "job_id": "JOB_ERROR",
                 "outputWidgetInfo": null
@@ -1200,7 +1226,8 @@
                     "retry_count": 0,
                     "retry_ids": [],
                     "running": 1642521775867,
-                    "status": "running"
+                    "status": "running",
+                    "wsid": 54321
                 },
                 "job_id": "JOB_RUNNING",
                 "outputWidgetInfo": null
@@ -1222,7 +1249,8 @@
                     "retry_count": 0,
                     "retry_ids": [],
                     "status": "terminated",
-                    "terminated_code": 0
+                    "terminated_code": 0,
+                    "wsid": 54321
                 },
                 "job_id": "JOB_TERMINATED",
                 "outputWidgetInfo": null

--- a/src/biokbase/narrative/tests/generate_test_results.py
+++ b/src/biokbase/narrative/tests/generate_test_results.py
@@ -37,11 +37,13 @@ for tag in app_version_tags:
     TEST_SPECS[tag] = spec_dict
 
 
-def get_test_spec(tag, app_id):
+def get_test_spec(tag: str, app_id: str) -> dict[str, dict]:
     return copy.deepcopy(TEST_SPECS[tag][app_id])
 
 
-def generate_mappings(all_jobs):
+def generate_mappings(
+    all_jobs: dict[str, dict]
+) -> tuple[dict[str, str], dict[str, dict], set[dict]]:
     # collect retried jobs and generate the cell-to-job mapping
     retried_jobs = {}
     jobs_by_cell_id = {}
@@ -57,7 +59,7 @@ def generate_mappings(all_jobs):
 
         # add the new job to the jobs_by_cell_id mapping if there is a cell_id present
         if cell_id:
-            if cell_id not in jobs_by_cell_id.keys():
+            if cell_id not in jobs_by_cell_id:
                 jobs_by_cell_id[cell_id] = set()
 
             jobs_by_cell_id[cell_id].add(job["job_id"])
@@ -67,7 +69,7 @@ def generate_mappings(all_jobs):
     return (retried_jobs, jobs_by_cell_id, batch_jobs)
 
 
-def _generate_job_output(job_id):
+def _generate_job_output(job_id: str) -> dict[str, str | dict]:
     state = get_test_job(job_id)
     widget_info = state.get("widget_info")
 
@@ -93,14 +95,14 @@ def _generate_job_output(job_id):
     return {"job_id": job_id, "jobState": state, "outputWidgetInfo": widget_info}
 
 
-def generate_bad_jobs():
+def generate_bad_jobs() -> dict[str, dict]:
     return {
         job_id: {"job_id": job_id, "error": generate_error(job_id, "not_found")}
         for job_id in BAD_JOBS
     }
 
 
-def generate_job_output_state(all_jobs):
+def generate_job_output_state(all_jobs: dict[str, dict]) -> dict[str, dict]:
     """
     Generate the expected output from a `job_status` request
     """
@@ -110,14 +112,13 @@ def generate_job_output_state(all_jobs):
     return job_status
 
 
-def generate_job_info(all_jobs):
+def generate_job_info(all_jobs: dict[str, dict]) -> dict[str, dict]:
     """
     Expected output from a `job_info` request
     """
     job_info = generate_bad_jobs()
     for job_id in all_jobs:
         test_job = get_test_job(job_id)
-        job_id = test_job.get("job_id")
         app_id = test_job.get("job_input", {}).get("app_id")
         tag = (
             test_job.get("job_input", {})
@@ -145,7 +146,9 @@ def generate_job_info(all_jobs):
     return job_info
 
 
-def generate_job_retries(all_jobs, retried_jobs):
+def generate_job_retries(
+    all_jobs: dict[str, dict], retried_jobs: dict[str, str]
+) -> dict[str, dict]:
     """
     Expected output from a `retry_job` request
     """
@@ -173,14 +176,11 @@ def generate_job_retries(all_jobs, retried_jobs):
     return job_retries
 
 
-def log_gen(n_lines):
-    lines = []
-    for i in range(n_lines):
-        lines.append({"is_error": 0, "line": f"This is line {str(i+1)}"})
-    return lines
+def log_gen(n_lines: int) -> list[dict[str, int | str]]:
+    return [{"is_error": 0, "line": f"This is line {i+1}"} for i in range(n_lines)]
 
 
-def generate_job_logs(all_jobs):
+def generate_job_logs(all_jobs: dict[str, dict]) -> dict[str, dict]:
     """
     Expected output from a `job_logs` request. Note that only completed jobs have logs in this case.
     """
@@ -211,11 +211,9 @@ def generate_job_logs(all_jobs):
 
 # mapping of cell IDs to jobs
 INVALID_CELL_ID = "invalid_cell_id"
-TEST_CELL_ID_LIST = list(JOBS_BY_CELL_ID.keys()) + [INVALID_CELL_ID]
+TEST_CELL_ID_LIST = [*list(JOBS_BY_CELL_ID.keys()), INVALID_CELL_ID]
 # mapping expected as output from get_job_states_by_cell_id
-TEST_CELL_IDs = {
-    cell_id: list(JOBS_BY_CELL_ID[cell_id]) for cell_id in JOBS_BY_CELL_ID.keys()
-}
+TEST_CELL_IDs = {cell_id: list(JOBS_BY_CELL_ID[cell_id]) for cell_id in JOBS_BY_CELL_ID}
 TEST_CELL_IDs[INVALID_CELL_ID] = []
 
 
@@ -230,7 +228,7 @@ if not os.path.exists(RESPONSE_DATA_FILE):
     config.write_json_file(RESPONSE_DATA_FILE, ALL_RESPONSE_DATA)
 
 
-def main(args=None):
+def main(args: list[str] | None = None) -> None:
     if args and args[0] == "--force" or not os.path.exists(RESPONSE_DATA_FILE):
         config.write_json_file(RESPONSE_DATA_FILE, ALL_RESPONSE_DATA)
 

--- a/src/biokbase/narrative/tests/job_test_constants.py
+++ b/src/biokbase/narrative/tests/job_test_constants.py
@@ -95,7 +95,7 @@ BATCH_CHILDREN = [
 
 BATCH_PARENT_CHILDREN = [BATCH_PARENT] + BATCH_CHILDREN
 
-JOBS_TERMINALITY = {
+JOB_TERMINAL_STATE = {
     job_id: TEST_JOBS[job_id]["status"] in TERMINAL_STATUSES
     for job_id in TEST_JOBS.keys()
 }
@@ -103,7 +103,7 @@ JOBS_TERMINALITY = {
 TERMINAL_JOBS = []
 ACTIVE_JOBS = []
 REFRESH_STATE = {}
-for key, value in JOBS_TERMINALITY.items():
+for key, value in JOB_TERMINAL_STATE.items():
     if value:
         TERMINAL_JOBS.append(key)
     else:

--- a/src/biokbase/narrative/tests/narrative_mock/mockclients.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockclients.py
@@ -18,7 +18,7 @@ from biokbase.narrative.tests.job_test_constants import (
 )
 from biokbase.workspace.baseclient import ServerError
 
-from ..util import ConfigTests
+from src.biokbase.narrative.tests.util import ConfigTests
 
 RANDOM_DATE = "2018-08-10T16:47:36+0000"
 RANDOM_TYPE = "ModuleA.TypeA-1.0"
@@ -29,11 +29,11 @@ NARR_WS = "wjriehl:1490995018528"
 NARR_HASH = "278abf8f0dbf8ab5ce349598a8674a6e"
 
 
-def generate_ee2_error(fn):
+def generate_ee2_error(fn: str) -> EEServerError:
     return EEServerError("JSONRPCError", -32000, fn + " failed")
 
 
-def get_nar_obj(i):
+def get_nar_obj(i: int) -> list[str | int | dict[str, str]]:
     return [
         i,
         "My_Test_Narrative",
@@ -291,9 +291,7 @@ class MockClients:
         job_id = params.get("job_id")
         if not job_id:
             return {}
-        job_state = self.job_state_data.get(
-            job_id, {"job_id": job_id, "status": "unmocked"}
-        )
+        job_state = self.job_state_data.get(job_id, {"job_id": job_id})
         if "exclude_fields" in params:
             for f in params["exclude_fields"]:
                 if f in job_state:
@@ -546,6 +544,9 @@ class FailingMockClient:
     def check_job(self, params):
         raise generate_ee2_error("check_job")
 
+    def check_jobs(self, params):
+        raise generate_ee2_error("check_jobs")
+
     def cancel_job(self, params):
         raise generate_ee2_error(MESSAGE_TYPE["CANCEL"])
 
@@ -618,7 +619,7 @@ class assert_obj_method_called:
 
         assert (
             getattr(self.target, self.method_name) == self.called
-        ), f"Method {self.target.__name__}.{self.method_name} was modified during context managment with {self.__class__.name}"
+        ), f"Method {self.target.__name__}.{self.method_name} was modified during context management with {self.__class__.name}"
         setattr(self.target, self.method_name, self.orig_method)
 
         self.assert_called(self.call_status)

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -316,6 +316,8 @@ class AppManagerTestCase(unittest.TestCase):
             c.return_value.send_comm_message, False, cell_id=cell_id
         )
 
+    # N.b. the following three tests contact the workspace
+    # src/config/config.json must be set to use the CI configuration
     @mock.patch(JOB_COMM_MOCK)
     def test_run_app__bad_id(self, c):
         c.return_value.send_comm_message = MagicMock()
@@ -507,6 +509,8 @@ class AppManagerTestCase(unittest.TestCase):
             c.return_value.send_comm_message, False, cell_id=cell_id
         )
 
+    # N.b. the following three tests contact the workspace
+    # src/config/config.json must be set to use the CI configuration
     @mock.patch(JOB_COMM_MOCK)
     def test_run_legacy_batch_app__bad_id(self, c):
         c.return_value.send_comm_message = MagicMock()
@@ -1094,6 +1098,8 @@ class AppManagerTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.am._generate_input({"symbols": -1})
 
+    # N.b. the following test contacts the workspace
+    # src/config/config.json must be set to use the CI configuration
     def test_transform_input_good(self):
         ws_name = self.public_ws
         test_data = [

--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -618,6 +618,14 @@ class JobCommTestCase(unittest.TestCase):
         exc = Exception("Test exception")
         exc_message = str(exc)
 
+        expected = {
+            job_id: copy.deepcopy(ALL_RESPONSE_DATA[STATUS][job_id])
+            for job_id in ALL_JOBS
+        }
+        for job_id in ACTIVE_JOBS:
+            # add in the ee2_error message
+            expected[job_id]["error"] = exc_message
+
         def mock_check_jobs(params):
             raise exc
 
@@ -627,14 +635,6 @@ class JobCommTestCase(unittest.TestCase):
         with mock.patch.object(MockClients, "check_jobs", side_effect=mock_check_jobs):
             self.jc._handle_comm_message(req_dict)
         msg = self.jc._comm.last_message
-
-        expected = {
-            job_id: copy.deepcopy(ALL_RESPONSE_DATA[STATUS][job_id])
-            for job_id in ALL_JOBS
-        }
-        for job_id in ACTIVE_JOBS:
-            # add in the ee2_error message
-            expected[job_id]["error"] = exc_message
 
         self.assertEqual(
             {

--- a/src/biokbase/narrative/tests/test_narrativeio.py
+++ b/src/biokbase/narrative/tests/test_narrativeio.py
@@ -5,10 +5,8 @@ Narrative and workspace service.
 import unittest
 from unittest.mock import patch
 
-from tornado.web import HTTPError
-
 import biokbase.auth
-import biokbase.narrative.clients as clients
+from biokbase.narrative import clients
 from biokbase.narrative.common.exceptions import WorkspaceError
 from biokbase.narrative.common.narrative_ref import NarrativeRef
 from biokbase.narrative.common.url_config import URLS
@@ -16,27 +14,26 @@ from biokbase.narrative.contents.narrativeio import (
     LIST_OBJECTS_FIELDS,
     KBaseWSManagerMixin,
 )
+from tornado.web import HTTPError
 
 from . import util
 from .narrative_mock.mockclients import MockClients, get_mock_client, get_nar_obj
 
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
-metadata_fields = set(
-    [
-        "objid",
-        "name",
-        "type",
-        "save_date",
-        "ver",
-        "saved_by",
-        "wsid",
-        "workspace",
-        "chsum",
-        "size",
-        "meta",
-    ]
-)
+metadata_fields = {
+    "objid",
+    "name",
+    "type",
+    "save_date",
+    "ver",
+    "saved_by",
+    "wsid",
+    "workspace",
+    "chsum",
+    "size",
+    "meta",
+}
 HAS_TEST_TOKEN = False
 
 

--- a/src/biokbase/narrative/tests/test_widgetmanager.py
+++ b/src/biokbase/narrative/tests/test_widgetmanager.py
@@ -74,6 +74,8 @@ class WidgetManagerTestCase(unittest.TestCase):
                 check_widget=True,
             )
 
+    # N.b. the following test contacts the workspace
+    # src/config/config.json must be set to use the CI configuration
     def test_show_advanced_viewer_widget(self):
         title = "Widget Viewer"
         cell_id = "abcde"


### PR DESCRIPTION
# Description of PR purpose/changes

This PR adds the user and wsid to the job objects returned by the narrative backend.

I added typing to quite a few of the methods so the diff looks bigger than it really is.

There's still some dodgy stuff going on with the job methods, but whatever. That can go in the next PR!

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-765
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
- [] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [x] [Version has been bumped](https://semver.org/) for each release
- [] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
