### PR TITLE
Fix semicolon error masking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN \
     /bin/bash scripts/install_narrative_docker.sh && \
     cd /tmp && \
     mkdir /tmp/narrative && \
-    chown -R nobody:www-data /tmp/narrative /kb/dev_container/narrative ; find / -xdev \( -perm -4000 \) -type f -print -exec rm {} \;
+    chown -R nobody:www-data /tmp/narrative /kb/dev_container/narrative && \
+    find / -xdev \( -perm -4000 \) -type f -print -exec rm {} \;
 
 # Set a default value for the environment variable VERSION_CHECK that gets expanded in the config.json.templ
 # into the location to check for a new narrative version. Normally we would put this in the template itself
@@ -61,17 +62,17 @@ ENV DOCKER_CONTAINER true
 USER nobody
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.vcs-url="https://github.com/kbase/narrative.git" \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.schema-version="1.0.0-rc1" \
-      us.kbase.vcs-branch=$BRANCH \
-      us.kbase.narrative-version=$NARRATIVE_VERSION \
-      maintainer="William Riehl wjriehl@lbl.gov"
+    org.label-schema.vcs-url="https://github.com/kbase/narrative.git" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.schema-version="1.0.0-rc1" \
+    us.kbase.vcs-branch=$BRANCH \
+    us.kbase.narrative-version=$NARRATIVE_VERSION \
+    maintainer="William Riehl wjriehl@lbl.gov"
 
 # populate the config files on start up
 ENTRYPOINT ["/kb/deployment/bin/dockerize"]
 CMD [ "--template", \
-      "/kb/dev_container/narrative/src/config.json.templ:/kb/dev_container/narrative/src/config.json", \
-      "--template", \
-      "/kb/dev_container/narrative/src/config.json.templ:/kb/dev_container/narrative/kbase-extension/static/kbase/config/config.json", \
-      "kbase-narrative"]
+    "/kb/dev_container/narrative/src/config.json.templ:/kb/dev_container/narrative/src/config.json", \
+    "--template", \
+    "/kb/dev_container/narrative/src/config.json.templ:/kb/dev_container/narrative/kbase-extension/static/kbase/config/config.json", \
+    "kbase-narrative"]


### PR DESCRIPTION
# Description of PR purpose/changes

A misplaced semicolon in some shell script in the Dockerfile was masking errors that might have occurred in commands earlier in the script.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
