### PR TITLE
Removing obsolete code to build documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ build-narrative-container:
 
 docker_image: build-narrative-container
 
+docker-narrative:
+	docker build -t kbase/narrative:local .
+
 # Per PR #1328, adding an option to skip minification
 dev-image:
 	SKIP_MINIFY=1 DOCKER_TAG=dev sh $(DOCKER_INSTALLER)
@@ -28,7 +31,7 @@ install:
 
 # runs the installer to locally build the Narrative in a
 # local venv.
-build-travis-narrative:
+build-venv-narrative:
 	bash $(INSTALLER) && \
 	npm run minify && \
 	sed <src/config.json.templ >src/config.json "s/{{ .Env.CONFIG_ENV }}/dev/" && \
@@ -64,14 +67,6 @@ test-integration:
 	@echo "running integration tests"
 	python scripts/run_tests.py -i
 	@echo "done"
-
-build-docs:
-	cd src && export PYTHONPATH=`pwd` && python2.7 setup.py doc
-	-mkdir docs
-	cp -R src/biokbase-doc/_build/html/* docs/
-
-docker-narrative:
-	docker build -t kbase/narrative:1.0.3 .
 
 clean:
 	git clean -f

--- a/src/biokbase/narrative/common/util.py
+++ b/src/biokbase/narrative/common/util.py
@@ -1,17 +1,19 @@
-"""
-Utility functions for dealing with KBase services, etc.
-"""
+"""Utility functions for dealing with KBase services, etc."""
+
 __author__ = "Dan Gunter <dkgunter@lbl.gov>"
 __date__ = "1/6/14"
 
 import os
 import re
 
-from setuptools import Command
 
+def kbase_debug_mode() -> bool:
+    """Check whether the KBASE_DEBUG env var is set.
 
-def kbase_debug_mode():
-    return bool(os.environ.get("KBASE_DEBUG", None))
+    :return: True or False
+    :rtype: bool
+    """
+    return bool(os.environ.get("KBASE_DEBUG"))
 
 
 class _KBaseEnv:
@@ -25,7 +27,7 @@ class _KBaseEnv:
     # Environment variables.
     # Each is associated with an attribute that is the
     # same as the variable name without the 'env_' prefix.
-    env_auth_token = "KB_AUTH_TOKEN"
+    env_auth_token = "KB_AUTH_TOKEN"  # noqa: S105
     env_narrative = "KB_NARRATIVE"
     env_session = "KB_SESSION"
     env_client_ip = "KB_CLIENT_IP"
@@ -38,20 +40,21 @@ class _KBaseEnv:
         "auth_token": "none",
         "narrative": "none",
         "session": "none",
-        "client_ip": "0.0.0.0",
+        "client_ip": "0.0.0.0",  # noqa: S104
         "user": "anonymous",
         "workspace": "none",
         "env": "none",
         "anon_user_id": "none",
     }
 
-    def __getattr__(self, name):
+    def __getattr__(self: "_KBaseEnv", name: str) -> str:
         ename = "env_" + name
         if ename in _KBaseEnv.__dict__:
             return os.environ.get(getattr(self.__class__, ename), self._defaults[name])
-        raise KeyError("kbase_env:{}".format(name))
+        err_msg = f"kbase_env: {name}"
+        raise KeyError(err_msg)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self: "_KBaseEnv", name: str, value: str | None):
         ename = "env_" + name
         if ename in _KBaseEnv.__dict__:
             env_var = getattr(self.__class__, ename)
@@ -62,25 +65,25 @@ class _KBaseEnv:
 
     # Dict emulation
 
-    def __iter__(self):
+    def __iter__(self: "_KBaseEnv"):
         return iter(self.keys())
 
-    def __getitem__(self, name):
+    def __getitem__(self: "_KBaseEnv", name: str):
         return getattr(self, name)
 
-    def __contains__(self, name):
+    def __contains__(self: "_KBaseEnv", name: str):
         return name in self._defaults
 
-    def keys(self):
+    def keys(self: "_KBaseEnv"):
         return list(self._defaults.keys())
 
-    def iterkeys(self):
+    def iterkeys(self: "_KBaseEnv"):
         return iter(self._defaults.keys())
 
-    def __str__(self):
-        return ", ".join(["{}: {}".format(k, self[k]) for k in self.keys()])
+    def __str__(self: "_KBaseEnv"):
+        return ", ".join([f"{k}: {self[k]}" for k in self.keys()])
 
-    def _user(self):
+    def _user(self: "_KBaseEnv"):
         token = self.auth_token
         if not token:
             return self._defaults["user"]
@@ -91,24 +94,3 @@ class _KBaseEnv:
 # Get/set KBase environment variables by getting/setting
 # attributes of this object.
 kbase_env = _KBaseEnv()
-
-
-class BuildDocumentation(Command):
-    """Setuptools command hook to build Sphinx docs"""
-
-    description = "build Sphinx documentation"
-    user_options = []
-
-    def initialize_options(self):
-        self.doc_dir = "biokbase-doc"
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        filedir = os.path.dirname(os.path.realpath(__file__))
-        p = filedir.find("/biokbase/")
-        top = filedir[: p + 1]
-        doc = top + self.doc_dir
-        os.chdir(doc)
-        os.system("make html")

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,12 +1,10 @@
-"""
-Installer for KBase narrative Python libraries
-"""
+"""Installer for KBase narrative Python libraries."""
+
 import glob
 
 from setuptools import find_packages, setup
 
 import ez_setup
-from biokbase.narrative.common.util import BuildDocumentation
 
 ez_setup.use_setuptools()
 
@@ -14,12 +12,15 @@ ez_setup.use_setuptools()
 
 long_desc = "This Python package contains all the KBase Python libraries to support the Python narrative UI, which is built on the IPython notebook."
 
+with open("requirements.txt") as f:
+    install_requires = [s.strip() for s in f]
+
 # Do the setup
 setup(
     name="biokbase",
     packages=find_packages(),
     version="0.0.1",
-    install_requires=[s.strip() for s in open("requirements.txt")],
+    install_requires=install_requires,
     extras_require={},
     package_data={"": ["*.json"]},
     scripts=glob.glob("scripts/kb-*"),
@@ -32,7 +33,7 @@ setup(
     long_description=long_desc,
     keywords=["kbase", "narrative", "UI"],
     classifiers=[
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.12",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "Operating System :: OS Independent",
@@ -42,7 +43,4 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     ext_modules=[],
-    cmdclass={
-        "doc": BuildDocumentation,
-    },
 )


### PR DESCRIPTION
# Description of PR purpose/changes

Removing some old stuff that built documentation, back in the days when documentation was something that was built (py 2.7 days). I did try to revive the documentation builder but there were still errors after updating the command to py 3, and rendering the docs as html is not particularly useful when we have them as markdown.

# Jira Ticket / Issue #

N/A

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Black and Flake8 on changed Python code manually or with a git precommit hook
