### PR TITLE
UIP-41 update dependabot config to be (hopefully) less annoying

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,33 @@ updates:
   schedule:
     interval: monthly
     time: '11:00'
+  groups:
+    python-dependencies:
+      patterns:
+        - "*"
+  open-pull-requests-limit: 20
+  ignore:
+    - dependency-name: "notebook"
+      versions: '>= 7.0.0'
+- package-ecosystem: pip
+  directory: "/docker_image_dependencies"
+  schedule:
+    interval: monthly
+    time: '11:00'
+  groups:
+    docker-image-python-deps:
+      patterns:
+        "*"
   open-pull-requests-limit: 20
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: monthly
     time: '11:00'
+  groups:
+    npm-dependencies:
+      patterns:
+        "*"
   open-pull-requests-limit: 20
 - package-ecosystem: docker
   directory: "/"


### PR DESCRIPTION
# Description of PR purpose/changes

A bit of a tangent to the posted ticket, but still hopefully useful.

The Dependabot config docs include rules for adding multiple dependency files from multiple sources (like we're using for the production image vs. local installation of Python deps), and a configuration for grouping updates into a single PR, per package-ecosystem.

I think I have it configured right, we'll see if it works and doesn't flood us with a zillion PRs at the top of each month!

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-41
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:
Most of this is N/A as no code is changed, so just deleted.
