### PR TITLE
UIP-47: Declassing jobcomm

### DIFF
--- a/src/biokbase/narrative/tests/test_jobcomm.py
+++ b/src/biokbase/narrative/tests/test_jobcomm.py
@@ -104,12 +104,12 @@ STOP_UPDATE = MESSAGE_TYPE["STOP_UPDATE"]
 LOG_LINES = [{"is_error": 0, "line": f"This is line {i}"} for i in range(MAX_LOG_LINES)]
 
 
-# # Fixture to set and unset environment variable
-# @pytest.fixture(autouse=True)
-# def set_env_var(monkeypatch, job_test_wsname: str) -> None:
-#     """Set the KB_WORKSPACE_ID env var for all job comm tests."""
-#     # Set the environment variable; monkey patch automatically removes it afterwards
-#     monkeypatch.setenv("KB_WORKSPACE_ID", job_test_wsname)
+# Fixture to set and unset environment variable
+@pytest.fixture(autouse=True)
+def set_env_var(monkeypatch, job_test_wsname: str) -> None:
+    """Set the KB_WORKSPACE_ID env var for all job comm tests."""
+    # Set the environment variable; monkey patch automatically removes it afterwards
+    monkeypatch.setenv("KB_WORKSPACE_ID", job_test_wsname)
 
 
 def check_error_message(
@@ -315,895 +315,951 @@ def check_retry_jobs(
     }
 
 
-class JobCommTestCase(unittest.TestCase):
-    maxDiff = None
-
-    @classmethod
-    @mock.patch("biokbase.narrative.jobs.jobcomm.Comm", MockComm)
-    @mock.patch(CLIENTS, get_mock_client)
-    def setUpClass(cls):
-        config = ConfigTests()
-        os.environ["KB_WORKSPACE_ID"] = config.get("jobs", "job_test_wsname")
-        cls.jm = JobManager()
-        cls.jc = JobComm()
-        cls.jc._comm = MockComm()
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def setUp(self):
-        job_comm = self.jc
-        job_comm._comm.clear_message_cache()
-        job_comm._jm.initialize_jobs()
-        job_comm.stop_job_status_loop()
-
-    # ---------------------
-    # Send comms methods
-    # ---------------------
-    def test_send_comm_msg_ok(self):
-        self.jc.send_comm_message("some_msg", {"foo": "bar"})
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": "some_msg",
-            "content": {"foo": "bar"},
-        }
-        self.jc._comm.clear_message_cache()
-
-    def test_send_error_msg__JobRequest(self):
-        req = make_job_request("bar", "aeaeae")
-        self.jc.send_error_message(req, {"extra": "field"})
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": ERROR,
-            "content": {
-                "source": "bar",
-                "extra": "field",
-                "request": req.rq_data,
-            },
-        }
-
-    def test_send_error_msg__dict(self):
-        req_dict = make_comm_msg("bar", "aeaeae")
-        self.jc.send_error_message(req_dict, {"extra": "field"})
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": ERROR,
-            "content": {
-                "source": "bar",
-                "extra": "field",
-                "request": req_dict["content"]["data"],
-            },
-        }
-
-    def test_send_error_msg__None(self):
-        self.jc.send_error_message(None, {"extra": "field"})
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": ERROR,
-            "content": {
-                "source": None,
-                "extra": "field",
-                "request": None,
-            },
-        }
-
-    def test_send_error_msg__str(self):
-        source = "test_jobcomm"
-        self.jc.send_error_message(source, {"extra": "field"})
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": ERROR,
-            "content": {
-                "source": source,
-                "extra": "field",
-                "request": source,
-            },
-        }
-
-    # ---------------------
-    # Requests
-    # ---------------------
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_req_no_inputs__succeed(self):
-        req_dict = make_comm_msg(STATUS_ALL, None)
-        self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-        assert msg["msg_type"] == STATUS_ALL
-
-    def test_req_no_inputs__fail(self):
-        functions = [
-            CANCEL,
-            INFO,
-            LOGS,
-            RETRY,
-            START_UPDATE,
-            STATUS,
-            STOP_UPDATE,
-        ]
-
-        for msg_type in functions:
-            req_dict = make_comm_msg(msg_type, None)
-            err = JobRequestException(ONE_INPUT_TYPE_ONLY_ERR)
-            with pytest.raises(type(err), match=str(err)):
-                self.jc._handle_comm_message(req_dict)
-            check_error_message(self.jc, req_dict, err)
-
-    def test_req_multiple_inputs__fail(self):
-        functions = [
-            CANCEL,
-            INFO,
-            LOGS,
-            RETRY,
-            STATUS,
-        ]
-
-        for msg_type in functions:
-            req_dict = make_comm_msg(msg_type, {"job_id": "something", "batch_id": "another_thing"})
-            err = JobRequestException(ONE_INPUT_TYPE_ONLY_ERR)
-            with pytest.raises(type(err), match=str(err)):
-                self.jc._handle_comm_message(req_dict)
-            check_error_message(self.jc, req_dict, err)
-
-    # ---------------------
-    # Start job status loop
-    # ---------------------
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_start_stop_job_status_loop(self):
-        assert self.jc._running_lookup_loop is False
-        assert self.jc._lookup_timer is None
-
-        self.jc.start_job_status_loop()
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": STATUS_ALL,
-            "content": {
-                job_id: ALL_RESPONSE_DATA[STATUS][job_id]
-                for job_id in REFRESH_STATE
-                if REFRESH_STATE[job_id]
-            },
-        }
-
-        assert self.jc._running_lookup_loop is True
-        assert self.jc._lookup_timer is not None
-
-        self.jc.stop_job_status_loop()
-        assert self.jc._running_lookup_loop is False
-        assert self.jc._lookup_timer is None
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_start_job_status_loop__cell_ids(self):
-        cell_ids = list(JOBS_BY_CELL_ID.keys())
-        # Iterate through all combinations of cell IDs
-        for combo_len in range(len(cell_ids) + 1):
-            for combo in itertools.combinations(cell_ids, combo_len):
-                self.jm._running_jobs = {}
-                assert self.jc._running_lookup_loop is False
-                assert self.jc._lookup_timer is None
-
-                self.jc.start_job_status_loop(init_jobs=True, cell_list=list(combo))
-                msg = self.jc._comm.last_message
-
-                exp_job_ids = [
-                    job_id
-                    for cell_id, job_ids in JOBS_BY_CELL_ID.items()
-                    for job_id in job_ids
-                    if cell_id in list(combo) and REFRESH_STATE[job_id]
-                ]
-                exp_msg = {
-                    "msg_type": "job_status_all",
-                    "content": {
-                        job_id: ALL_RESPONSE_DATA[STATUS][job_id] for job_id in exp_job_ids
-                    },
-                }
-                assert exp_msg == msg
-
-                if exp_job_ids:
-                    assert self.jc._running_lookup_loop
-                    assert self.jc._lookup_timer
-
-                    self.jc.stop_job_status_loop()
-
-                    assert self.jc._running_lookup_loop is False
-                    assert self.jc._lookup_timer is None
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_start_job_status_loop__initialise_jobs_error(self) -> None:
-        # patch all client calls to return clients that return errors
-        with mock.patch(CLIENTS, side_effect=get_failing_mock_client):
-            # check_workspace_jobs throws an EEServerError
-            self.jc.start_job_status_loop(init_jobs=True)
-            assert self.jc._comm.last_message == {
-                "msg_type": ERROR,
-                "content": {
-                    "code": -32000,
-                    "error": "Unable to get initial jobs list",
-                    "message": "check_workspace_jobs failed",
-                    "name": "JSONRPCError",
-                    "request": "jc.start_job_status_loop",
-                    "source": "ee2",
-                },
-            }
-            assert self.jc._running_lookup_loop is False
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_start_job_status_loop__no_jobs_stop_loop(self):
-        # reset the job manager so there are no jobs
-        self.jm._running_jobs = {}
-        self.jm._jobs_by_cell_id = {}
-        self.jm = JobManager()
-        assert self.jm._running_jobs == {}
-        # this will trigger a call to get_all_job_states
-        # a message containing all jobs (i.e. {}) will be sent out
-        # when it returns 0 jobs, the JobComm will run stop_job_status_loop
-        self.jc.start_job_status_loop()
-        assert self.jc._running_lookup_loop is False
-        assert self.jc._lookup_timer is None
-        assert self.jc._comm.last_message == {"msg_type": STATUS_ALL, "content": {}}
-
-    # ---------------------
-    # Lookup all job states
-    # ---------------------
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_all_job_states__ok(self):
-        check_job_output_states(
-            self.jc, request_type=STATUS_ALL, response_type=STATUS_ALL, ok_states=ALL_JOBS
-        )
-
-    # -----------------------
-    # Lookup single job state
-    # -----------------------
-    def test_get_job_state__1_ok(self):
-        output_states = self.jc.get_job_state(JOB_COMPLETED)
-        check_job_output_states(self.jc, output_states=output_states, ok_states=[JOB_COMPLETED])
-
-    def test_get_job_state__no_job(self):
-        with pytest.raises(JobRequestException, match=re.escape(f"{JOBS_MISSING_ERR}: {[None]}")):
-            self.jc.get_job_state(None)  # type: ignore
-
-    # -----------------------
-    # Lookup select job states
-    # -----------------------
-    def test_get_job_states__job_id__ok(self):
-        check_job_output_states(self.jc, params={JOB_ID: JOB_COMPLETED}, ok_states=[JOB_COMPLETED])
-
-    def test_get_job_states__job_id__dne(self):
-        check_job_output_states(
-            self.jc, params={JOB_ID: JOB_NOT_FOUND}, error_states=[JOB_NOT_FOUND]
-        )
-
-    def test_get_job_states__job_id__invalid(self):
-        check_job_id__no_job_test(self.jc, STATUS)
-
-    def test_get_job_states__job_id_list__1_ok(self):
-        job_id_list = [JOB_COMPLETED]
-        check_job_output_states(self.jc, params={JOB_ID_LIST: job_id_list}, ok_states=job_id_list)
-
-    def test_get_job_states__job_id_list__2_ok(self):
-        job_id_list = [JOB_COMPLETED, BATCH_PARENT]
-        check_job_output_states(self.jc, params={JOB_ID_LIST: job_id_list}, ok_states=job_id_list)
-
-    def test_get_job_states__job_id_list__ok_bad(self):
-        job_id_list = [BAD_JOB_ID, JOB_COMPLETED]
-        check_job_output_states(
-            self.jc,
-            params={JOB_ID_LIST: job_id_list},
-            ok_states=[JOB_COMPLETED],
-            error_states=[BAD_JOB_ID],
-        )
-
-    def test_get_job_states__job_id_list__no_jobs(self):
-        check_job_id_list__no_jobs(self.jc, STATUS)
-
-    def test_get_job_states__batch_id__ok(self):
-        check_job_output_states(
-            self.jc,
-            request_type=STATUS,
-            params={BATCH_ID: BATCH_PARENT},
-            ok_states=BATCH_PARENT_CHILDREN,
-        )
-
-    def test_get_job_states__batch_id__dne(self):
-        check_batch_id__dne_test(self.jc, STATUS)
-
-    def test_get_job_states__batch_id__no_job(self):
-        check_batch_id__no_job_test(self.jc, STATUS)
-
-    def test_get_job_states__batch_id__not_batch(self):
-        check_batch_id__not_batch_test(self.jc, STATUS)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_states__job_id_list__ee2_error(self):
-        exc = Exception("Test exception")
-        exc_message = str(exc)
-
-        expected = {job_id: copy.deepcopy(ALL_RESPONSE_DATA[STATUS][job_id]) for job_id in ALL_JOBS}
-        for job_id in ACTIVE_JOBS:
-            # add in the ee2_error message
-            expected[job_id]["error"] = exc_message
-
-        def mock_check_jobs(params):
-            raise exc
-
-        job_id_list = ALL_JOBS
-        req_dict = make_comm_msg(STATUS, job_id_list)
-
-        with mock.patch.object(MockClients, "check_jobs", side_effect=mock_check_jobs):
-            self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-
-        assert msg == {
-            "msg_type": STATUS,
-            "content": expected,
-        }
-
-    # -----------------------
-    # get cell job states
-    # -----------------------
-    def test_get_job_states_by_cell_id__cell_id_list_none(self):
-        cell_id_list = None
-        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
-        err = JobRequestException(CELLS_NOT_PROVIDED_ERR)
-        with pytest.raises(type(err), match=re.escape(str(err))):
-            self.jc._handle_comm_message(req_dict)
-        check_error_message(self.jc, req_dict, err)
-
-    def test_get_job_states_by_cell_id__empty_cell_id_list(self):
-        cell_id_list = []
-        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
-        err = JobRequestException(CELLS_NOT_PROVIDED_ERR)
-        with pytest.raises(type(err), match=re.escape(str(err))):
-            self.jc._handle_comm_message(req_dict)
-        check_error_message(self.jc, req_dict, err)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_states_by_cell_id__invalid_cell_id_list(self):
-        cell_id_list = ["a", "b", "c"]
-        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
-        self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": CELL_JOB_STATUS,
-            "content": NO_JOBS_MAPPING,
-        }
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_states_by_cell_id__invalid_cell_id_list_req(self):
-        cell_id_list = ["a", "b", "c"]
-        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
-        result = self.jc._handle_comm_message(req_dict)
-        assert result == NO_JOBS_MAPPING
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": CELL_JOB_STATUS,
-            "content": NO_JOBS_MAPPING,
-        }
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_states_by_cell_id__all_results(self):
-        cell_id_list = TEST_CELL_ID_LIST
-        expected_ids = ALL_JOBS
-        expected_states = {job_id: ALL_RESPONSE_DATA[STATUS][job_id] for job_id in expected_ids}
-
-        req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
-        self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-        assert set(msg.keys()), set(["msg_type" == "content"])
-        assert msg["msg_type"] == CELL_JOB_STATUS
-        assert msg["content"]["jobs"] == expected_states
-        assert set(cell_id_list) == set(msg["content"]["mapping"].keys())
-        for key in msg["content"]["mapping"]:
-            assert set(TEST_CELL_IDs[key]) == set(msg["content"]["mapping"][key])
-
-    # -----------------------
-    # Lookup job info
-    # -----------------------
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_info__job_id__ok(self):
-        check_job_info_results(self.jc, {JOB_ID: JOB_COMPLETED}, [JOB_COMPLETED])
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_info__job_id__dne(self):
-        check_job_info_results(self.jc, {JOB_ID: JOB_NOT_FOUND}, [JOB_NOT_FOUND])
-
-    def test_get_job_info__job_id__invalid(self):
-        check_job_id__no_job_test(self.jc, INFO)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_info__job_id_list__ok(self):
-        check_job_info_results(self.jc, ALL_JOBS, ALL_JOBS)
-
-    def test_get_job_info__job_id_list__no_jobs(self):
-        check_job_id_list__no_jobs(self.jc, INFO)
-
-    def test_get_job_info__job_id_list__ok_bad(self):
-        job_id_list = [JOB_COMPLETED, JOB_NOT_FOUND]
-        check_job_info_results(self.jc, job_id_list, job_id_list)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_info__batch_id__ok(self):
-        job_id = BATCH_PARENT
-        check_job_info_results(self.jc, {BATCH_ID: job_id}, BATCH_PARENT_CHILDREN)
-
-    def test_get_job_info__batch_id__no_job(self):
-        check_batch_id__no_job_test(self.jc, INFO)
-
-    def test_get_job_info__batch_id__dne(self):
-        check_batch_id__dne_test(self.jc, INFO)
-
-    def test_get_job_info__batch_id__not_batch(self):
-        check_batch_id__not_batch_test(self.jc, INFO)
-
-    # ------------
-    # Cancel list of jobs
-    # ------------
-    def test_cancel_jobs__job_id__ok(self):
-        check_job_output_states(
-            self.jc, request_type=CANCEL, params={JOB_ID: JOB_RUNNING}, ok_states=[JOB_RUNNING]
-        )
-
-    def test_cancel_jobs__job_id__dne(self):
-        check_job_output_states(
-            self.jc,
-            request_type=CANCEL,
-            params={JOB_ID: JOB_NOT_FOUND},
-            error_states=[JOB_NOT_FOUND],
-        )
-
-    def test_cancel_jobs__job_id__invalid(self):
-        check_job_id__no_job_test(self.jc, CANCEL)
-        job_id_list = [None, ""]
-        for job_id in job_id_list:
-            req_dict = make_comm_msg(CANCEL, {JOB_ID: job_id})
-            err = JobRequestException(JOBS_MISSING_ERR, [job_id])
-            with pytest.raises(type(err), match=re.escape(str(err))):
-                self.jc._handle_comm_message(req_dict)
-            check_error_message(self.jc, req_dict, err)
-
-    def test_cancel_jobs__job_id_list__1_ok(self):
-        job_id_list = [JOB_RUNNING]
-        check_job_output_states(
-            self.jc,
-            request_type=CANCEL,
-            params={JOB_ID_LIST: job_id_list},
-            ok_states=job_id_list,
-        )
-
-    def test_cancel_jobs__job_id_list__2_ok(self):
-        job_id_list = [JOB_CREATED, JOB_RUNNING, None]
-        check_job_output_states(
-            self.jc,
-            request_type=CANCEL,
-            params={JOB_ID_LIST: job_id_list},
-            ok_states=[JOB_CREATED, JOB_RUNNING],
-        )
-
-    def test_cancel_jobs__job_id_list__no_jobs(self):
-        job_id_list = None
-        req_dict = make_comm_msg(CANCEL, {JOB_ID_LIST: job_id_list})
-        err = JobRequestException(JOBS_MISSING_ERR, job_id_list)
+# ---------------------
+# Send comms methods
+# ---------------------
+def test_send_comm_msg_ok(job_comm: JobComm) -> None:
+    job_comm.send_comm_message("some_msg", {"foo": "bar"})
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": "some_msg",
+        "content": {"foo": "bar"},
+    }
+    job_comm._comm.clear_message_cache()
+
+
+def test_send_error_msg__JobRequest(job_comm: JobComm) -> None:
+    req = make_job_request("bar", "aeaeae")
+    job_comm.send_error_message(req, {"extra": "field"})
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": ERROR,
+        "content": {
+            "source": "bar",
+            "extra": "field",
+            "request": req.rq_data,
+        },
+    }
+
+
+def test_send_error_msg__dict(job_comm: JobComm) -> None:
+    req_dict = make_comm_msg("bar", "aeaeae")
+    job_comm.send_error_message(req_dict, {"extra": "field"})
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": ERROR,
+        "content": {
+            "source": "bar",
+            "extra": "field",
+            "request": req_dict["content"]["data"],
+        },
+    }
+
+
+def test_send_error_msg__None(job_comm: JobComm) -> None:
+    job_comm.send_error_message(None, {"extra": "field"})
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": ERROR,
+        "content": {
+            "source": None,
+            "extra": "field",
+            "request": None,
+        },
+    }
+
+
+def test_send_error_msg__str(job_comm: JobComm) -> None:
+    source = "test_jobcomm"
+    job_comm.send_error_message(source, {"extra": "field"})
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": ERROR,
+        "content": {
+            "source": source,
+            "extra": "field",
+            "request": source,
+        },
+    }
+
+
+# ---------------------
+# Requests
+# ---------------------
+@mock.patch(CLIENTS, get_mock_client)
+def test_req_no_inputs__succeed(job_comm: JobComm) -> None:
+    req_dict = make_comm_msg(STATUS_ALL, None)
+    job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+    assert msg["msg_type"] == STATUS_ALL
+
+
+def test_req_no_inputs__fail(job_comm: JobComm) -> None:
+    functions = [
+        CANCEL,
+        INFO,
+        LOGS,
+        RETRY,
+        START_UPDATE,
+        STATUS,
+        STOP_UPDATE,
+    ]
+
+    for msg_type in functions:
+        req_dict = make_comm_msg(msg_type, None)
+        err = JobRequestException(ONE_INPUT_TYPE_ONLY_ERR)
         with pytest.raises(type(err), match=str(err)):
-            self.jc._handle_comm_message(req_dict)
+            job_comm._handle_comm_message(req_dict)
+        check_error_message(job_comm, req_dict, err)
 
-        job_id_list = [None, ""]
-        req_dict = make_comm_msg(CANCEL, job_id_list)
-        err = JobRequestException(JOBS_MISSING_ERR, job_id_list)
-        with pytest.raises(type(err), match=re.escape(str(err))):
-            self.jc._handle_comm_message(req_dict)
-        check_error_message(self.jc, req_dict, err)
 
-    def test_cancel_jobs__job_id_list__ok_bad(self):
-        job_id_list = [
-            None,
-            JOB_NOT_FOUND,
-            JOB_NOT_FOUND,
-            "",
-            JOB_RUNNING,
-            JOB_CREATED,
-            BAD_JOB_ID,
-        ]
-        check_job_output_states(
-            self.jc,
-            request_type=CANCEL,
-            params={JOB_ID_LIST: job_id_list},
-            ok_states=[JOB_CREATED, JOB_RUNNING],
-            error_states=[JOB_NOT_FOUND, BAD_JOB_ID],
-        )
+def test_req_multiple_inputs__fail(job_comm: JobComm) -> None:
+    functions = [
+        CANCEL,
+        INFO,
+        LOGS,
+        RETRY,
+        STATUS,
+    ]
 
-    def test_cancel_jobs__job_id_list__all_bad_jobs(self):
-        job_id_list = [None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, BAD_JOB_ID]
-        check_job_output_states(
-            self.jc,
-            request_type=CANCEL,
-            params={JOB_ID_LIST: job_id_list},
-            error_states=[JOB_NOT_FOUND, BAD_JOB_ID],
-        )
+    for msg_type in functions:
+        req_dict = make_comm_msg(msg_type, {"job_id": "something", "batch_id": "another_thing"})
+        err = JobRequestException(ONE_INPUT_TYPE_ONLY_ERR)
+        with pytest.raises(type(err), match=str(err)):
+            job_comm._handle_comm_message(req_dict)
+        check_error_message(job_comm, req_dict, err)
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_cancel_jobs__job_id_list__failure(self):
-        # the mock client will throw an error with BATCH_RETRY_RUNNING
-        job_id_list = [JOB_RUNNING, BATCH_RETRY_RUNNING]
-        req_dict = make_comm_msg(CANCEL, job_id_list)
-        output = self.jc._handle_comm_message(req_dict)
 
-        expected = {
-            JOB_RUNNING: ALL_RESPONSE_DATA[STATUS][JOB_RUNNING],
-            BATCH_RETRY_RUNNING: {
-                **ALL_RESPONSE_DATA[STATUS][BATCH_RETRY_RUNNING],
-                "error": CANCEL + " failed",
-            },
-        }
+# ---------------------
+# Start job status loop
+# ---------------------
+@mock.patch(CLIENTS, get_mock_client)
+def test_start_stop_job_status_loop(job_comm: JobComm) -> None:
+    assert job_comm._running_lookup_loop is False
+    assert job_comm._lookup_timer is None
 
-        assert output == expected
-        assert self.jc._comm.last_message == {
-            "msg_type": STATUS,
-            "content": expected,
-        }
+    job_comm.start_job_status_loop()
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": STATUS_ALL,
+        "content": {
+            job_id: ALL_RESPONSE_DATA[STATUS][job_id]
+            for job_id in REFRESH_STATE
+            if REFRESH_STATE[job_id]
+        },
+    }
 
-    # ------------
-    # Retry list of jobs
-    # ------------
+    assert job_comm._running_lookup_loop is True
+    assert job_comm._lookup_timer is not None
 
-    def test_retry_jobs__job_id__ok(self):
-        job_id_list = [BATCH_TERMINATED_RETRIED]
-        check_retry_jobs(self.jc, {JOB_ID: BATCH_TERMINATED_RETRIED}, job_id_list)
+    job_comm.stop_job_status_loop()
+    assert job_comm._running_lookup_loop is False
+    assert job_comm._lookup_timer is None
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs__job_id__dne(self):
-        job_id_list = [JOB_NOT_FOUND]
-        check_retry_jobs(self.jc, {JOB_ID: JOB_NOT_FOUND}, job_id_list)
 
-    def test_retry_jobs__job_id__invalid(self):
-        check_job_id__no_job_test(self.jc, RETRY)
+@mock.patch(CLIENTS, get_mock_client)
+def test_start_job_status_loop__cell_ids(job_comm: JobComm) -> None:
+    cell_ids = list(JOBS_BY_CELL_ID.keys())
+    # Iterate through all combinations of cell IDs
+    for combo_len in range(len(cell_ids) + 1):
+        for combo in itertools.combinations(cell_ids, combo_len):
+            job_comm._jm._running_jobs = {}
+            assert job_comm._running_lookup_loop is False
+            assert job_comm._lookup_timer is None
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs__job_id_list__2_ok(self):
-        job_id_list = [BATCH_TERMINATED_RETRIED, BATCH_ERROR_RETRIED, None]
-        check_retry_jobs(self.jc, job_id_list, job_id_list)
+            job_comm.start_job_status_loop(init_jobs=True, cell_list=list(combo))
+            msg = job_comm._comm.last_message
 
-    def test_retry_jobs__job_id_list__no_jobs(self):
-        check_job_id_list__no_jobs(self.jc, RETRY)
-
-    def test_retry_jobs__job_id_list__ok_bad(self):
-        job_id_list = [BATCH_TERMINATED_RETRIED, BAD_JOB_ID, BAD_JOB_ID_2]
-        check_retry_jobs(self.jc, job_id_list, job_id_list)
-
-    def test_retry_jobs__job_id_list__all_jobs(self):
-        job_id_list = ALL_JOBS + BAD_JOBS
-        for job_id in job_id_list:
-            check_retry_jobs(self.jc, {JOB_ID: job_id}, [job_id])
-        check_retry_jobs(self.jc, job_id_list, job_id_list)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs__job_id_list__all_bad_jobs(self):
-        job_id_list = [BAD_JOB_ID, BAD_JOB_ID_2]
-        check_retry_jobs(self.jc, job_id_list, job_id_list)
-
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_retry_jobs__job_id_list__failure(self):
-        job_id_list = [JOB_COMPLETED, JOB_CREATED, JOB_TERMINATED]
-        req_dict = make_comm_msg(RETRY, job_id_list)
-        err = transform_job_exception(generate_ee2_error(RETRY), "Unable to retry job(s)")
-
-        # patch all client calls to return clients that return errors
-        with mock.patch(CLIENTS, side_effect=get_failing_mock_client):
-            with pytest.raises(type(err), match=re.escape(str(err))):
-                self.jc._handle_comm_message(req_dict)
-
-            msg = self.jc._comm.last_message
-            assert msg == {
-                "msg_type": ERROR,
-                "content": {
-                    "request": req_dict["content"]["data"],
-                    "source": RETRY,
-                    "name": "JSONRPCError",
-                    "error": "Unable to retry job(s)",
-                    "code": -32000,
-                    "message": RETRY + " failed",
-                },
+            exp_job_ids = [
+                job_id
+                for cell_id, job_ids in JOBS_BY_CELL_ID.items()
+                for job_id in job_ids
+                if cell_id in list(combo) and REFRESH_STATE[job_id]
+            ]
+            exp_msg = {
+                "msg_type": "job_status_all",
+                "content": {job_id: ALL_RESPONSE_DATA[STATUS][job_id] for job_id in exp_job_ids},
             }
+            assert exp_msg == msg
 
-    # -----------------
-    # Fetching job logs
-    # -----------------
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs__job_id__ok(self):
-        job_id = JOB_COMPLETED
-        lines_available = MAX_LOG_LINES  # just for convenience if the mock changes
-        # first_line, num_lines, latest, number of lines in output
-        cases = [
-            (0, 1, False, 1),
-            (-100, 1, False, 1),
-            (5, 2, False, 2),
-            (0, 5000, False, lines_available),
-            (0, None, False, lines_available),
-            (8, None, False, 2),
-            (0, 1, True, 1),
-            (-100, 1, True, 1),
-            (5, 2, True, 2),
-            (0, 5000, True, lines_available),
-            (0, None, True, lines_available),
-            (8, None, True, lines_available),
-        ]
-        for c in cases:
-            content = {
-                PARAM["FIRST_LINE"]: c[0],
-                PARAM["NUM_LINES"]: c[1],
-                PARAM["LATEST"]: c[2],
-            }
-            req_dict = make_comm_msg(LOGS, [job_id], content)
-            self.jc._handle_comm_message(req_dict)
-            msg = self.jc._comm.last_message
-            assert msg["msg_type"] == LOGS
-            msg_content = msg["content"][job_id]
-            assert job_id == msg_content["job_id"]
-            assert msg_content["batch_id"] is None
-            assert lines_available == msg_content["max_lines"]
-            assert c[3] == len(msg_content["lines"])
-            assert c[2] == msg_content["latest"]
-            first = 0 if c[1] is None and c[2] is True else c[0]
-            n_lines = c[1] if c[1] else lines_available
-            if first < 0:
-                first = 0
-            if c[2]:
-                first = lines_available - min(n_lines, lines_available)
+            if exp_job_ids:
+                assert job_comm._running_lookup_loop
+                assert job_comm._lookup_timer
 
-            assert first == msg_content["first"]
-            for idx, line in enumerate(msg_content["lines"]):
-                assert str(first + idx) in line["line"]
-                assert line["is_error"] == 0
+                job_comm.stop_job_status_loop()
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs__job_id__failure(self):
-        job_id = JOB_CREATED
-        req_dict = make_comm_msg(LOGS, job_id)
-        self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": LOGS,
+                assert job_comm._running_lookup_loop is False
+                assert job_comm._lookup_timer is None
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_start_job_status_loop__initialise_jobs_error(job_comm: JobComm) -> None:
+    # patch all client calls to return clients that return errors
+    with mock.patch(CLIENTS, side_effect=get_failing_mock_client):
+        # check_workspace_jobs throws an EEServerError
+        job_comm.start_job_status_loop(init_jobs=True)
+        assert job_comm._comm.last_message == {
+            "msg_type": ERROR,
             "content": {
-                JOB_CREATED: {
-                    "job_id": JOB_CREATED,
-                    "batch_id": None,
-                    "error": "Cannot find job log with id: " + JOB_CREATED,
-                }
+                "code": -32000,
+                "error": "Unable to get initial jobs list",
+                "message": "check_workspace_jobs failed",
+                "name": "JSONRPCError",
+                "request": "jc.start_job_status_loop",
+                "source": "ee2",
             },
         }
+        assert job_comm._running_lookup_loop is False
 
-    def test_get_job_logs__job_id__no_job(self):
-        job_id = None
-        req_dict = make_comm_msg(LOGS, {JOB_ID: job_id})
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_start_job_status_loop__no_jobs_stop_loop(job_comm: JobComm) -> None:
+    # reset the job manager so there are no jobs
+    job_comm._jm._running_jobs = {}
+    job_comm._jm._jobs_by_cell_id = {}
+    job_comm._jm = JobManager()
+    assert job_comm._jm._running_jobs == {}
+    # this will trigger a call to get_all_job_states
+    # a message containing all jobs (i.e. {}) will be sent out
+    # when it returns 0 jobs, the JobComm will run stop_job_status_loop
+    job_comm.start_job_status_loop()
+    assert job_comm._running_lookup_loop is False
+    assert job_comm._lookup_timer is None
+    assert job_comm._comm.last_message == {"msg_type": STATUS_ALL, "content": {}}
+
+
+# ---------------------
+# Lookup all job states
+# ---------------------
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_all_job_states__ok(job_comm: JobComm) -> None:
+    check_job_output_states(
+        job_comm, request_type=STATUS_ALL, response_type=STATUS_ALL, ok_states=ALL_JOBS
+    )
+
+
+# -----------------------
+# Lookup single job state
+# -----------------------
+def test_get_job_state__1_ok(job_comm: JobComm) -> None:
+    output_states = job_comm.get_job_state(JOB_COMPLETED)
+    check_job_output_states(job_comm, output_states=output_states, ok_states=[JOB_COMPLETED])
+
+
+def test_get_job_state__no_job(job_comm: JobComm) -> None:
+    with pytest.raises(JobRequestException, match=re.escape(f"{JOBS_MISSING_ERR}: {[None]}")):
+        job_comm.get_job_state(None)  # type: ignore
+
+
+# -----------------------
+# Lookup select job states
+# -----------------------
+def test_get_job_states__job_id__ok(job_comm: JobComm) -> None:
+    check_job_output_states(job_comm, params={JOB_ID: JOB_COMPLETED}, ok_states=[JOB_COMPLETED])
+
+
+def test_get_job_states__job_id__dne(job_comm: JobComm) -> None:
+    check_job_output_states(job_comm, params={JOB_ID: JOB_NOT_FOUND}, error_states=[JOB_NOT_FOUND])
+
+
+def test_get_job_states__job_id__invalid(job_comm: JobComm) -> None:
+    check_job_id__no_job_test(job_comm, STATUS)
+
+
+def test_get_job_states__job_id_list__1_ok(job_comm: JobComm) -> None:
+    job_id_list = [JOB_COMPLETED]
+    check_job_output_states(job_comm, params={JOB_ID_LIST: job_id_list}, ok_states=job_id_list)
+
+
+def test_get_job_states__job_id_list__2_ok(job_comm: JobComm) -> None:
+    job_id_list = [JOB_COMPLETED, BATCH_PARENT]
+    check_job_output_states(job_comm, params={JOB_ID_LIST: job_id_list}, ok_states=job_id_list)
+
+
+def test_get_job_states__job_id_list__ok_bad(job_comm: JobComm) -> None:
+    job_id_list = [BAD_JOB_ID, JOB_COMPLETED]
+    check_job_output_states(
+        job_comm,
+        params={JOB_ID_LIST: job_id_list},
+        ok_states=[JOB_COMPLETED],
+        error_states=[BAD_JOB_ID],
+    )
+
+
+def test_get_job_states__job_id_list__no_jobs(job_comm: JobComm) -> None:
+    check_job_id_list__no_jobs(job_comm, STATUS)
+
+
+def test_get_job_states__batch_id__ok(job_comm: JobComm) -> None:
+    check_job_output_states(
+        job_comm,
+        request_type=STATUS,
+        params={BATCH_ID: BATCH_PARENT},
+        ok_states=BATCH_PARENT_CHILDREN,
+    )
+
+
+def test_get_job_states__batch_id__dne(job_comm: JobComm) -> None:
+    check_batch_id__dne_test(job_comm, STATUS)
+
+
+def test_get_job_states__batch_id__no_job(job_comm: JobComm) -> None:
+    check_batch_id__no_job_test(job_comm, STATUS)
+
+
+def test_get_job_states__batch_id__not_batch(job_comm: JobComm) -> None:
+    check_batch_id__not_batch_test(job_comm, STATUS)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_states__job_id_list__ee2_error(job_comm: JobComm) -> None:
+    exc = Exception("Test exception")
+    exc_message = str(exc)
+
+    expected = {job_id: copy.deepcopy(ALL_RESPONSE_DATA[STATUS][job_id]) for job_id in ALL_JOBS}
+    for job_id in ACTIVE_JOBS:
+        # add in the ee2_error message
+        expected[job_id]["error"] = exc_message
+
+    def mock_check_jobs(params):
+        raise exc
+
+    job_id_list = ALL_JOBS
+    req_dict = make_comm_msg(STATUS, job_id_list)
+
+    with mock.patch.object(MockClients, "check_jobs", side_effect=mock_check_jobs):
+        job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+
+    assert msg == {
+        "msg_type": STATUS,
+        "content": expected,
+    }
+
+
+# -----------------------
+# get cell job states
+# -----------------------
+def test_get_job_states_by_cell_id__cell_id_list_none(job_comm: JobComm) -> None:
+    cell_id_list = None
+    req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
+    err = JobRequestException(CELLS_NOT_PROVIDED_ERR)
+    with pytest.raises(type(err), match=re.escape(str(err))):
+        job_comm._handle_comm_message(req_dict)
+    check_error_message(job_comm, req_dict, err)
+
+
+def test_get_job_states_by_cell_id__empty_cell_id_list(job_comm: JobComm) -> None:
+    cell_id_list = []
+    req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
+    err = JobRequestException(CELLS_NOT_PROVIDED_ERR)
+    with pytest.raises(type(err), match=re.escape(str(err))):
+        job_comm._handle_comm_message(req_dict)
+    check_error_message(job_comm, req_dict, err)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_states_by_cell_id__invalid_cell_id_list(job_comm: JobComm) -> None:
+    cell_id_list = ["a", "b", "c"]
+    req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
+    job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": CELL_JOB_STATUS,
+        "content": NO_JOBS_MAPPING,
+    }
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_states_by_cell_id__invalid_cell_id_list_req(job_comm: JobComm) -> None:
+    cell_id_list = ["a", "b", "c"]
+    req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
+    result = job_comm._handle_comm_message(req_dict)
+    assert result == NO_JOBS_MAPPING
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": CELL_JOB_STATUS,
+        "content": NO_JOBS_MAPPING,
+    }
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_states_by_cell_id__all_results(job_comm: JobComm) -> None:
+    cell_id_list = TEST_CELL_ID_LIST
+    expected_ids = ALL_JOBS
+    expected_states = {job_id: ALL_RESPONSE_DATA[STATUS][job_id] for job_id in expected_ids}
+
+    req_dict = make_comm_msg(CELL_JOB_STATUS, {CELL_ID_LIST: cell_id_list})
+    job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+    assert set(msg.keys()), set(["msg_type" == "content"])
+    assert msg["msg_type"] == CELL_JOB_STATUS
+    assert msg["content"]["jobs"] == expected_states
+    assert set(cell_id_list) == set(msg["content"]["mapping"].keys())
+    for key in msg["content"]["mapping"]:
+        assert set(TEST_CELL_IDs[key]) == set(msg["content"]["mapping"][key])
+
+
+# -----------------------
+# Lookup job info
+# -----------------------
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_info__job_id__ok(job_comm: JobComm) -> None:
+    check_job_info_results(job_comm, {JOB_ID: JOB_COMPLETED}, [JOB_COMPLETED])
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_info__job_id__dne(job_comm: JobComm) -> None:
+    check_job_info_results(job_comm, {JOB_ID: JOB_NOT_FOUND}, [JOB_NOT_FOUND])
+
+
+def test_get_job_info__job_id__invalid(job_comm: JobComm) -> None:
+    check_job_id__no_job_test(job_comm, INFO)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_info__job_id_list__ok(job_comm: JobComm) -> None:
+    check_job_info_results(job_comm, ALL_JOBS, ALL_JOBS)
+
+
+def test_get_job_info__job_id_list__no_jobs(job_comm: JobComm) -> None:
+    check_job_id_list__no_jobs(job_comm, INFO)
+
+
+def test_get_job_info__job_id_list__ok_bad(job_comm: JobComm) -> None:
+    job_id_list = [JOB_COMPLETED, JOB_NOT_FOUND]
+    check_job_info_results(job_comm, job_id_list, job_id_list)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_info__batch_id__ok(job_comm: JobComm) -> None:
+    job_id = BATCH_PARENT
+    check_job_info_results(job_comm, {BATCH_ID: job_id}, BATCH_PARENT_CHILDREN)
+
+
+def test_get_job_info__batch_id__no_job(job_comm: JobComm) -> None:
+    check_batch_id__no_job_test(job_comm, INFO)
+
+
+def test_get_job_info__batch_id__dne(job_comm: JobComm) -> None:
+    check_batch_id__dne_test(job_comm, INFO)
+
+
+def test_get_job_info__batch_id__not_batch(job_comm: JobComm) -> None:
+    check_batch_id__not_batch_test(job_comm, INFO)
+
+
+# ------------
+# Cancel list of jobs
+# ------------
+def test_cancel_jobs__job_id__ok(job_comm: JobComm) -> None:
+    check_job_output_states(
+        job_comm, request_type=CANCEL, params={JOB_ID: JOB_RUNNING}, ok_states=[JOB_RUNNING]
+    )
+
+
+def test_cancel_jobs__job_id__dne(job_comm: JobComm) -> None:
+    check_job_output_states(
+        job_comm,
+        request_type=CANCEL,
+        params={JOB_ID: JOB_NOT_FOUND},
+        error_states=[JOB_NOT_FOUND],
+    )
+
+
+def test_cancel_jobs__job_id__invalid(job_comm: JobComm) -> None:
+    check_job_id__no_job_test(job_comm, CANCEL)
+    job_id_list = [None, ""]
+    for job_id in job_id_list:
+        req_dict = make_comm_msg(CANCEL, {JOB_ID: job_id})
         err = JobRequestException(JOBS_MISSING_ERR, [job_id])
         with pytest.raises(type(err), match=re.escape(str(err))):
-            self.jc._handle_comm_message(req_dict)
-        check_error_message(self.jc, req_dict, err)
+            job_comm._handle_comm_message(req_dict)
+        check_error_message(job_comm, req_dict, err)
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs__job_id__job_dne(self):
-        req_dict = make_comm_msg(LOGS, JOB_NOT_FOUND)
-        self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-        assert msg == {
-            "msg_type": LOGS,
-            "content": {
-                JOB_NOT_FOUND: {
-                    "job_id": JOB_NOT_FOUND,
-                    "error": generate_error(JOB_NOT_FOUND, "not_found"),
-                }
-            },
-        }
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs__job_id_list__one_ok_one_bad_one_fetch_fail(self):
-        req_dict = make_comm_msg(LOGS, [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND])
-        self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-        assert msg["msg_type"] == LOGS
+def test_cancel_jobs__job_id_list__1_ok(job_comm: JobComm) -> None:
+    job_id_list = [JOB_RUNNING]
+    check_job_output_states(
+        job_comm,
+        request_type=CANCEL,
+        params={JOB_ID_LIST: job_id_list},
+        ok_states=job_id_list,
+    )
 
-        assert msg["content"] == {
-            JOB_COMPLETED: {
-                "job_id": JOB_COMPLETED,
-                "first": 0,
-                "max_lines": MAX_LOG_LINES,
-                "latest": False,
-                "batch_id": None,
-                "lines": LOG_LINES,
-            },
-            JOB_CREATED: {
-                "job_id": JOB_CREATED,
-                "batch_id": None,
-                "error": generate_error(JOB_CREATED, "no_logs"),
-            },
-            JOB_NOT_FOUND: {
-                "job_id": JOB_NOT_FOUND,
-                "error": generate_error(JOB_NOT_FOUND, "not_found"),
-            },
-        }
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_get_job_logs__job_id_list__one_ok_one_bad_one_fetch_fail__with_params(
-        self,
-    ):
-        num_lines = int(MAX_LOG_LINES / 5)
-        first = MAX_LOG_LINES - num_lines
-        lines = LOG_LINES[-num_lines::]
+def test_cancel_jobs__job_id_list__2_ok(job_comm: JobComm) -> None:
+    job_id_list = [JOB_CREATED, JOB_RUNNING, None]
+    check_job_output_states(
+        job_comm,
+        request_type=CANCEL,
+        params={JOB_ID_LIST: job_id_list},
+        ok_states=[JOB_CREATED, JOB_RUNNING],
+    )
 
-        req_dict = make_comm_msg(
-            LOGS,
-            [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND],
-            content={"num_lines": num_lines, "latest": True},
-        )
-        self.jc._handle_comm_message(req_dict)
-        msg = self.jc._comm.last_message
-        assert msg["msg_type"] == LOGS
 
-        assert msg["content"] == {
-            JOB_COMPLETED: {
-                "job_id": JOB_COMPLETED,
-                "first": first,
-                "max_lines": MAX_LOG_LINES,
-                "latest": True,
-                "batch_id": None,
-                "lines": lines,
-            },
-            JOB_CREATED: {
-                "job_id": JOB_CREATED,
-                "batch_id": None,
-                "error": generate_error(JOB_CREATED, "no_logs"),
-            },
-            JOB_NOT_FOUND: {
-                "job_id": JOB_NOT_FOUND,
-                "error": generate_error(JOB_NOT_FOUND, "not_found"),
-            },
-        }
+def test_cancel_jobs__job_id_list__no_jobs(job_comm: JobComm) -> None:
+    job_id_list = None
+    req_dict = make_comm_msg(CANCEL, {JOB_ID_LIST: job_id_list})
+    err = JobRequestException(JOBS_MISSING_ERR, job_id_list)
+    with pytest.raises(type(err), match=str(err)):
+        job_comm._handle_comm_message(req_dict)
 
-    # ------------------------
-    # Modify job update
-    # ------------------------
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__job_id_list__start__ok(self):
-        job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
-        check_job_output_states(
-            self.jc,
-            request_type=START_UPDATE,
-            params={JOB_ID_LIST: job_id_list},
-            ok_states=[JOB_COMPLETED, JOB_CREATED, BATCH_PARENT],
-        )
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                assert self.jm._running_jobs[job_id]["refresh"]
-            else:
-                assert self.jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
-        assert self.jc._lookup_timer
-        assert self.jc._running_lookup_loop
+    job_id_list = [None, ""]
+    req_dict = make_comm_msg(CANCEL, job_id_list)
+    err = JobRequestException(JOBS_MISSING_ERR, job_id_list)
+    with pytest.raises(type(err), match=re.escape(str(err))):
+        job_comm._handle_comm_message(req_dict)
+    check_error_message(job_comm, req_dict, err)
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__job_id_list__stop__ok(self):
-        job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
-        check_job_output_states(
-            self.jc,
-            request_type=STOP_UPDATE,
-            params={JOB_ID_LIST: job_id_list},
-            ok_states=[JOB_COMPLETED, JOB_CREATED, BATCH_PARENT],
-        )
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                assert self.jm._running_jobs[job_id]["refresh"] is False
-            else:
-                assert self.jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
-        assert self.jc._lookup_timer is None
-        assert self.jc._running_lookup_loop is False
 
-    def test_modify_job_update__job_id_list__no_jobs(self):
-        job_id_list = [None]
-        req_dict = make_comm_msg(START_UPDATE, job_id_list)  # type: ignore
-        err = JobRequestException(JOBS_MISSING_ERR, job_id_list)
+def test_cancel_jobs__job_id_list__ok_bad(job_comm: JobComm) -> None:
+    job_id_list = [
+        None,
+        JOB_NOT_FOUND,
+        JOB_NOT_FOUND,
+        "",
+        JOB_RUNNING,
+        JOB_CREATED,
+        BAD_JOB_ID,
+    ]
+    check_job_output_states(
+        job_comm,
+        request_type=CANCEL,
+        params={JOB_ID_LIST: job_id_list},
+        ok_states=[JOB_CREATED, JOB_RUNNING],
+        error_states=[JOB_NOT_FOUND, BAD_JOB_ID],
+    )
+
+
+def test_cancel_jobs__job_id_list__all_bad_jobs(job_comm: JobComm) -> None:
+    job_id_list = [None, "", JOB_NOT_FOUND, JOB_NOT_FOUND, BAD_JOB_ID]
+    check_job_output_states(
+        job_comm,
+        request_type=CANCEL,
+        params={JOB_ID_LIST: job_id_list},
+        error_states=[JOB_NOT_FOUND, BAD_JOB_ID],
+    )
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_cancel_jobs__job_id_list__failure(job_comm: JobComm) -> None:
+    # the mock client will throw an error with BATCH_RETRY_RUNNING
+    job_id_list = [JOB_RUNNING, BATCH_RETRY_RUNNING]
+    req_dict = make_comm_msg(CANCEL, job_id_list)
+    output = job_comm._handle_comm_message(req_dict)
+
+    expected = {
+        JOB_RUNNING: ALL_RESPONSE_DATA[STATUS][JOB_RUNNING],
+        BATCH_RETRY_RUNNING: {
+            **ALL_RESPONSE_DATA[STATUS][BATCH_RETRY_RUNNING],
+            "error": CANCEL + " failed",
+        },
+    }
+
+    assert output == expected
+    assert job_comm._comm.last_message == {
+        "msg_type": STATUS,
+        "content": expected,
+    }
+
+
+# ------------
+# Retry list of jobs
+# ------------
+
+
+def test_retry_jobs__job_id__ok(job_comm: JobComm) -> None:
+    job_id_list = [BATCH_TERMINATED_RETRIED]
+    check_retry_jobs(job_comm, {JOB_ID: BATCH_TERMINATED_RETRIED}, job_id_list)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_retry_jobs__job_id__dne(job_comm: JobComm) -> None:
+    job_id_list = [JOB_NOT_FOUND]
+    check_retry_jobs(job_comm, {JOB_ID: JOB_NOT_FOUND}, job_id_list)
+
+
+def test_retry_jobs__job_id__invalid(job_comm: JobComm) -> None:
+    check_job_id__no_job_test(job_comm, RETRY)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_retry_jobs__job_id_list__2_ok(job_comm: JobComm) -> None:
+    job_id_list = [BATCH_TERMINATED_RETRIED, BATCH_ERROR_RETRIED, None]
+    check_retry_jobs(job_comm, job_id_list, job_id_list)
+
+
+def test_retry_jobs__job_id_list__no_jobs(job_comm: JobComm) -> None:
+    check_job_id_list__no_jobs(job_comm, RETRY)
+
+
+def test_retry_jobs__job_id_list__ok_bad(job_comm: JobComm) -> None:
+    job_id_list = [BATCH_TERMINATED_RETRIED, BAD_JOB_ID, BAD_JOB_ID_2]
+    check_retry_jobs(job_comm, job_id_list, job_id_list)
+
+
+def test_retry_jobs__job_id_list__all_jobs(job_comm: JobComm) -> None:
+    job_id_list = ALL_JOBS + BAD_JOBS
+    for job_id in job_id_list:
+        check_retry_jobs(job_comm, {JOB_ID: job_id}, [job_id])
+    check_retry_jobs(job_comm, job_id_list, job_id_list)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_retry_jobs__job_id_list__all_bad_jobs(job_comm: JobComm) -> None:
+    job_id_list = [BAD_JOB_ID, BAD_JOB_ID_2]
+    check_retry_jobs(job_comm, job_id_list, job_id_list)
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_retry_jobs__job_id_list__failure(job_comm: JobComm) -> None:
+    job_id_list = [JOB_COMPLETED, JOB_CREATED, JOB_TERMINATED]
+    req_dict = make_comm_msg(RETRY, job_id_list)
+    err = transform_job_exception(generate_ee2_error(RETRY), "Unable to retry job(s)")
+
+    # patch all client calls to return clients that return errors
+    with mock.patch(CLIENTS, side_effect=get_failing_mock_client):
         with pytest.raises(type(err), match=re.escape(str(err))):
-            self.jc._handle_comm_message(req_dict)
-        check_error_message(self.jc, req_dict, err)
+            job_comm._handle_comm_message(req_dict)
 
-    def test_modify_job_update__job_id_list__stop__ok_bad_job(self):
-        job_id_list = [JOB_COMPLETED, JOB_CREATED]
-        check_job_output_states(
-            self.jc,
-            request_type=STOP_UPDATE,
-            params={JOB_ID_LIST: [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND]},
-            ok_states=[JOB_COMPLETED, JOB_CREATED],
-            error_states=[JOB_NOT_FOUND],
-        )
+        msg = job_comm._comm.last_message
+        assert msg == {
+            "msg_type": ERROR,
+            "content": {
+                "request": req_dict["content"]["data"],
+                "source": RETRY,
+                "name": "JSONRPCError",
+                "error": "Unable to retry job(s)",
+                "code": -32000,
+                "message": RETRY + " failed",
+            },
+        }
 
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                assert self.jm._running_jobs[job_id]["refresh"] is False
-            else:
-                assert self.jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
-        assert self.jc._lookup_timer is None
-        assert self.jc._running_lookup_loop is False
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__job_id_list__stop__loop_still_running(self):
-        """Lookup loop should not get stopped"""
-        self.jc.start_job_status_loop()
+# -----------------
+# Fetching job logs
+# -----------------
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_logs__job_id__ok(job_comm: JobComm) -> None:
+    job_id = JOB_COMPLETED
+    lines_available = MAX_LOG_LINES  # just for convenience if the mock changes
+    # first_line, num_lines, latest, number of lines in output
+    cases = [
+        (0, 1, False, 1),
+        (-100, 1, False, 1),
+        (5, 2, False, 2),
+        (0, 5000, False, lines_available),
+        (0, None, False, lines_available),
+        (8, None, False, 2),
+        (0, 1, True, 1),
+        (-100, 1, True, 1),
+        (5, 2, True, 2),
+        (0, 5000, True, lines_available),
+        (0, None, True, lines_available),
+        (8, None, True, lines_available),
+    ]
+    for c in cases:
+        content = {
+            PARAM["FIRST_LINE"]: c[0],
+            PARAM["NUM_LINES"]: c[1],
+            PARAM["LATEST"]: c[2],
+        }
+        req_dict = make_comm_msg(LOGS, [job_id], content)
+        job_comm._handle_comm_message(req_dict)
+        msg = job_comm._comm.last_message
+        assert msg["msg_type"] == LOGS
+        msg_content = msg["content"][job_id]
+        assert job_id == msg_content["job_id"]
+        assert msg_content["batch_id"] is None
+        assert lines_available == msg_content["max_lines"]
+        assert c[3] == len(msg_content["lines"])
+        assert c[2] == msg_content["latest"]
+        first = 0 if c[1] is None and c[2] is True else c[0]
+        n_lines = c[1] if c[1] else lines_available
+        if first < 0:
+            first = 0
+        if c[2]:
+            first = lines_available - min(n_lines, lines_available)
 
-        job_id_list = [JOB_COMPLETED, BATCH_PARENT, JOB_RUNNING]
-        check_job_output_states(
-            self.jc,
-            request_type=STOP_UPDATE,
-            params={JOB_ID_LIST: job_id_list},
-            ok_states=job_id_list,
-        )
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                assert self.jm._running_jobs[job_id]["refresh"] is False
-            else:
-                assert self.jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
-        assert self.jc._lookup_timer
-        assert self.jc._running_lookup_loop
+        assert first == msg_content["first"]
+        for idx, line in enumerate(msg_content["lines"]):
+            assert str(first + idx) in line["line"]
+            assert line["is_error"] == 0
 
-    # ------------------------
-    # Modify job update batch
-    # ------------------------
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__batch_id__start__ok(self):
-        batch_id = BATCH_PARENT
-        job_id_list = BATCH_PARENT_CHILDREN
-        check_job_output_states(
-            self.jc,
-            request_type=START_UPDATE,
-            params={BATCH_ID: batch_id},
-            ok_states=job_id_list,
-        )
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                assert self.jm._running_jobs[job_id]["refresh"]
-            else:
-                assert self.jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
-        assert self.jc._lookup_timer
-        assert self.jc._running_lookup_loop
 
-    @mock.patch(CLIENTS, get_mock_client)
-    def test_modify_job_update__batch_id__stop__ok(self):
-        batch_id = BATCH_PARENT
-        job_id_list = BATCH_PARENT_CHILDREN
-        check_job_output_states(
-            self.jc,
-            request_type=STOP_UPDATE,
-            params={BATCH_ID: batch_id},
-            ok_states=job_id_list,
-        )
-        for job_id in ALL_JOBS:
-            if job_id in job_id_list:
-                assert self.jm._running_jobs[job_id]["refresh"] is False
-            else:
-                assert self.jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
-        assert self.jc._lookup_timer is None
-        assert self.jc._running_lookup_loop is False
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_logs__job_id__failure(job_comm: JobComm) -> None:
+    job_id = JOB_CREATED
+    req_dict = make_comm_msg(LOGS, job_id)
+    job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": LOGS,
+        "content": {
+            JOB_CREATED: {
+                "job_id": JOB_CREATED,
+                "batch_id": None,
+                "error": "Cannot find job log with id: " + JOB_CREATED,
+            }
+        },
+    }
 
-    def test_modify_job_update__batch_id__no_job(self):
-        check_batch_id__no_job_test(self.jc, START_UPDATE)
-        check_batch_id__no_job_test(self.jc, STOP_UPDATE)
 
-    def test_modify_job_update__batch_id__bad_job(self):
-        check_batch_id__dne_test(self.jc, START_UPDATE)
-        check_batch_id__dne_test(self.jc, STOP_UPDATE)
+def test_get_job_logs__job_id__no_job(job_comm: JobComm) -> None:
+    job_id = None
+    req_dict = make_comm_msg(LOGS, {JOB_ID: job_id})
+    err = JobRequestException(JOBS_MISSING_ERR, [job_id])
+    with pytest.raises(type(err), match=re.escape(str(err))):
+        job_comm._handle_comm_message(req_dict)
+    check_error_message(job_comm, req_dict, err)
 
-    def test_modify_job_update__batch_id__not_batch(self):
-        check_batch_id__not_batch_test(self.jc, START_UPDATE)
-        check_batch_id__not_batch_test(self.jc, STOP_UPDATE)
 
-    # ------------------------
-    # Handle bad comm messages
-    # ------------------------
-    def test_handle_comm_message_bad(self):
-        with pytest.raises(JobRequestException, match=INVALID_REQUEST_ERR):
-            self.jc._handle_comm_message({"foo": "bar"})
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_logs__job_id__job_dne(job_comm: JobComm) -> None:
+    req_dict = make_comm_msg(LOGS, JOB_NOT_FOUND)
+    job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+    assert msg == {
+        "msg_type": LOGS,
+        "content": {
+            JOB_NOT_FOUND: {
+                "job_id": JOB_NOT_FOUND,
+                "error": generate_error(JOB_NOT_FOUND, "not_found"),
+            }
+        },
+    }
 
-        with pytest.raises(JobRequestException, match=MISSING_REQUEST_TYPE_ERR):
-            self.jc._handle_comm_message({"content": {"data": {"request_type": None}}})
 
-    def test_handle_comm_message_unknown(self):
-        unknown = "NotAJobRequest"
-        with pytest.raises(
-            JobRequestException,
-            match=re.escape(f"Unknown KBaseJobs message '{unknown}'"),
-        ):
-            self.jc._handle_comm_message({"content": {"data": {"request_type": unknown}}})
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_logs__job_id_list__one_ok_one_bad_one_fetch_fail(job_comm: JobComm) -> None:
+    req_dict = make_comm_msg(LOGS, [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND])
+    job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+    assert msg["msg_type"] == LOGS
+
+    assert msg["content"] == {
+        JOB_COMPLETED: {
+            "job_id": JOB_COMPLETED,
+            "first": 0,
+            "max_lines": MAX_LOG_LINES,
+            "latest": False,
+            "batch_id": None,
+            "lines": LOG_LINES,
+        },
+        JOB_CREATED: {
+            "job_id": JOB_CREATED,
+            "batch_id": None,
+            "error": generate_error(JOB_CREATED, "no_logs"),
+        },
+        JOB_NOT_FOUND: {
+            "job_id": JOB_NOT_FOUND,
+            "error": generate_error(JOB_NOT_FOUND, "not_found"),
+        },
+    }
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_get_job_logs__job_id_list__one_ok_one_bad_one_fetch_fail__with_params(
+    job_comm,
+):
+    num_lines = int(MAX_LOG_LINES / 5)
+    first = MAX_LOG_LINES - num_lines
+    lines = LOG_LINES[-num_lines::]
+
+    req_dict = make_comm_msg(
+        LOGS,
+        [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND],
+        content={"num_lines": num_lines, "latest": True},
+    )
+    job_comm._handle_comm_message(req_dict)
+    msg = job_comm._comm.last_message
+    assert msg["msg_type"] == LOGS
+
+    assert msg["content"] == {
+        JOB_COMPLETED: {
+            "job_id": JOB_COMPLETED,
+            "first": first,
+            "max_lines": MAX_LOG_LINES,
+            "latest": True,
+            "batch_id": None,
+            "lines": lines,
+        },
+        JOB_CREATED: {
+            "job_id": JOB_CREATED,
+            "batch_id": None,
+            "error": generate_error(JOB_CREATED, "no_logs"),
+        },
+        JOB_NOT_FOUND: {
+            "job_id": JOB_NOT_FOUND,
+            "error": generate_error(JOB_NOT_FOUND, "not_found"),
+        },
+    }
+
+
+# ------------------------
+# Modify job update
+# ------------------------
+@mock.patch(CLIENTS, get_mock_client)
+def test_modify_job_update__job_id_list__start__ok(job_comm: JobComm) -> None:
+    job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
+    check_job_output_states(
+        job_comm,
+        request_type=START_UPDATE,
+        params={JOB_ID_LIST: job_id_list},
+        ok_states=[JOB_COMPLETED, JOB_CREATED, BATCH_PARENT],
+    )
+    for job_id in ALL_JOBS:
+        if job_id in job_id_list:
+            assert job_comm._jm._running_jobs[job_id]["refresh"]
+        else:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
+    assert job_comm._lookup_timer
+    assert job_comm._running_lookup_loop
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_modify_job_update__job_id_list__stop__ok(job_comm: JobComm) -> None:
+    job_id_list = [JOB_COMPLETED, JOB_CREATED, BATCH_PARENT]
+    check_job_output_states(
+        job_comm,
+        request_type=STOP_UPDATE,
+        params={JOB_ID_LIST: job_id_list},
+        ok_states=[JOB_COMPLETED, JOB_CREATED, BATCH_PARENT],
+    )
+    for job_id in ALL_JOBS:
+        if job_id in job_id_list:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] is False
+        else:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
+    assert job_comm._lookup_timer is None
+    assert job_comm._running_lookup_loop is False
+
+
+def test_modify_job_update__job_id_list__no_jobs(job_comm: JobComm) -> None:
+    job_id_list = [None]
+    req_dict = make_comm_msg(START_UPDATE, job_id_list)  # type: ignore
+    err = JobRequestException(JOBS_MISSING_ERR, job_id_list)
+    with pytest.raises(type(err), match=re.escape(str(err))):
+        job_comm._handle_comm_message(req_dict)
+    check_error_message(job_comm, req_dict, err)
+
+
+def test_modify_job_update__job_id_list__stop__ok_bad_job(job_comm: JobComm) -> None:
+    job_id_list = [JOB_COMPLETED, JOB_CREATED]
+    check_job_output_states(
+        job_comm,
+        request_type=STOP_UPDATE,
+        params={JOB_ID_LIST: [JOB_COMPLETED, JOB_CREATED, JOB_NOT_FOUND]},
+        ok_states=[JOB_COMPLETED, JOB_CREATED],
+        error_states=[JOB_NOT_FOUND],
+    )
+
+    for job_id in ALL_JOBS:
+        if job_id in job_id_list:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] is False
+        else:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
+    assert job_comm._lookup_timer is None
+    assert job_comm._running_lookup_loop is False
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_modify_job_update__job_id_list__stop__loop_still_running(job_comm: JobComm) -> None:
+    """Lookup loop should not get stopped"""
+    job_comm.start_job_status_loop()
+
+    job_id_list = [JOB_COMPLETED, BATCH_PARENT, JOB_RUNNING]
+    check_job_output_states(
+        job_comm,
+        request_type=STOP_UPDATE,
+        params={JOB_ID_LIST: job_id_list},
+        ok_states=job_id_list,
+    )
+    for job_id in ALL_JOBS:
+        if job_id in job_id_list:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] is False
+        else:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
+    assert job_comm._lookup_timer
+    assert job_comm._running_lookup_loop
+
+
+# ------------------------
+# Modify job update batch
+# ------------------------
+@mock.patch(CLIENTS, get_mock_client)
+def test_modify_job_update__batch_id__start__ok(job_comm: JobComm) -> None:
+    batch_id = BATCH_PARENT
+    job_id_list = BATCH_PARENT_CHILDREN
+    check_job_output_states(
+        job_comm,
+        request_type=START_UPDATE,
+        params={BATCH_ID: batch_id},
+        ok_states=job_id_list,
+    )
+    for job_id in ALL_JOBS:
+        if job_id in job_id_list:
+            assert job_comm._jm._running_jobs[job_id]["refresh"]
+        else:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
+    assert job_comm._lookup_timer
+    assert job_comm._running_lookup_loop
+
+
+@mock.patch(CLIENTS, get_mock_client)
+def test_modify_job_update__batch_id__stop__ok(job_comm: JobComm) -> None:
+    batch_id = BATCH_PARENT
+    job_id_list = BATCH_PARENT_CHILDREN
+    check_job_output_states(
+        job_comm,
+        request_type=STOP_UPDATE,
+        params={BATCH_ID: batch_id},
+        ok_states=job_id_list,
+    )
+    for job_id in ALL_JOBS:
+        if job_id in job_id_list:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] is False
+        else:
+            assert job_comm._jm._running_jobs[job_id]["refresh"] == REFRESH_STATE[job_id]
+    assert job_comm._lookup_timer is None
+    assert job_comm._running_lookup_loop is False
+
+
+def test_modify_job_update__batch_id__no_job(job_comm: JobComm) -> None:
+    check_batch_id__no_job_test(job_comm, START_UPDATE)
+    check_batch_id__no_job_test(job_comm, STOP_UPDATE)
+
+
+def test_modify_job_update__batch_id__bad_job(job_comm: JobComm) -> None:
+    check_batch_id__dne_test(job_comm, START_UPDATE)
+    check_batch_id__dne_test(job_comm, STOP_UPDATE)
+
+
+def test_modify_job_update__batch_id__not_batch(job_comm: JobComm) -> None:
+    check_batch_id__not_batch_test(job_comm, START_UPDATE)
+    check_batch_id__not_batch_test(job_comm, STOP_UPDATE)
+
+
+# ------------------------
+# Handle bad comm messages
+# ------------------------
+def test_handle_comm_message_bad(job_comm: JobComm) -> None:
+    with pytest.raises(JobRequestException, match=INVALID_REQUEST_ERR):
+        job_comm._handle_comm_message({"foo": "bar"})
+
+    with pytest.raises(JobRequestException, match=MISSING_REQUEST_TYPE_ERR):
+        job_comm._handle_comm_message({"content": {"data": {"request_type": None}}})
+
+
+def test_handle_comm_message_unknown(job_comm: JobComm) -> None:
+    unknown = "NotAJobRequest"
+    with pytest.raises(
+        JobRequestException,
+        match=re.escape(f"Unknown KBaseJobs message '{unknown}'"),
+    ):
+        job_comm._handle_comm_message({"content": {"data": {"request_type": unknown}}})


### PR DESCRIPTION
# Description of PR purpose/changes

More pytestification.

This removes the unittest class around the JobComm tests.

The first commit removes the class wrapper, de-indents the tests, and replaces all the `self` and `self.jc` references with `job_comm`.

The second commit fixes all the little bits and pieces left after doing that.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-47
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

N/A
