### PR TITLE
UIP-47: Updating clustergrammer widget to v2 and un-skip clustergrammer test

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,10 @@ This is built on the Jupyter Notebook v6.5.6 and IPython 8.10.0 (more notes will
 -   UIP-41 - Fix Dropzone dependency issues, address problems with unit tests
 -   UIP-41 - Removed unused Python dependencies
 
+### Notebook widget updates
+
+- The clustergrammer widget was updated to clustergrammer2; see the python dependency changes below for version information.
+
 ### Dependency Changes
 
 - Updated to include all Python dependencies in the image built in this repo, and removed those that are not directly referenced in KBase code.
@@ -24,10 +28,13 @@ This is built on the Jupyter Notebook v6.5.6 and IPython 8.10.0 (more notes will
 - the requirements in `src/requirements-dev.txt` are needed for Narrative development and testing.
 - flake8, isort, and black have been replaced by the multifunctional formatter and linter Ruff.
 
+
 - Python dependency updates
   - beautifulsoup4: 4.12.2 -> 4.12.3
   - black: 24.4.2 -> replaced by Ruff
   - coverage: 7.3.1 -> 7.5.0
+  - clustergrammer_widget: removed
+  - clustergrammer2: 0.18.0 (new)
   - cryptography: 41.0.4 -> 42.0.5
   - flake8: 7.0.0 -> replaced by Ruff
   - idna: 3.4 -> 3.6

--- a/nbextensions/install.sh
+++ b/nbextensions/install.sh
@@ -36,4 +36,6 @@ jupyter nbextension install "${dir}/bulkImportCell" --symlink --sys-prefix
 jupyter nbextension enable bulkImportCell/main --sys-prefix
 
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
-jupyter nbextension enable --py --sys-prefix clustergrammer_widget
+
+jupyter nbextension install --py --sys-prefix clustergrammer2
+jupyter nbextension enable --py --sys-prefix clustergrammer2

--- a/src/biokbase/narrative/app_util.py
+++ b/src/biokbase/narrative/app_util.py
@@ -21,9 +21,8 @@ def check_tag(tag, raise_exception: bool = False):
     """
     tag_exists = tag in app_version_tags
     if not tag_exists and raise_exception:
-        raise ValueError(
-            "Can't find tag %s - allowed tags are %s" % (tag, ", ".join(app_version_tags))
-        )
+        msg = f"Can't find tag {tag} - allowed tags are {', '.join(app_version_tags)}"
+        raise ValueError(msg)
     return tag_exists
 
 

--- a/src/biokbase/narrative/tests/test_viewers.py
+++ b/src/biokbase/narrative/tests/test_viewers.py
@@ -11,6 +11,7 @@ EXPRESSION_MATRIX_REF = "28852/11/1"
 
 @pytest.mark.parametrize("arg_type", ["col_categories", "row_categories", "normalize_on"])
 def test_bad_view_as_clustergrammer_params_generic_ref(arg_type: str) -> None:
+    """Test that the clustergrammer widget throws an error with invalid params."""
     with pytest.raises(
         AssertionError,
         match=f"Error with clustergrammer arguments:\n{arg_type}",
@@ -20,13 +21,14 @@ def test_bad_view_as_clustergrammer_params_generic_ref(arg_type: str) -> None:
 
 @pytest.mark.vcr()
 def test_bad_view_as_clustergrammer_params_attr_set_ref() -> None:
+    """Test that the clustergrammer widget throws an error with invalid input."""
     with pytest.raises(ValueError, match="not a compatible data type"):
         viewers.view_as_clustergrammer(ATTRIBUTE_SET_REF)
 
 
 @pytest.mark.vcr()
-@pytest.mark.skip("Clustergrammer widget is currently broken")
 def test_view_as_clustergrammer() -> None:
+    """Ensure that the clustergrammer widget can be successfully launched."""
     assert (
         str(type(viewers.view_as_clustergrammer(GENERIC_REF)))
         == "<class 'clustergrammer2.example.CGM2'>"

--- a/src/biokbase/narrative/viewers.py
+++ b/src/biokbase/narrative/viewers.py
@@ -2,13 +2,10 @@
 
 from typing import Any
 
-import clustergrammer_widget
 import pandas as pd
 from biokbase.narrative import clients
 from biokbase.narrative.system import system_variable
-from clustergrammer_widget.clustergrammer import Network
-
-# from clustergrammer2 import CGM2, Network
+from clustergrammer2 import CGM2, Network
 
 
 def view_as_clustergrammer(
@@ -16,7 +13,7 @@ def view_as_clustergrammer(
     col_categories: tuple | set | list | None = (),
     row_categories: tuple | set | list | None = (),
     normalize_on: str | None = None,
-):
+) -> CGM2:
     """This function returns an interactive clustergrammer widget for a specified object.
 
     Data type must contain a 'data' key with a FloatMatrix2D type value
@@ -43,7 +40,7 @@ def view_as_clustergrammer(
 
     generic_df = get_df(ws_ref, col_categories, row_categories, True)
 
-    net = Network(clustergrammer_widget)
+    net = Network(CGM2)
     # load pandas dataframe
     net.load_df(generic_df)
     if normalize_on:

--- a/src/biokbase/narrative/widgetmanager.py
+++ b/src/biokbase/narrative/widgetmanager.py
@@ -1,3 +1,5 @@
+"""Implements the WidgetManager class that programmatically shows KBase JavaScript widgets."""
+
 import json
 import os
 import time
@@ -16,12 +18,6 @@ from jinja2 import Template
 
 from .upa import is_ref, is_upa
 
-"""
-widgetmanager.py
-
-Implements the WidgetManager class that programmatically shows
-KBase JavaScript widgets.
-"""
 __author__ = "Bill Riehl <wjriehl@lbl.gov>"
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-clustergrammer_widget==1.13.3
+clustergrammer2==0.18.0
 ipython==8.24.0
 ipywidgets==7.7.1
 jinja2==3.1.3
@@ -8,4 +8,5 @@ pymongo==4.7.0
 pyyaml==6.0.1
 requests==2.31.0
 scikit-learn==1.4.2
+statsmodels==0.14.2
 tornado==6.4


### PR DESCRIPTION
# Description of PR purpose/changes

This PR updates the clustergrammer widget to the new version.

Next PR will be another small one with an update to the Comm class that comes up in the pytest output.
I'll check on the various python updates needed and if they look straightforward, make a PR to update them, too.
I'll update the release notes and version once all this kerfuffle is done.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-47
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
