### PR TITLE
UIP-47: using newer "create_comm" function in place of antiquated "Comm()" call

### DIFF
--- a/src/biokbase/narrative/jobs/jobcomm.py
+++ b/src/biokbase/narrative/jobs/jobcomm.py
@@ -8,8 +8,8 @@ from biokbase.narrative.common import kblogging
 from biokbase.narrative.exception_util import JobRequestException, NarrativeException
 from biokbase.narrative.jobs.jobmanager import JobManager
 from biokbase.narrative.jobs.util import load_job_constants
+from comm import create_comm
 from comm.base_comm import BaseComm
-from ipykernel.comm import Comm
 
 (PARAM, MESSAGE_TYPE) = load_job_constants()
 
@@ -167,7 +167,6 @@ class JobComm:
 
     # The kernel job comm channel that talks to the front end.
     _comm: BaseComm | None = None
-
     # The JobManager that actually manages things.
     _jm: JobManager | None = None
 
@@ -185,10 +184,12 @@ class JobComm:
     def __init__(self: "JobComm") -> None:
         """Initialise the JobComm class."""
         if self._comm is None:
-            self._comm = Comm(target_name="KBaseJobs", data={})
+            self._comm = create_comm(target_name="KBaseJobs", data={})
             self._comm.on_msg(self._handle_comm_message)
+
         if self._jm is None:
             self._jm = JobManager()
+
         if self._msg_map is None:
             self._msg_map = {
                 MESSAGE_TYPE["CANCEL"]: self.cancel_jobs,
@@ -524,7 +525,7 @@ class JobComm:
 
     def send_error_message(
         self: "JobComm",
-        req: JobRequest | dict[str, Any] | str,
+        req: JobRequest | dict[str, Any] | str | None,
         content: dict[str, Any] | None = None,
     ) -> None:
         """Sends an error message over the KBaseJobs channel.

--- a/src/biokbase/narrative/tests/narrative_mock/mockcomm.py
+++ b/src/biokbase/narrative/tests/narrative_mock/mockcomm.py
@@ -21,12 +21,6 @@ class MockComm(BaseComm):
             return None
         return self.messages[-1]
 
-    def pop_message(self: "MockComm") -> str | None:
-        """Pop the last message off the message list."""
-        if len(self.messages) == 0:
-            return None
-        return self.messages.pop()
-
     def on_msg(self: "MockComm", *args, **kwargs) -> None:
         """Mock the msg router."""
 


### PR DESCRIPTION
# Description of PR purpose/changes

Pytest was issuing a warning that `Comm()` has been replaced by `create_comm`, so I have duly updated the code.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-47
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

JS tests failed but the ol' faithful python tests completed successfully.

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
