### PR TITLE
UIP-43 Change Narrative JSON downloads to use a download-to-staging app

### DIFF
--- a/kbase-extension/static/kbase/js/common/data.js
+++ b/kbase-extension/static/kbase/js/common/data.js
@@ -5,6 +5,9 @@ define(['kb_service/client/workspace', 'kb_service/utils', 'common/runtime'], (
 ) => {
     'use strict';
     function filterObjectInfoByType(objects, types) {
+        if (types.includes('*')) {
+            return objects.filter((item) => item !== undefined);
+        }
         return objects
             .map((objectInfo) => {
                 const type = objectInfo.typeModule + '.' + objectInfo.typeName;

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
@@ -16,6 +16,7 @@ define([
     return KBWidget({
         name: 'kbaseNarrativeDownloadPanel',
         version: '1.0.0',
+        // TODO: remove / refactor duplication in options.
         options: {
             token: null,
             type: null,
@@ -28,9 +29,8 @@ define([
         type: null, // Type of workspace object to show downloaders for
         objId: null,
         loadingImage: Config.get('loading_gif'),
-        wsUrl: Config.url('workspace'),
-        ujsURL: Config.url('user_and_job_state'),
         shockURL: Config.url('shock'),
+        // TODO: remove data_import_export code
         exportURL: Config.url('data_import_export'),
         useDynamicDownloadSupport: false,
         nmsURL: Config.url('narrative_method_store'),
@@ -54,9 +54,11 @@ define([
             const lastUpdateTime = this.downloadSpecCache['lastUpdateTime'];
             if (lastUpdateTime) {
                 this.render();
+                return Promise.resolve(this);
             } else {
+                // TODO: remove this, and fetch downloader info from NarrativeService, in a TBD function.
                 const nms = new NarrativeMethodStore(this.nmsURL, { token: this.token });
-                Promise.resolve(
+                return Promise.resolve(
                     nms.list_categories({ load_methods: 0, load_apps: 0, load_types: 1 })
                 )
                     .then((data) => {
@@ -76,18 +78,20 @@ define([
                         this.downloadSpecCache['types'] = types;
                         this.downloadSpecCache['lastUpdateTime'] = Date.now();
                         this.render();
+                        return this;
                     })
                     .catch((error) => {
                         this.showError(error);
+                        return this;
                     });
             }
-            return this;
         },
 
         render: function () {
             const self = this;
             const downloadPanel = this.$elem;
 
+            // TODO: migrate to SCSS
             const $labeltd = $('<td>')
                 .css({ 'white-space': 'nowrap', padding: '1px' })
                 .append('Export as:');
@@ -151,6 +155,7 @@ define([
             downloadPanel.append(self.$statusDiv.hide());
         },
 
+        // TODO: move this to result of as-yet-unwritten NarrativeService call
         prepareDownloaders: function (type) {
             const ret = [];
             if (!this.downloadSpecCache['types']) {

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
@@ -109,6 +109,16 @@ define([
                             }
                         );
                     });
+                } else if (descr.name.toLocaleLowerCase() === 'json') {
+                    $dlBtn.click(() => {
+                        Jupyter.narrative.addAndPopulateApp(
+                            'kb_staging_exporter/export_json_to_staging',
+                            'dev',
+                            {
+                                input_ref: self.objName,
+                            }
+                        );
+                    });
                 } else {
                     $dlBtn.click(() => {
                         $btnTd.find('.kb-data-list-btn').prop('disabled', true);
@@ -120,24 +130,11 @@ define([
 
             const downloaders = self.prepareDownloaders(self.type);
             downloaders.forEach((dl) => addDownloader(dl));
+            addDownloader({
+                name: 'JSON',
+                local_function: ''
+            });
 
-            $btnTd.append(
-                $('<button>')
-                    .addClass('kb-data-list-btn')
-                    .append('JSON')
-                    .click(() => {
-                        const urlSuffix =
-                            '/download?' +
-                            'ref=' +
-                            encodeURIComponent(self.ref) +
-                            '&url=' +
-                            encodeURIComponent(self.wsUrl) +
-                            '&wszip=1' +
-                            '&name=' +
-                            encodeURIComponent(self.objName + '.JSON.zip');
-                        self.downloadFile(urlSuffix);
-                    })
-            );
             $btnTd.append(
                 $('<button>')
                     .addClass('kb-data-list-cancel-btn')

--- a/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
@@ -4,11 +4,25 @@ define([
     'base/js/namespace',
     'narrativeMocks',
     'testUtil',
-], ($, kbaseNarrativeDownloadPanel, Jupyter, Mocks, TestUtil) => {
+    'narrativeConfig'
+], ($, kbaseNarrativeDownloadPanel, Jupyter, Mocks, TestUtil, Config) => {
     'use strict';
 
-    describe('The kbaseNarrativeDownloadPanel widget', () => {
+    fdescribe('The kbaseNarrativeDownloadPanel widget', () => {
         let $div = null;
+        const ws = 1111,
+            oid = 2222,
+            ver = 3333,
+            name = 'fake_test_object',
+            objType = 'FakeModule.FakeType',
+            saveDate = '2018-08-03T00:17:04+0000',
+            userId = 'fakeUser',
+            wsName = 'fakeWs',
+            checksum = '12345',
+            meta = {},
+            size = 1234567,
+            upa = `${ws}/${oid}/${ver}`;
+
         beforeEach(() => {
             jasmine.Ajax.install();
             const AUTH_TOKEN = 'fakeAuthToken';
@@ -27,95 +41,72 @@ define([
             TestUtil.clearRuntime();
         });
 
-        it('Should properly load with a valid upa', () => {
-            const ws = 1111,
-                oid = 2222,
-                ver = 3333,
-                name = 'fake_test_object',
-                objType = 'FakeModule.FakeType-7.7',
-                saveDate = '2018-08-03T00:17:04+0000',
-                userId = 'fakeUser',
-                wsName = 'fakeWs',
-                checksum = '12345',
-                meta = {},
-                size = 1234567,
-                upa = String(ws) + '/' + String(oid) + '/' + String(ver);
-
-            jasmine.Ajax.stubRequest('https://ci.kbase.us/services/ws').andReturn({
-                status: 200,
-                statusText: 'success',
-                contentType: 'application/json',
-                responseHeaders: '',
-                responseText: JSON.stringify({
-                    version: '1.1',
-                    result: [
-                        {
-                            infos: [
-                                [
-                                    oid,
-                                    name,
-                                    objType,
-                                    saveDate,
-                                    ver,
-                                    userId,
-                                    ws,
-                                    wsName,
-                                    checksum,
-                                    size,
-                                    meta,
-                                ],
-                            ],
-                            paths: [[upa]],
+        const exportCases = [
+            ['single method', { FAKE: 'fake_method' }],
+            ['a staging method', { FAKE: 'fake_method', STAGING: 'fake_staging_method' }],
+            ['no downloaders', {}]
+        ];
+        exportCases.forEach((exportCase) => {
+            it(`Should properly load with ${exportCase[0]}`, async () => {
+                const exporters = exportCase[1];
+                await new kbaseNarrativeDownloadPanel($div, {
+                    token: null,
+                    type: objType,
+                    objId: oid,
+                    ref: upa,
+                    objName: name,
+                    downloadSpecCache: {
+                        lastUpdateTime: 100,
+                        types: {
+                            [objType]: { export_functions: exporters },
                         },
-                    ],
-                }),
-            });
-
-            new kbaseNarrativeDownloadPanel($div, {
-                token: null,
-                type: objType,
-                objId: oid,
-                ref: upa,
-                objName: name,
-                downloadSpecCache: {
-                    lastUpdateTime: 100,
-                    types: {
-                        [objType]: { export_functions: { FAKE: 'fake_method' } },
                     },
-                },
+                });
+                const exportBtns = $div.find('.kb-data-list-btn');
+                const names = Object.keys(exporters);
+                expect(exportBtns.length).toEqual(1 + names.length);
+                [...names, 'JSON'].forEach((exporterName, idx) => {
+                    expect(exportBtns[idx].textContent).toContain(exporterName);
+                });
+                expect($div.find('.kb-data-list-cancel-btn').html()).toContain('Cancel');
             });
-            expect($div.html()).toContain('JSON');
-            expect($div.html()).toContain('FAKE');
         });
 
-        it('Should load and register a Staging app button', () => {
-            const ws = 1111,
-                oid = 2222,
-                ver = 3333,
-                name = 'fake_test_object',
-                objType = 'KBaseGenomes.Genome',
-                upa = String(ws) + '/' + String(oid) + '/' + String(ver);
-
-            new kbaseNarrativeDownloadPanel($div, {
-                token: null,
-                type: objType,
-                objName: name,
-                objId: oid,
-                ref: upa,
-                downloadSpecCache: {
-                    lastUpdateTime: 100,
-                    types: {
-                        [objType]: {
+        it('Should load after fetching exporter info from NMS', async () => {
+            jasmine.Ajax.stubRequest(
+                Config.url('narrative_method_store'),
+                /NarrativeMethodStore.list_categories/
+            ).andReturn({
+                status: 200,
+                statusText: 'HTTP/1 200 OK',
+                contentType: 'application/json',
+                responseText: JSON.stringify({
+                    version: '1.1',
+                    id: '12345',
+                    result: [{}, {}, {}, {
+                        'FakeModule.FakeType': {
                             export_functions: {
-                                FAKE: 'fake_method',
-                                STAGING: 'staging_method',
-                            },
-                        },
-                    },
-                },
+                                SOME_FORMAT: 'export_as_some_format'
+                            }
+                        }
+                    }]
+                })
             });
 
-            expect($div.html()).toContain('STAGING');
+            await new kbaseNarrativeDownloadPanel($div, {
+                token: null,
+                type: objType,
+                objId: oid,
+                ref: upa,
+                objName: name,
+                downloadSpecCache: {}
+            });
+            const exportBtns = $div.find('.kb-data-list-btn');
+            expect(exportBtns.length).toEqual(2);
+            ['SOME_FORMAT', 'JSON'].forEach((exporterName, idx) => {
+                expect(exportBtns[idx].textContent).toContain(exporterName);
+            });
+            expect($div.find('.kb-data-list-cancel-btn').html()).toContain('Cancel');
         });
     });
 });


### PR DESCRIPTION
# Description of PR purpose/changes

First step in removing the Data Import Export service from the Narrative - remove the usage of the JSON downloaders. Instead, like most other downloaders, this migrates their usage to an app that downloads them to the staging area for easier export.

There's a lot of work to do on the download panel, this also updates the existing (slim) tests and adds some TODOs.

Also, to support the single download-to-staging app for JSON files, this includes a new wildcard operator for which types are available to use as an app input field. The same function is used for every data type, so as long as an input field is specified by a "*", then it will include all data objects as a possible input.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-43
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [n/a] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [n/a] [Version has been bumped](https://semver.org/) for each release
- [n/a] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
