### PR TITLE
UIP-43 fix printed warning when running an app with a wildcard allowed type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3443,9 +3443,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001639",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
-            "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
+            "version": "1.0.30001640",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+            "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
             "dev": true,
             "funding": [
                 {

--- a/src/biokbase/narrative/tests/test_app_util.py
+++ b/src/biokbase/narrative/tests/test_app_util.py
@@ -262,6 +262,11 @@ app_param_cases = [
     ),
     (
         "text",
+        {"text_options": {"valid_ws_types": ["*", "FooBar.Baz"]}},
+        {"allowed_types": ["*", "FooBar.Baz"]},
+    ),
+    (
+        "text",
         {"text_options": {"regex_constraint": "/\\d+/"}},
         {"regex_constraint": "/\\d+/"},
     ),

--- a/src/biokbase/narrative/tests/test_appmanager.py
+++ b/src/biokbase/narrative/tests/test_appmanager.py
@@ -987,6 +987,22 @@ class AppManagerTestCase(unittest.TestCase):
 
     @mock.patch(CLIENTS_AM_SM, get_mock_client)
     @mock.patch(CLIENTS_SM, get_mock_client)
+    def test_validate_params_wildcard_type(self):
+        inputs = {
+            "input_ref": READS_OBJ_1,
+            "destination_dir": "workspace_export",
+            "format": "legacy_data_import_export",
+        }
+        app_id = "kb_staging_exporter/export_json_to_staging"
+        tag = "dev"
+        spec = self.am.spec_manager.get_spec(app_id, tag=tag)
+        spec_params = self.am.spec_manager.app_params(spec)
+        (params, ws_inputs) = app_util.validate_parameters(app_id, tag, spec_params, inputs)
+        assert params == inputs
+        assert ws_inputs == ["12345/7/1"]
+
+    @mock.patch(CLIENTS_AM_SM, get_mock_client)
+    @mock.patch(CLIENTS_SM, get_mock_client)
     @mock.patch(CLIENTS, get_mock_client)
     def test_input_mapping(self):
         self.maxDiff = None


### PR DESCRIPTION
# Description of PR purpose/changes

A warning appears when running the upload JSON object to Staging app. This skips the code that would trigger that warning. Also a bit of linting to make ruff happy.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-43
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
