### PR TITLE
UIP-45 update the report widget to use the new blobstore links for file downloads

### DIFF
--- a/test/unit/spec/function_output/kbaseReportView-spec.js
+++ b/test/unit/spec/function_output/kbaseReportView-spec.js
@@ -6,7 +6,6 @@ define([
     'narrativeConfig',
     'testUtil',
 ], (ReportView, Jupyter, $, Mocks, Config, TestUtil) => {
-    'use strict';
     const FAKE_SERV_URL = 'https://ci.kbase.us/report_serv';
     const REPORT_REF = '1/2/3';
 
@@ -330,10 +329,8 @@ define([
                 badUrl = 'https://ci.kbase.us/not/a/shock/url';
             expect(reportWidget.importExportLink(badUrl, name)).toBeNull();
             const result = reportWidget.importExportLink(goodUrl, name);
-            expect(result).toMatch(new RegExp('^' + Config.url('data_import_export')));
-            expect(result).toContain('wszip=0');
-            expect(result).toContain('name=some_file.txt');
-            expect(result).toContain('id=' + shockNode);
+            expect(result).toMatch(new RegExp('^' + Config.url('blobstore')));
+            expect(result).toContain('/node/' + shockNode + '?download');
         });
 
         it('should respond to errors by rendering an error string', async function () {
@@ -416,7 +413,7 @@ define([
             const fileInfo = REPORT_OBJ.file_links[0];
             const fileUrlParts = fileInfo.URL.split('/');
             const fileNode = fileUrlParts[fileUrlParts.length - 1];
-            const expectedUrl = `${Config.url('data_import_export')}/download?id=${fileNode}&wszip=0&name=${fileInfo.name}`;
+            const expectedUrl = `${Config.url('blobstore')}/node/${fileNode}?download`;
             expect(dlIframe.getAttribute('src')).toEqual(expectedUrl);
         });
     });


### PR DESCRIPTION
# Description of PR purpose/changes

Some reports have files that can be downloaded. Currently, these use the data_import_export service, which we're working on removing. This updates those links to use the Blobstore service instead. It also updates those links so they behave as links and show an HTML on hover in the usual browsers, where it didn't before.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
