### PR TITLE
UIP-45 add text only output

### DIFF
--- a/nbextensions/appCell2/widgets/appCellWidget.js
+++ b/nbextensions/appCell2/widgets/appCellWidget.js
@@ -76,8 +76,6 @@ define(
         AppParamsWidget,
         AppParamsViewWidget
     ) => {
-        'use strict';
-
         const t = html.tag,
             div = t('div'),
             span = t('span'),
@@ -1301,7 +1299,8 @@ define(
                 skip the output cell creation.
                 */
                 // widgets named 'no-display' are a trigger to skip the output cell process.
-                const skipOutputCell = model.getItem('exec.outputWidgetInfo.name') === 'no-display';
+                const widgetName = model.getItem('exec.outputWidgetInfo.name');
+                const skipOutputCell = widgetName === 'no-display' || widgetName === 'text-only';
                 let cellInfo;
                 if (skipOutputCell) {
                     cellInfo = {
@@ -1834,7 +1833,6 @@ define(
         };
     },
     (err) => {
-        'use strict';
         console.error('ERROR loading appCell appCellWidget', err);
     }
 );

--- a/nbextensions/appCell2/widgets/tabs/resultsViewer.js
+++ b/nbextensions/appCell2/widgets/tabs/resultsViewer.js
@@ -117,11 +117,24 @@ define([
             return renderReportView(reportInputs);
         }
 
+        /**
+         * Expects that the result text should be a string, but handles other cases as well.
+         * If resultText is not a string or number, or is an empty string, this sets the text
+         * to "App completed successfully." Otherwise, it truncates the result to 1000 characters.
+         *
+         * This then gets HTML-escaped and embedded in a div for returning.
+         * @param {str} resultText
+         * @returns
+         */
         function buildOutputText(resultText) {
             // default if text is empty, null, or undefined
-            if (resultText === null || resultText === undefined || resultText === '') {
+            if (
+                !(typeof resultText === 'string' && resultText.trim().length > 0) &&
+                typeof resultText !== 'number'
+            ) {
                 resultText = 'App completed successfully.';
             }
+            resultText = String(resultText).trim();
             // cap the results at 1,000 characters.
             if (resultText.length > 1000) {
                 resultText =

--- a/test/unit/spec/nbextensions/appCell2/widgets/tabs/resultsViewer-spec.js
+++ b/test/unit/spec/nbextensions/appCell2/widgets/tabs/resultsViewer-spec.js
@@ -160,6 +160,21 @@ define([
             expect(node.innerHTML).toContain('A'.repeat(10));
         });
 
+        it('starts a viewer with truncated output', async () => {
+            const textLength = 10000;
+            const maxLen = 1000;
+            const { model, state } = buildTextModel(textLength);
+            const viewer = ResultsViewer.make({ model });
+            await viewer.start({
+                node,
+                jobState: state,
+                isParentJob: false,
+            });
+            expect(node.querySelector('.kb-app-results-tab')).toBeDefined();
+            expect(node.innerHTML).toContain('A'.repeat(maxLen));
+            expect(node.innerHTML).toContain(`[truncated from ${textLength} characters]`);
+        });
+
         it('starts and stops a viewer with a report from a batch job', async () => {
             const model = buildModel({ hasReport: true, isParentJob: true, jobComplete: true });
             const viewer = ResultsViewer.make({ model });


### PR DESCRIPTION
# Description of PR purpose/changes

Adds a text-only output option for apps.
If the app has output widget `text-only` and includes `result_text` as an output value, then it will just display that text in the results, unformatted (save for HTML escaping).

I don't really like the magic names here, either, but they're a mimic of the report stuff. To do it the right way would be much more work (and should include changing up how we handle reports at the NMS level).

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
