### PR TITLE
UIP-46 fix bug with displaying wildcard in data type input in app cell info tab

### DIFF
--- a/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
+++ b/kbase-extension/static/kbase/js/common/cellComponents/tabs/infoTab.js
@@ -4,8 +4,6 @@ define(['domPurify', 'common/format', 'common/html', 'util/string'], (
     html,
     string
 ) => {
-    'use strict';
-
     // Note - would destructure in the arguments, but that would require a change to eslint rules.
     const { sanitize } = DOMPurify;
 
@@ -29,7 +27,11 @@ define(['domPurify', 'common/format', 'common/html', 'util/string'], (
         const parameterArray = appSpec.parameters.map((param) => {
             const textOptions = param.text_options;
             let types = null;
-            if (textOptions && Array.isArray(textOptions.valid_ws_types)) {
+            if (
+                textOptions &&
+                Array.isArray(textOptions.valid_ws_types) &&
+                textOptions.valid_ws_types.indexOf('*') === -1
+            ) {
                 const typesArray = textOptions.valid_ws_types.map((type) => {
                     return a(
                         {
@@ -220,12 +222,12 @@ define(['domPurify', 'common/format', 'common/html', 'util/string'], (
                             ),
                             appTag
                                 ? span(
-                                    {
-                                        class: `${cssBaseClass}__tag label label-primary`,
-                                        title: `${appTag} version of the app`,
-                                    },
-                                    appTag
-                                )
+                                      {
+                                          class: `${cssBaseClass}__tag label label-primary`,
+                                          title: `${appTag} version of the app`,
+                                      },
+                                      appTag
+                                  )
                                 : '',
                         ]
                     ),

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
@@ -15,6 +15,7 @@ define([
 ], (Promise, KBWidget, $, Config, APIUtil, kbase_client_api, GenericClient, Jupyter) => {
     const STAGING_EXPORT_APP = 'kb_staging_exporter/export_to_staging';
     const JSON_EXPORT_APP = 'kb_staging_exporter/export_json_to_staging';
+    const CSS_BASE = 'kb-download-panel';
 
     return KBWidget({
         name: 'kbaseNarrativeDownloadPanel',
@@ -92,19 +93,19 @@ define([
         },
 
         renderStructure: function () {
-            const $container = $('<div>').addClass('kb-download-panel');
-            const $label = $('<div>').addClass('kb-download-panel__label').append('Export as:');
-            const $buttons = $('<div>').addClass('kb-download-panel__buttons');
+            const $container = $('<div>').addClass(CSS_BASE);
+            const $label = $('<div>').addClass(`${CSS_BASE}__label`).append('Export as:');
+            const $buttons = $('<div>').addClass(`${CSS_BASE}__buttons`);
             $container.append($label).append($buttons);
 
             this.$elem.append($container);
-            this.$statusDiv = $('<div>').addClass('kb-download-panel__status');
+            this.$statusDiv = $('<div>').addClass(`${CSS_BASE}__status`);
             this.$elem.append(this.$statusDiv.hide());
         },
 
         renderDownloadButtons: function () {
             const downloaders = this.prepareDownloaders(this.type);
-            const $btnPanel = this.$elem.find('.kb-download-panel__buttons');
+            const $btnPanel = this.$elem.find(`.${CSS_BASE}__buttons`);
             downloaders.forEach((dlInfo) => {
                 if (dlInfo.name.toLocaleLowerCase() === 'staging') {
                     $btnPanel.append(
@@ -259,7 +260,7 @@ define([
         },
 
         showMessage: function (msg) {
-            this.$statusDiv.empty().append(msg);
+            this.$statusDiv.empty().append(msg).show();
         },
 
         showError: function (error) {
@@ -272,11 +273,14 @@ define([
             }
             // error is final state, so reactivate!
             this.$elem.find('.kb-data-list-btn').prop('disabled', false);
-            this.$statusDiv.empty().append(
-                $('<span>')
-                    .addClass('kb-download-panel__status_error')
-                    .append('Error: ' + error)
-            );
+            this.$statusDiv
+                .empty()
+                .append(
+                    $('<span>')
+                        .addClass(`${CSS_BASE}__status_error`)
+                        .append('Error: ' + error)
+                )
+                .show();
         },
 
         stopTimer: function () {

--- a/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
@@ -3,9 +3,7 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
     Props,
     TestUtil
 ) => {
-    'use strict';
-
-    describe('The App Info Tab module', () => {
+    fdescribe('The App Info Tab module', () => {
         it('loads', () => {
             expect(InfoTab).not.toBe(null);
         });
@@ -16,7 +14,7 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
         });
     });
 
-    describe('The App Info Tab instance', () => {
+    fdescribe('The App Info Tab instance', () => {
         afterEach(() => {
             TestUtil.clearRuntime();
         });
@@ -85,6 +83,13 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
                         {
                             ui_name: 'Adapters',
                             id: 'adapters',
+                        },
+                        {
+                            text_options: {
+                                valid_ws_types: ['*', 'SomeModule.SomeType'],
+                            },
+                            ui_name: 'Any old object',
+                            id: 'any_old_object',
                         },
                     ],
                 },
@@ -303,6 +308,19 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
                     expect(
                         paramTwo.querySelector(`.${cssBaseClass}__param--ui-name`).textContent
                     ).toBe(appData[APP.ONE.ID].app.spec.parameters[1].ui_name);
+                });
+
+                it('renders no links for a parameter than can be a wildcard type', () => {
+                    const paramThree = container.querySelectorAll(
+                        `.${cssBaseClass}__list_item--params`
+                    )[2];
+                    expect(
+                        paramThree.querySelector(`.${cssBaseClass}__param--id`).textContent
+                    ).toBe(appData[APP.ONE.ID].app.spec.parameters[2].id);
+                    expect(
+                        paramThree.querySelector(`.${cssBaseClass}__param--ui-name`).textContent
+                    ).toBe(appData[APP.ONE.ID].app.spec.parameters[2].ui_name);
+                    expect(paramThree.querySelectorAll('a').length).toBe(0);
                 });
 
                 it('renders run stats correctly', () => {

--- a/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
+++ b/test/unit/spec/common/cellComponents/tabs/infoTab-Spec.js
@@ -3,7 +3,7 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
     Props,
     TestUtil
 ) => {
-    fdescribe('The App Info Tab module', () => {
+    describe('The App Info Tab module', () => {
         it('loads', () => {
             expect(InfoTab).not.toBe(null);
         });
@@ -14,7 +14,7 @@ define(['common/cellComponents/tabs/infoTab', 'common/props', 'testUtil'], (
         });
     });
 
-    fdescribe('The App Info Tab instance', () => {
+    describe('The App Info Tab instance', () => {
         afterEach(() => {
             TestUtil.clearRuntime();
         });

--- a/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
@@ -8,6 +8,7 @@ define([
 ], ($, kbaseNarrativeDownloadPanel, Jupyter, Mocks, TestUtil, Config) => {
     const JSON_EXPORT_APP = 'kb_staging_exporter/export_json_to_staging';
     const STAGING_EXPORT_APP = 'kb_staging_exporter/export_to_staging';
+    const CSS_BASE = 'kb-download-panel';
 
     describe('The kbaseNarrativeDownloadPanel widget', () => {
         let $div = null;
@@ -124,7 +125,7 @@ define([
             });
 
             await initDownloadPanel(null, {});
-            const $status = $div.find('.kb-download-status');
+            const $status = $div.find(`.${CSS_BASE}__status`);
             expect($status.text()).toContain('Error: an error happened');
         });
 
@@ -236,14 +237,14 @@ define([
             await TestUtil.waitForElementState(
                 $div[0],
                 () => {
-                    const text = $div[0].querySelector('.kb-download-status').textContent || '';
+                    const text = $div[0].querySelector(`.${CSS_BASE}__status`).textContent || '';
                     return text.endsWith(errorMsg);
                 },
                 () => {
                     exportBtns[0].click();
                 }
             );
-            expect($div[0].querySelector('.kb-download-status').textContent).toContain(errorMsg);
+            expect($div[0].querySelector(`.${CSS_BASE}__status`).textContent).toContain(errorMsg);
             expect(widget.timer).toBeNull();
         });
 
@@ -323,22 +324,22 @@ define([
             await TestUtil.waitForElementState(
                 $div[0],
                 () => {
-                    const text = $div[0].querySelector('.kb-download-status').textContent || '';
+                    const text = $div[0].querySelector(`.${CSS_BASE}__status`).textContent || '';
                     return text.endsWith('some log');
                 },
                 () => {
                     exportBtns[0].click();
                 }
             );
-            expect($div[0].querySelector('.kb-download-status').textContent).toContain('some log');
+            expect($div[0].querySelector(`.${CSS_BASE}__status`).textContent).toContain('some log');
             expect(widget.timer).not.toBeNull();
 
             await TestUtil.waitForElementState($div[0], () => {
-                const text = $div[0].querySelector('.kb-download-status').textContent;
+                const text = $div[0].querySelector(`.${CSS_BASE}__status`).textContent;
                 return text === '';
             });
 
-            expect($div[0].querySelector('.kb-download-status').textContent).toBe('');
+            expect($div[0].querySelector(`.${CSS_BASE}__status`).textContent).toBe('');
             expect(widget.timer).toBeNull();
         });
 
@@ -383,14 +384,14 @@ define([
             await TestUtil.waitForElementState(
                 $div[0],
                 () => {
-                    const text = $div[0].querySelector('.kb-download-status').textContent || '';
+                    const text = $div[0].querySelector(`.${CSS_BASE}__status`).textContent || '';
                     return text.endsWith(errorMsg);
                 },
                 () => {
                     exportBtns[0].click();
                 }
             );
-            expect($div[0].querySelector('.kb-download-status').textContent).toContain(errorMsg);
+            expect($div[0].querySelector(`.${CSS_BASE}__status`).textContent).toContain(errorMsg);
             expect(widget.timer).toBeNull();
         });
 


### PR DESCRIPTION
# Description of PR purpose/changes

As reported, the Info tab in app cells running the new JSON exporter (which allows any time in an input field) renders this:

![image](https://github.com/user-attachments/assets/48d389f7-a3b8-4486-a1f4-29b47b018a04)

The * link goes to a broken type spec page. Since any data type is allowed there, it shouldn't really have a link at all, so this checks for a wildcard in the allowed types, and if present, doesn't list the types.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/DATAUP-X
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
