### PR TITLE
UIP-51 fix downloader app inputs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,36 +2,38 @@
 
 The Narrative Interface allows users to craft KBase Narratives using a combination of GUI-based commands, Python and R scripts, and graphical output elements.
 
-This is built on the Jupyter Notebook v6.5.6 and IPython 8.25.0 (more notes will follow).
+This is built on the Jupyter Notebook v6.5.6 and IPython 8.26.0 (more notes will follow).
 
 ## Version 5.4.1
+- UIP-51 fix issue where JSON and STAGING download apps aren't getting properly instantiated with object inputs.
+
 ### Dependency Changes
 - Python dependency updates
   - biopython 1.79 -> 1.84
   - bokeh 3.0.3 -> 3.4.2
+  - certifi 2024.6.2 -> 2024.7.4
+  - chardet 5.0.0 -> 5.2.0
+  - ipython 8.25.0 -> 8.26.0
   - networkx 3.0 -> 3.3
   - numpy 1.24.1 -> 2.0.0
+  - pexpect 4.8.0 -> 4.9.0
+  - pillow 10.3.0 -> 10.4.0
   - plotly 5.13.0 -> 5.22.0
   - pyasn1 0.4.8 -> 0.6.0
-  - ruff 0.4.7 -> 0.5.0
   - pygments 2.17.2 -> 2.18.0
-  - pexpect 4.8.0 -> 4.9.0
-  - seaborn 0.12.0 -> 0.13.2
-  - setuptools 69.5.1 -> 70.1.1
-  - certifi 2024.6.2 -> 2024.7.4
-  - sympy 1.10.1 -> 1.12.1
-  - pillow 10.3.0 -> 10.4.0
   - python-daemon 2.3.2 -> 3.0.1
-  - chardet 5.0.0 -> 5.2.0
   - python-dateutil 2.8.2 -> 2.9.0.post0
   - scipy 1.10.0 -> 1.14.0
-  - ipython 8.25.0 -> 8.26.0
+  - seaborn 0.12.0 -> 0.13.2
+  - setuptools 69.5.1 -> 70.1.1
+  - sympy 1.10.1 -> 1.12.1
+  - ruff 0.4.7 -> 0.5.0
 
 - JavaScript dependency updates
+  - @wdio/mocha-framework  8.38.2 -> 8.39.0 
+  - chrome-launcher  1.1.1 -> 1.1.2 
   - chromedriver  126.0.0 -> 126.0.4 
   - postcss  8.4.38 -> 8.4.39 
-  - chrome-launcher  1.1.1 -> 1.1.2 
-  - @wdio/mocha-framework  8.38.2 -> 8.39.0 
   - selenium-webdriver  4.21.0 -> 4.22.0 
 
 ## Version 5.4.0

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeDownloadPanel.js
@@ -76,7 +76,7 @@ define([
             $dlBtn.click(() => {
                 if (makeCell) {
                     Jupyter.narrative.addAndPopulateApp(dlInfo.appId, APIUtil.getAppVersionTag(), {
-                        input_ref: this.objName,
+                        input_ref: this.upa,
                     });
                 } else {
                     $dlBtn.parent().find('.kb-data-list-btn').prop('disabled', true);

--- a/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
+++ b/test/unit/spec/narrative_core/kbaseNarrativeDownloadPanel-spec.js
@@ -12,20 +12,20 @@ define([
 
     describe('The kbaseNarrativeDownloadPanel widget', () => {
         let $div = null;
-        const ws = 1111,
-            oid = 2222,
-            ver = 3333,
-            name = 'fake_test_object',
-            objType = 'FakeModule.FakeType',
-            upa = `${ws}/${oid}/${ver}`;
+        const WS = 1111,
+            OBJ_ID = 2222,
+            OBJ_VER = 3333,
+            OBJ_NAME = 'fake_test_object',
+            OBJ_TYPE = 'FakeModule.FakeType',
+            INPUT_UPA = `${WS}/${OBJ_ID}/${OBJ_VER}`;
 
         const initDownloadPanel = async (authToken, exporterCache) => {
             return await new kbaseNarrativeDownloadPanel($div, {
                 token: authToken,
-                type: objType,
-                objId: oid,
-                ref: upa,
-                objName: name,
+                type: OBJ_TYPE,
+                objId: OBJ_ID,
+                upa: INPUT_UPA,
+                objName: OBJ_NAME,
                 downloadSpecCache: exporterCache,
             });
         };
@@ -65,7 +65,7 @@ define([
                 const exporterCache = {
                     lastUpdateTime: 100,
                     types: {
-                        [objType]: { export_functions: exporters },
+                        [OBJ_TYPE]: { export_functions: exporters },
                     },
                 };
 
@@ -141,7 +141,7 @@ define([
                 exporterCache = {
                     lastUpdateTime: 100,
                     types: {
-                        [objType]: {
+                        [OBJ_TYPE]: {
                             export_functions: {
                                 SOME_FORMAT: exportApp,
                             },
@@ -215,7 +215,7 @@ define([
                 exporterCache = {
                     lastUpdateTime: 100,
                     types: {
-                        [objType]: {
+                        [OBJ_TYPE]: {
                             export_functions: {
                                 SOME_FORMAT: exportApp,
                             },
@@ -254,7 +254,7 @@ define([
                 exporterCache = {
                     lastUpdateTime: 100,
                     types: {
-                        [objType]: {
+                        [OBJ_TYPE]: {
                             export_functions: {
                                 SOME_FORMAT: exportApp,
                             },
@@ -355,7 +355,7 @@ define([
                 exporterCache = {
                     lastUpdateTime: 100,
                     types: {
-                        [objType]: {
+                        [OBJ_TYPE]: {
                             export_functions: {
                                 SOME_FORMAT: exportApp,
                             },
@@ -401,7 +401,7 @@ define([
             const exporterCache = {
                 lastUpdateTime: 100,
                 types: {
-                    [objType]: {
+                    [OBJ_TYPE]: {
                         export_functions: {
                             STAGING: 'gets_overwritten_right_now',
                         },
@@ -416,14 +416,14 @@ define([
             expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledOnceWith(
                 STAGING_EXPORT_APP,
                 'release',
-                { input_ref: 'fake_test_object' }
+                { input_ref: INPUT_UPA }
             );
         });
 
         it('Should create an app cell with the JSON exporter', async () => {
             /* use mock for Jupyter.narrative.addAndPopulateApp */
             spyOn(Jupyter.narrative, 'addAndPopulateApp');
-            await initDownloadPanel(null, { lastUpdateTime: 100, types: { [objType]: {} } });
+            await initDownloadPanel(null, { lastUpdateTime: 100, types: { [OBJ_TYPE]: {} } });
             const exportBtn = $div.find('.kb-data-list-btn');
             // only one is JSON
             expect(exportBtn.length).toEqual(1);
@@ -431,14 +431,14 @@ define([
             expect(Jupyter.narrative.addAndPopulateApp).toHaveBeenCalledOnceWith(
                 JSON_EXPORT_APP,
                 'release',
-                { input_ref: 'fake_test_object' }
+                { input_ref: INPUT_UPA }
             );
         });
 
         it('Should have a cancel button that empties the widget', async () => {
             const widget = await initDownloadPanel(null, {
                 lastUpdateTime: 100,
-                types: { [objType]: {} },
+                types: { [OBJ_TYPE]: {} },
             });
             const cancelBtn = $div.find('.kb-data-list-cancel-btn');
             cancelBtn.click();


### PR DESCRIPTION
# Description of PR purpose/changes

The downloader apps (from the STAGING and JSON button options) make app cells that should (used to) get autopopulated with the object used to trigger the download, but haven't for a while. They should now do so again!

FWIW, I think this is more bleedover from moving to setting object inputs to UPAs sometime last year.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/UIP-51
- [x] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [n/a] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [x] [Version has been bumped](https://semver.org/) for each release
- [x] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
