### PR TITLE
Fix WebdriverIO configs

### DIFF
--- a/test/integration/specs/narrative_basic_test.js
+++ b/test/integration/specs/narrative_basic_test.js
@@ -1,12 +1,12 @@
 'use strict';
-const { login, makeURL } = require('../wdioUtils');
+const { login } = require('../wdioUtils');
 const env = process.env.ENV || 'ci';
 const testData = require('./narrative_basic_data.json');
 const testCases = testData.envs[env];
 
 describe('Narrative tree page with login', () => {
     beforeEach(async () => {
-        await browser.setTimeout({ implicit: 30000 });
+        await browser.setTimeout({ pageLoad: 30000 });
         await browser.reloadSession();
         await login();
     });
@@ -16,7 +16,7 @@ describe('Narrative tree page with login', () => {
     });
 
     it('opens a narrative', async () => {
-        await browser.url(makeURL(`narrative/${testCases.CASE_1.narrativeId}`));
+        await browser.url(`/narrative/${testCases.CASE_1.narrativeId}`);
         const loadingBlocker = await $('#kb-loading-blocker');
         const loadingText = await loadingBlocker.getText();
         await expect(loadingText).toContain('Connecting to KBase services...');

--- a/test/integration/wdio.conf.js
+++ b/test/integration/wdio.conf.js
@@ -4,8 +4,6 @@
 const testConfig = require('../testConfig');
 const fs = require('fs');
 
-const CHROME_BINARY = require('puppeteer').executablePath();
-
 /**
  * Given a preset key, return set set of common configuration keys for a given service, os, and browser
  * This is useful because testing services support a limited number of browser dimensions, which differs
@@ -176,7 +174,6 @@ const serviceConfigs = {
         logPath: 'selenium-standalone-logs',
         // drivers
     },
-    chromedriver: {},
     browserstack: {
         browserstackLocal: true,
         opts: {},
@@ -196,21 +193,19 @@ function makeCapabilities(config) {
         case 'chromedriver':
             return (() => {
                 const args = [
-                    '--disable-gpu',
-                    '--no-sandbox',
+                    'headless',
+                    'disable-gpu',
                     `window-size=${config.WIDTH},${config.HEIGHT}`,
                 ];
-                if (config.HEADLESS === 't') {
-                    args.push('--headless');
-                }
                 return {
                     browserName: 'chrome',
+                    browserVersion: '128',
                     acceptInsecureCerts: true,
                     maxInstances: 1,
                     'goog:chromeOptions': {
                         args,
-                        binary: CHROME_BINARY,
                     },
+                    'wdio:enforceWebDriverClassic': true
                 };
             })();
         case 'selenium-standalone':
@@ -322,7 +317,7 @@ const wdioConfig = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 10,
+    maxInstances: 1,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -392,7 +387,6 @@ const wdioConfig = {
     // Services take over a specific job you don't want to take care of. They enhance
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
-    services: [[testParams.SERVICE, serviceConfigs[testParams.SERVICE]]],
 
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber
@@ -427,6 +421,7 @@ const wdioConfig = {
     // The only one supported by default is 'dot'
     // see also: https://webdriver.io/docs/dot-reporter.html
     reporters: ['spec'],
+
 
     //
     // Options to be passed to Mocha.


### PR DESCRIPTION
# Description of PR purpose/changes

The last batch of JS updates played some havoc with the webdriverio configs.
Mainly, in a previous major version of wdio, they started wrapping the most popular browser drivers into wdio itself, which made the `wdio-chromedriver-service` obsolete. Which, it hasn't been updated in 2 years and has been marked obsolete on Github, so that's a good thing anyway.

But the configs needed a little patching and updating to tell wdio we're not using that service anymore.

Eventually, we'll need to do the same for the standalone-selenium-service (which was put in to talk to firefox), and do some fiddling with browserstack (which I don't think we're actually using).

Chrome alone gets used in GHA, so that gets priority here.

There's a bunch of other little bits of polish to add to the config situation, too, but that's a later project. This does need to fixed, though to get integration tests passing again, and so I can put in more to handle this auth business.

