### PR TITLE
URO-366 Add focus on open. Tweak display icon.

### DIFF
--- a/kbase-extension/kbase_templates/narrative_header.html
+++ b/kbase-extension/kbase_templates/narrative_header.html
@@ -27,7 +27,7 @@
             </div>
             <div>Created by: <span id="kb-narr-creator"></span>
                 <span id="kb-view-mode">
-                    <span class="fa fa-pencil"></span>
+                    <span class="fa fa-eye-slash"></span>
                 </span>
             </div>
         </div>

--- a/kbase-extension/static/kbase/js/kbaseNarrative.js
+++ b/kbase-extension/static/kbase/js/kbaseNarrative.js
@@ -360,6 +360,12 @@ define([
                 shareWidget.refresh();
             }
             shareDialog.show();
+
+            // After a few seconds, focus the share field.
+            setTimeout(() => {
+                $('.select2-search__field').focus();
+            }, 2000);
+
         });
     };
 

--- a/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
+++ b/kbase-extension/static/kbase/js/widgets/narrative_core/kbaseNarrativeWorkspace.js
@@ -358,7 +358,7 @@ define([
             // mechanism should be disabled (and the button hidden as well.)
             const icon = $('#kb-view-mode span');
             icon.toggleClass('fa-eye', this.uiMode === 'view');
-            icon.toggleClass('fa-pencil', this.uiMode === 'edit');
+            icon.toggleClass('fa-eye-slash', this.uiMode === 'edit');
             Jupyter.narrative.readonly = this.uiMode === 'view';
 
             // Warning, do not look for the code for this ... it will burn your


### PR DESCRIPTION
# Description of PR purpose/changes

See ticket - opening the share panel doesn't focus on the user search input field which has been causing confusion.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/URO-366
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
