### PR TITLE
URO-352 Fix checkbox inputs not actually getting a default value set when it should

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
+++ b/kbase-extension/static/kbase/js/widgets/appWidgets2/input/checkboxInput.js
@@ -217,10 +217,11 @@ define([
 
                 // initialize based on config.initialValue. If it's not 0 or 1, then
                 // note that we have an initial value error, and set to the default.
-                const initValue =
+                let initValue =
                     'initialValue' in config ? config.initialValue : spec.data.defaultValue;
                 if (initValue !== 0 && initValue !== 1) {
                     model.hasInitialValueError = true;
+                    initValue = spec.data.defaultValue;
                 }
 
                 setModelValue(initValue);


### PR DESCRIPTION
# Description of PR purpose/changes

A little case that occurs in the following combined conditions:
1. We're making a bulk import cell
2. Using a import spec file or DTS manifest
3. That importer spec / manifest has a bad value for a checkbox input field
4. The user doesn't click on the little 'x' in the warning / ignores it all together.

What this will do is keep the incorrect value and pass it along to the app, potentially causing all manner of chaos (or minor headaches).

The warning says that the checkbox value being set is the default. While that happens visually, it doesn't actually affect the data model until the user clicks the little 'x' to close the warning.

This forces the data model to set the value to the default on input widget load.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/URO-352
- [x] Added the Jira Ticket to the title of the PR

# Testing Instructions
* Details for how to test the PR:
- [x] Tests pass locally and in GitHub Actions
- [x] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [ ] (Python) I have run Ruff `format` and `check` on changed Python code manually or with a git precommit hook
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
