### PR TITLE
PTV-1930 fix datatable error when data is missing from FeatureClusters object

### DIFF
--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
@@ -555,7 +555,9 @@ define([
                     if (feature) {
                         if (feature.aliases && feature.aliases.length > 0)
                             aliases = feature.aliases.join(', ');
-                        type = feature.type || '';
+                        if (feature.type) {
+                            type = feature.type;
+                        }
                         if (feature.function) {
                             func = feature.function;
                         }

--- a/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
+++ b/kbase-extension/static/kbase/js/widgets/function_output/kbaseExpressionFeatureClusters.js
@@ -555,7 +555,7 @@ define([
                     if (feature) {
                         if (feature.aliases && feature.aliases.length > 0)
                             aliases = feature.aliases.join(', ');
-                        type = feature.type;
+                        type = feature.type || '';
                         if (feature.function) {
                             func = feature.function;
                         }


### PR DESCRIPTION
# Description of PR purpose/changes

When data (specifically the `type` field) is missing from FeatureClusters object info - or, rather, the linked features from the genome object - a `null` value gets fed into the datatable. Datatables doesn't like that and whines whenever it gets rendered. There's probably a config to stop that, but other parts of that viewer expect to put in a dash for a missing value, so this column now does that, too.

# Jira Ticket / Issue #

Related Jira ticket: https://kbase-jira.atlassian.net/browse/PTV-1930
- [ ] Added the Jira Ticket to the title of the PR (e.g. `DATAUP-69 Adds a PR template`)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions
- [ ] Changes available by spinning up a local narrative and navigating to _X_ to see _Y_

# Dev Checklist:

- [x] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (JavaScript) I have run Prettier and ESLint on changed code manually or with a git precommit hook
- [x] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

Will bump version in next PR for a new release.

- [ ] [Version has been bumped](https://semver.org/) for each release
- [ ] [Release notes](/RELEASE_NOTES.md) have been updated for each release (and during the merge of feature branches)
